### PR TITLE
Harden backend reliability and test coverage

### DIFF
--- a/Application/Compression/CodeCompressionPrewarmer.cs
+++ b/Application/Compression/CodeCompressionPrewarmer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
+using System.Security;
 using System.Threading.Channels;
 
 namespace DevProjex.Application.Compression;
@@ -322,7 +323,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 					throw;
 				}
 				catch (Exception exception) when (
-					exception is IOException or UnauthorizedAccessException or NotSupportedException)
+					exception is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
 				{
 					Increment(WarmFileOutcome.Failed, ref warmed, ref skipped, ref failed);
 					ReportProgress(progress, ref processed, candidates.Count);
@@ -372,7 +373,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 						throw;
 					}
 					catch (Exception exception) when (
-						exception is IOException or UnauthorizedAccessException or NotSupportedException)
+						exception is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
 					{
 						Increment(WarmFileOutcome.Failed, ref warmed, ref skipped, ref failed);
 					}
@@ -479,7 +480,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 			return true;
 		}
 		catch (Exception exception) when (
-			exception is IOException or UnauthorizedAccessException or NotSupportedException)
+			exception is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
 		{
 			length = 0;
 			return false;

--- a/Application/Compression/CodeCompressionPrewarmer.cs
+++ b/Application/Compression/CodeCompressionPrewarmer.cs
@@ -142,7 +142,11 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 			Math.Min(MaximumIoParallelism, Math.Max(1, Environment.ProcessorCount)),
 			candidates.Count);
 		var producers = Enumerable.Range(0, producerCount)
-			.Select(_ => Task.Run(RunProducerAsync, CancellationToken.None))
+			.Select(_ => Task.Factory.StartNew(
+				RunProducerAsync,
+				CancellationToken.None,
+				TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+				TaskScheduler.Default).Unwrap())
 			.ToArray();
 		try
 		{

--- a/Application/Compression/ContentSelectionSnapshot.cs
+++ b/Application/Compression/ContentSelectionSnapshot.cs
@@ -30,7 +30,7 @@ public sealed record ContentSelectionSnapshot(
 		}
 
 		using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-		Append(hash, Path.GetFullPath(projectRoot));
+		Append(hash, PathUtility.Normalize(projectRoot));
 		foreach (var path in paths.OrderBy(static path => path, PathComparer.Default))
 			Append(hash, path);
 		return new ContentSelectionSnapshot(

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -164,7 +164,7 @@ public sealed class SecretRedactionSession : IDisposable
 	{
 		if (_persistentMarkStore is null)
 			return;
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		long expectedGeneration;
 		lock (_sync)
 		{
@@ -231,7 +231,7 @@ public sealed class SecretRedactionSession : IDisposable
 		ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
 		ArgumentNullException.ThrowIfNull(selection);
 		ValidateFeatures(features);
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 
 		HashSet<string> keptOccurrences;
 		long overrideRevision;
@@ -342,7 +342,7 @@ public sealed class SecretRedactionSession : IDisposable
 		ArgumentNullException.ThrowIfNull(snapshot);
 		ReplaceMarkedSecretsCore(
 			snapshot.Marks,
-			Path.GetFullPath(projectRoot),
+			PathUtility.Normalize(projectRoot),
 			snapshot.Revision,
 			snapshot.StateAppliedRevisions,
 			expectedGeneration: null);
@@ -461,7 +461,7 @@ public sealed class SecretRedactionSession : IDisposable
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
 		ArgumentNullException.ThrowIfNull(delta);
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		ValidatePendingDelta(delta);
 		bool changed;
 		lock (_sync)
@@ -504,7 +504,7 @@ public sealed class SecretRedactionSession : IDisposable
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
 		ArgumentNullException.ThrowIfNull(snapshot);
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		var replacement = NormalizePersistentMarks(snapshot.Marks);
 		bool changed;
 		lock (_sync)
@@ -544,7 +544,7 @@ public sealed class SecretRedactionSession : IDisposable
 	public bool RollbackPendingPersistentMarkDelta(string projectRoot, Guid operationId)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		bool changed;
 		lock (_sync)
 		{
@@ -749,7 +749,7 @@ public sealed class SecretRedactionSession : IDisposable
 		ValidatePendingDelta(delta);
 		if (delta.Kind != PersistentSecretMarkDeltaKind.Add)
 			throw new ArgumentException("Only an add delta can replace a session source anchor.", nameof(delta));
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		var anchor = new SessionMarkedSecret(
 			relativePath.Replace('\\', '/'),
 			sourceOffset,
@@ -1082,7 +1082,7 @@ public sealed class SecretRedactionSession : IDisposable
 	{
 		if (_persistentMarkStore is null)
 			return;
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		PersistentSecretMarkDelta[] migrations;
 		long expectedGeneration;
 		lock (_sync)
@@ -1129,7 +1129,7 @@ public sealed class SecretRedactionSession : IDisposable
 	internal void SchedulePendingPersistentMarkMigrationsAfterPreview(string projectRoot)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		CancellationTokenSource? obsoleteSchedule;
 		CancellationTokenSource schedule;
 		long expectedGeneration;
@@ -1499,7 +1499,7 @@ public sealed class SecretRedactionSession : IDisposable
 	public void AdvanceContentGeneration(string projectRoot)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
-		var normalizedProjectRoot = Path.GetFullPath(projectRoot);
+		var normalizedProjectRoot = PathUtility.Normalize(projectRoot);
 		CancellationTokenSource obsoleteGeneration;
 		lock (_sync)
 		{
@@ -2219,7 +2219,7 @@ public sealed class SecretRedactionScope
 	{
 		_session = session;
 		_transformIdentity = transformIdentity;
-		_projectRoot = Path.GetFullPath(projectRoot);
+		_projectRoot = PathUtility.Normalize(projectRoot);
 		_keptOccurrenceIds = keptOccurrenceIds;
 		_overrideRevision = overrideRevision;
 		_snapshotRevision = snapshotRevision;

--- a/Application/Secrets/SecretRedactionTempDirectory.cs
+++ b/Application/Secrets/SecretRedactionTempDirectory.cs
@@ -11,7 +11,7 @@ internal sealed class SecretRedactionTempDirectory : IDisposable
 	internal const string LeaseFileName = ".lease";
 	internal const string OwnerFileName = ".owner";
 	// The marker is one SHA-256 hex digest. A small allowance rejects attacker-controlled temp
-	// files before ReadAllText can allocate from an arbitrary length.
+	// files before their contents are materialized.
 	private const long MaximumOwnerMarkerBytes = 128;
 	// Cleanup runs in the background. A deletion cap bounds destructive work while rejected live,
 	// young, or foreign entries do not prevent reachable stale output from being reclaimed.
@@ -23,6 +23,7 @@ internal sealed class SecretRedactionTempDirectory : IDisposable
 	internal static readonly TimeSpan MinimumScavengeAge = TimeSpan.FromHours(24);
 
 	private static readonly string OwnerIdentity = CreateOwnerIdentity();
+	private static readonly byte[] OwnerIdentityBytes = Encoding.UTF8.GetBytes(OwnerIdentity);
 	private FileStream? _lease;
 	private int _disposed;
 
@@ -153,8 +154,7 @@ internal sealed class SecretRedactionTempDirectory : IDisposable
 			    IsReparsePoint(directory) ||
 			    IsReparsePoint(ownerPath) ||
 			    !File.Exists(ownerPath) ||
-			    new FileInfo(ownerPath).Length > MaximumOwnerMarkerBytes ||
-			    !File.ReadAllText(ownerPath, Encoding.UTF8).Equals(OwnerIdentity, StringComparison.Ordinal) ||
+			    !HasExpectedOwnerMarker(ownerPath) ||
 			    !IsOwnedByCurrentUser(directory))
 			{
 				return false;
@@ -168,6 +168,32 @@ internal sealed class SecretRedactionTempDirectory : IDisposable
 		{
 			return false;
 		}
+	}
+
+	private static bool HasExpectedOwnerMarker(string path)
+	{
+		using var stream = new FileStream(
+			path,
+			FileMode.Open,
+			FileAccess.Read,
+			FileShare.Read | FileShare.Delete,
+			bufferSize: 128,
+			FileOptions.SequentialScan);
+		return HasExpectedOwnerMarker(stream);
+	}
+
+	internal static bool HasExpectedOwnerMarker(Stream stream)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+		if (stream.Length != OwnerIdentityBytes.Length || stream.Length > MaximumOwnerMarkerBytes)
+			return false;
+
+		Span<byte> marker = stackalloc byte[OwnerIdentityBytes.Length];
+		stream.ReadExactly(marker);
+		Span<byte> overflowProbe = stackalloc byte[1];
+		return stream.Read(overflowProbe) == 0 &&
+		       stream.Length == OwnerIdentityBytes.Length &&
+		       marker.SequenceEqual(OwnerIdentityBytes);
 	}
 
 	internal static bool HasExpectedDirectoryName(string directory)

--- a/Application/Secrets/SecretRedactionTempDirectory.cs
+++ b/Application/Secrets/SecretRedactionTempDirectory.cs
@@ -65,7 +65,7 @@ internal sealed class SecretRedactionTempDirectory : IDisposable
 		throw new IOException("A unique secret-redaction temporary directory could not be created.");
 	}
 
-	private static SecretRedactionTempDirectory Initialize(string directory)
+	internal static SecretRedactionTempDirectory Initialize(string directory)
 	{
 		FileStream? lease = null;
 		try
@@ -89,11 +89,8 @@ internal sealed class SecretRedactionTempDirectory : IDisposable
 		}
 		catch
 		{
-			if (lease is not null)
-			{
-				lease.Dispose();
-				TryDelete(directory);
-			}
+			lease?.Dispose();
+			TryDelete(directory);
 			throw;
 		}
 	}

--- a/Application/Secrets/SecretScanCache.cs
+++ b/Application/Secrets/SecretScanCache.cs
@@ -105,7 +105,7 @@ internal sealed class SecretScanCache
 
 	public void SynchronizeProject(string projectRoot)
 	{
-		var canonicalRoot = Path.GetFullPath(projectRoot);
+		var canonicalRoot = PathUtility.Normalize(projectRoot);
 		lock (_sync)
 		{
 			if (_projectRoot is null || !PathComparer.Default.Equals(_projectRoot, canonicalRoot))
@@ -243,7 +243,7 @@ internal sealed class SecretScanCache
 		string rulesIdentity,
 		string transformIdentity,
 		int markedSecretsRevision) =>
-		new(Path.GetFullPath(path), rulesIdentity, transformIdentity, markedSecretsRevision);
+		new(PathUtility.Normalize(path), rulesIdentity, transformIdentity, markedSecretsRevision);
 
 	private static SecretScanCacheKey CreateKey(SecretScanCacheEntry entry) =>
 		new(

--- a/Application/Selection/SelectionRefreshEngine.cs
+++ b/Application/Selection/SelectionRefreshEngine.cs
@@ -829,7 +829,10 @@ public sealed class SelectionRefreshEngine(
                 stateCache,
                 stateCacheIsComplete);
         }
-        catch
+        catch (Exception exception) when (exception is
+               IOException or
+               UnauthorizedAccessException or
+               System.Security.SecurityException)
         {
             return IgnoreOptionsAvailabilityResolver.CreateUnmeasured(
                 includeGitIgnore: false,

--- a/Application/Services/FileContentAnalyzer.cs
+++ b/Application/Services/FileContentAnalyzer.cs
@@ -1247,6 +1247,7 @@ public sealed class FileContentAnalyzer :
 			}
 			finally
 			{
+				CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(buffer.AsSpan()));
 				ArrayPool<char>.Shared.Return(buffer);
 			}
 		}
@@ -1456,6 +1457,7 @@ public sealed class FileContentAnalyzer :
 			}
 			finally
 			{
+				CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(buffer.AsSpan()));
 				ArrayPool<char>.Shared.Return(buffer);
 			}
 		}

--- a/Application/Services/FileContentAnalyzer.cs
+++ b/Application/Services/FileContentAnalyzer.cs
@@ -55,7 +55,7 @@ public sealed class FileContentAnalyzer :
 		".bin", ".dat", ".db", ".sqlite", ".mdb"
 	}.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 	private static readonly Encoding StrictUtf8 = new UTF8Encoding(
-		encoderShouldEmitUTF8Identifier: false,
+		encoderShouldEmitUTF8Identifier: true,
 		throwOnInvalidBytes: true);
 	private static readonly Encoding StrictUtf16Le = new UnicodeEncoding(
 		bigEndian: false,
@@ -996,12 +996,8 @@ public sealed class FileContentAnalyzer :
 
 	private static Encoding ResolveBomFallbackEncoding(Encoding bomEncoding)
 	{
-		// The BOM-less strict UTF-8 instance has no preamble, so StreamReader auto-detection switches
-		// it to the framework replacement-fallback UTF-8 encoding. UTF-16/32 preambles match their
-		// supplied strict encodings and keep exception fallback. Preserve that established split.
-		if (ReferenceEquals(bomEncoding, StrictUtf8))
-			return Encoding.UTF8;
-		if (ReferenceEquals(bomEncoding, StrictUtf16Le) ||
+		if (ReferenceEquals(bomEncoding, StrictUtf8) ||
+		    ReferenceEquals(bomEncoding, StrictUtf16Le) ||
 		    ReferenceEquals(bomEncoding, StrictUtf16Be) ||
 		    ReferenceEquals(bomEncoding, StrictUtf32Le) ||
 		    ReferenceEquals(bomEncoding, StrictUtf32Be))

--- a/Application/Services/FileContentAnalyzer.cs
+++ b/Application/Services/FileContentAnalyzer.cs
@@ -382,8 +382,7 @@ public sealed class FileContentAnalyzer :
 		{
 			if (buffer is not null)
 			{
-				CryptographicOperations.ZeroMemory(
-					MemoryMarshal.AsBytes(buffer.AsSpan(0, written)));
+				ClearSensitiveCharacterBuffer(buffer);
 				ArrayPool<char>.Shared.Return(buffer);
 			}
 		}
@@ -994,6 +993,12 @@ public sealed class FileContentAnalyzer :
 		return true;
 	}
 
+	internal static void ClearSensitiveCharacterBuffer(char[] buffer)
+	{
+		ArgumentNullException.ThrowIfNull(buffer);
+		CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(buffer.AsSpan()));
+	}
+
 	private static Encoding ResolveBomFallbackEncoding(Encoding bomEncoding)
 	{
 		if (ReferenceEquals(bomEncoding, StrictUtf8) ||
@@ -1329,8 +1334,7 @@ public sealed class FileContentAnalyzer :
 			var current = Interlocked.Exchange(ref _buffer, null);
 			if (current is not null)
 			{
-				CryptographicOperations.ZeroMemory(
-					MemoryMarshal.AsBytes(current.AsSpan(0, length)));
+				ClearSensitiveCharacterBuffer(current);
 				ArrayPool<char>.Shared.Return(current);
 			}
 			return ValueTask.CompletedTask;

--- a/Application/Services/IgnoreRulesService.cs
+++ b/Application/Services/IgnoreRulesService.cs
@@ -21,8 +21,6 @@ public sealed class IgnoreRulesService(
 		pathComparisonSemanticsResolver ?? PlatformGitPathComparisonSemanticsResolver.Instance;
 
 	private static readonly StringComparer PathStringComparer = PathComparer.Default;
-	private static readonly StringComparison PathStringComparison = PathComparer.Comparison;
-
 	public IgnoreRules Build(string rootPath, IReadOnlyCollection<IgnoreOptionId> selectedOptions) =>
 		Build(rootPath, selectedOptions, selectedRootFolders: null);
 
@@ -47,7 +45,7 @@ public sealed class IgnoreRulesService(
 		string normalizedRoot;
 		try
 		{
-			normalizedRoot = Path.GetFullPath(rootPath);
+			normalizedRoot = PathUtility.Normalize(rootPath);
 		}
 		catch
 		{
@@ -58,7 +56,7 @@ public sealed class IgnoreRulesService(
 		{
 			foreach (var cachePath in GitIgnoreCache.Keys.ToArray())
 			{
-				if (IsSameOrDescendantPath(cachePath, normalizedRoot))
+				if (PathUtility.IsPathInside(cachePath, normalizedRoot))
 					RemoveGitIgnoreCacheEntry(cachePath);
 			}
 		}
@@ -495,20 +493,6 @@ public sealed class IgnoreRulesService(
 		ProjectRootFileSignature Signature,
 		GitPathComparisonSemantics ComparisonSemantics,
 		GitIgnoreMatcher Matcher);
-
-	private static bool IsSameOrDescendantPath(string candidatePath, string rootPath)
-	{
-		if (PathStringComparer.Equals(candidatePath, rootPath))
-			return true;
-		if (!candidatePath.StartsWith(rootPath, PathStringComparison))
-			return false;
-
-		return candidatePath.Length > rootPath.Length &&
-		       IsDirectorySeparator(candidatePath[rootPath.Length]);
-	}
-
-	private static bool IsDirectorySeparator(char value) =>
-		value == Path.DirectorySeparatorChar || value == Path.AltDirectorySeparatorChar;
 
 	private sealed record ScopedSmartIgnoreBuildResult(
 		IReadOnlySet<string> FolderNames,

--- a/Application/Services/OutputRootPathPresentation.cs
+++ b/Application/Services/OutputRootPathPresentation.cs
@@ -1,4 +1,5 @@
 using DevProjex.Application.Secrets;
+using DevProjex.Kernel;
 
 namespace DevProjex.Application.Services;
 
@@ -44,7 +45,7 @@ public static class OutputRootPathPresentation
 		string normalizedProjectRoot;
 		try
 		{
-			normalizedProjectRoot = Path.GetFullPath(redaction.ProjectRoot);
+			normalizedProjectRoot = PathUtility.Normalize(redaction.ProjectRoot);
 		}
 		catch
 		{

--- a/Application/Services/ProjectCopyExportService.cs
+++ b/Application/Services/ProjectCopyExportService.cs
@@ -368,7 +368,7 @@ public sealed class ProjectCopyExportService(
 		}
 		finally
 		{
-			ArrayPool<byte>.Shared.Return(buffer);
+			ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
 			try
 			{
 				await DeleteStagingDirectoryAsync(stagingPath).ConfigureAwait(false);
@@ -517,7 +517,7 @@ public sealed class ProjectCopyExportService(
 		}
 		finally
 		{
-			ArrayPool<byte>.Shared.Return(buffer);
+			ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
 			try
 			{
 				await DeleteStagingFileAsync(stagingPath).ConfigureAwait(false);

--- a/Application/Services/ProjectRootFactsProvider.cs
+++ b/Application/Services/ProjectRootFactsProvider.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.IO.Enumeration;
 using System.Security.Cryptography;
 using DevProjex.Application.Diagnostics;
@@ -270,12 +271,22 @@ public sealed class ProjectRootFactsProvider
 				return null;
 			if (linkInfo.Length > GitIgnoreFileReader.MaximumFileSizeBytes)
 				return null;
+			var expectedLastWriteTicks = linkInfo.LastWriteTimeUtc.Ticks;
+			var expectedLength = linkInfo.Length;
+			var fingerprint = ComputeContentFingerprint(linkInfo.FullName, expectedLength);
+			linkInfo.Refresh();
+			if (!linkInfo.Exists ||
+			    linkInfo.LastWriteTimeUtc.Ticks != expectedLastWriteTicks ||
+			    linkInfo.Length != expectedLength)
+			{
+				return null;
+			}
 
 			return new ProjectRootFileSignature(
-				linkInfo.LastWriteTimeUtc.Ticks,
-				linkInfo.Length,
+				expectedLastWriteTicks,
+				expectedLength,
 				LinkTarget: string.Empty,
-				ComputeContentFingerprint(linkInfo.FullName));
+				fingerprint);
 		}
 		catch (Exception exception) when (exception is
 		       IOException or
@@ -317,7 +328,7 @@ public sealed class ProjectRootFactsProvider
 		}
 	}
 
-	private static string ComputeContentFingerprint(string filePath)
+	private static string ComputeContentFingerprint(string filePath, long expectedLength)
 	{
 		using var stream = new FileStream(
 			filePath,
@@ -326,7 +337,39 @@ public sealed class ProjectRootFactsProvider
 			FileShare.ReadWrite | FileShare.Delete,
 			bufferSize: 4096,
 			FileOptions.SequentialScan);
-		return Convert.ToHexString(SHA256.HashData(stream));
+		return ComputeContentFingerprint(stream, expectedLength);
+	}
+
+	internal static string ComputeContentFingerprint(Stream stream, long expectedLength)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+		ArgumentOutOfRangeException.ThrowIfNegative(expectedLength);
+		if (stream.Length != expectedLength)
+			throw new IOException("The project root file changed before it could be hashed.");
+
+		using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+		var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
+		try
+		{
+			var remaining = expectedLength;
+			while (remaining > 0)
+			{
+				var readSize = (int)Math.Min(buffer.Length, remaining);
+				var read = stream.Read(buffer, 0, readSize);
+				if (read == 0)
+					throw new IOException("The project root file changed while it was being hashed.");
+				hash.AppendData(buffer, 0, read);
+				remaining -= read;
+			}
+
+			if (stream.Read(buffer, 0, 1) != 0 || stream.Length != expectedLength)
+				throw new IOException("The project root file changed while it was being hashed.");
+			return Convert.ToHexString(hash.GetHashAndReset());
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+		}
 	}
 
 	private static bool TryNormalizePath(string path, out string normalizedPath)

--- a/Application/Services/ProjectRootFactsProvider.cs
+++ b/Application/Services/ProjectRootFactsProvider.cs
@@ -53,28 +53,24 @@ public sealed class ProjectRootFactsProvider
 		if (string.IsNullOrWhiteSpace(rootPath))
 			return ProjectRootFacts.Missing(rootPath);
 
-		string normalizedRootPath;
-		try
-		{
-			normalizedRootPath = Path.GetFullPath(rootPath);
-		}
-		catch
-		{
+		if (!TryNormalizePath(rootPath, out var normalizedRootPath))
 			return ProjectRootFacts.Missing(rootPath);
-		}
 
 		var now = _utcNowProvider();
 		if (!forceRefresh && _cacheLimit > 0)
 		{
 			lock (_cacheSync)
 			{
-				if (_cache.TryGetValue(normalizedRootPath, out var cachedNode) &&
-				    now - cachedNode.Value.CachedAtUtc <= _cacheTtl)
+				if (_cache.TryGetValue(normalizedRootPath, out var cachedNode))
 				{
-					_cacheLru.Remove(cachedNode);
-					_cacheLru.AddFirst(cachedNode);
-					IgnorePipelineDiagnostics.RecordRootFactsCacheHit();
-					return cachedNode.Value.Facts;
+					var age = now - cachedNode.Value.CachedAtUtc;
+					if (age >= TimeSpan.Zero && age <= _cacheTtl)
+					{
+						_cacheLru.Remove(cachedNode);
+						_cacheLru.AddFirst(cachedNode);
+						IgnorePipelineDiagnostics.RecordRootFactsCacheHit();
+						return cachedNode.Value.Facts;
+					}
 				}
 			}
 		}
@@ -337,7 +333,7 @@ public sealed class ProjectRootFactsProvider
 	{
 		try
 		{
-			normalizedPath = Path.GetFullPath(path);
+			normalizedPath = PathUtility.Normalize(path);
 			return true;
 		}
 		catch
@@ -348,22 +344,7 @@ public sealed class ProjectRootFactsProvider
 	}
 
 	private static bool IsSameOrDescendantPath(string candidatePath, string rootPath)
-	{
-		if (PathComparer.Default.Equals(candidatePath, rootPath))
-			return true;
-		if (!candidatePath.StartsWith(rootPath, PathComparison))
-			return false;
-
-		return candidatePath.Length > rootPath.Length &&
-		       IsDirectorySeparator(candidatePath[rootPath.Length]);
-	}
-
-	private static bool IsDirectorySeparator(char value) =>
-		value == Path.DirectorySeparatorChar || value == Path.AltDirectorySeparatorChar;
-
-	private static StringComparison PathComparison => OperatingSystem.IsWindows()
-		? StringComparison.OrdinalIgnoreCase
-		: StringComparison.Ordinal;
+		=> PathUtility.IsPathInside(candidatePath, rootPath);
 
 	private readonly record struct ProjectRootEntry(
 		string Name,

--- a/Application/Services/ProjectScopeDiscoveryService.cs
+++ b/Application/Services/ProjectScopeDiscoveryService.cs
@@ -9,7 +9,8 @@ namespace DevProjex.Application.Services;
 
 public sealed class ProjectScopeDiscoveryService(
 	SmartIgnoreService smartIgnore,
-	ProjectRootFactsProvider? rootFactsProvider = null)
+	ProjectRootFactsProvider? rootFactsProvider = null,
+	Func<DateTime>? utcNowProvider = null)
 {
 	private const int ScopeCacheLimit = 128;
 	private static readonly TimeSpan ScopeCacheTtl = TimeSpan.FromSeconds(5);
@@ -149,6 +150,7 @@ public sealed class ProjectScopeDiscoveryService(
 	private readonly LinkedList<ScopeCacheEntry> _scopeCacheLru = new();
 	private readonly Dictionary<string, long> _latestDiscoverySequences = new(PathStringComparer);
 	private readonly ProjectRootFactsProvider _rootFactsProvider = rootFactsProvider ?? smartIgnore.RootFactsProvider;
+	private readonly Func<DateTime> _utcNowProvider = utcNowProvider ?? (() => DateTime.UtcNow);
 	private long _scopeCacheGeneration;
 	private long _nextDiscoverySequence;
 
@@ -171,18 +173,21 @@ public sealed class ProjectScopeDiscoveryService(
 		}
 
 		var cacheKey = BuildScopeCacheKey(normalizedRoot, selectedRootFolders);
-		var now = DateTime.UtcNow;
+		var now = _utcNowProvider();
 
 		long cacheGeneration;
 		long discoverySequence;
 		lock (_scopeCacheSync)
 		{
-			if (_scopeCache.TryGetValue(cacheKey, out var cachedNode) &&
-				now - cachedNode.Value.CachedAtUtc <= ScopeCacheTtl)
+			if (_scopeCache.TryGetValue(cacheKey, out var cachedNode))
 			{
-				_scopeCacheLru.Remove(cachedNode);
-				_scopeCacheLru.AddFirst(cachedNode);
-				return cachedNode.Value.Context;
+				var age = now - cachedNode.Value.CachedAtUtc;
+				if (age >= TimeSpan.Zero && age <= ScopeCacheTtl)
+				{
+					_scopeCacheLru.Remove(cachedNode);
+					_scopeCacheLru.AddFirst(cachedNode);
+					return cachedNode.Value.Context;
+				}
 			}
 
 			RemoveScopeCacheEntry(cacheKey);
@@ -226,7 +231,7 @@ public sealed class ProjectScopeDiscoveryService(
 
 			_latestDiscoverySequences.Remove(cacheKey);
 			RemoveScopeCacheEntry(cacheKey);
-			var entry = new ScopeCacheEntry(cacheKey, DateTime.UtcNow, context, discoveryStamp);
+			var entry = new ScopeCacheEntry(cacheKey, _utcNowProvider(), context, discoveryStamp);
 			_scopeCache[cacheKey] = _scopeCacheLru.AddFirst(entry);
 
 			while (_scopeCache.Count > ScopeCacheLimit &&
@@ -314,7 +319,7 @@ public sealed class ProjectScopeDiscoveryService(
 			allCurrent = false;
 			break;
 		}
-		var now = DateTime.UtcNow;
+		var now = _utcNowProvider();
 		lock (_scopeCacheSync)
 		{
 			if (!allCurrent)

--- a/Application/Services/ProjectScopeDiscoveryService.cs
+++ b/Application/Services/ProjectScopeDiscoveryService.cs
@@ -163,7 +163,7 @@ public sealed class ProjectScopeDiscoveryService(
 		string normalizedRoot;
 		try
 		{
-			normalizedRoot = Path.GetFullPath(rootPath);
+			normalizedRoot = PathUtility.Normalize(rootPath);
 		}
 		catch
 		{
@@ -244,7 +244,7 @@ public sealed class ProjectScopeDiscoveryService(
 		string normalizedRoot;
 		try
 		{
-			normalizedRoot = Path.GetFullPath(rootPath);
+			normalizedRoot = PathUtility.Normalize(rootPath);
 		}
 		catch
 		{
@@ -280,7 +280,7 @@ public sealed class ProjectScopeDiscoveryService(
 		string normalizedRoot;
 		try
 		{
-			normalizedRoot = Path.GetFullPath(rootPath);
+			normalizedRoot = PathUtility.Normalize(rootPath);
 		}
 		catch
 		{

--- a/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
+++ b/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
@@ -203,9 +203,10 @@ internal static class GitTrackedPathIndexCache
 			process.StandardInput.Close();
 			Volatile.Write(ref _gitAvailability, 1);
 		}
-		catch (Win32Exception)
+		catch (Win32Exception exception)
 		{
-			Volatile.Write(ref _gitAvailability, -1);
+			if (IsPermanentGitStartFailure(exception))
+				Volatile.Write(ref _gitAvailability, -1);
 			return null;
 		}
 
@@ -271,6 +272,15 @@ internal static class GitTrackedPathIndexCache
 			throwOnInvalidBytes: false);
 		startInfo.Environment["GIT_OPTIONAL_LOCKS"] = "0";
 		return startInfo;
+	}
+
+	internal static bool IsPermanentGitStartFailure(Win32Exception exception)
+	{
+		ArgumentNullException.ThrowIfNull(exception);
+		if (exception.NativeErrorCode == 2)
+			return true;
+
+		return OperatingSystem.IsWindows() && exception.NativeErrorCode is 3 or 193 or 216;
 	}
 
 	internal static async Task<List<string>?> ReadNullDelimitedPathsAsync(

--- a/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
+++ b/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
@@ -598,7 +598,7 @@ internal static class GitTrackedPathIndexCache
 
 	private static void Store(GitIndexSignature signature, LoadedGitTrackedPathIndex loaded)
 	{
-		if (loaded.EstimatedRetainedBytes > MaximumSingleEntryBytes)
+		if (!CanRetainCacheEntry(loaded.EstimatedRetainedBytes))
 			return;
 
 		lock (CacheSync)
@@ -619,6 +619,9 @@ internal static class GitTrackedPathIndexCache
 			}
 		}
 	}
+
+	internal static bool CanRetainCacheEntry(long estimatedRetainedBytes) =>
+		estimatedRetainedBytes is >= EstimatedEmptyIndexBytes and <= CacheByteLimit;
 
 	private static void Remove(string repositoryRootPath)
 	{

--- a/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
+++ b/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
@@ -12,7 +12,7 @@ internal static class GitTrackedPathIndexCache
 	private const long MaximumSingleEntryBytes = 64L * 1024 * 1024;
 	private const long EstimatedEmptyIndexBytes = 64;
 	private const int MaximumTrackedPathLength = 32768;
-	private const int GitFileMaximumLength = 64 * 1024;
+	internal const int GitFileMaximumLength = 64 * 1024;
 	private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(30);
 	private static readonly object CacheSync = new();
 	private static readonly Dictionary<string, LinkedListNode<CacheEntry>> Cache =
@@ -536,19 +536,7 @@ internal static class GitTrackedPathIndexCache
 			FileShare.ReadWrite | FileShare.Delete,
 			bufferSize: 1024,
 			FileOptions.SequentialScan);
-		using var reader = new StreamReader(
-			stream,
-			Encoding.UTF8,
-			detectEncodingFromByteOrderMarks: true,
-			bufferSize: 1024,
-			leaveOpen: false);
-		var firstLine = reader.ReadLine();
-		const string prefix = "gitdir:";
-		if (firstLine is null || !firstLine.StartsWith(prefix, StringComparison.Ordinal))
-			return false;
-
-		var target = firstLine[prefix.Length..].Trim();
-		if (target.Length == 0)
+		if (!TryReadGitDirectoryPointer(stream, out var target))
 			return false;
 
 		var resolvedPath = Path.IsPathRooted(target)
@@ -556,6 +544,29 @@ internal static class GitTrackedPathIndexCache
 			: Path.Combine(repositoryRootPath, target);
 		gitDirectoryPath = PathUtility.Normalize(resolvedPath);
 		return Directory.Exists(gitDirectoryPath);
+	}
+
+	internal static bool TryReadGitDirectoryPointer(Stream stream, out string target)
+	{
+		target = string.Empty;
+		if (!GitLocalConfigSemanticsReader.TryReadBoundedText(
+				stream,
+				GitFileMaximumLength,
+				out var content))
+		{
+			return false;
+		}
+
+		var lineEnd = content.AsSpan().IndexOfAny('\r', '\n');
+		var firstLine = lineEnd >= 0 ? content[..lineEnd] : content;
+		const string prefix = "gitdir:";
+		if (!firstLine.StartsWith(prefix, StringComparison.Ordinal))
+			return false;
+
+		target = firstLine[prefix.Length..].Trim();
+		if (target.Length == 0)
+			return false;
+		return true;
 	}
 
 	private static bool TryMetadataEntryExists(string gitMetadataPath)

--- a/Infrastructure/Git/GitBranchNameValidator.cs
+++ b/Infrastructure/Git/GitBranchNameValidator.cs
@@ -25,7 +25,7 @@ internal static class GitBranchNameValidator
 		{
 			if (component.Length == 0 ||
 			    component[0] == '.' ||
-			    component.EndsWith(".lock", StringComparison.OrdinalIgnoreCase))
+			    component.EndsWith(".lock", StringComparison.Ordinal))
 			{
 				return false;
 			}
@@ -33,7 +33,7 @@ internal static class GitBranchNameValidator
 
 		foreach (var character in branchName)
 		{
-			if (char.IsControl(character))
+			if (character < ' ' || character == '\u007F')
 				return false;
 		}
 

--- a/Infrastructure/Git/GitBranchNameValidator.cs
+++ b/Infrastructure/Git/GitBranchNameValidator.cs
@@ -11,7 +11,6 @@ internal static class GitBranchNameValidator
 	{
 		if (string.IsNullOrEmpty(branchName) ||
 		    branchName[0] == '-' ||
-		    branchName is "@" ||
 		    branchName[^1] is '/' or '.' ||
 		    branchName.Contains("..", StringComparison.Ordinal) ||
 		    branchName.Contains("@{", StringComparison.Ordinal) ||

--- a/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
+++ b/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
@@ -23,6 +23,10 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 	private readonly object _cacheSync = new();
 	private readonly Dictionary<string, RepositorySemanticsCacheEntry> _repositoryCache =
 		new(PathComparer.Default);
+	private readonly Dictionary<string, long> _latestResolutionSequences =
+		new(PathComparer.Default);
+	private long _cacheGeneration;
+	private long _nextResolutionSequence;
 
 	public static GitConfigPathComparisonSemanticsResolver Instance { get; } = new();
 
@@ -57,6 +61,8 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 		}
 
 		var now = _utcNowProvider();
+		long cacheGeneration;
+		long resolutionSequence;
 		lock (_cacheSync)
 		{
 			if (_repositoryCache.TryGetValue(repositoryRoot, out var cached))
@@ -68,13 +74,30 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 					return cached.Semantics;
 				}
 			}
+
+			if (!_latestResolutionSequences.ContainsKey(repositoryRoot) &&
+			    _latestResolutionSequences.Count >= CacheLimit)
+			{
+				_cacheGeneration++;
+				_repositoryCache.Clear();
+				_latestResolutionSequences.Clear();
+			}
+
+			cacheGeneration = _cacheGeneration;
+			resolutionSequence = ++_nextResolutionSequence;
+			_latestResolutionSequences[repositoryRoot] = resolutionSequence;
 		}
 
 		var resolved = _repositorySemanticsResolver(repositoryRoot, gitMetadataPath);
 		lock (_cacheSync)
 		{
-			if (_repositoryCache.Count >= CacheLimit)
-				_repositoryCache.Clear();
+			if (cacheGeneration != _cacheGeneration ||
+			    !_latestResolutionSequences.TryGetValue(repositoryRoot, out var latestResolutionSequence) ||
+			    latestResolutionSequence != resolutionSequence)
+			{
+				return resolved;
+			}
+
 			_repositoryCache[repositoryRoot] = new RepositorySemanticsCacheEntry(
 				resolved,
 				_utcNowProvider());
@@ -90,10 +113,17 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 
 		lock (_cacheSync)
 		{
+			_cacheGeneration++;
 			foreach (var repositoryRoot in _repositoryCache.Keys.ToArray())
 			{
 				if (PathsOverlap(repositoryRoot, normalizedRootPath))
 					_repositoryCache.Remove(repositoryRoot);
+			}
+
+			foreach (var repositoryRoot in _latestResolutionSequences.Keys.ToArray())
+			{
+				if (PathsOverlap(repositoryRoot, normalizedRootPath))
+					_latestResolutionSequences.Remove(repositoryRoot);
 			}
 		}
 	}

--- a/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
+++ b/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
@@ -9,6 +9,7 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 	private const int CacheLimit = 128;
 	private const int CommandTimeoutMilliseconds = 5000;
 	private const int KillWaitMilliseconds = 1000;
+	private static readonly TimeSpan UnavailableRetryDelay = TimeSpan.FromSeconds(5);
 	// Values on an unavailable result are intentionally non-contractual. Consumers must
 	// reject non-authoritative semantics instead of guessing across escaped patterns,
 	// character classes, negations, or tracked membership.
@@ -16,11 +17,34 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 		IgnoreCase: true,
 		NormalizeUnicode: true,
 		IsAuthoritative: false);
+	private readonly Func<string, string, GitPathComparisonSemantics> _repositorySemanticsResolver;
+	private readonly Func<DateTime> _utcNowProvider;
+	private readonly TimeSpan _unavailableRetryDelay;
 	private readonly object _cacheSync = new();
-	private readonly Dictionary<string, GitPathComparisonSemantics> _repositoryCache =
+	private readonly Dictionary<string, RepositorySemanticsCacheEntry> _repositoryCache =
 		new(PathComparer.Default);
 
 	public static GitConfigPathComparisonSemanticsResolver Instance { get; } = new();
+
+	public GitConfigPathComparisonSemanticsResolver()
+		: this(ResolveRepositorySemantics, static () => DateTime.UtcNow, UnavailableRetryDelay)
+	{
+	}
+
+	internal GitConfigPathComparisonSemanticsResolver(
+		Func<string, string, GitPathComparisonSemantics> repositorySemanticsResolver,
+		Func<DateTime> utcNowProvider,
+		TimeSpan unavailableRetryDelay)
+	{
+		ArgumentNullException.ThrowIfNull(repositorySemanticsResolver);
+		ArgumentNullException.ThrowIfNull(utcNowProvider);
+		if (unavailableRetryDelay < TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(unavailableRetryDelay));
+
+		_repositorySemanticsResolver = repositorySemanticsResolver;
+		_utcNowProvider = utcNowProvider;
+		_unavailableRetryDelay = unavailableRetryDelay;
+	}
 
 	public GitPathComparisonSemantics Resolve(string scopeRootPath)
 	{
@@ -32,18 +56,28 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 			return ResolveFileSystemFallback(scopeRootPath, gitMetadataPath: null);
 		}
 
+		var now = _utcNowProvider();
 		lock (_cacheSync)
 		{
 			if (_repositoryCache.TryGetValue(repositoryRoot, out var cached))
-				return cached;
+			{
+				var elapsed = now - cached.CapturedUtc;
+				if (cached.Semantics.IsAuthoritative ||
+				    elapsed >= TimeSpan.Zero && elapsed < _unavailableRetryDelay)
+			{
+					return cached.Semantics;
+				}
+			}
 		}
 
-		var resolved = ResolveRepositorySemantics(repositoryRoot, gitMetadataPath);
+		var resolved = _repositorySemanticsResolver(repositoryRoot, gitMetadataPath);
 		lock (_cacheSync)
 		{
 			if (_repositoryCache.Count >= CacheLimit)
 				_repositoryCache.Clear();
-			_repositoryCache[repositoryRoot] = resolved;
+			_repositoryCache[repositoryRoot] = new RepositorySemanticsCacheEntry(
+				resolved,
+				_utcNowProvider());
 		}
 
 		return resolved;
@@ -354,5 +388,9 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 			// Timeout cleanup is best-effort; no process output reaches a user surface.
 		}
 	}
+
+	private readonly record struct RepositorySemanticsCacheEntry(
+		GitPathComparisonSemantics Semantics,
+		DateTime CapturedUtc);
 
 }

--- a/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
+++ b/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
@@ -339,21 +339,8 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 	}
 
 	private static bool PathsOverlap(string leftPath, string rightPath) =>
-		IsSameOrDescendantPath(leftPath, rightPath) ||
-		IsSameOrDescendantPath(rightPath, leftPath);
-
-	private static bool IsSameOrDescendantPath(string candidatePath, string rootPath)
-	{
-		if (PathComparer.Default.Equals(candidatePath, rootPath))
-			return true;
-		if (!candidatePath.StartsWith(rootPath, PathComparer.Comparison) ||
-		    candidatePath.Length <= rootPath.Length)
-		{
-			return false;
-		}
-
-		return candidatePath[rootPath.Length] is '\\' or '/';
-	}
+		PathUtility.IsPathInside(leftPath, rightPath) ||
+		PathUtility.IsPathInside(rightPath, leftPath);
 
 	private static void TryKill(Process process)
 	{

--- a/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
+++ b/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
@@ -234,8 +234,14 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 				return false;
 
 			process.StandardInput.Close();
-			var outputTask = process.StandardOutput.ReadToEndAsync();
-			var errorTask = process.StandardError.ReadToEndAsync();
+			var outputTask = GitProcessOutputReader.ReadAsync(
+				process.StandardOutput,
+				GitProcessOutputReader.MaximumOutputCharacters,
+				CancellationToken.None);
+			var errorTask = GitProcessOutputReader.ReadAsync(
+				process.StandardError,
+				GitProcessOutputReader.MaximumOutputCharacters,
+				CancellationToken.None);
 			if (!process.WaitForExit(CommandTimeoutMilliseconds))
 			{
 				TryKill(process);
@@ -247,8 +253,11 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 				return false;
 			}
 
-			standardOutput = outputTask.GetAwaiter().GetResult();
-			_ = errorTask.GetAwaiter().GetResult();
+			var output = outputTask.GetAwaiter().GetResult();
+			var error = errorTask.GetAwaiter().GetResult();
+			if (output.ExceededLimit || error.ExceededLimit)
+				return false;
+			standardOutput = output.Text;
 			exitCode = process.ExitCode;
 			return true;
 		}

--- a/Infrastructure/Git/GitLocalConfigSemanticsReader.cs
+++ b/Infrastructure/Git/GitLocalConfigSemanticsReader.cs
@@ -236,13 +236,7 @@ internal static class GitLocalConfigSemanticsReader
 				FileOptions.SequentialScan);
 			if (stream.Length > maximumLengthBytes)
 				return false;
-			using var reader = new StreamReader(
-				stream,
-				Encoding.UTF8,
-				detectEncodingFromByteOrderMarks: true,
-				bufferSize: 4096,
-				leaveOpen: false);
-			if (!TryReadBoundedText(reader, maximumLengthBytes, out var observedText))
+			if (!TryReadBoundedText(stream, maximumLengthBytes, out var observedText))
 				return false;
 
 			fileInfo.Refresh();
@@ -260,39 +254,49 @@ internal static class GitLocalConfigSemanticsReader
 	}
 
 	internal static bool TryReadBoundedText(
-		TextReader reader,
-		int maximumCharacters,
+		Stream stream,
+		int maximumBytes,
 		out string text)
 	{
-		ArgumentNullException.ThrowIfNull(reader);
-		ArgumentOutOfRangeException.ThrowIfNegative(maximumCharacters);
+		ArgumentNullException.ThrowIfNull(stream);
+		ArgumentOutOfRangeException.ThrowIfNegative(maximumBytes);
 		text = string.Empty;
-		var bufferSize = maximumCharacters >= 4095 ? 4096 : maximumCharacters + 1;
-		var buffer = ArrayPool<char>.Shared.Rent(bufferSize);
-		var builder = new StringBuilder(Math.Min(maximumCharacters, 4096));
+		if (stream.Length > maximumBytes)
+			return false;
+
+		var initialCapacity = (int)Math.Min(stream.Length, Math.Min(maximumBytes, 4096));
+		using var content = new MemoryStream(initialCapacity);
+		var buffer = ArrayPool<byte>.Shared.Rent(4096);
 		try
 		{
 			var total = 0;
 			while (true)
 			{
-				var remaining = maximumCharacters - total;
+				var remaining = maximumBytes - total;
 				var readSize = remaining >= buffer.Length ? buffer.Length : remaining + 1;
-				var read = reader.Read(buffer, 0, readSize);
+				var read = stream.Read(buffer, 0, readSize);
 				if (read == 0)
-				{
-					text = builder.ToString();
-					return true;
-				}
+					break;
 				if (read > remaining)
 					return false;
-				builder.Append(buffer, 0, read);
+				content.Write(buffer, 0, read);
 				total += read;
 			}
 		}
 		finally
 		{
-			ArrayPool<char>.Shared.Return(buffer, clearArray: true);
+			ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
 		}
+
+		content.Position = 0;
+		using var reader = new StreamReader(
+			content,
+			Encoding.UTF8,
+			detectEncodingFromByteOrderMarks: true,
+			bufferSize: 1024,
+			leaveOpen: true);
+		text = reader.ReadToEnd();
+		return true;
 	}
 
 	private static bool TryParse(

--- a/Infrastructure/Git/GitLocalConfigSemanticsReader.cs
+++ b/Infrastructure/Git/GitLocalConfigSemanticsReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Globalization;
 
 namespace DevProjex.Infrastructure.Git;
@@ -233,13 +234,16 @@ internal static class GitLocalConfigSemanticsReader
 				FileShare.Read | FileShare.Delete,
 				bufferSize: 4096,
 				FileOptions.SequentialScan);
+			if (stream.Length > maximumLengthBytes)
+				return false;
 			using var reader = new StreamReader(
 				stream,
 				Encoding.UTF8,
 				detectEncodingFromByteOrderMarks: true,
 				bufferSize: 4096,
 				leaveOpen: false);
-			var observedText = reader.ReadToEnd();
+			if (!TryReadBoundedText(reader, maximumLengthBytes, out var observedText))
+				return false;
 
 			fileInfo.Refresh();
 			if (fileInfo.Exists &&
@@ -253,6 +257,42 @@ internal static class GitLocalConfigSemanticsReader
 		}
 
 		return false;
+	}
+
+	internal static bool TryReadBoundedText(
+		TextReader reader,
+		int maximumCharacters,
+		out string text)
+	{
+		ArgumentNullException.ThrowIfNull(reader);
+		ArgumentOutOfRangeException.ThrowIfNegative(maximumCharacters);
+		text = string.Empty;
+		var bufferSize = maximumCharacters >= 4095 ? 4096 : maximumCharacters + 1;
+		var buffer = ArrayPool<char>.Shared.Rent(bufferSize);
+		var builder = new StringBuilder(Math.Min(maximumCharacters, 4096));
+		try
+		{
+			var total = 0;
+			while (true)
+			{
+				var remaining = maximumCharacters - total;
+				var readSize = remaining >= buffer.Length ? buffer.Length : remaining + 1;
+				var read = reader.Read(buffer, 0, readSize);
+				if (read == 0)
+				{
+					text = builder.ToString();
+					return true;
+				}
+				if (read > remaining)
+					return false;
+				builder.Append(buffer, 0, read);
+				total += read;
+			}
+		}
+		finally
+		{
+			ArrayPool<char>.Shared.Return(buffer, clearArray: true);
+		}
 	}
 
 	private static bool TryParse(

--- a/Infrastructure/Git/GitProcessOutputReader.cs
+++ b/Infrastructure/Git/GitProcessOutputReader.cs
@@ -1,0 +1,50 @@
+using System.Buffers;
+using System.Text;
+
+namespace DevProjex.Infrastructure.Git;
+
+internal static class GitProcessOutputReader
+{
+	internal const int MaximumOutputCharacters = 1024 * 1024;
+
+	internal static async Task<GitProcessOutput> ReadAsync(
+		TextReader reader,
+		int maximumCharacters,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(reader);
+		if (maximumCharacters <= 0)
+			throw new ArgumentOutOfRangeException(nameof(maximumCharacters));
+
+		var buffer = ArrayPool<char>.Shared.Rent(Math.Min(4096, maximumCharacters));
+		var output = new StringBuilder(Math.Min(4096, maximumCharacters));
+		var exceededLimit = false;
+		try
+		{
+			while (true)
+			{
+				var read = await reader
+					.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+					.ConfigureAwait(false);
+				if (read == 0)
+					break;
+
+				var remaining = maximumCharacters - output.Length;
+				if (remaining > 0)
+					output.Append(buffer, 0, Math.Min(read, remaining));
+				if (read > remaining)
+					exceededLimit = true;
+			}
+
+			return exceededLimit
+				? new GitProcessOutput(string.Empty, ExceededLimit: true)
+				: new GitProcessOutput(output.ToString(), ExceededLimit: false);
+		}
+		finally
+		{
+			ArrayPool<char>.Shared.Return(buffer, clearArray: true);
+		}
+	}
+}
+
+internal readonly record struct GitProcessOutput(string Text, bool ExceededLimit);

--- a/Infrastructure/Git/GitProcessOutputReader.cs
+++ b/Infrastructure/Git/GitProcessOutputReader.cs
@@ -45,6 +45,18 @@ internal static class GitProcessOutputReader
 			ArrayPool<char>.Shared.Return(buffer, clearArray: true);
 		}
 	}
+
+	internal static async Task ObserveCompletionAsync(params Task[] readers)
+	{
+		try
+		{
+			await Task.WhenAll(readers).ConfigureAwait(false);
+		}
+		catch
+		{
+			// The process cancellation remains the primary failure after both pipes release resources.
+		}
+	}
 }
 
 internal readonly record struct GitProcessOutput(string Text, bool ExceededLimit);

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -399,6 +399,9 @@ public sealed class GitRepositoryService : IGitRepositoryService
         try
         {
             branchName = GitBranchNameValidator.ValidateAndNormalize(branchName);
+            // Git resolves the otherwise valid branch name "@" as HEAD for a bare checkout target.
+            if (branchName == "@")
+                return false;
             if (RepositoryCacheLayout.IsManaged(repositoryPath))
             {
                 return await SwitchManagedWorktreeBranchAsync(

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -808,12 +808,13 @@ public sealed class GitRepositoryService : IGitRepositoryService
             if (e.Data is not null)
             {
                 var line = e.Data;
-                if (TryExtractProgressPercent(line, out var percent))
+                var classification = ClassifyGitStderrLine(line);
+                if (classification.Percent is { } percent)
                 {
                     if (progress is not null)
                     {
                         var previousPercent = Interlocked.Exchange(ref lastReportedPercent, percent);
-                        if (IsSafeGitProgressLine(line))
+                        if (classification.IsSafeProgressLine)
                         {
                             // Preserve the phase detail for richer consumers without also
                             // emitting a second standalone percentage for the same Git line.
@@ -825,14 +826,19 @@ public sealed class GitRepositoryService : IGitRepositoryService
                         }
                     }
 
-                    // Progress lines can be very noisy during clone/fetch and are not
-                    // needed in the final error payload.
-                    return;
+                    if (!classification.RetainForError)
+                    {
+                        // Progress lines can be very noisy during clone/fetch and are not
+                        // needed in the final error payload.
+                        return;
+                    }
                 }
 
                 errorBuffer.Add(line);
 
-                if (progress is not null && IsSafeGitProgressLine(line))
+                if (progress is not null &&
+                    classification.Percent is null &&
+                    classification.IsSafeProgressLine)
                     progress.Report(line);
             }
         };
@@ -986,6 +992,21 @@ public sealed class GitRepositoryService : IGitRepositoryService
                trimmed.StartsWith("Checking out files:", StringComparison.OrdinalIgnoreCase) ||
                trimmed.StartsWith("Updating files:", StringComparison.OrdinalIgnoreCase);
     }
+
+    internal static GitStderrLineClassification ClassifyGitStderrLine(string line)
+    {
+        var hasPercent = TryExtractProgressPercent(line, out var percent);
+        var isSafeProgressLine = IsSafeGitProgressLine(line);
+        return new GitStderrLineClassification(
+            hasPercent ? percent : null,
+            isSafeProgressLine,
+            RetainForError: !hasPercent || !isSafeProgressLine);
+    }
+
+    internal readonly record struct GitStderrLineClassification(
+        int? Percent,
+        bool IsSafeProgressLine,
+        bool RetainForError);
 
     private sealed class BoundedLineBuffer(int maxChars)
     {

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -154,7 +154,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
     /// Parses git clone error messages and returns user-friendly error text.
     /// Git errors can be cryptic - this method translates them to understandable messages.
     /// </summary>
-    private static string ParseGitCloneError(string gitError)
+    internal static string ParseGitCloneError(string gitError)
     {
         if (string.IsNullOrWhiteSpace(gitError))
             return "Clone failed";
@@ -198,7 +198,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
     /// - https://github.com/user/repo.git -> repo
     /// - https://github.com/user/repo -> repo
     /// </summary>
-    private static string ExtractRepositoryName(string url)
+    internal static string ExtractRepositoryName(string url)
     {
         try
         {
@@ -936,7 +936,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
         }
     }
 
-    private static bool TryExtractProgressPercent(string line, out int percent)
+    internal static bool TryExtractProgressPercent(string line, out int percent)
     {
         percent = -1;
         if (string.IsNullOrWhiteSpace(line))
@@ -956,7 +956,11 @@ public sealed class GitRepositoryService : IGitRepositoryService
                     start--;
 
                 var length = end - start;
-                if (length > 0 &&
+                var hasInvalidNumericPrefix = start >= 0 &&
+                                              (char.IsLetterOrDigit(line[start]) ||
+                                               line[start] is '+' or '-' or '.' or '_');
+                if (!hasInvalidNumericPrefix &&
+                    length > 0 &&
                     int.TryParse(line.AsSpan(start + 1, length), out var value) &&
                     value is >= 0 and <= 100)
                 {
@@ -971,7 +975,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
         return false;
     }
 
-    private static bool IsSafeGitProgressLine(string line)
+    internal static bool IsSafeGitProgressLine(string line)
     {
         var trimmed = line.AsSpan().TrimStart();
         return trimmed.StartsWith("remote: Enumerating objects:", StringComparison.OrdinalIgnoreCase) ||

--- a/Infrastructure/Git/GitWorktreeManager.cs
+++ b/Infrastructure/Git/GitWorktreeManager.cs
@@ -1,6 +1,4 @@
-using System.Buffers;
 using System.ComponentModel;
-using System.Text;
 
 namespace DevProjex.Infrastructure.Git;
 
@@ -26,7 +24,7 @@ internal interface IGitWorktreeManager
 internal sealed class GitWorktreeManager : IGitWorktreeManager
 {
 	private static readonly TimeSpan SupportProbeTimeout = TimeSpan.FromSeconds(10);
-	internal const int MaximumProcessOutputCharacters = 1024 * 1024;
+	internal const int MaximumProcessOutputCharacters = GitProcessOutputReader.MaximumOutputCharacters;
 	private readonly object _supportSync = new();
 	private readonly Func<string, Task<WorktreeSupportState>> _probeSupport;
 	private Task<WorktreeSupportState>? _supportProbe;
@@ -353,11 +351,11 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		if (!process.Start())
 			return new GitProcessResult(-1, string.Empty, string.Empty);
 
-		var outputTask = ReadBoundedOutputAsync(
+		var outputTask = GitProcessOutputReader.ReadAsync(
 			process.StandardOutput,
 			MaximumProcessOutputCharacters,
 			cancellationToken);
-		var errorTask = ReadBoundedOutputAsync(
+		var errorTask = GitProcessOutputReader.ReadAsync(
 			process.StandardError,
 			MaximumProcessOutputCharacters,
 			cancellationToken);
@@ -386,47 +384,7 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		}
 	}
 
-	internal static async Task<BoundedProcessOutput> ReadBoundedOutputAsync(
-		TextReader reader,
-		int maximumCharacters,
-		CancellationToken cancellationToken)
-	{
-		ArgumentNullException.ThrowIfNull(reader);
-		if (maximumCharacters <= 0)
-			throw new ArgumentOutOfRangeException(nameof(maximumCharacters));
-
-		var buffer = ArrayPool<char>.Shared.Rent(Math.Min(4096, maximumCharacters));
-		var output = new StringBuilder(Math.Min(4096, maximumCharacters));
-		var exceededLimit = false;
-		try
-		{
-			while (true)
-			{
-				var read = await reader
-					.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
-					.ConfigureAwait(false);
-				if (read == 0)
-					break;
-
-				var remaining = maximumCharacters - output.Length;
-				if (remaining > 0)
-					output.Append(buffer, 0, Math.Min(read, remaining));
-				if (read > remaining)
-					exceededLimit = true;
-			}
-
-			return exceededLimit
-				? new BoundedProcessOutput(string.Empty, ExceededLimit: true)
-				: new BoundedProcessOutput(output.ToString(), ExceededLimit: false);
-		}
-		finally
-		{
-			ArrayPool<char>.Shared.Return(buffer, clearArray: true);
-		}
-	}
-
 	internal sealed record GitProcessResult(int ExitCode, string Output, string Error);
-	internal readonly record struct BoundedProcessOutput(string Text, bool ExceededLimit);
 
 	private static void TryDeletePartialWorktree(string path)
 	{

--- a/Infrastructure/Git/GitWorktreeManager.cs
+++ b/Infrastructure/Git/GitWorktreeManager.cs
@@ -178,7 +178,13 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 				? WorktreeSupportState.PermanentUnsupported
 				: WorktreeSupportState.TransientFailure;
 		}
-		catch (Exception exception) when (exception is Win32Exception or PlatformNotSupportedException)
+		catch (Win32Exception exception)
+		{
+			return IsPermanentGitStartFailure(exception)
+				? WorktreeSupportState.PermanentUnsupported
+				: WorktreeSupportState.TransientFailure;
+		}
+		catch (PlatformNotSupportedException)
 		{
 			return WorktreeSupportState.PermanentUnsupported;
 		}
@@ -190,6 +196,14 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		{
 			return WorktreeSupportState.TransientFailure;
 		}
+	}
+
+	private static bool IsPermanentGitStartFailure(Win32Exception exception)
+	{
+		if (exception.NativeErrorCode == 2)
+			return true;
+
+		return OperatingSystem.IsWindows() && exception.NativeErrorCode is 3 or 193 or 216;
 	}
 
 	private static async Task<string> ResolveRevisionAsync(

--- a/Infrastructure/Git/GitWorktreeManager.cs
+++ b/Infrastructure/Git/GitWorktreeManager.cs
@@ -54,6 +54,7 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		Task<WorktreeSupportState> probe;
 		lock (_supportSync)
 		{
+			PublishCompletedProbeLocked();
 			if (_cachedSupportState != WorktreeSupportState.Unknown)
 				return _cachedSupportState == WorktreeSupportState.Supported;
 			_supportProbe ??= _probeSupport(basePath);
@@ -85,6 +86,23 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		}
 
 		return state == WorktreeSupportState.Supported;
+	}
+
+	private void PublishCompletedProbeLocked()
+	{
+		if (_supportProbe is not { IsCompleted: true } completed)
+			return;
+
+		_supportProbe = null;
+		if (completed.IsCompletedSuccessfully)
+		{
+			var state = completed.GetAwaiter().GetResult();
+			if (state is WorktreeSupportState.Supported or WorktreeSupportState.PermanentUnsupported)
+				_cachedSupportState = state;
+			return;
+		}
+
+		_ = completed.Exception;
 	}
 
 	public async Task<bool> PreparePrimaryAsync(

--- a/Infrastructure/Git/GitWorktreeManager.cs
+++ b/Infrastructure/Git/GitWorktreeManager.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using System.ComponentModel;
+using System.Text;
 
 namespace DevProjex.Infrastructure.Git;
 
@@ -24,6 +26,7 @@ internal interface IGitWorktreeManager
 internal sealed class GitWorktreeManager : IGitWorktreeManager
 {
 	private static readonly TimeSpan SupportProbeTimeout = TimeSpan.FromSeconds(10);
+	internal const int MaximumProcessOutputCharacters = 1024 * 1024;
 	private readonly object _supportSync = new();
 	private readonly Func<string, Task<WorktreeSupportState>> _probeSupport;
 	private Task<WorktreeSupportState>? _supportProbe;
@@ -350,13 +353,23 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		if (!process.Start())
 			return new GitProcessResult(-1, string.Empty, string.Empty);
 
-		var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-		var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+		var outputTask = ReadBoundedOutputAsync(
+			process.StandardOutput,
+			MaximumProcessOutputCharacters,
+			cancellationToken);
+		var errorTask = ReadBoundedOutputAsync(
+			process.StandardError,
+			MaximumProcessOutputCharacters,
+			cancellationToken);
 		try
 		{
 			await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 			await Task.WhenAll(outputTask, errorTask).ConfigureAwait(false);
-			return new GitProcessResult(process.ExitCode, await outputTask, await errorTask);
+			var output = await outputTask.ConfigureAwait(false);
+			var error = await errorTask.ConfigureAwait(false);
+			return output.ExceededLimit || error.ExceededLimit
+				? new GitProcessResult(-1, string.Empty, "Git process output exceeded the safety limit.")
+				: new GitProcessResult(process.ExitCode, output.Text, error.Text);
 		}
 		catch (OperationCanceledException)
 		{
@@ -373,7 +386,47 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		}
 	}
 
+	internal static async Task<BoundedProcessOutput> ReadBoundedOutputAsync(
+		TextReader reader,
+		int maximumCharacters,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(reader);
+		if (maximumCharacters <= 0)
+			throw new ArgumentOutOfRangeException(nameof(maximumCharacters));
+
+		var buffer = ArrayPool<char>.Shared.Rent(Math.Min(4096, maximumCharacters));
+		var output = new StringBuilder(Math.Min(4096, maximumCharacters));
+		var exceededLimit = false;
+		try
+		{
+			while (true)
+			{
+				var read = await reader
+					.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+					.ConfigureAwait(false);
+				if (read == 0)
+					break;
+
+				var remaining = maximumCharacters - output.Length;
+				if (remaining > 0)
+					output.Append(buffer, 0, Math.Min(read, remaining));
+				if (read > remaining)
+					exceededLimit = true;
+			}
+
+			return exceededLimit
+				? new BoundedProcessOutput(string.Empty, ExceededLimit: true)
+				: new BoundedProcessOutput(output.ToString(), ExceededLimit: false);
+		}
+		finally
+		{
+			ArrayPool<char>.Shared.Return(buffer, clearArray: true);
+		}
+	}
+
 	internal sealed record GitProcessResult(int ExitCode, string Output, string Error);
+	internal readonly record struct BoundedProcessOutput(string Text, bool ExceededLimit);
 
 	private static void TryDeletePartialWorktree(string path)
 	{

--- a/Infrastructure/Git/GitWorktreeManager.cs
+++ b/Infrastructure/Git/GitWorktreeManager.cs
@@ -379,6 +379,9 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 			catch
 			{
 			}
+			await GitProcessOutputReader
+				.ObserveCompletionAsync(outputTask, errorTask)
+				.ConfigureAwait(false);
 
 			throw;
 		}

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -2014,11 +2014,13 @@ public sealed class RepoCacheService : IRepoCacheService
 			                IsInCache(entry.LocalPath))
 			.Select(entry => entry with
 			{
+				Identity = RepositoryUrlUtility.GetComparisonKey(entry.RepositoryUrl),
 				LastUsedUtc = entry.LastUsedUtc <= DateTimeOffset.UnixEpoch ||
 				              entry.LastUsedUtc > maximumAcceptedTimestamp
 					? DateTimeOffset.UnixEpoch
 					: entry.LastUsedUtc
 			})
+			.Where(static entry => entry.Identity.Length > 0)
 			.GroupBy(static entry => entry.Identity, StringComparer.OrdinalIgnoreCase)
 			.Select(static group => group.OrderByDescending(entry => entry.LastOpenedUtc).First())
 			.OrderByDescending(static entry => entry.LastOpenedUtc)

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -1118,6 +1118,7 @@ public sealed class RepoCacheService : IRepoCacheService
 				{
 					_testHooks?.BeforeUnusedWorktreeCleanup?.Invoke(basePath);
 					await CleanupUnusedWorktreesAsync(basePath, retainedPath, timeout.Token).ConfigureAwait(false);
+					_testHooks?.AfterUnusedWorktreeCleanup?.Invoke(basePath);
 				}
 				catch (OperationCanceledException) when (timeout.IsCancellationRequested)
 				{
@@ -2118,6 +2119,7 @@ internal sealed class RepoCacheTestHooks
 	public Action? BeforeScheduledGarbageCollection { get; init; }
 	public Action? AfterScheduledGarbageCollection { get; init; }
 	public Action<string>? BeforeUnusedWorktreeCleanup { get; init; }
+	public Action<string>? AfterUnusedWorktreeCleanup { get; init; }
 	public Action<string>? BeforeRepositorySizeRefresh { get; init; }
 	public Action<string>? AfterRepositorySizeCalculated { get; init; }
 	public Action<string>? AfterRepositorySizeRefresh { get; init; }

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -16,6 +16,7 @@ public sealed class RepoCacheService : IRepoCacheService
 	private const string CacheFolderName = "RepoCache";
 	private const string CacheIndexFileName = "cache-index.json";
 	private const int CacheIndexSchemaVersion = 2;
+	internal const long MaximumCacheIndexBytes = 64L * 1024 * 1024;
 	private const byte RepositorySizeRefreshRunning = 1;
 	private const byte RepositorySizeRefreshPending = 2;
 	private static readonly TimeSpan IndexLockTimeout = TimeSpan.FromSeconds(5);
@@ -256,7 +257,7 @@ public sealed class RepoCacheService : IRepoCacheService
 
 			using (heldLock)
 			{
-				if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+				if (HasUnsupportedIndexDocument(fileSet))
 					continue;
 
 				var document = LoadIndex(fileSet);
@@ -434,7 +435,7 @@ public sealed class RepoCacheService : IRepoCacheService
 		string? pathToTrash = null;
 		using (heldLock)
 		{
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+			if (HasUnsupportedIndexDocument(fileSet))
 				return;
 
 			var document = LoadIndex(fileSet);
@@ -493,7 +494,7 @@ public sealed class RepoCacheService : IRepoCacheService
 		var trashPaths = new List<string>();
 		using (heldLock)
 		{
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+			if (HasUnsupportedIndexDocument(fileSet))
 				return;
 
 			var document = LoadIndex(fileSet);
@@ -613,7 +614,7 @@ public sealed class RepoCacheService : IRepoCacheService
 		var trashPaths = new List<string>();
 		using (heldLock)
 		{
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+			if (HasUnsupportedIndexDocument(fileSet))
 				return;
 
 			var document = LoadIndex(fileSet);
@@ -670,7 +671,7 @@ public sealed class RepoCacheService : IRepoCacheService
 
 		using (heldLock)
 		{
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+			if (HasUnsupportedIndexDocument(fileSet))
 				return;
 
 			var document = LoadIndex(fileSet);
@@ -724,7 +725,7 @@ public sealed class RepoCacheService : IRepoCacheService
 
 		using (heldLock)
 		{
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+			if (HasUnsupportedIndexDocument(fileSet))
 				return;
 
 			var document = LoadIndex(fileSet);
@@ -1335,7 +1336,7 @@ public sealed class RepoCacheService : IRepoCacheService
 
 		using (heldLock)
 		{
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CacheIndexSchemaVersion))
+			if (HasUnsupportedIndexDocument(fileSet))
 				return;
 
 			var document = LoadIndex(fileSet);
@@ -1992,7 +1993,8 @@ public sealed class RepoCacheService : IRepoCacheService
 			    static () => RepositoryCacheIndexDocument.Empty,
 			    NormalizeIndex,
 			    out document,
-			    out _))
+			    out _,
+			    MaximumCacheIndexBytes))
 		{
 			document = RepositoryCacheIndexDocument.Empty;
 			return false;
@@ -2034,7 +2036,14 @@ public sealed class RepoCacheService : IRepoCacheService
 		JsonStorePersistence.TryWriteAtomic(
 			fileSet,
 			new RepositoryCacheIndexDocument(CacheIndexSchemaVersion, entries),
-			IndexSerializerOptions);
+			IndexSerializerOptions,
+			MaximumCacheIndexBytes);
+
+	private static bool HasUnsupportedIndexDocument(JsonStoreFileSet fileSet) =>
+		JsonStorePersistence.ContainsFutureDocument(
+			fileSet,
+			CacheIndexSchemaVersion,
+			maximumDocumentBytes: MaximumCacheIndexBytes);
 
 	private sealed class WorktreeCleanupState(string initialRetainedPath)
 	{

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -945,6 +945,9 @@ public sealed class RepoCacheService : IRepoCacheService
 
 		using (heldLock)
 		{
+			if (HasUnsupportedIndexDocument(fileSet))
+				return null;
+
 			var document = LoadIndex(fileSet);
 			var current = FindByIdentity(document, identity);
 			if (current is null ||
@@ -960,7 +963,7 @@ public sealed class RepoCacheService : IRepoCacheService
 				LastUsedUtc = _timeProvider.GetUtcNow(),
 				ContentKind = kind
 			};
-			WriteIndex(
+			if (!WriteIndex(
 				fileSet,
 				document.Entries
 					.Where(candidate => !string.Equals(
@@ -969,7 +972,10 @@ public sealed class RepoCacheService : IRepoCacheService
 						StringComparison.OrdinalIgnoreCase))
 					.Append(updated)
 					.OrderByDescending(static candidate => candidate.LastOpenedUtc)
-					.ToList());
+					.ToList()))
+			{
+				return null;
+			}
 			return updated;
 		}
 	}
@@ -1381,6 +1387,9 @@ public sealed class RepoCacheService : IRepoCacheService
 
 		using (heldLock)
 		{
+			if (HasUnsupportedIndexDocument(fileSet))
+				return null;
+
 			var document = LoadIndex(fileSet);
 			var entry = FindByIdentity(document, identity);
 			if (entry is null ||

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -1064,13 +1064,25 @@ public sealed class RepoCacheService : IRepoCacheService
 		};
 		process.Start();
 		process.StandardInput.Close();
-		var output = process.StandardOutput.ReadToEndAsync(cancellationToken);
-		var error = process.StandardError.ReadToEndAsync(cancellationToken);
+		var output = GitProcessOutputReader.ReadAsync(
+			process.StandardOutput,
+			GitProcessOutputReader.MaximumOutputCharacters,
+			cancellationToken);
+		var error = GitProcessOutputReader.ReadAsync(
+			process.StandardError,
+			GitProcessOutputReader.MaximumOutputCharacters,
+			cancellationToken);
 		try
 		{
 			await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 			await Task.WhenAll(output, error).ConfigureAwait(false);
-			return process.ExitCode == 0 ? await output.ConfigureAwait(false) : null;
+			var standardOutput = await output.ConfigureAwait(false);
+			var standardError = await error.ConfigureAwait(false);
+			return process.ExitCode == 0 &&
+			       !standardOutput.ExceededLimit &&
+			       !standardError.ExceededLimit
+				? standardOutput.Text
+				: null;
 		}
 		catch (OperationCanceledException)
 		{

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -40,7 +40,8 @@ public sealed class RepoCacheService : IRepoCacheService
 	private readonly IGitWorktreeManager _worktreeManager;
 	private readonly RepoCacheTestHooks? _testHooks;
 	private readonly object _garbageCollectionSync = new();
-	private readonly ConcurrentDictionary<string, byte> _worktreeCleanupInFlight = new(PathComparer.Default);
+	private readonly ConcurrentDictionary<string, WorktreeCleanupState> _worktreeCleanupInFlight =
+		new(PathComparer.Default);
 	private readonly ConcurrentDictionary<string, byte> _repositorySizeRefreshInFlight = new(PathComparer.Default);
 	private int _scheduledGarbageCollectionState;
 
@@ -1077,29 +1078,55 @@ public sealed class RepoCacheService : IRepoCacheService
 
 	private void ScheduleUnusedWorktreeCleanup(string basePath, string retainedPath)
 	{
-		if (!_worktreeCleanupInFlight.TryAdd(basePath, 0))
-			return;
-		_ = Task.Run(async () =>
+		while (true)
 		{
-			using var timeout = new CancellationTokenSource(WorktreeCleanupTimeout);
-			try
+			if (_worktreeCleanupInFlight.TryGetValue(basePath, out var active))
 			{
-				_testHooks?.BeforeUnusedWorktreeCleanup?.Invoke(basePath);
-				await CleanupUnusedWorktreesAsync(basePath, retainedPath, timeout.Token).ConfigureAwait(false);
+				if (active.TryQueue(retainedPath))
+					return;
+				Thread.Yield();
+				continue;
 			}
-			catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+
+			var state = new WorktreeCleanupState(retainedPath);
+			if (!_worktreeCleanupInFlight.TryAdd(basePath, state))
+				continue;
+			_ = Task.Run(() => RunScheduledWorktreeCleanupAsync(basePath, state), CancellationToken.None);
+			return;
+		}
+	}
+
+	private async Task RunScheduledWorktreeCleanupAsync(string basePath, WorktreeCleanupState state)
+	{
+		var retainedPath = state.InitialRetainedPath;
+		try
+		{
+			while (true)
 			{
-				Trace.TraceWarning("Repository worktree cleanup timed out for '{0}'.", basePath);
+				using var timeout = new CancellationTokenSource(WorktreeCleanupTimeout);
+				try
+				{
+					_testHooks?.BeforeUnusedWorktreeCleanup?.Invoke(basePath);
+					await CleanupUnusedWorktreesAsync(basePath, retainedPath, timeout.Token).ConfigureAwait(false);
+				}
+				catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+				{
+					Trace.TraceWarning("Repository worktree cleanup timed out for '{0}'.", basePath);
+				}
+				catch (Exception exception)
+				{
+					Trace.TraceWarning("Repository worktree cleanup failed for '{0}': {1}", basePath, exception.Message);
+				}
+
+				if (!state.TryTakePending(out retainedPath))
+					return;
 			}
-			catch (Exception exception)
-			{
-				Trace.TraceWarning("Repository worktree cleanup failed for '{0}': {1}", basePath, exception.Message);
-			}
-			finally
-			{
-				_worktreeCleanupInFlight.TryRemove(basePath, out _);
-			}
-		}, CancellationToken.None);
+		}
+		finally
+		{
+			_worktreeCleanupInFlight.TryRemove(
+				new KeyValuePair<string, WorktreeCleanupState>(basePath, state));
+		}
 	}
 
 	private void ScheduleRepositorySizeRefresh(string basePath)
@@ -1992,6 +2019,44 @@ public sealed class RepoCacheService : IRepoCacheService
 			fileSet,
 			new RepositoryCacheIndexDocument(CacheIndexSchemaVersion, entries),
 			IndexSerializerOptions);
+
+	private sealed class WorktreeCleanupState(string initialRetainedPath)
+	{
+		private readonly object _sync = new();
+		private string _pendingRetainedPath = initialRetainedPath;
+		private bool _hasPending;
+		private bool _isCompleting;
+
+		public string InitialRetainedPath { get; } = initialRetainedPath;
+
+		public bool TryQueue(string retainedPath)
+		{
+			lock (_sync)
+			{
+				if (_isCompleting)
+					return false;
+				_pendingRetainedPath = retainedPath;
+				_hasPending = true;
+				return true;
+			}
+		}
+
+		public bool TryTakePending(out string retainedPath)
+		{
+			lock (_sync)
+			{
+				if (_hasPending)
+				{
+					_hasPending = false;
+					retainedPath = _pendingRetainedPath;
+					return true;
+				}
+				_isCompleting = true;
+				retainedPath = string.Empty;
+				return false;
+			}
+		}
+	}
 
 	private sealed record RepositoryCacheIndexDocument(
 		int SchemaVersion,

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -1094,6 +1094,9 @@ public sealed class RepoCacheService : IRepoCacheService
 			catch (Exception exception) when (exception is InvalidOperationException or Win32Exception)
 			{
 			}
+			await GitProcessOutputReader
+				.ObserveCompletionAsync(output, error)
+				.ConfigureAwait(false);
 			throw;
 		}
 	}

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -2039,20 +2039,38 @@ public sealed class RepoCacheService : IRepoCacheService
 			                !string.IsNullOrWhiteSpace(entry.RepositoryUrl) &&
 			                !string.IsNullOrWhiteSpace(entry.LocalPath) &&
 			                IsInCache(entry.LocalPath))
-			.Select(entry => entry with
-			{
-				Identity = RepositoryUrlUtility.GetComparisonKey(entry.RepositoryUrl),
-				LastUsedUtc = entry.LastUsedUtc <= DateTimeOffset.UnixEpoch ||
-				              entry.LastUsedUtc > maximumAcceptedTimestamp
-					? DateTimeOffset.UnixEpoch
-					: entry.LastUsedUtc
-			})
-			.Where(static entry => entry.Identity.Length > 0)
+			.Select(entry => NormalizeIndexEntryOrNull(entry, maximumAcceptedTimestamp))
+			.Where(static entry => entry is not null)
+			.Select(static entry => entry!)
 			.GroupBy(static entry => entry.Identity, StringComparer.OrdinalIgnoreCase)
 			.Select(static group => group.OrderByDescending(entry => entry.LastOpenedUtc).First())
 			.OrderByDescending(static entry => entry.LastOpenedUtc)
 			.ToList();
 		return new RepositoryCacheIndexDocument(CacheIndexSchemaVersion, entries);
+	}
+
+	private static RepositoryCacheIndexEntry? NormalizeIndexEntryOrNull(
+		RepositoryCacheIndexEntry entry,
+		DateTimeOffset maximumAcceptedTimestamp)
+	{
+		try
+		{
+			var identity = RepositoryUrlUtility.GetComparisonKey(entry.RepositoryUrl);
+			if (identity.Length == 0)
+				return null;
+			return entry with
+			{
+				Identity = identity,
+				LastUsedUtc = entry.LastUsedUtc <= DateTimeOffset.UnixEpoch ||
+				              entry.LastUsedUtc > maximumAcceptedTimestamp
+					? DateTimeOffset.UnixEpoch
+					: entry.LastUsedUtc
+			};
+		}
+		catch
+		{
+			return null;
+		}
 	}
 
 	private static bool WriteIndex(

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -16,6 +16,8 @@ public sealed class RepoCacheService : IRepoCacheService
 	private const string CacheFolderName = "RepoCache";
 	private const string CacheIndexFileName = "cache-index.json";
 	private const int CacheIndexSchemaVersion = 2;
+	private const byte RepositorySizeRefreshRunning = 1;
+	private const byte RepositorySizeRefreshPending = 2;
 	private static readonly TimeSpan IndexLockTimeout = TimeSpan.FromSeconds(5);
 	private static readonly TimeSpan WorktreeCleanupTimeout = TimeSpan.FromSeconds(5);
 	private static readonly TimeSpan RepositorySizeRefreshTimeout = TimeSpan.FromSeconds(30);
@@ -656,6 +658,7 @@ public sealed class RepoCacheService : IRepoCacheService
 		var size = CalculateDirectorySize(
 			RepositoryCacheLayout.GetContainer(localPath),
 			cancellationToken);
+		_testHooks?.AfterRepositorySizeCalculated?.Invoke(localPath);
 
 		var fileSet = GetIndexFileSet();
 		if (!CrossProcessFileLock.TryAcquire(fileSet, IndexLockTimeout, out var heldLock))
@@ -1101,30 +1104,62 @@ public sealed class RepoCacheService : IRepoCacheService
 
 	private void ScheduleRepositorySizeRefresh(string basePath)
 	{
-		if (!_repositorySizeRefreshInFlight.TryAdd(basePath, 0))
-			return;
-		_ = Task.Run(() =>
+		while (true)
 		{
-			using var timeout = new CancellationTokenSource(RepositorySizeRefreshTimeout);
-			try
+			if (_repositorySizeRefreshInFlight.TryAdd(basePath, RepositorySizeRefreshRunning))
 			{
-				_testHooks?.BeforeRepositorySizeRefresh?.Invoke(basePath);
-				RefreshIndexedRepositorySize(basePath, timeout.Token);
+				_ = Task.Run(() => RunScheduledRepositorySizeRefresh(basePath), CancellationToken.None);
+				return;
 			}
-			catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+
+			if (_repositorySizeRefreshInFlight.TryUpdate(
+				    basePath,
+				    RepositorySizeRefreshPending,
+				    RepositorySizeRefreshRunning) ||
+			    _repositorySizeRefreshInFlight.TryGetValue(basePath, out var state) &&
+			    state == RepositorySizeRefreshPending)
 			{
-				Trace.TraceWarning("Repository size refresh timed out for '{0}'.", basePath);
+				return;
 			}
-			catch (Exception exception)
+		}
+	}
+
+	private void RunScheduledRepositorySizeRefresh(string basePath)
+	{
+		while (true)
+		{
+			using (var timeout = new CancellationTokenSource(RepositorySizeRefreshTimeout))
 			{
-				Trace.TraceWarning("Repository size refresh failed for '{0}': {1}", basePath, exception.Message);
+				try
+				{
+					_testHooks?.BeforeRepositorySizeRefresh?.Invoke(basePath);
+					RefreshIndexedRepositorySize(basePath, timeout.Token);
+				}
+				catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+				{
+					Trace.TraceWarning("Repository size refresh timed out for '{0}'.", basePath);
+				}
+				catch (Exception exception)
+				{
+					Trace.TraceWarning("Repository size refresh failed for '{0}': {1}", basePath, exception.Message);
+				}
 			}
-			finally
+
+			while (true)
 			{
-				_repositorySizeRefreshInFlight.TryRemove(basePath, out _);
-				_testHooks?.AfterRepositorySizeRefresh?.Invoke(basePath);
+				if (_repositorySizeRefreshInFlight.TryUpdate(
+					    basePath,
+					    RepositorySizeRefreshRunning,
+					    RepositorySizeRefreshPending))
+					break;
+				if (_repositorySizeRefreshInFlight.TryRemove(
+					    new KeyValuePair<string, byte>(basePath, RepositorySizeRefreshRunning)))
+				{
+					_testHooks?.AfterRepositorySizeRefresh?.Invoke(basePath);
+					return;
+				}
 			}
-		}, CancellationToken.None);
+		}
 	}
 
 	private async Task CleanupUnusedWorktreesAsync(
@@ -1985,5 +2020,6 @@ internal sealed class RepoCacheTestHooks
 	public Action? AfterScheduledGarbageCollection { get; init; }
 	public Action<string>? BeforeUnusedWorktreeCleanup { get; init; }
 	public Action<string>? BeforeRepositorySizeRefresh { get; init; }
+	public Action<string>? AfterRepositorySizeCalculated { get; init; }
 	public Action<string>? AfterRepositorySizeRefresh { get; init; }
 }

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -21,6 +21,7 @@ public sealed class RepoCacheService : IRepoCacheService
 	private static readonly TimeSpan IndexLockTimeout = TimeSpan.FromSeconds(5);
 	private static readonly TimeSpan WorktreeCleanupTimeout = TimeSpan.FromSeconds(5);
 	private static readonly TimeSpan RepositorySizeRefreshTimeout = TimeSpan.FromSeconds(30);
+	private static readonly TimeSpan MaximumPersistedClockSkew = TimeSpan.FromDays(1);
 	private static readonly JsonSerializerOptions IndexSerializerOptions = new(JsonSerializerDefaults.Web)
 	{
 		WriteIndented = true,
@@ -1999,12 +2000,23 @@ public sealed class RepoCacheService : IRepoCacheService
 
 	private RepositoryCacheIndexDocument NormalizeIndex(RepositoryCacheIndexDocument document)
 	{
+		var utcNow = _timeProvider.GetUtcNow();
+		var maximumAcceptedTimestamp = utcNow <= DateTimeOffset.MaxValue - MaximumPersistedClockSkew
+			? utcNow + MaximumPersistedClockSkew
+			: DateTimeOffset.MaxValue;
 		var entries = (document.Entries ?? [])
 			.Where(entry => entry is not null &&
 			                !string.IsNullOrWhiteSpace(entry.Identity) &&
 			                !string.IsNullOrWhiteSpace(entry.RepositoryUrl) &&
 			                !string.IsNullOrWhiteSpace(entry.LocalPath) &&
 			                IsInCache(entry.LocalPath))
+			.Select(entry => entry with
+			{
+				LastUsedUtc = entry.LastUsedUtc <= DateTimeOffset.UnixEpoch ||
+				              entry.LastUsedUtc > maximumAcceptedTimestamp
+					? DateTimeOffset.UnixEpoch
+					: entry.LastUsedUtc
+			})
 			.GroupBy(static entry => entry.Identity, StringComparer.OrdinalIgnoreCase)
 			.Select(static group => group.OrderByDescending(entry => entry.LastOpenedUtc).First())
 			.OrderByDescending(static entry => entry.LastOpenedUtc)

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -632,7 +632,9 @@ public sealed class RepoCacheService : IRepoCacheService
 				using (leases)
 				{
 					entries.Remove(entry);
-					totalSize -= Math.Max(0, entry.ApproximateSizeBytes);
+					totalSize = totalSize == long.MaxValue
+						? CalculateIndexedSize(entries)
+						: totalSize - Math.Max(0, entry.ApproximateSizeBytes);
 					trashPaths.Add(RepositoryCacheLayout.GetContainer(entry.LocalPath));
 				}
 			}

--- a/Infrastructure/Git/ZipDownloadService.cs
+++ b/Infrastructure/Git/ZipDownloadService.cs
@@ -532,6 +532,8 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 			var normalized = segments[index].Normalize(NormalizationForm.FormC).TrimEnd(' ', '.');
 			if (normalized.Length == 0 || normalized is "." or "..")
 				throw new InvalidDataException($"ZIP entry has an invalid path: {entryPath}");
+			if (OperatingSystem.IsWindows() && normalized.Contains(':', StringComparison.Ordinal))
+				throw new InvalidDataException($"ZIP entry uses an NTFS alternate data stream path: {entryPath}");
 			if (OperatingSystem.IsWindows() && IsWindowsReservedDeviceName(normalized.AsSpan()))
 				throw new InvalidDataException($"ZIP entry uses a reserved Windows device name: {entryPath}");
 			segments[index] = normalized;

--- a/Infrastructure/Git/ZipDownloadService.cs
+++ b/Infrastructure/Git/ZipDownloadService.cs
@@ -13,6 +13,7 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 {
     private const int StreamBufferSize = 81920;
     private const int ExtractionProgressReportInterval = 50;
+	private const long MaximumRepositoryMetadataBytes = 64 * 1024;
 
     private readonly HttpClient _httpClient;
     private readonly ZipResourceLimits _limits;
@@ -419,6 +420,11 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 				cancellationToken).ConfigureAwait(false);
 			if (!response.IsSuccessStatusCode)
 				return null;
+			if (response.Content.Headers.ContentLength is > MaximumRepositoryMetadataBytes)
+				return null;
+			await response.Content
+				.LoadIntoBufferAsync(MaximumRepositoryMetadataBytes, cancellationToken)
+				.ConfigureAwait(false);
 
 			await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 			using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken)

--- a/Infrastructure/Git/ZipDownloadService.cs
+++ b/Infrastructure/Git/ZipDownloadService.cs
@@ -600,7 +600,13 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
             return null;
 
         var folderName = entryPath[..slashIndex];
-        return folderName is "." or ".." ? null : folderName;
+        if (folderName is "." or ".." ||
+            OperatingSystem.IsWindows() && folderName.Contains(':', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return folderName;
     }
 
     private static bool StartsWithFolderPrefix(string value, string folderName)

--- a/Infrastructure/Git/ZipDownloadService.cs
+++ b/Infrastructure/Git/ZipDownloadService.cs
@@ -559,8 +559,11 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 		return baseName.Length == 4 &&
 		       (baseName[..3].Equals("COM", StringComparison.OrdinalIgnoreCase) ||
 		        baseName[..3].Equals("LPT", StringComparison.OrdinalIgnoreCase)) &&
-		       baseName[3] is >= '1' and <= '9';
+		       IsReservedWindowsDeviceNumber(baseName[3]);
 	}
+
+	private static bool IsReservedWindowsDeviceNumber(char value) =>
+		value is >= '1' and <= '9' or '\u00B9' or '\u00B2' or '\u00B3';
 
 	private static InvalidDataException CreateArchiveCollisionException(string entryName) =>
 		new($"ZIP entries resolve to the same file-system path: {entryName}");

--- a/Infrastructure/Git/ZipDownloadService.cs
+++ b/Infrastructure/Git/ZipDownloadService.cs
@@ -596,7 +596,11 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
             return null;
 
         var slashIndex = entryPath.IndexOf('/');
-        return slashIndex > 0 ? entryPath[..slashIndex] : null;
+        if (slashIndex <= 0)
+            return null;
+
+        var folderName = entryPath[..slashIndex];
+        return folderName is "." or ".." ? null : folderName;
     }
 
     private static bool StartsWithFolderPrefix(string value, string folderName)

--- a/Infrastructure/Persistence/CrossProcessFileLock.cs
+++ b/Infrastructure/Persistence/CrossProcessFileLock.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace DevProjex.Infrastructure.Persistence;
 
 internal static class CrossProcessFileLock
@@ -32,7 +34,7 @@ internal static class CrossProcessFileLock
 
         Directory.CreateDirectory(fileSet.DirectoryPath);
 
-        var startedUtc = DateTime.UtcNow;
+		var startedTimestamp = Stopwatch.GetTimestamp();
         while (true)
         {
             try
@@ -48,7 +50,7 @@ internal static class CrossProcessFileLock
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                if (DateTime.UtcNow - startedUtc >= timeout)
+				if (Stopwatch.GetElapsedTime(startedTimestamp) >= timeout)
                     throw;
 
                 Thread.Sleep(RetryDelay);

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DevProjex.Infrastructure.Persistence;
 
@@ -276,11 +277,50 @@ internal static class JsonStorePersistence
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentOutOfRangeException.ThrowIfNegative(maximumDocumentBytes);
         text = string.Empty;
+        if (!TryBufferWithinSizeLimit(stream, maximumDocumentBytes, out var content))
+            return false;
+
+        using (content)
+        using (var reader = new StreamReader(
+                   content,
+                   Encoding.UTF8,
+                   detectEncodingFromByteOrderMarks: true,
+                   bufferSize: 1024,
+                   leaveOpen: true))
+        {
+            text = reader.ReadToEnd();
+        }
+        return true;
+    }
+
+    internal static bool TryParseDocumentWithinSizeLimit(
+        Stream stream,
+        int maximumDocumentBytes,
+        JsonDocumentOptions options,
+        [NotNullWhen(true)] out JsonDocument? document)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumDocumentBytes);
+        document = null;
+        if (!TryBufferWithinSizeLimit(stream, maximumDocumentBytes, out var content))
+            return false;
+
+        using (content)
+            document = JsonDocument.Parse(content, options);
+        return true;
+    }
+
+    private static bool TryBufferWithinSizeLimit(
+        Stream stream,
+        int maximumDocumentBytes,
+        [NotNullWhen(true)] out MemoryStream? content)
+    {
+        content = null;
         if (stream.Length > maximumDocumentBytes)
             return false;
 
         var initialCapacity = (int)Math.Min(stream.Length, Math.Min(maximumDocumentBytes, 16 * 1024));
-        using var content = new MemoryStream(initialCapacity);
+        var buffered = new MemoryStream(initialCapacity);
         var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
         try
         {
@@ -294,24 +334,20 @@ internal static class JsonStorePersistence
                     break;
                 if (read > remaining)
                     return false;
-                content.Write(buffer, 0, read);
+                buffered.Write(buffer, 0, read);
                 totalBytes += read;
             }
+
+            buffered.Position = 0;
+            content = buffered;
+            return true;
         }
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+            if (content is null)
+                buffered.Dispose();
         }
-
-        content.Position = 0;
-        using var reader = new StreamReader(
-            content,
-            Encoding.UTF8,
-            detectEncodingFromByteOrderMarks: true,
-            bufferSize: 1024,
-            leaveOpen: true);
-        text = reader.ReadToEnd();
-        return true;
     }
 
     private static bool IsFutureDocument(

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -267,22 +267,26 @@ internal static class JsonStorePersistence
                 FileShare.ReadWrite | FileShare.Delete);
             using var document = ParseDocument(stream);
             var root = document.RootElement;
-            var schemaVersion = root.TryGetProperty("schemaVersion", out var schemaElement) &&
-                                schemaElement.TryGetInt32(out var schema)
-                ? schema
-                : 0;
-            if (schemaVersion > currentSchemaVersion)
+            if (IsVersionNewer(root, "schemaVersion", currentSchemaVersion))
                 return true;
 
             return currentDefaultsRevision is { } currentRevision &&
-                   root.TryGetProperty("defaultsRevision", out var revisionElement) &&
-                   revisionElement.TryGetInt32(out var revision) &&
-                   revision > currentRevision;
+                   IsVersionNewer(root, "defaultsRevision", currentRevision);
         }
         catch
         {
             return false;
         }
+    }
+
+    private static bool IsVersionNewer(JsonElement root, string propertyName, int currentVersion)
+    {
+        if (!root.TryGetProperty(propertyName, out var element))
+            return false;
+        if (element.TryGetInt64(out var signedVersion))
+            return signedVersion > currentVersion;
+        return element.TryGetUInt64(out var unsignedVersion) &&
+               unsignedVersion > (ulong)Math.Max(0, currentVersion);
     }
 
     private static JsonDocument ParseDocument(FileStream stream)

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -3,6 +3,22 @@ namespace DevProjex.Infrastructure.Persistence;
 internal static class JsonStorePersistence
 {
     internal const long SmallDocumentMaximumBytes = 8 * 1024 * 1024;
+    private static readonly Encoding StrictUtf16LittleEndian = new UnicodeEncoding(
+        bigEndian: false,
+        byteOrderMark: true,
+        throwOnInvalidBytes: true);
+    private static readonly Encoding StrictUtf16BigEndian = new UnicodeEncoding(
+        bigEndian: true,
+        byteOrderMark: true,
+        throwOnInvalidBytes: true);
+    private static readonly Encoding StrictUtf32LittleEndian = new UTF32Encoding(
+        bigEndian: false,
+        byteOrderMark: true,
+        throwOnInvalidCharacters: true);
+    private static readonly Encoding StrictUtf32BigEndian = new UTF32Encoding(
+        bigEndian: true,
+        byteOrderMark: true,
+        throwOnInvalidCharacters: true);
 
     // A future backup is authoritative even when the primary is missing, corrupt or older.
     // Treating the complete file set as read-only prevents recovery from downgrading both copies.
@@ -249,7 +265,7 @@ internal static class JsonStorePersistence
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.ReadWrite | FileShare.Delete);
-            using var document = JsonDocument.Parse(stream);
+            using var document = ParseDocument(stream);
             var root = document.RootElement;
             var schemaVersion = root.TryGetProperty("schemaVersion", out var schemaElement) &&
                                 schemaElement.TryGetInt32(out var schema)
@@ -267,6 +283,43 @@ internal static class JsonStorePersistence
         {
             return false;
         }
+    }
+
+    private static JsonDocument ParseDocument(FileStream stream)
+    {
+        var encoding = DetectUnicodeEncoding(stream);
+        if (encoding is null)
+            return JsonDocument.Parse(stream);
+
+        using var reader = new StreamReader(
+            stream,
+            encoding,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1024,
+            leaveOpen: true);
+        return JsonDocument.Parse(reader.ReadToEnd());
+    }
+
+    private static Encoding? DetectUnicodeEncoding(FileStream stream)
+    {
+        Span<byte> prefix = stackalloc byte[4];
+        var bytesRead = stream.Read(prefix);
+        stream.Position = 0;
+        if (bytesRead >= 4)
+        {
+            if (prefix[0] == 0xFF && prefix[1] == 0xFE && prefix[2] == 0x00 && prefix[3] == 0x00)
+                return StrictUtf32LittleEndian;
+            if (prefix[0] == 0x00 && prefix[1] == 0x00 && prefix[2] == 0xFE && prefix[3] == 0xFF)
+                return StrictUtf32BigEndian;
+        }
+        if (bytesRead >= 2)
+        {
+            if (prefix[0] == 0xFF && prefix[1] == 0xFE)
+                return StrictUtf16LittleEndian;
+            if (prefix[0] == 0xFE && prefix[1] == 0xFF)
+                return StrictUtf16BigEndian;
+        }
+        return null;
     }
 }
 

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -2,14 +2,17 @@ namespace DevProjex.Infrastructure.Persistence;
 
 internal static class JsonStorePersistence
 {
+    internal const long SmallDocumentMaximumBytes = 8 * 1024 * 1024;
+
     // A future backup is authoritative even when the primary is missing, corrupt or older.
     // Treating the complete file set as read-only prevents recovery from downgrading both copies.
     public static bool ContainsFutureDocument(
         JsonStoreFileSet fileSet,
         int currentSchemaVersion,
-        int? currentDefaultsRevision = null) =>
-        IsFutureDocument(fileSet.PrimaryPath, currentSchemaVersion, currentDefaultsRevision) ||
-        IsFutureDocument(fileSet.BackupPath, currentSchemaVersion, currentDefaultsRevision);
+        int? currentDefaultsRevision = null,
+        long maximumDocumentBytes = long.MaxValue) =>
+        IsFutureDocument(fileSet.PrimaryPath, currentSchemaVersion, currentDefaultsRevision, maximumDocumentBytes) ||
+        IsFutureDocument(fileSet.BackupPath, currentSchemaVersion, currentDefaultsRevision, maximumDocumentBytes);
 
     public static bool TryReadNormalized<TDocument>(
         string path,
@@ -17,7 +20,8 @@ internal static class JsonStorePersistence
         Func<TDocument> createDefault,
         Func<TDocument, TDocument> normalize,
         out TDocument document,
-        out bool requiresRewrite)
+        out bool requiresRewrite,
+        long maximumDocumentBytes = long.MaxValue)
     {
         document = createDefault();
         requiresRewrite = false;
@@ -27,6 +31,9 @@ internal static class JsonStorePersistence
 
         try
         {
+            if (!IsDocumentWithinSizeLimit(path, maximumDocumentBytes))
+                return false;
+
             var json = File.ReadAllText(path);
             var deserialized = JsonSerializer.Deserialize<TDocument>(json, serializerOptions);
             if (deserialized is null)
@@ -207,16 +214,36 @@ internal static class JsonStorePersistence
         }
     }
 
+    internal static bool IsDocumentWithinSizeLimit(string path, long maximumDocumentBytes)
+    {
+        if (maximumDocumentBytes < 0)
+            return false;
+
+        try
+        {
+            return new FileInfo(path).Length <= maximumDocumentBytes;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static bool IsFutureDocument(
         string path,
         int currentSchemaVersion,
-        int? currentDefaultsRevision)
+        int? currentDefaultsRevision,
+        long maximumDocumentBytes)
     {
         if (!File.Exists(path))
             return false;
 
         try
         {
+            // An unbounded document cannot be classified safely and must not be downgraded.
+            if (!IsDocumentWithinSizeLimit(path, maximumDocumentBytes))
+                return true;
+
             using var stream = new FileStream(
                 path,
                 FileMode.Open,

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace DevProjex.Infrastructure.Persistence;
 
 internal static class JsonStorePersistence
@@ -47,10 +49,16 @@ internal static class JsonStorePersistence
 
         try
         {
-            if (!IsDocumentWithinSizeLimit(path, maximumDocumentBytes))
+            string json;
+            if (maximumDocumentBytes == long.MaxValue)
+            {
+                json = File.ReadAllText(path);
+            }
+            else if (maximumDocumentBytes > int.MaxValue ||
+                     !TryReadAllTextWithinSizeLimit(path, (int)maximumDocumentBytes, out json))
+            {
                 return false;
-
-            var json = File.ReadAllText(path);
+            }
             var deserialized = JsonSerializer.Deserialize<TDocument>(json, serializerOptions);
             if (deserialized is null)
                 return false;
@@ -245,6 +253,65 @@ internal static class JsonStorePersistence
         }
     }
 
+    internal static bool TryReadAllTextWithinSizeLimit(
+        string path,
+        int maximumDocumentBytes,
+        out string text)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete,
+            bufferSize: 16 * 1024,
+            FileOptions.SequentialScan);
+        return TryReadAllTextWithinSizeLimit(stream, maximumDocumentBytes, out text);
+    }
+
+    internal static bool TryReadAllTextWithinSizeLimit(
+        Stream stream,
+        int maximumDocumentBytes,
+        out string text)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumDocumentBytes);
+        text = string.Empty;
+        if (stream.Length > maximumDocumentBytes)
+            return false;
+
+        var initialCapacity = (int)Math.Min(stream.Length, Math.Min(maximumDocumentBytes, 16 * 1024));
+        using var content = new MemoryStream(initialCapacity);
+        var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
+        try
+        {
+            var totalBytes = 0;
+            while (true)
+            {
+                var read = stream.Read(buffer, 0, buffer.Length);
+                if (read == 0)
+                    break;
+                if (read > maximumDocumentBytes - totalBytes)
+                    return false;
+                content.Write(buffer, 0, read);
+                totalBytes += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+        }
+
+        content.Position = 0;
+        using var reader = new StreamReader(
+            content,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1024,
+            leaveOpen: true);
+        text = reader.ReadToEnd();
+        return true;
+    }
+
     private static bool IsFutureDocument(
         string path,
         int currentSchemaVersion,
@@ -256,22 +323,35 @@ internal static class JsonStorePersistence
 
         try
         {
-            // An unbounded document cannot be classified safely and must not be downgraded.
-            if (!IsDocumentWithinSizeLimit(path, maximumDocumentBytes))
-                return true;
+            JsonDocument document;
+            if (maximumDocumentBytes == long.MaxValue)
+            {
+                using var stream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                document = ParseDocument(stream);
+            }
+            else
+            {
+                // An unbounded document cannot be classified safely and must not be downgraded.
+                if (maximumDocumentBytes > int.MaxValue ||
+                    !TryReadAllTextWithinSizeLimit(path, (int)maximumDocumentBytes, out var json))
+                {
+                    return true;
+                }
+                document = JsonDocument.Parse(json);
+            }
+            using (document)
+            {
+                var root = document.RootElement;
+                if (IsVersionNewer(root, "schemaVersion", currentSchemaVersion))
+                    return true;
 
-            using var stream = new FileStream(
-                path,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.ReadWrite | FileShare.Delete);
-            using var document = ParseDocument(stream);
-            var root = document.RootElement;
-            if (IsVersionNewer(root, "schemaVersion", currentSchemaVersion))
-                return true;
-
-            return currentDefaultsRevision is { } currentRevision &&
-                   IsVersionNewer(root, "defaultsRevision", currentRevision);
+                return currentDefaultsRevision is { } currentRevision &&
+                       IsVersionNewer(root, "defaultsRevision", currentRevision);
+            }
         }
         catch
         {

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -287,10 +287,12 @@ internal static class JsonStorePersistence
             var totalBytes = 0;
             while (true)
             {
-                var read = stream.Read(buffer, 0, buffer.Length);
+                var remaining = maximumDocumentBytes - totalBytes;
+                var readSize = remaining >= buffer.Length ? buffer.Length : remaining + 1;
+                var read = stream.Read(buffer, 0, readSize);
                 if (read == 0)
                     break;
-                if (read > maximumDocumentBytes - totalBytes)
+                if (read > remaining)
                     return false;
                 content.Write(buffer, 0, read);
                 totalBytes += read;

--- a/Infrastructure/ProjectProfiles/PersistentSecretMarkStore.cs
+++ b/Infrastructure/ProjectProfiles/PersistentSecretMarkStore.cs
@@ -176,7 +176,8 @@ internal sealed class PersistentSecretMarkStore(
 				if (!CrossProcessFileLock.TryAcquire(fileSet, _lockTimeout, out var heldLock))
 					return;
 				using var _ = heldLock;
-				if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
+				if (!HasOversizedDocument(fileSet) &&
+				    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 					return;
 				File.Delete(fileSet.PrimaryPath);
 				File.Delete(fileSet.BackupPath);
@@ -383,6 +384,8 @@ internal sealed class PersistentSecretMarkStore(
 
 	private StoreLoadResult LoadDatabase(JsonStoreFileSet fileSet)
 	{
+		if (HasOversizedDocument(fileSet))
+			return StoreLoadResult.Failure(PersistentSecretMarkStoreStatus.InvalidStorage);
 		if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 			return StoreLoadResult.Failure(PersistentSecretMarkStoreStatus.UnsupportedFutureSchema);
 		if (TryLoadFromPath(fileSet.PrimaryPath, out var primary, out var primaryRequiresRewrite))
@@ -796,6 +799,15 @@ internal sealed class PersistentSecretMarkStore(
 
 	private JsonStoreFileSet GetFileSet() =>
 		JsonStoreFileSet.Create(appDataPathProvider, FolderName, FileName);
+
+	private static bool HasOversizedDocument(JsonStoreFileSet fileSet) =>
+		IsOversizedDocument(fileSet.PrimaryPath) || IsOversizedDocument(fileSet.BackupPath);
+
+	private static bool IsOversizedDocument(string path) =>
+		File.Exists(path) &&
+		!JsonStorePersistence.IsDocumentWithinSizeLimit(
+			path,
+			ProjectProfileStorageLimits.MaximumJsonBytes);
 
 	private static bool TrySave(JsonStoreFileSet fileSet, PersistentSecretMarkDb database)
 	{

--- a/Infrastructure/ProjectProfiles/PersistentSecretMarkStore.cs
+++ b/Infrastructure/ProjectProfiles/PersistentSecretMarkStore.cs
@@ -422,12 +422,18 @@ internal sealed class PersistentSecretMarkStore(
 				FileMode.Open,
 				FileAccess.Read,
 				FileShare.ReadWrite | FileShare.Delete);
-			if (stream.Length > ProjectProfileStorageLimits.MaximumJsonBytes)
-				return false;
-			using var document = JsonDocument.Parse(
+			if (!JsonStorePersistence.TryParseDocumentWithinSizeLimit(
 				stream,
-				new JsonDocumentOptions { MaxDepth = 64 });
-			return TryParseDatabase(document.RootElement, out database, out requiresRewrite);
+				(int)ProjectProfileStorageLimits.MaximumJsonBytes,
+				new JsonDocumentOptions { MaxDepth = 64 },
+				out var document))
+			{
+				return false;
+			}
+			using (document)
+			{
+				return TryParseDatabase(document.RootElement, out database, out requiresRewrite);
+			}
 		}
 		catch
 		{

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -12,6 +12,7 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 	private const int CurrentSchemaVersion = 3;
 	private const string FolderName = "DevProjex";
 	private const string FileName = "project-profiles.json";
+	private static readonly DateTimeOffset MaximumSafeProfileTimestamp = DateTimeOffset.MaxValue.AddDays(-1);
 
 	private static readonly JsonSerializerOptions SerializerOptions = new()
 	{
@@ -438,8 +439,7 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 			profile.IgnoreOptionStates);
 		NormalizeGitFilteringState(profile.SelectedIgnoreOptions, profile.IgnoreOptionStates);
 
-		if (profile.UpdatedUtc <= DateTimeOffset.UnixEpoch)
-			profile.UpdatedUtc = DateTimeOffset.UtcNow;
+		profile.UpdatedUtc = NormalizeProfileTimestamp(profile.UpdatedUtc);
 
 		return profile;
 	}
@@ -503,9 +503,14 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 			IgnoreOptionStates = ignoreOptionStates,
 			SelectedPaths = selectedPaths,
 			MarkedSecrets = null,
-			UpdatedUtc = updatedUtc
+			UpdatedUtc = NormalizeProfileTimestamp(updatedUtc)
 		};
 	}
+
+	private static DateTimeOffset NormalizeProfileTimestamp(DateTimeOffset timestamp) =>
+		timestamp <= DateTimeOffset.UnixEpoch || timestamp > MaximumSafeProfileTimestamp
+			? DateTimeOffset.UtcNow
+			: timestamp;
 
 	private static ProjectSelectionProfile ToProfile(
 		PersistedProjectProfile profile,

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -37,7 +37,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 				return false;
 
 			using var _ = heldLock;
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
+			if (HasOversizedDocument(fileSet) ||
+			    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 				return false;
 			return EnsureStorageExistsCore(fileSet);
 		}
@@ -110,7 +111,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 				return new ProjectProfileSaveResult(Succeeded: false, WasTruncated: false);
 
 			using var _ = heldLock;
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
+			if (HasOversizedDocument(fileSet) ||
+			    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 				return new ProjectProfileSaveResult(Succeeded: false, WasTruncated: false);
 			var db = LoadInternal(fileSet);
 			db.SchemaVersion = CurrentSchemaVersion;
@@ -143,7 +145,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 				if (CrossProcessFileLock.TryAcquire(fileSet, out var heldLock))
 				{
 					using var _ = heldLock;
-					if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
+					if (!HasOversizedDocument(fileSet) &&
+					    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 						return;
 					if (File.Exists(fileSet.PrimaryPath))
 						File.Delete(fileSet.PrimaryPath);
@@ -184,6 +187,12 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 			}
 
 			using var _ = heldLock;
+			if (HasOversizedDocument(fileSet))
+			{
+				return new ProjectProfileLookupResult(
+					ProjectProfileLookupStatus.InvalidStorage,
+					null);
+			}
 			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 			{
 				return new ProjectProfileLookupResult(
@@ -226,7 +235,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 				return false;
 
 			using var _ = heldLock;
-			if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
+			if (HasOversizedDocument(fileSet) ||
+			    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
 				return false;
 			var db = LoadInternal(fileSet);
 			selectionDeleted = !db.Profiles.Remove(normalizedPath) || TrySaveInternal(fileSet, db);
@@ -287,6 +297,15 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 
 	private JsonStoreFileSet GetFileSet()
 		=> JsonStoreFileSet.Create(_appDataPathProvider, FolderName, FileName);
+
+	private static bool HasOversizedDocument(JsonStoreFileSet fileSet) =>
+		IsOversizedDocument(fileSet.PrimaryPath) || IsOversizedDocument(fileSet.BackupPath);
+
+	private static bool IsOversizedDocument(string path) =>
+		File.Exists(path) &&
+		!JsonStorePersistence.IsDocumentWithinSizeLimit(
+			path,
+			ProjectProfileStorageLimits.MaximumJsonBytes);
 
 	private ProjectProfileDb LoadInternal(JsonStoreFileSet fileSet)
 	{

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -98,7 +98,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		if (!TryNormalizePath(localProjectPath, out var normalizedPath))
 			return new ProjectProfileSaveResult(Succeeded: false, WasTruncated: false);
 
-		var persistedProfile = ToPersistedProfile(profile, updatedUtc, out var wasTruncated);
+		var normalizedUpdatedUtc = NormalizeProfileTimestamp(updatedUtc);
+		var persistedProfile = ToPersistedProfile(profile, normalizedUpdatedUtc, out var wasTruncated);
 		if (wasTruncated)
 			return new ProjectProfileSaveResult(Succeeded: false, WasTruncated: true);
 
@@ -118,7 +119,7 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 			// The caller-provided timestamp reflects when the profile became user-approved.
 			if (db.Profiles.TryGetValue(normalizedPath, out var existing) &&
 				existing is not null &&
-				existing.UpdatedUtc > updatedUtc)
+				existing.UpdatedUtc > normalizedUpdatedUtc)
 			{
 				return new ProjectProfileSaveResult(Succeeded: true, WasTruncated: false);
 			}

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -529,7 +529,7 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 
 	private static DateTimeOffset NormalizeProfileTimestamp(DateTimeOffset timestamp) =>
 		timestamp <= DateTimeOffset.UnixEpoch || timestamp > MaximumSafeProfileTimestamp
-			? DateTimeOffset.UtcNow
+			? DateTimeOffset.UnixEpoch.AddTicks(1)
 			: timestamp;
 
 	private static ProjectSelectionProfile ToProfile(

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -784,14 +784,20 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 				FileMode.Open,
 				FileAccess.Read,
 				FileShare.ReadWrite | FileShare.Delete);
-			if (stream.Length > ProjectProfileStorageLimits.MaximumJsonBytes)
-				return false;
-			using var document = JsonDocument.Parse(
+			if (!JsonStorePersistence.TryParseDocumentWithinSizeLimit(
 				stream,
-				new JsonDocumentOptions { MaxDepth = 64 });
-			if (!TryParseDatabase(document.RootElement, out db, out requiresRewrite))
+				(int)ProjectProfileStorageLimits.MaximumJsonBytes,
+				new JsonDocumentOptions { MaxDepth = 64 },
+				out var document))
+			{
 				return false;
-			return true;
+			}
+			using (document)
+			{
+				if (!TryParseDatabase(document.RootElement, out db, out requiresRewrite))
+					return false;
+				return true;
+			}
 		}
 		catch
 		{

--- a/Infrastructure/RecentProjects/RecentProjectsStore.cs
+++ b/Infrastructure/RecentProjects/RecentProjectsStore.cs
@@ -11,6 +11,7 @@ public sealed class RecentProjectsStore
 	private const int MaxRecentRepositoryRemovals = 32;
 	private const string FolderName = "DevProjex";
 	private const string FileName = "recent-projects.json";
+	private static readonly DateTimeOffset MaximumSafeHistoryTimestamp = DateTimeOffset.MaxValue.AddDays(-1);
 	private static readonly string LegacyRepoCacheRootPath = Path.Combine(
 		Path.GetTempPath(),
 		FolderName,
@@ -443,7 +444,7 @@ public sealed class RecentProjectsStore
 			.Select(static entry => new RecentFolderEntry
 			{
 				Path = PathUtility.Normalize(entry.Path),
-				OpenedUtc = entry.OpenedUtc <= DateTimeOffset.UnixEpoch ? DateTimeOffset.UtcNow : entry.OpenedUtc
+				OpenedUtc = NormalizeHistoryTimestamp(entry.OpenedUtc)
 			})
 			.Where(static entry => !IsRepoCachePath(entry.Path))
 			.Where(entry => !removalTimes.TryGetValue(entry.Path, out var removedUtc) || entry.OpenedUtc > removedUtc)
@@ -472,9 +473,7 @@ public sealed class RecentProjectsStore
 			.Select(static entry => new RecentFolderRemovalEntry
 			{
 				Path = PathUtility.Normalize(entry.Path),
-				RemovedUtc = entry.RemovedUtc <= DateTimeOffset.UnixEpoch
-					? DateTimeOffset.UtcNow
-					: entry.RemovedUtc
+				RemovedUtc = NormalizeHistoryTimestamp(entry.RemovedUtc)
 			})
 			.OrderByDescending(static entry => entry.RemovedUtc)
 			.ToList();
@@ -502,7 +501,7 @@ public sealed class RecentProjectsStore
 			.Select(static entry => new RecentRepositoryEntry
 			{
 				Url = RepositoryUrlUtility.Normalize(entry.Url),
-				OpenedUtc = entry.OpenedUtc <= DateTimeOffset.UnixEpoch ? DateTimeOffset.UtcNow : entry.OpenedUtc
+				OpenedUtc = NormalizeHistoryTimestamp(entry.OpenedUtc)
 			})
 			.Where(entry =>
 			{
@@ -534,9 +533,7 @@ public sealed class RecentProjectsStore
 			.Select(static entry => new RecentRepositoryRemovalEntry
 			{
 				Url = RepositoryUrlUtility.Normalize(entry.Url),
-				RemovedUtc = entry.RemovedUtc <= DateTimeOffset.UnixEpoch
-					? DateTimeOffset.UtcNow
-					: entry.RemovedUtc
+				RemovedUtc = NormalizeHistoryTimestamp(entry.RemovedUtc)
 			})
 			.OrderByDescending(static entry => entry.RemovedUtc)
 			.ToList();
@@ -554,6 +551,11 @@ public sealed class RecentProjectsStore
 
 		return unique;
 	}
+
+	private static DateTimeOffset NormalizeHistoryTimestamp(DateTimeOffset timestamp) =>
+		timestamp <= DateTimeOffset.UnixEpoch || timestamp > MaximumSafeHistoryTimestamp
+			? DateTimeOffset.UtcNow
+			: timestamp;
 
 	private static void MoveToFront<TEntry>(
 		List<TEntry> entries,

--- a/Infrastructure/RecentProjects/RecentProjectsStore.cs
+++ b/Infrastructure/RecentProjects/RecentProjectsStore.cs
@@ -281,6 +281,12 @@ public sealed class RecentProjectsStore
 		out RecentProjectsLoadStatus status,
 		bool persistLegacyMigration = false)
 	{
+		if (HasFutureSchema(fileSet))
+		{
+			status = RecentProjectsLoadStatus.Success;
+			return CreateDefaultDb();
+		}
+
 		if (!File.Exists(fileSet.PrimaryPath) &&
 		    !File.Exists(fileSet.BackupPath) &&
 		    TryLoadLegacy(fileSet, out var legacyDb))
@@ -339,6 +345,9 @@ public sealed class RecentProjectsStore
 
 	private bool EnsureStorageExistsCore(JsonStoreFileSet fileSet)
 	{
+		if (HasFutureSchema(fileSet))
+			return true;
+
 		if (!File.Exists(fileSet.PrimaryPath) &&
 		    !File.Exists(fileSet.BackupPath) &&
 		    TryLoadLegacy(fileSet, out var legacyDb))
@@ -697,9 +706,18 @@ public sealed class RecentProjectsStore
 
 	private bool TrySave(JsonStoreFileSet fileSet, RecentProjectsDb db)
 	{
+		if (HasFutureSchema(fileSet))
+			return false;
+
 		var sanitized = SanitizeState(fileSet, db);
 		return JsonStorePersistence.TryWriteAtomic(fileSet, sanitized, SerializerOptions);
 	}
+
+	private static bool HasFutureSchema(JsonStoreFileSet fileSet) =>
+		JsonStorePersistence.ContainsFutureDocument(
+			fileSet,
+			CurrentSchemaVersion,
+			maximumDocumentBytes: JsonStorePersistence.SmallDocumentMaximumBytes);
 
 	private static bool TryLoadFromPath(string path, out RecentProjectsDb db, out bool requiresRewrite)
 	{

--- a/Infrastructure/RecentProjects/RecentProjectsStore.cs
+++ b/Infrastructure/RecentProjects/RecentProjectsStore.cs
@@ -711,6 +711,13 @@ public sealed class RecentProjectsStore
 
 		try
 		{
+			if (!JsonStorePersistence.IsDocumentWithinSizeLimit(
+				    path,
+				    JsonStorePersistence.SmallDocumentMaximumBytes))
+			{
+				return false;
+			}
+
 			var json = File.ReadAllText(path);
 			var deserialized = JsonSerializer.Deserialize<RecentProjectsDb>(json, SerializerOptions);
 			if (deserialized is null)

--- a/Infrastructure/RecentProjects/RecentProjectsStore.cs
+++ b/Infrastructure/RecentProjects/RecentProjectsStore.cs
@@ -729,14 +729,13 @@ public sealed class RecentProjectsStore
 
 		try
 		{
-			if (!JsonStorePersistence.IsDocumentWithinSizeLimit(
+			if (!JsonStorePersistence.TryReadAllTextWithinSizeLimit(
 				    path,
-				    JsonStorePersistence.SmallDocumentMaximumBytes))
+				    (int)JsonStorePersistence.SmallDocumentMaximumBytes,
+				    out var json))
 			{
 				return false;
 			}
-
-			var json = File.ReadAllText(path);
 			var deserialized = JsonSerializer.Deserialize<RecentProjectsDb>(json, SerializerOptions);
 			if (deserialized is null)
 				return false;

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -821,11 +821,13 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 	private static double CalculateShannonEntropy(ReadOnlySpan<char> value)
 	{
+		if (value.Length == 0)
+			return 0;
 		Span<int> frequencies = stackalloc int[128];
 		foreach (var character in value)
 		{
 			if (character >= frequencies.Length)
-				return CalculateShannonEntropy(value.ToString());
+				return CalculateNonAsciiShannonEntropy(value);
 			frequencies[character]++;
 		}
 
@@ -886,10 +888,11 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		return content[lineStart..lineEnd].ToString();
 	}
 
-	internal static double CalculateShannonEntropy(string value)
+	internal static double CalculateShannonEntropy(string value) =>
+		CalculateShannonEntropy(value.AsSpan());
+
+	private static double CalculateNonAsciiShannonEntropy(ReadOnlySpan<char> value)
 	{
-		if (value.Length == 0)
-			return 0;
 		var frequencies = new Dictionary<char, int>();
 		foreach (var character in value)
 			frequencies[character] = frequencies.GetValueOrDefault(character) + 1;

--- a/Infrastructure/Secrets/PersistentSecretIdentityProvider.cs
+++ b/Infrastructure/Secrets/PersistentSecretIdentityProvider.cs
@@ -29,7 +29,7 @@ public sealed class PersistentSecretIdentityProvider : IPersistentSecretIdentity
 	private readonly Action<byte[]>? _sensitiveBufferClearedObserver;
 	private byte[]? _key;
 	private Task<PersistentSecretIdentityAvailability>? _initializationTask;
-	private DateTimeOffset _retryNotBeforeUtc;
+	private long _transientFailureTimestamp;
 	private PersistentSecretIdentityProviderState _state;
 	private int _initializationAttemptCount;
 
@@ -91,7 +91,7 @@ public sealed class PersistentSecretIdentityProvider : IPersistentSecretIdentity
 			if (_state == PersistentSecretIdentityProviderState.PermanentFault)
 				return ValueTask.FromResult(PersistentSecretIdentityAvailability.PermanentlyUnavailable);
 			if (_state == PersistentSecretIdentityProviderState.TransientFault &&
-			    _timeProvider.GetUtcNow() < _retryNotBeforeUtc)
+			    _timeProvider.GetElapsedTime(_transientFailureTimestamp) < _transientRetryCooldown)
 			{
 				return ValueTask.FromResult(PersistentSecretIdentityAvailability.TemporarilyUnavailable);
 			}
@@ -212,7 +212,7 @@ public sealed class PersistentSecretIdentityProvider : IPersistentSecretIdentity
 					return PersistentSecretIdentityAvailability.Ready;
 				case KeyInitializationStatus.TransientFault:
 					_state = PersistentSecretIdentityProviderState.TransientFault;
-					_retryNotBeforeUtc = _timeProvider.GetUtcNow() + _transientRetryCooldown;
+					_transientFailureTimestamp = _timeProvider.GetTimestamp();
 					return PersistentSecretIdentityAvailability.TemporarilyUnavailable;
 				default:
 					_state = PersistentSecretIdentityProviderState.PermanentFault;

--- a/Infrastructure/Secrets/PersistentSecretIdentityProvider.cs
+++ b/Infrastructure/Secrets/PersistentSecretIdentityProvider.cs
@@ -337,10 +337,13 @@ public sealed class PersistentSecretIdentityProvider : IPersistentSecretIdentity
 			using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
 			if (stream.Length is <= 0 or > MaximumKeyFileBytes)
 				return KeyFileReadResult.Permanent();
-			byte[]? bytes = new byte[checked((int)stream.Length)];
-			stream.ReadExactly(bytes);
+			var expectedLength = stream.Length;
+			byte[]? bytes = new byte[checked((int)expectedLength)];
 			try
 			{
+				stream.ReadExactly(bytes);
+				if (!HasStableLengthAfterRead(stream, expectedLength))
+					return KeyFileReadResult.Transient();
 				if (bytes.AsSpan().StartsWith(EnvelopeMagic))
 				{
 					if (!TryParseEnvelope(bytes, out var payload))
@@ -485,9 +488,21 @@ public sealed class PersistentSecretIdentityProvider : IPersistentSecretIdentity
 				stream.Write(envelope);
 				stream.Flush(flushToDisk: true);
 			}
-			var persisted = File.ReadAllBytes(tempPath);
+			byte[]? persisted = null;
 			try
 			{
+				using var validationStream = new FileStream(
+					tempPath,
+					FileMode.Open,
+					FileAccess.Read,
+					FileShare.Read);
+				if (validationStream.Length is <= 0 or > MaximumKeyFileBytes)
+					return false;
+				var expectedLength = validationStream.Length;
+				persisted = new byte[checked((int)expectedLength)];
+				validationStream.ReadExactly(persisted);
+				if (!HasStableLengthAfterRead(validationStream, expectedLength))
+					return false;
 				if (!persisted.AsSpan().SequenceEqual(envelope) ||
 				    !TryParseEnvelope(persisted, out var validationPayload))
 				{
@@ -515,6 +530,13 @@ public sealed class PersistentSecretIdentityProvider : IPersistentSecretIdentity
 				// The committed file is authoritative; an abandoned temp is ignored on the next load.
 			}
 		}
+	}
+
+	internal static bool HasStableLengthAfterRead(Stream stream, long expectedLength)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+		Span<byte> overflowProbe = stackalloc byte[1];
+		return stream.Read(overflowProbe) == 0 && stream.Length == expectedLength;
 	}
 
 	private static bool HasOwnerOnlyPermissions(string path)

--- a/Infrastructure/ThemePresets/ThemeSettingsStore.cs
+++ b/Infrastructure/ThemePresets/ThemeSettingsStore.cs
@@ -258,14 +258,13 @@ public sealed class ThemeSettingsStore(Func<string>? appDataPathProvider = null)
 
         try
         {
-            if (!JsonStorePersistence.IsDocumentWithinSizeLimit(
+            if (!JsonStorePersistence.TryReadAllTextWithinSizeLimit(
                     path,
-                    JsonStorePersistence.SmallDocumentMaximumBytes))
+                    (int)JsonStorePersistence.SmallDocumentMaximumBytes,
+                    out var json))
             {
                 return ThemeDocumentReadStatus.MissingOrInvalid;
             }
-
-            var json = File.ReadAllText(path);
             var deserialized = JsonSerializer.Deserialize<ThemeSettingsDocument>(json, SerializerOptions);
             if (deserialized is null)
                 return ThemeDocumentReadStatus.MissingOrInvalid;

--- a/Infrastructure/ThemePresets/ThemeSettingsStore.cs
+++ b/Infrastructure/ThemePresets/ThemeSettingsStore.cs
@@ -258,6 +258,13 @@ public sealed class ThemeSettingsStore(Func<string>? appDataPathProvider = null)
 
         try
         {
+            if (!JsonStorePersistence.IsDocumentWithinSizeLimit(
+                    path,
+                    JsonStorePersistence.SmallDocumentMaximumBytes))
+            {
+                return ThemeDocumentReadStatus.MissingOrInvalid;
+            }
+
             var json = File.ReadAllText(path);
             var deserialized = JsonSerializer.Deserialize<ThemeSettingsDocument>(json, SerializerOptions);
             if (deserialized is null)
@@ -432,7 +439,8 @@ public sealed class ThemeSettingsStore(Func<string>? appDataPathProvider = null)
         JsonStorePersistence.ContainsFutureDocument(
             fileSet,
             CurrentSchemaVersion,
-            CurrentDefaultsRevision);
+            CurrentDefaultsRevision,
+            JsonStorePersistence.SmallDocumentMaximumBytes);
 
     private static bool TryParseKeyStatic(string? key, out ThemeVariant theme, out ThemeEffectMode effect)
     {

--- a/Infrastructure/ThemePresets/UserSettingsStore.cs
+++ b/Infrastructure/ThemePresets/UserSettingsStore.cs
@@ -242,7 +242,8 @@ public sealed class UserSettingsStore(Func<string>? appDataPathProvider = null)
             CreateDefaultDb,
             NormalizeAfterRead,
             out database,
-            out requiresRewrite);
+            out requiresRewrite,
+            JsonStorePersistence.SmallDocumentMaximumBytes);
 
     private bool EnsureStorageExistsCore(JsonStoreFileSet fileSet)
     {
@@ -273,7 +274,10 @@ public sealed class UserSettingsStore(Func<string>? appDataPathProvider = null)
     };
 
     private static bool HasFutureSchema(JsonStoreFileSet fileSet) =>
-        JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion);
+        JsonStorePersistence.ContainsFutureDocument(
+            fileSet,
+            CurrentSchemaVersion,
+            maximumDocumentBytes: JsonStorePersistence.SmallDocumentMaximumBytes);
 
     private static bool TrySaveInternal(JsonStoreFileSet fileSet, UserSettingsDb database)
         => JsonStorePersistence.TryWriteAtomic(fileSet, database, SerializerOptions);

--- a/Infrastructure/Updates/GitHubReleaseUpdateService.cs
+++ b/Infrastructure/Updates/GitHubReleaseUpdateService.cs
@@ -8,6 +8,7 @@ public sealed class GitHubReleaseUpdateService : IApplicationUpdateService, IDis
     private static readonly Uri LatestReleaseEndpoint = new(
         "https://api.github.com/repos/Avazbek22/DevProjex/releases/latest");
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+    internal const long MaximumReleaseMetadataBytes = 1024 * 1024;
 
     private readonly HttpClient _httpClient;
 
@@ -50,7 +51,10 @@ public sealed class GitHubReleaseUpdateService : IApplicationUpdateService, IDis
                 timeout.Token);
             if (!response.IsSuccessStatusCode)
                 return Failed(current.ToString());
+            if (response.Content.Headers.ContentLength is > MaximumReleaseMetadataBytes)
+                return Failed(current.ToString());
 
+            await response.Content.LoadIntoBufferAsync(MaximumReleaseMetadataBytes, timeout.Token);
             await using var content = await response.Content.ReadAsStreamAsync(timeout.Token);
             var release = await JsonSerializer.DeserializeAsync(
                 content,

--- a/Kernel/Models/RepositoryUrlUtility.cs
+++ b/Kernel/Models/RepositoryUrlUtility.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace DevProjex.Kernel.Models;
 
 public static class RepositoryUrlUtility
@@ -62,6 +65,18 @@ public static class RepositoryUrlUtility
 				uri.Host,
 				uri.IsDefaultPort ? -1 : uri.Port,
 				uri.AbsolutePath);
+		}
+		if (uri?.IsFile == true)
+			return BuildFileSystemKey(uri.LocalPath);
+
+		try
+		{
+			if (Path.IsPathFullyQualified(normalized))
+				return BuildFileSystemKey(normalized);
+		}
+		catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+		{
+			return string.Empty;
 		}
 
 		return TrimGitSuffix(normalized);
@@ -143,6 +158,12 @@ public static class RepositoryUrlUtility
 		var normalizedPath = TrimGitSuffix(NormalizePath(path));
 		var portSuffix = port > 0 ? $":{port}" : string.Empty;
 		return $"{normalizedHost}{portSuffix}/{normalizedPath.TrimStart('/')}";
+	}
+
+	private static string BuildFileSystemKey(string path)
+	{
+		var normalizedPath = PathUtility.NormalizeForCacheKey(TrimGitSuffix(path));
+		return $"file/{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPath)))}";
 	}
 
 	private static string GetLastPathSegment(string value)

--- a/Kernel/PathUtility.cs
+++ b/Kernel/PathUtility.cs
@@ -41,10 +41,15 @@ public static class PathUtility
 
 		if (normalizedPath.Length <= normalizedRootPath.Length)
 			return false;
+		if (IsDirectorySeparator(normalizedRootPath[^1]))
+			return true;
 
 		var next = normalizedPath[normalizedRootPath.Length];
-		return next == Path.DirectorySeparatorChar || next == Path.AltDirectorySeparatorChar;
+		return IsDirectorySeparator(next);
 	}
+
+	private static bool IsDirectorySeparator(char value) =>
+		value == Path.DirectorySeparatorChar || value == Path.AltDirectorySeparatorChar;
 
 	private static string TrimTrailingSeparators(string path)
 	{

--- a/Tests/DevProjex.Tests.Integration/GitBranchOperationsTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitBranchOperationsTests.cs
@@ -160,6 +160,33 @@ public class GitBranchOperationsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SwitchBranchAsync_AtSignDoesNotReportHeadAsSuccessfulBranchSwitch()
+    {
+        if (!_gitAvailable)
+            return;
+
+        var repoPath = _tempDir.CreateDirectory("switch-at-sign");
+        var cloneResult = await _service.CloneAsync(
+            TestRepoUrl,
+            repoPath,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(cloneResult.Success);
+        var branchBefore = await _service.GetCurrentBranchAsync(
+            repoPath,
+            TestContext.Current.CancellationToken);
+
+        var success = await _service.SwitchBranchAsync(
+            repoPath,
+            "@",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(success);
+        Assert.Equal(
+            branchBefore,
+            await _service.GetCurrentBranchAsync(repoPath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
     public async Task SwitchBranchAsync_ToSameBranch_Succeeds()
     {
         if (!_gitAvailable)

--- a/Tests/DevProjex.Tests.Integration/GitPathComparisonSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitPathComparisonSemanticsIntegrationTests.cs
@@ -122,6 +122,24 @@ public sealed class GitPathComparisonSemanticsIntegrationTests
 	}
 
 	[Fact]
+	public void InvalidatingFromFileSystemRootEvictsDescendantRepositorySemantics()
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		var repositoryRoot = temp.CreateDirectory("root-invalidation-repository");
+		RunGit(repositoryRoot, "init", "--quiet");
+		RunGit(repositoryRoot, "config", "core.ignoreCase", "false");
+		var resolver = GitConfigPathComparisonSemanticsResolver.Instance;
+		resolver.Invalidate(repositoryRoot);
+		Assert.False(resolver.Resolve(repositoryRoot).IgnoreCase);
+
+		RunGit(repositoryRoot, "config", "core.ignoreCase", "true");
+		resolver.Invalidate(Path.GetPathRoot(repositoryRoot)!);
+
+		Assert.True(resolver.Resolve(repositoryRoot).IgnoreCase);
+	}
+
+	[Fact]
 	public void CoreIgnoreCaseMatchesNativeGitAsciiOnlyCaseFolding()
 	{
 		EnsureGitAvailable();

--- a/Tests/DevProjex.Tests.Integration/RepositoryCacheWorktreeIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/RepositoryCacheWorktreeIntegrationTests.cs
@@ -417,7 +417,21 @@ public sealed class RepositoryCacheWorktreeIntegrationTests
 		await using var source = await GitTestRepository.CreateAsync(
 			cancellationToken: TestContext.Current.CancellationToken);
 		using var cache = new TemporaryDirectory();
-		RepoCacheService service = new(cache.Path);
+		using var cleanupCompleted = new ManualResetEventSlim();
+		var cleanupCount = 0;
+		RepoCacheService service = new(
+			cache.Path,
+			RepositoryCachePolicy.Default,
+			TimeProvider.System,
+			new GitWorktreeManager(),
+			new RepoCacheTestHooks
+			{
+				AfterUnusedWorktreeCleanup = _ =>
+				{
+					if (Interlocked.Increment(ref cleanupCount) >= 2)
+						cleanupCompleted.Set();
+				}
+			});
 		var git = new GitRepositoryService();
 		var cloneCount = 0;
 
@@ -450,6 +464,7 @@ public sealed class RepositoryCacheWorktreeIntegrationTests
 			Assert.Equal(firstPath, reused.RepositoryPath, PathComparer.Default);
 		}
 
+		Assert.True(cleanupCompleted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 		service = new RepoCacheService(
 			cache.Path,
 			new RepositoryCachePolicy(1, TimeSpan.FromDays(60)),

--- a/Tests/DevProjex.Tests.Integration/RepositoryCacheWorktreeIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/RepositoryCacheWorktreeIntegrationTests.cs
@@ -2,6 +2,8 @@ namespace DevProjex.Tests.Integration;
 
 public sealed class RepositoryCacheWorktreeIntegrationTests
 {
+	private static readonly TimeSpan BackgroundCleanupTimeout = TimeSpan.FromSeconds(15);
+
 	[Fact]
 	public async Task TwoWindows_SwitchingOneDetachedWorktreeDoesNotChangeTheOther()
 	{
@@ -540,10 +542,12 @@ public sealed class RepositoryCacheWorktreeIntegrationTests
 
 	private static async Task WaitUntilAsync(Func<bool> condition)
 	{
-		var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+		var stopwatch = Stopwatch.StartNew();
 		while (!condition())
 		{
-			Assert.True(DateTime.UtcNow < deadline, "The background worktree cleanup did not finish.");
+			Assert.True(
+				stopwatch.Elapsed < BackgroundCleanupTimeout,
+				"The background worktree cleanup did not finish.");
 			await Task.Delay(25, TestContext.Current.CancellationToken);
 		}
 	}

--- a/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
@@ -957,6 +957,10 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 		var legacyPath = Path.Combine(sourceRoot, "legacy-windows-1250.txt");
 		var legacyPrefix = Encoding.ASCII.GetBytes(legacySentinel + "-");
 		File.WriteAllBytes(legacyPath, [.. legacyPrefix, 0xE9, .. Encoding.ASCII.GetBytes("-END")]);
+		var malformedBomPath = Path.Combine(sourceRoot, "malformed-utf8-bom.txt");
+		File.WriteAllBytes(
+			malformedBomPath,
+			[0xEF, 0xBB, 0xBF, .. Encoding.ASCII.GetBytes(legacySentinel + "-"), 0xC3, 0x28]);
 		var binaryPath = Path.Combine(sourceRoot, "payload.bin");
 		var binaryBytes = new byte[] { 0x00, 0x01, 0xFF, 0x42 };
 		File.WriteAllBytes(binaryPath, binaryBytes);
@@ -979,10 +983,13 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			redaction,
 			plan.IncludedFiles,
 			TestContext.Current.CancellationToken);
-		var unscannable = Assert.Single(analysis.UnscannableFiles);
-		Assert.Equal(legacyPath, unscannable.Path);
-		Assert.Equal(FileContentClassification.UnsupportedEncoding, unscannable.Classification);
-		Assert.Equal(1, analysis.SkippedFileCount);
+		Assert.Equal(2, analysis.UnscannableFiles.Count);
+		Assert.All(
+			analysis.UnscannableFiles,
+			file => Assert.Equal(FileContentClassification.UnsupportedEncoding, file.Classification));
+		Assert.Contains(analysis.UnscannableFiles, file => PathComparer.Default.Equals(file.Path, legacyPath));
+		Assert.Contains(analysis.UnscannableFiles, file => PathComparer.Default.Equals(file.Path, malformedBomPath));
+		Assert.Equal(2, analysis.SkippedFileCount);
 		Assert.Equal(0, analysis.FailedFileCount);
 
 		var contextService = new ProjectContextDocumentService(
@@ -998,8 +1005,10 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			TestContext.Current.CancellationToken,
 			plain: true);
 		var contextText = Encoding.UTF8.GetString(contextDestination.ToArray());
-		Assert.Equal(FileContentClassification.UnsupportedEncoding,
-			Assert.Single(contextReport.UnscannableFiles).Classification);
+		Assert.Equal(2, contextReport.UnscannableFiles.Count);
+		Assert.All(
+			contextReport.UnscannableFiles,
+			file => Assert.Equal(FileContentClassification.UnsupportedEncoding, file.Classification));
 		Assert.Contains("DEVPROJEX_REDACTED[", contextText, StringComparison.Ordinal);
 		Assert.DoesNotContain(legacySentinel, contextText, StringComparison.Ordinal);
 
@@ -1011,9 +1020,12 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			ProjectCopyExportFormat.Folder,
 			hideSecrets,
 			hidePrivateData);
-		Assert.Equal(FileContentClassification.UnsupportedEncoding,
-			Assert.Single(folder.UnscannableFiles!).Classification);
+		Assert.Equal(2, folder.UnscannableFiles!.Count);
+		Assert.All(
+			folder.UnscannableFiles,
+			file => Assert.Equal(FileContentClassification.UnsupportedEncoding, file.Classification));
 		Assert.False(File.Exists(Path.Combine(folder.DestinationPath, Path.GetFileName(legacyPath))));
+		Assert.False(File.Exists(Path.Combine(folder.DestinationPath, Path.GetFileName(malformedBomPath))));
 		Assert.Equal(binaryBytes, File.ReadAllBytes(Path.Combine(folder.DestinationPath, "payload.bin")));
 		Assert.Contains(
 			"DEVPROJEX_REDACTED[",
@@ -1028,10 +1040,13 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			ProjectCopyExportFormat.Zip,
 			hideSecrets,
 			hidePrivateData);
-		Assert.Equal(FileContentClassification.UnsupportedEncoding,
-			Assert.Single(zip.UnscannableFiles!).Classification);
+		Assert.Equal(2, zip.UnscannableFiles!.Count);
+		Assert.All(
+			zip.UnscannableFiles,
+			file => Assert.Equal(FileContentClassification.UnsupportedEncoding, file.Classification));
 		using var archive = ZipFile.OpenRead(zip.DestinationPath);
 		Assert.Null(archive.GetEntry(Path.GetFileName(legacyPath)));
+		Assert.Null(archive.GetEntry(Path.GetFileName(malformedBomPath)));
 		Assert.Equal(binaryBytes, ReadZipBytes(archive, "payload.bin"));
 		Assert.Contains(
 			"DEVPROJEX_REDACTED[",

--- a/Tests/DevProjex.Tests.Integration/SmartSecretsPerformanceCharacterizationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/SmartSecretsPerformanceCharacterizationTests.cs
@@ -65,7 +65,7 @@ public sealed class SmartSecretsPerformanceCharacterizationTests
 				SecretRedactionOutputPreparer.MaximumParallelScans,
 				Math.Max(1, Environment.ProcessorCount)));
 		Assert.InRange(diagnostics.RetainedBytes, 1, diagnostics.MaximumRetainedBytes);
-		const int maximumPerFileOverheadBytes = 2 * 1024;
+		const int maximumPerFileOverheadBytes = 3 * 1024;
 		var allocationBudget = sourceBytes * 2 + fileCount * maximumPerFileOverheadBytes;
 		Assert.True(
 			allocated < allocationBudget,

--- a/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
@@ -372,6 +372,28 @@ public class ZipDownloadServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DownloadAndExtractAsync_OnWindowsRejectsDriveLikeFirstArchiveEntry()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var archive = CreateArchive(("C:/outside.txt", "payload"u8.ToArray()));
+        using var service = new ZipDownloadService(
+            new ArchiveBytesHandler(archive),
+            ZipResourceLimits.Default with { FreeSpaceReserveBytes = 0 });
+        var targetDir = Path.Combine(_tempDir!, "first-entry-drive");
+
+        var result = await service.DownloadAndExtractAsync(
+            TestRepoUrl,
+            targetDir,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Contains("alternate data stream", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(targetDir));
+    }
+
+    [Fact]
     public async Task DownloadAndExtractAsync_FailureDuringStagedExtractionLeavesOccupiedTargetUntouched()
     {
         var archive = CreateArchive(

--- a/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
@@ -211,6 +211,29 @@ public class ZipDownloadServiceTests : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task DownloadAndExtractAsync_OversizedRepositoryMetadataUsesLegacyBranchFallback()
+	{
+		var archive = CreateArchive(("repo-main/file.txt", "main"u8.ToArray()));
+		var metadata = Encoding.UTF8.GetBytes(
+			$"{{\"default_branch\":\"develop\",\"padding\":\"{new string('x', 70 * 1024)}\"}}");
+		var handler = new DefaultBranchArchiveHandler("develop", archive, metadata);
+		using var service = new ZipDownloadService(handler, ZipResourceLimits.Default with
+		{
+			FreeSpaceReserveBytes = 0
+		});
+		var targetDir = Path.Combine(_tempDir!, "oversized-metadata");
+
+		var result = await service.DownloadAndExtractAsync(
+			"https://github.com/owner/repo",
+			targetDir,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.True(result.Success, result.ErrorMessage);
+		Assert.Equal("main", result.DefaultBranch);
+		Assert.Contains("/refs/heads/main.zip", handler.ArchiveRequestUri, StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public void CreateZipUrl_EncodesSpecialCharactersInsideEachBranchSegment()
 	{
 		var url = ZipDownloadService.CreateZipUrl(
@@ -898,7 +921,10 @@ public class ZipDownloadServiceTests : IAsyncLifetime
         }
     }
 
-    private sealed class DefaultBranchArchiveHandler(string defaultBranch, byte[] archive) : HttpMessageHandler
+    private sealed class DefaultBranchArchiveHandler(
+	    string defaultBranch,
+	    byte[] archive,
+	    byte[]? metadata = null) : HttpMessageHandler
     {
         public string? ArchiveRequestUri { get; private set; }
 
@@ -912,7 +938,9 @@ public class ZipDownloadServiceTests : IAsyncLifetime
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent($"{{\"default_branch\":\"{defaultBranch}\"}}")
+	                Content = metadata is null
+	                    ? new StringContent($"{{\"default_branch\":\"{defaultBranch}\"}}")
+	                    : new UnknownLengthContent(metadata)
                 });
             }
 

--- a/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
@@ -227,6 +227,8 @@ public class ZipDownloadServiceTests : IAsyncLifetime
 	[InlineData("nul")]
 	[InlineData("CON.txt")]
 	[InlineData("com1.tar.gz")]
+	[InlineData("COM\u00B9.txt")]
+	[InlineData("src/LPT\u00B2/file.cs")]
 	[InlineData("src/AUX/x.cs")]
 	public async Task DownloadAndExtractAsync_RejectsWindowsReservedDeviceNames(string entryPath)
 	{

--- a/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
@@ -274,6 +274,34 @@ public class ZipDownloadServiceTests : IAsyncLifetime
 		Assert.True(File.Exists(Path.Combine(targetDir, entryPath.Replace('/', Path.DirectorySeparatorChar))));
 	}
 
+	[Fact]
+	public async Task DownloadAndExtractAsync_RejectsNtfsAlternateDataStreamPathOnWindows()
+	{
+		const string entryPath = "readme.txt:hidden";
+		var archive = CreateArchive(($"repo-main/{entryPath}", "payload"u8.ToArray()));
+		using var service = new ZipDownloadService(
+			new ArchiveBytesHandler(archive),
+			ZipResourceLimits.Default with { FreeSpaceReserveBytes = 0 });
+		var targetDir = Path.Combine(_tempDir!, $"alternate-stream-{Guid.NewGuid():N}");
+
+		var result = await service.DownloadAndExtractAsync(
+			TestRepoUrl,
+			targetDir,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		if (OperatingSystem.IsWindows())
+		{
+			Assert.False(result.Success);
+			Assert.Contains("alternate data stream", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+			Assert.False(Directory.Exists(targetDir));
+		}
+		else
+		{
+			Assert.True(result.Success, result.ErrorMessage);
+			Assert.True(File.Exists(Path.Combine(targetDir, entryPath)));
+		}
+	}
+
     [Theory]
     [InlineData("case")]
     [InlineData("duplicate")]

--- a/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipDownloadServiceTests.cs
@@ -352,6 +352,26 @@ public class ZipDownloadServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DownloadAndExtractAsync_RejectsTraversalWhenItIsTheFirstArchiveEntry()
+    {
+        var archive = CreateArchive(("../outside.txt", "payload"u8.ToArray()));
+        using var service = new ZipDownloadService(
+            new ArchiveBytesHandler(archive),
+            ZipResourceLimits.Default with { FreeSpaceReserveBytes = 0 });
+        var targetDir = Path.Combine(_tempDir!, "first-entry-traversal");
+
+        var result = await service.DownloadAndExtractAsync(
+            TestRepoUrl,
+            targetDir,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Contains("invalid path", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(targetDir));
+        Assert.False(File.Exists(Path.Combine(_tempDir!, "outside.txt")));
+    }
+
+    [Fact]
     public async Task DownloadAndExtractAsync_FailureDuringStagedExtractionLeavesOccupiedTargetUntouched()
     {
         var archive = CreateArchive(

--- a/Tests/DevProjex.Tests.UI/MainWindowApplySettingsSelectionUiTests.cs
+++ b/Tests/DevProjex.Tests.UI/MainWindowApplySettingsSelectionUiTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using DevProjex.Application.Services;
 using DevProjex.Application.UseCases;
@@ -44,6 +45,17 @@ public sealed class MainWindowApplySettingsSelectionUiTests
         File.WriteAllText(firstDisappearingPath, "first\n");
         File.WriteAllText(secondDisappearingPath, "second\n");
         var window = await UiTestDriver.CreateLoadedMainWindowAsync(project);
+        var observedToastMessages = new ConcurrentQueue<string>();
+        var toastItems = UiTestDriver.GetToastService(window).Items;
+        System.Collections.Specialized.NotifyCollectionChangedEventHandler toastChanged = (_, args) =>
+        {
+            if (args.NewItems is null)
+                return;
+
+            foreach (var toast in args.NewItems.OfType<ToastMessageViewModel>())
+                observedToastMessages.Enqueue(toast.Message);
+        };
+        toastItems.CollectionChanged += toastChanged;
         try
         {
             await UiTestDriver.WaitForInitialMetricsBaselineAsync(window);
@@ -58,11 +70,8 @@ public sealed class MainWindowApplySettingsSelectionUiTests
             await UiTestDriver.ClickApplySettingsAsync(window);
             await UiTestDriver.WaitForConditionAsync(
                 window,
-                () => UiTestDriver.GetToastService(window).Items.Any(
-                    toast => string.Equals(
-                        toast.Message,
-                        "Checked items hidden by the current settings: 2",
-                        StringComparison.Ordinal)),
+                () => observedToastMessages.Contains(
+                    "Checked items hidden by the current settings: 2"),
                 "exact structural selection-loss toast");
 
             var selectedPaths = UiTestDriver.GetCheckedTreePaths(window);
@@ -71,11 +80,8 @@ public sealed class MainWindowApplySettingsSelectionUiTests
             Assert.DoesNotContain(firstDisappearingPath, selectedPaths);
             Assert.DoesNotContain(secondDisappearingPath, selectedPaths);
             Assert.Contains(
-                UiTestDriver.GetToastService(window).Items,
-                toast => string.Equals(
-                    toast.Message,
-                    "Checked items hidden by the current settings: 2",
-                    StringComparison.Ordinal));
+                "Checked items hidden by the current settings: 2",
+                observedToastMessages);
 
             await UiTestDriver.ClickExtensionCheckBoxAsync(window, ".tree-state");
             await UiTestDriver.ClickApplySettingsAsync(window);
@@ -86,6 +92,7 @@ public sealed class MainWindowApplySettingsSelectionUiTests
         }
         finally
         {
+            toastItems.CollectionChanged -= toastChanged;
             await UiTestDriver.CloseWindowAsync(window);
         }
     }

--- a/Tests/DevProjex.Tests.Unit/CodeCompressionSessionTests.cs
+++ b/Tests/DevProjex.Tests.Unit/CodeCompressionSessionTests.cs
@@ -220,6 +220,29 @@ public sealed class CodeCompressionSessionTests
 	}
 
 	[Fact]
+	public async Task Prewarm_SecurityFailureIsIsolatedToTheUnreadableFile()
+	{
+		using var temp = new TemporaryDirectory();
+		var readable = temp.CreateFile("src/readable.cs", "same-content");
+		var denied = temp.CreateFile("src/denied.cs", "denied-content");
+		using var compressor = new RecordingCompressor();
+		using var session = new CodeCompressionSession(compressor);
+
+		var result = await new CodeCompressionPrewarmer(new SelectiveSecurityFailureAnalyzer(denied))
+			.WarmAsync(
+				new CodeCompressionContext(temp.Path, session),
+				[readable, denied],
+				TestContext.Current.CancellationToken);
+
+		Assert.Equal(2, result.CandidateFiles);
+		Assert.Equal(1, result.WarmedFiles);
+		Assert.Equal(1, result.FailedFiles);
+		Assert.Equal(0, result.SkippedFiles);
+		Assert.Equal(1, session.Snapshot.TotalFiles);
+		Assert.Equal(1, compressor.AnalysisCount);
+	}
+
+	[Fact]
 	public async Task Prewarm_BodiesModeStreamsCommentOnlyMetricsWithoutMaterializingContent()
 	{
 		const string source = "/* remove */\n.card { color: red; }\n";
@@ -1807,5 +1830,45 @@ public sealed class CodeCompressionSessionTests
 			long maxSizeForFullRead,
 			CancellationToken cancellationToken = default) =>
 			ValueTask.FromResult<TextFileContent?>(Content);
+	}
+
+	private sealed class SelectiveSecurityFailureAnalyzer(string deniedPath) : IFileContentAnalyzer
+	{
+		public ValueTask<bool> IsTextFileAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			ValueTask.FromResult(true);
+
+		public ValueTask<TextFileMetrics?> GetTextFileMetricsAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			long maxSizeForFullRead,
+			CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public ValueTask<ContentReadFact> ReadFactAsync(
+			string path,
+			long maxSizeForFullRead,
+			CancellationToken cancellationToken = default)
+		{
+			if (PathComparer.Default.Equals(path, deniedPath))
+				throw new System.Security.SecurityException("Access policy denied the file.");
+
+			const string content = "same-content";
+			return ValueTask.FromResult(new ContentReadFact(
+				content,
+				FileContentClassification.Text,
+				new TextFileMetrics(content.Length, 1, content.Length, false, false),
+				ContentFingerprint.Compute(content)));
+		}
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/CodeCompressionSessionTests.cs
+++ b/Tests/DevProjex.Tests.Unit/CodeCompressionSessionTests.cs
@@ -412,14 +412,15 @@ public sealed class CodeCompressionSessionTests
 	}
 
 	[Fact]
-	public async Task Prewarm_SchedulesSynchronousUnsupportedMetricReadsConcurrently()
+	public async Task Prewarm_SynchronousUnsupportedMetricReadsRespectAvailableParallelism()
 	{
 		var paths = Enumerable.Range(0, 4)
 			.Select(index => $"C:/project/site-{index}.css")
 			.ToArray();
 		using var compressor = CodeCompressionTestHarness.CreateCompressor();
 		using var session = new CodeCompressionSession(compressor);
-		using var analyzer = new SynchronousMetricsConcurrencyAnalyzer(requiredConcurrency: 2);
+		var expectedConcurrency = Math.Min(2, Math.Max(1, Environment.ProcessorCount));
+		using var analyzer = new SynchronousMetricsConcurrencyAnalyzer(expectedConcurrency);
 
 		var result = await Task.Run(() =>
 				new CodeCompressionPrewarmer(analyzer).WarmAsync(
@@ -431,7 +432,7 @@ public sealed class CodeCompressionSessionTests
 			TestContext.Current.CancellationToken);
 
 		Assert.Equal(paths.Length, result.WarmedFiles);
-		Assert.True(analyzer.PeakConcurrentReads >= 2);
+		Assert.True(analyzer.PeakConcurrentReads >= expectedConcurrency);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/FileContentAnalyzerTests.cs
+++ b/Tests/DevProjex.Tests.Unit/FileContentAnalyzerTests.cs
@@ -9,6 +9,17 @@ public sealed class FileContentAnalyzerTests
 {
 	private readonly IFileContentAnalyzer _analyzer = new FileContentAnalyzer();
 
+	[Fact]
+	public void SensitiveCharacterBufferCleanup_ClearsUsedContentAndUnusedCapacity()
+	{
+		var buffer = Enumerable.Repeat('x', 64).ToArray();
+		buffer.AsSpan(0, 8).Fill('s');
+
+		FileContentAnalyzer.ClearSensitiveCharacterBuffer(buffer);
+
+		Assert.All(buffer, static character => Assert.Equal('\0', character));
+	}
+
 	[Theory]
 	[InlineData(ProbeOperation.CompleteTextBuffer)]
 	[InlineData(ProbeOperation.StreamingMetrics)]

--- a/Tests/DevProjex.Tests.Unit/FileContentAnalyzerTests.cs
+++ b/Tests/DevProjex.Tests.Unit/FileContentAnalyzerTests.cs
@@ -799,7 +799,7 @@ public sealed class FileContentAnalyzerTests
 	}
 
 	[Fact]
-	public async Task StreamingMetrics_MalformedBomPayloadsMatchMaterializedReplacementFallback()
+	public async Task MalformedBomPayloadsAreUnsupportedAcrossReadSurfaces()
 	{
 		using var temp = new TemporaryDirectory();
 		var malformedPayloads = new Dictionary<string, byte[]>(StringComparer.Ordinal)
@@ -825,41 +825,20 @@ public sealed class FileContentAnalyzerTests
 			await using var snapshot = await _analyzer.OpenCompleteSnapshotAsync(
 				path,
 				TestContext.Current.CancellationToken);
+			await using var buffer = await _analyzer.OpenCompleteTextBufferAsync(
+				path,
+				long.MaxValue,
+				TestContext.Current.CancellationToken);
 
-			Assert.True(
-				streaming.Classification == materialized.Classification,
-				$"Streaming/materialized classification mismatch for {caseId}: " +
-				$"{streaming.Classification}/{materialized.Classification}.");
-			Assert.True(
-				snapshot.Result.Classification == materialized.Classification,
-				$"Snapshot/materialized classification mismatch for {caseId}: " +
-				$"{snapshot.Result.Classification}/{materialized.Classification}.");
-			if (materialized.Classification == FileContentClassification.Text)
-			{
-				Assert.NotNull(materialized.Content);
-				var expected = FileContentAnalyzer.ComputeMetrics(materialized.Content, payload.Length);
-				Assert.Equal(expected, streaming.Metrics);
-				Assert.Equal(expected, materialized.RawMetrics);
-				Assert.Equal(expected, snapshot.Result.Metrics);
-
-				var copied = new StringBuilder();
-				await snapshot.CopyTextToAsync(
-					materialized.Content.Length,
-					(chunk, _) =>
-					{
-						copied.Append(chunk.Span);
-						return ValueTask.CompletedTask;
-					},
-					TestContext.Current.CancellationToken);
-				Assert.Equal(materialized.Content, copied.ToString());
-			}
-			else
-			{
-				Assert.Null(streaming.Metrics);
-				Assert.Null(materialized.Content);
-				Assert.Null(materialized.RawMetrics);
-				Assert.Null(snapshot.Result.Metrics);
-			}
+			Assert.Equal(FileContentClassification.UnsupportedEncoding, streaming.Classification);
+			Assert.Equal(FileContentClassification.UnsupportedEncoding, materialized.Classification);
+			Assert.Equal(FileContentClassification.UnsupportedEncoding, snapshot.Result.Classification);
+			Assert.Equal(FileContentClassification.UnsupportedEncoding, buffer.Classification);
+			Assert.Null(streaming.Metrics);
+			Assert.Null(materialized.Content);
+			Assert.Null(materialized.RawMetrics);
+			Assert.Null(snapshot.Result.Metrics);
+			Assert.True(buffer.Content.IsEmpty, caseId);
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Unit/GitConfigPathComparisonSemanticsResolverTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitConfigPathComparisonSemanticsResolverTests.cs
@@ -61,4 +61,80 @@ public sealed class GitConfigPathComparisonSemanticsResolverTests
 		Assert.Equal(expected, resolver.Resolve(repositoryRoot));
 		Assert.Equal(1, resolutionCount);
 	}
+
+	[Fact]
+	public async Task Invalidate_DuringResolution_PreventsLateResultFromRepopulatingCache()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		using var firstResolutionStarted = new ManualResetEventSlim();
+		using var releaseFirstResolution = new ManualResetEventSlim();
+		var resolutionCount = 0;
+		var stale = new GitPathComparisonSemantics(IgnoreCase: true, NormalizeUnicode: false);
+		var fresh = new GitPathComparisonSemantics(IgnoreCase: false, NormalizeUnicode: false);
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) =>
+			{
+				var resolution = Interlocked.Increment(ref resolutionCount);
+				if (resolution == 1)
+				{
+					firstResolutionStarted.Set();
+					Assert.True(releaseFirstResolution.Wait(TimeSpan.FromSeconds(30)));
+					return stale;
+				}
+
+				return fresh;
+			},
+			static () => new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc),
+			TimeSpan.FromMinutes(1));
+
+		var lateResolution = Task.Run(() => resolver.Resolve(repositoryRoot));
+		Assert.True(firstResolutionStarted.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
+		resolver.Invalidate(repositoryRoot);
+		releaseFirstResolution.Set();
+
+		Assert.Equal(stale, await lateResolution);
+		Assert.Equal(fresh, resolver.Resolve(repositoryRoot));
+		Assert.Equal(fresh, resolver.Resolve(repositoryRoot));
+		Assert.Equal(2, resolutionCount);
+	}
+
+	[Fact]
+	public async Task ConcurrentResolution_NewerStartCannotBeOverwrittenByOlderCompletion()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		using var olderResolutionStarted = new ManualResetEventSlim();
+		using var releaseOlderResolution = new ManualResetEventSlim();
+		var resolutionCount = 0;
+		var older = new GitPathComparisonSemantics(IgnoreCase: true, NormalizeUnicode: false);
+		var newer = new GitPathComparisonSemantics(IgnoreCase: false, NormalizeUnicode: true);
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) =>
+			{
+				var resolution = Interlocked.Increment(ref resolutionCount);
+				if (resolution == 1)
+				{
+					olderResolutionStarted.Set();
+					Assert.True(releaseOlderResolution.Wait(TimeSpan.FromSeconds(30)));
+					return older;
+				}
+
+				return newer;
+			},
+			static () => new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc),
+			TimeSpan.FromMinutes(1));
+
+		var olderResolution = Task.Run(() => resolver.Resolve(repositoryRoot));
+		Assert.True(olderResolutionStarted.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
+		var newerResolution = await Task.Run(() => resolver.Resolve(repositoryRoot));
+		releaseOlderResolution.Set();
+
+		Assert.Equal(older, await olderResolution);
+		Assert.Equal(newer, newerResolution);
+		Assert.Equal(newer, resolver.Resolve(repositoryRoot));
+		Assert.Equal(2, resolutionCount);
+	}
 }

--- a/Tests/DevProjex.Tests.Unit/GitConfigPathComparisonSemanticsResolverTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitConfigPathComparisonSemanticsResolverTests.cs
@@ -1,0 +1,64 @@
+namespace DevProjex.Tests.Unit;
+
+public sealed class GitConfigPathComparisonSemanticsResolverTests
+{
+	[Fact]
+	public void Resolve_RetriesUnavailableRepositorySemanticsAfterBackoff()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		var now = new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc);
+		var resolutionCount = 0;
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) => ++resolutionCount == 1
+				? new GitPathComparisonSemantics(
+					IgnoreCase: true,
+					NormalizeUnicode: true,
+					IsAuthoritative: false)
+				: new GitPathComparisonSemantics(
+					IgnoreCase: false,
+					NormalizeUnicode: false),
+			() => now,
+			TimeSpan.FromMinutes(1));
+
+		var unavailable = resolver.Resolve(repositoryRoot);
+		var coalesced = resolver.Resolve(repositoryRoot);
+		now = now.AddMinutes(1);
+		var recovered = resolver.Resolve(repositoryRoot);
+		var cached = resolver.Resolve(repositoryRoot);
+
+		Assert.False(unavailable.IsAuthoritative);
+		Assert.False(coalesced.IsAuthoritative);
+		Assert.True(recovered.IsAuthoritative);
+		Assert.False(recovered.IgnoreCase);
+		Assert.Equal(recovered, cached);
+		Assert.Equal(2, resolutionCount);
+	}
+
+	[Fact]
+	public void Resolve_KeepsAuthoritativeRepositorySemanticsCached()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		var now = new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc);
+		var resolutionCount = 0;
+		var expected = new GitPathComparisonSemantics(
+			IgnoreCase: true,
+			NormalizeUnicode: OperatingSystem.IsMacOS());
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) =>
+			{
+				resolutionCount++;
+				return expected;
+			},
+			() => now,
+			TimeSpan.FromSeconds(1));
+
+		Assert.Equal(expected, resolver.Resolve(repositoryRoot));
+		now = now.AddDays(1);
+		Assert.Equal(expected, resolver.Resolve(repositoryRoot));
+		Assert.Equal(1, resolutionCount);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/GitHubReleaseUpdateServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitHubReleaseUpdateServiceTests.cs
@@ -103,6 +103,42 @@ public sealed class GitHubReleaseUpdateServiceTests
         Assert.Null(result.LatestVersion);
     }
 
+    [Fact]
+    public async Task CheckAsync_DeclaredOversizedMetadata_ReturnsTypedFailureWithoutReadingBody()
+    {
+        var content = new TrackingHttpContent(
+            GitHubReleaseUpdateService.MaximumReleaseMetadataBytes + 1,
+            writeBytes: 0);
+        using var handler = new StubHttpMessageHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        using var service = new GitHubReleaseUpdateService(handler);
+
+        var result = await service.CheckAsync(
+            "5.0",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ApplicationUpdateAvailability.CheckFailed, result.Availability);
+        Assert.Equal(0, content.SerializeCallCount);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ChunkedOversizedMetadata_ReturnsTypedFailureAtBufferLimit()
+    {
+        var content = new TrackingHttpContent(
+            declaredLength: null,
+            writeBytes: GitHubReleaseUpdateService.MaximumReleaseMetadataBytes + 1);
+        using var handler = new StubHttpMessageHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        using var service = new GitHubReleaseUpdateService(handler);
+
+        var result = await service.CheckAsync(
+            "5.0",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ApplicationUpdateAvailability.CheckFailed, result.Availability);
+        Assert.Equal(1, content.SerializeCallCount);
+    }
+
     private static HttpResponseMessage JsonResponse(string json)
         => new(HttpStatusCode.OK)
         {
@@ -121,6 +157,32 @@ public sealed class GitHubReleaseUpdateServiceTests
             Request = request;
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class TrackingHttpContent(long? declaredLength, long writeBytes) : HttpContent
+    {
+        public int SerializeCallCount { get; private set; }
+
+        protected override async Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context)
+        {
+            SerializeCallCount++;
+            var buffer = new byte[4096];
+            var remaining = writeBytes;
+            while (remaining > 0)
+            {
+                var count = (int)Math.Min(buffer.Length, remaining);
+                await stream.WriteAsync(buffer.AsMemory(0, count));
+                remaining -= count;
+            }
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = declaredLength.GetValueOrDefault();
+            return declaredLength.HasValue;
         }
     }
 }

--- a/Tests/DevProjex.Tests.Unit/GitLocalConfigSemanticsReaderTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitLocalConfigSemanticsReaderTests.cs
@@ -188,6 +188,27 @@ public sealed class GitLocalConfigSemanticsReaderTests
 			out _));
 	}
 
+	[Fact]
+	public void BoundedTextRead_ExactLimitSucceedsAndOverflowStopsAfterProbeCharacter()
+	{
+		using var exactReader = new CountingTextReader("0123456789");
+		using var oversizedReader = new CountingTextReader(new string('x', 10_000));
+
+		var exact = GitLocalConfigSemanticsReader.TryReadBoundedText(
+			exactReader,
+			maximumCharacters: 10,
+			out var text);
+		var oversized = GitLocalConfigSemanticsReader.TryReadBoundedText(
+			oversizedReader,
+			maximumCharacters: 10,
+			out _);
+
+		Assert.True(exact);
+		Assert.Equal("0123456789", text);
+		Assert.False(oversized);
+		Assert.Equal(11, oversizedReader.CharactersRead);
+	}
+
 	private static string CreateStandardMetadata(TemporaryDirectory temp, string relativeGitPath)
 	{
 		var gitMetadataPath = temp.CreateFolder(relativeGitPath);
@@ -195,5 +216,23 @@ public sealed class GitLocalConfigSemanticsReaderTests
 		temp.CreateFolder(Path.Combine(relativeGitPath, "objects"));
 		temp.CreateFolder(Path.Combine(relativeGitPath, "refs"));
 		return gitMetadataPath;
+	}
+
+	private sealed class CountingTextReader(string content) : TextReader
+	{
+		private int _position;
+
+		public int CharactersRead { get; private set; }
+
+		public override int Read(char[] buffer, int index, int count)
+		{
+			var length = Math.Min(count, content.Length - _position);
+			if (length <= 0)
+				return 0;
+			content.CopyTo(_position, buffer, index, length);
+			_position += length;
+			CharactersRead += length;
+			return length;
+		}
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/GitLocalConfigSemanticsReaderTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitLocalConfigSemanticsReaderTests.cs
@@ -191,22 +191,26 @@ public sealed class GitLocalConfigSemanticsReaderTests
 	[Fact]
 	public void BoundedTextRead_ExactLimitSucceedsAndOverflowStopsAfterProbeCharacter()
 	{
-		using var exactReader = new CountingTextReader("0123456789");
-		using var oversizedReader = new CountingTextReader(new string('x', 10_000));
+		using var exactReader = new StaleLengthMemoryStream(
+			Encoding.UTF8.GetBytes("0123456789"),
+			reportedLength: 10);
+		using var oversizedReader = new StaleLengthMemoryStream(
+			Encoding.UTF8.GetBytes(new string('\u00E9', 10_000)),
+			reportedLength: 10);
 
 		var exact = GitLocalConfigSemanticsReader.TryReadBoundedText(
 			exactReader,
-			maximumCharacters: 10,
+			maximumBytes: 10,
 			out var text);
 		var oversized = GitLocalConfigSemanticsReader.TryReadBoundedText(
 			oversizedReader,
-			maximumCharacters: 10,
+			maximumBytes: 10,
 			out _);
 
 		Assert.True(exact);
 		Assert.Equal("0123456789", text);
 		Assert.False(oversized);
-		Assert.Equal(11, oversizedReader.CharactersRead);
+		Assert.Equal(11, oversizedReader.Position);
 	}
 
 	private static string CreateStandardMetadata(TemporaryDirectory temp, string relativeGitPath)
@@ -218,21 +222,9 @@ public sealed class GitLocalConfigSemanticsReaderTests
 		return gitMetadataPath;
 	}
 
-	private sealed class CountingTextReader(string content) : TextReader
+	private sealed class StaleLengthMemoryStream(byte[] buffer, long reportedLength) :
+		MemoryStream(buffer, writable: false)
 	{
-		private int _position;
-
-		public int CharactersRead { get; private set; }
-
-		public override int Read(char[] buffer, int index, int count)
-		{
-			var length = Math.Min(count, content.Length - _position);
-			if (length <= 0)
-				return 0;
-			content.CopyTo(_position, buffer, index, length);
-			_position += length;
-			CharactersRead += length;
-			return length;
-		}
+		public override long Length => reportedLength;
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceCancellationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceCancellationTests.cs
@@ -5,6 +5,8 @@ namespace DevProjex.Tests.Unit;
 
 public sealed class GitRepositoryServiceCancellationTests
 {
+    private static readonly TimeSpan ProcessTreeStartupTimeout = TimeSpan.FromSeconds(30);
+
     [Fact]
     public async Task IsGitAvailableAsync_PreCanceledToken_ThrowsWhenGitCliIsAvailable()
     {
@@ -55,7 +57,7 @@ public sealed class GitRepositoryServiceCancellationTests
         try
         {
             await childReady.Task
-                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+                .WaitAsync(ProcessTreeStartupTimeout, TestContext.Current.CancellationToken);
             childProcessId = int.Parse(
                 await File.ReadAllTextAsync(readyPath, TestContext.Current.CancellationToken),
                 NumberStyles.None,

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -155,6 +155,8 @@ public class GitRepositoryServiceUnitTests
 	[Theory]
 	[InlineData("feature/space+plus")]
 	[InlineData("release/v1.2@beta")]
+	[InlineData("feature.LOCK")]
+	[InlineData("feature/next\u0085checkpoint")]
 	[InlineData("тема/исправление")]
 	public void BranchNameValidator_AcceptsValidUnusualNames(string branchName)
 	{
@@ -170,6 +172,8 @@ public class GitRepositoryServiceUnitTests
 	[InlineData("feature/.hidden")]
 	[InlineData("feature.lock")]
 	[InlineData("feature\\name")]
+	[InlineData("feature/next\u001Fcheckpoint")]
+	[InlineData("feature/next\u007Fcheckpoint")]
 	public void BranchNameValidator_RejectsInvalidNamesBeforeCommandConstruction(string branchName)
 	{
 		Assert.False(GitBranchNameValidator.IsValid(branchName));

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -47,6 +47,38 @@ public class GitRepositoryServiceUnitTests
 	}
 
 	[Fact]
+	public async Task WorktreeProcessOutput_AtLimitIsPreserved()
+	{
+		const int limit = 257;
+		var expected = new string('x', limit);
+		using var reader = new StringReader(expected);
+
+		var result = await GitWorktreeManager.ReadBoundedOutputAsync(
+			reader,
+			limit,
+			TestContext.Current.CancellationToken);
+
+		Assert.False(result.ExceededLimit);
+		Assert.Equal(expected, result.Text);
+	}
+
+	[Fact]
+	public async Task WorktreeProcessOutput_OverLimitIsDrainedAndRejected()
+	{
+		const int limit = 257;
+		using var reader = new StringReader(new string('x', limit + 4096));
+
+		var result = await GitWorktreeManager.ReadBoundedOutputAsync(
+			reader,
+			limit,
+			TestContext.Current.CancellationToken);
+
+		Assert.True(result.ExceededLimit);
+		Assert.Empty(result.Text);
+		Assert.Equal(-1, reader.Peek());
+	}
+
+	[Fact]
 	public async Task WorktreeSupportProbe_FaultedProbeIsRetriedOnNextRequest()
 	{
 		var calls = 0;

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -97,6 +97,40 @@ public class GitRepositoryServiceUnitTests
 		Assert.Equal(2, probeCount);
 	}
 
+	[Fact]
+	public async Task WorktreeSupportProbe_TransientProcessStartFailureIsRetried()
+	{
+		var probeCount = 0;
+		var manager = new GitWorktreeManager(
+			(_, _, _) => Interlocked.Increment(ref probeCount) == 1
+				? Task.FromException<GitWorktreeManager.GitProcessResult>(
+					new System.ComponentModel.Win32Exception(5))
+				: Task.FromResult(new GitWorktreeManager.GitProcessResult(0, string.Empty, string.Empty)),
+			TimeSpan.FromSeconds(1));
+
+		Assert.False(await manager.IsSupportedAsync("repository", TestContext.Current.CancellationToken));
+		Assert.True(await manager.IsSupportedAsync("repository", TestContext.Current.CancellationToken));
+		Assert.Equal(2, probeCount);
+	}
+
+	[Fact]
+	public async Task WorktreeSupportProbe_MissingGitExecutableIsCachedAsPermanent()
+	{
+		var probeCount = 0;
+		var manager = new GitWorktreeManager(
+			(_, _, _) =>
+			{
+				Interlocked.Increment(ref probeCount);
+				return Task.FromException<GitWorktreeManager.GitProcessResult>(
+					new System.ComponentModel.Win32Exception(2));
+			},
+			TimeSpan.FromSeconds(1));
+
+		Assert.False(await manager.IsSupportedAsync("repository", TestContext.Current.CancellationToken));
+		Assert.False(await manager.IsSupportedAsync("repository", TestContext.Current.CancellationToken));
+		Assert.Equal(1, probeCount);
+	}
+
 	[Theory]
 	[InlineData("feature/space+plus")]
 	[InlineData("release/v1.2@beta")]

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -53,7 +53,7 @@ public class GitRepositoryServiceUnitTests
 		var expected = new string('x', limit);
 		using var reader = new StringReader(expected);
 
-		var result = await GitWorktreeManager.ReadBoundedOutputAsync(
+		var result = await GitProcessOutputReader.ReadAsync(
 			reader,
 			limit,
 			TestContext.Current.CancellationToken);
@@ -68,7 +68,7 @@ public class GitRepositoryServiceUnitTests
 		const int limit = 257;
 		using var reader = new StringReader(new string('x', limit + 4096));
 
-		var result = await GitWorktreeManager.ReadBoundedOutputAsync(
+		var result = await GitProcessOutputReader.ReadAsync(
 			reader,
 			limit,
 			TestContext.Current.CancellationToken);

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -283,4 +283,22 @@ public class GitRepositoryServiceUnitTests
 	{
 		Assert.Equal(expected, GitRepositoryService.IsSafeGitProgressLine(message));
 	}
+
+	[Theory]
+	[InlineData("Receiving objects: 50% (5/10)", 50, true, false)]
+	[InlineData("fatal: Authentication failed 50%", 50, false, true)]
+	[InlineData("remote: warning https://user:token@example.test 50%", 50, false, true)]
+	[InlineData("fatal: repository not found", null, false, true)]
+	public void ClassifyGitStderrLine_RetainsErrorsThatContainPercentages(
+		string message,
+		int? expectedPercent,
+		bool expectedSafeProgressLine,
+		bool expectedRetainForError)
+	{
+		var classification = GitRepositoryService.ClassifyGitStderrLine(message);
+
+		Assert.Equal(expectedPercent, classification.Percent);
+		Assert.Equal(expectedSafeProgressLine, classification.IsSafeProgressLine);
+		Assert.Equal(expectedRetainForError, classification.RetainForError);
+	}
 }

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -79,6 +79,26 @@ public class GitRepositoryServiceUnitTests
 	}
 
 	[Fact]
+	public async Task WorktreeProcessOutput_CancellationObservationWaitsForPipeCleanup()
+	{
+		var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var reader = Task.Run(
+			async () =>
+			{
+				await release.Task;
+				throw new IOException("Pipe closed during process cancellation.");
+			},
+			TestContext.Current.CancellationToken);
+
+		var observation = GitProcessOutputReader.ObserveCompletionAsync(reader);
+		Assert.False(observation.IsCompleted);
+
+		release.SetResult();
+		await observation;
+		Assert.True(reader.IsFaulted);
+	}
+
+	[Fact]
 	public async Task WorktreeSupportProbe_FaultedProbeIsRetriedOnNextRequest()
 	{
 		var calls = 0;

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -66,6 +66,27 @@ public class GitRepositoryServiceUnitTests
 	}
 
 	[Fact]
+	public async Task WorktreeSupportProbe_TransientResultAfterWaiterCancellationIsRetried()
+	{
+		var calls = 0;
+		var firstProbe = new TaskCompletionSource<WorktreeSupportState>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		var manager = new GitWorktreeManager(_ => Interlocked.Increment(ref calls) == 1
+			? firstProbe.Task
+			: Task.FromResult(WorktreeSupportState.Supported));
+		using var cancellation = new CancellationTokenSource();
+
+		var canceledWaiter = manager.IsSupportedAsync("repository", cancellation.Token);
+		cancellation.Cancel();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWaiter);
+		firstProbe.SetResult(WorktreeSupportState.TransientFailure);
+		await firstProbe.Task;
+
+		Assert.True(await manager.IsSupportedAsync("repository", TestContext.Current.CancellationToken));
+		Assert.Equal(2, calls);
+	}
+
+	[Fact]
 	public async Task WorktreeSupportProbe_TimeoutIsTransientAndNextRequestStartsNewProbe()
 	{
 		var probeCount = 0;

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -1,8 +1,7 @@
 namespace DevProjex.Tests.Unit;
 
 /// <summary>
-/// Unit tests for GitRepositoryService helper methods.
-/// Tests URL extraction, error parsing, and validation logic without requiring Git.
+/// Unit tests for GitRepositoryService process and parsing contracts without requiring Git.
 /// </summary>
 public class GitRepositoryServiceUnitTests
 {
@@ -181,64 +180,38 @@ public class GitRepositoryServiceUnitTests
 		Assert.Throws<ArgumentException>(() => GitBranchNameValidator.ValidateAndNormalize(branchName));
 	}
 
-    #region Repository Name Extraction Tests
+	[Theory]
+	[InlineData("https://github.com/user/repo", "repo")]
+	[InlineData("https://github.com/user/my-repo.git", "my-repo")]
+	[InlineData("git@github.com:user/repo.git", "repo")]
+	[InlineData("https://github.com/org/project-name?tab=readme", "project-name")]
+	public void ExtractRepositoryName_UsesTheCloneMetadataParser(string url, string expectedName)
+	{
+		Assert.Equal(expectedName, GitRepositoryService.ExtractRepositoryName(url));
+	}
 
-    [Theory]
-    [InlineData("https://github.com/user/repo", "repo")]
-    [InlineData("https://github.com/user/my-repo", "my-repo")]
-    [InlineData("https://github.com/user/repo.git", "repo")]
-    [InlineData("https://github.com/org/project-name", "project-name")]
-    public void RepositoryUrl_ExtractsName_FromUrl(string url, string expectedName)
-    {
-        // Test URL parsing logic (structural test)
-        var uri = new Uri(url);
-        var pathParts = uri.AbsolutePath.Trim('/').Split('/');
-        var repoNameWithGit = pathParts[^1];
-        var repoName = repoNameWithGit.EndsWith(".git") ? repoNameWithGit[..^4] : repoNameWithGit;
+	[Theory]
+	[InlineData("fatal: repository 'https://github.com/user/repo' not found", "Invalid repository URL or repository does not exist")]
+	[InlineData("fatal: unable to access: Could not resolve host", "Network error - check your internet connection")]
+	[InlineData("fatal: Authentication failed for private repository", "Authentication failed - repository may be private")]
+	[InlineData("Permission denied (publickey)", "Authentication failed - repository may be private")]
+	[InlineData("operation timed out", "Connection timeout - repository may be too large or network is slow")]
+	[InlineData("", "Clone failed")]
+	public void ParseGitCloneError_MapsKnownFailureClasses(string gitError, string expected)
+	{
+		Assert.Equal(expected, GitRepositoryService.ParseGitCloneError(gitError));
+	}
 
-        Assert.Equal(expectedName, repoName);
-    }
+	[Fact]
+	public void ParseGitCloneError_DoesNotEchoUnknownAuthenticatedStderr()
+	{
+		const string stderr = "fatal: transport rejected https://user:token@example.test/repo";
 
-    #endregion
+		var result = GitRepositoryService.ParseGitCloneError(stderr);
 
-    #region Error Message Detection Tests
-
-    [Theory]
-    [InlineData("Repository not found")]
-    [InlineData("fatal: repository 'https://github.com/user/repo' not found")]
-    [InlineData("ERROR: Repository not found")]
-    public void GitErrors_NotFound_ContainKeywords(string gitError)
-    {
-        // Structural test - verify error messages contain expected keywords
-        Assert.Contains("not found", gitError, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Theory]
-    [InlineData("Authentication failed")]
-    [InlineData("fatal: Authentication failed for 'https://github.com/private/repo'")]
-    [InlineData("Permission denied")]
-    public void GitErrors_Authentication_ContainKeywords(string gitError)
-    {
-        // Structural test
-        Assert.True(
-            gitError.Contains("authentication", StringComparison.OrdinalIgnoreCase) ||
-            gitError.Contains("permission", StringComparison.OrdinalIgnoreCase)
-        );
-    }
-
-    [Theory]
-    [InlineData("Could not resolve host")]
-    [InlineData("Network is unreachable")]
-    public void GitErrors_Network_ContainKeywords(string gitError)
-    {
-        // Structural test
-        Assert.True(
-            gitError.Contains("network", StringComparison.OrdinalIgnoreCase) ||
-            gitError.Contains("resolve", StringComparison.OrdinalIgnoreCase)
-        );
-    }
-
-    #endregion
+		Assert.Equal("Clone failed", result);
+		Assert.DoesNotContain("token", result, StringComparison.Ordinal);
+	}
 
     #region Default Branch Detection Tests
 
@@ -279,172 +252,35 @@ public class GitRepositoryServiceUnitTests
 
     #endregion
 
-    #region Shallow Clone Optimization Tests
+	[Theory]
+	[InlineData("Receiving objects: 50% (500/1000)", 50)]
+	[InlineData("remote: Counting objects: 100% (12/12)", 100)]
+	[InlineData("prefix 150% then 7%", 7)]
+	public void TryExtractProgressPercent_ReturnsTheFirstValidPercentage(string message, int expected)
+	{
+		Assert.True(GitRepositoryService.TryExtractProgressPercent(message, out var percent));
+		Assert.Equal(expected, percent);
+	}
 
-    [Fact]
-    public void CloneCommand_IncludesDepthOne()
-    {
-        // Verify shallow clone optimization is used
-        // The actual command should include --depth 1 for performance
-        var testUrl = "https://github.com/user/repo";
-        var testPath = "/tmp/test";
+	[Theory]
+	[InlineData("")]
+	[InlineData("Receiving objects without percentage")]
+	[InlineData("Receiving objects: 101%")]
+	[InlineData("Receiving objects: -1%")]
+	[InlineData("Receiving objects: 1.5%")]
+	[InlineData("Receiving objects: phase1%")]
+	public void TryExtractProgressPercent_RejectsMissingOrOutOfRangeValues(string message)
+	{
+		Assert.False(GitRepositoryService.TryExtractProgressPercent(message, out _));
+	}
 
-        // This is a structural test verifying the pattern is correct
-        Assert.StartsWith("https://", testUrl);
-        Assert.NotEmpty(testPath);
-    }
-
-    #endregion
-
-    #region Branch Name Validation Tests
-
-    [Theory]
-    [InlineData("main")]
-    [InlineData("master")]
-    [InlineData("develop")]
-    [InlineData("feature/new-feature")]
-    [InlineData("bugfix/fix-123")]
-    [InlineData("release/v1.0")]
-    public void BranchNames_ValidFormats_AreValid(string branchName)
-    {
-        // Valid branch names should not contain forbidden characters
-        Assert.DoesNotContain(" ", branchName);
-        Assert.DoesNotContain("\t", branchName);
-        Assert.DoesNotContain("\n", branchName);
-        Assert.NotEmpty(branchName);
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(" ")]
-    [InlineData("\t")]
-    [InlineData("\n")]
-    public void BranchNames_InvalidFormats_AreInvalid(string branchName)
-    {
-        // Invalid branch names
-        Assert.True(string.IsNullOrWhiteSpace(branchName));
-    }
-
-    #endregion
-
-    #region URL Format Tests
-
-    [Theory]
-    [InlineData("https://github.com/user/repo")]
-    [InlineData("https://github.com/user/repo.git")]
-    [InlineData("https://gitlab.com/org/project")]
-    [InlineData("https://bitbucket.org/team/app")]
-    public void GitUrls_CommonFormats_AreValid(string url)
-    {
-        Assert.True(Uri.TryCreate(url, UriKind.Absolute, out var uri));
-        Assert.True(uri.Scheme == "https" || uri.Scheme == "http");
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("not a url")]
-    [InlineData("ftp://github.com/user/repo")]
-    [InlineData("file:///C:/repos/local")]
-    public void GitUrls_InvalidFormats_AreInvalid(string url)
-    {
-        if (string.IsNullOrWhiteSpace(url))
-        {
-            Assert.True(string.IsNullOrWhiteSpace(url));
-        }
-        else
-        {
-            var isValid = Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
-                          (uri.Scheme == "https" || uri.Scheme == "http");
-            Assert.False(isValid);
-        }
-    }
-
-    #endregion
-
-    #region Path Handling Tests
-
-    [Theory]
-    [InlineData(@"C:\temp\repo")]
-    [InlineData(@"C:\Users\Name\Documents\Projects\repo")]
-    [InlineData(@"D:\repos\my-project")]
-    public void RepositoryPaths_WindowsFormat_AreValid(string path)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            Assert.True(Path.IsPathRooted(path));
-            Assert.DoesNotContain("//", path.Replace("\\", "/"));
-        }
-    }
-
-    [Theory]
-    [InlineData("/tmp/repo")]
-    [InlineData("/home/user/repos/project")]
-    [InlineData("/var/git/my-repo")]
-    public void RepositoryPaths_UnixFormat_AreValid(string path)
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            Assert.True(Path.IsPathRooted(path));
-            Assert.DoesNotContain("\\", path);
-        }
-    }
-
-    #endregion
-
-    #region Command Building Tests
-
-    [Fact]
-    public void GitCommands_QuotesPaths()
-    {
-        // Paths with spaces should be quoted
-        var pathWithSpaces = @"C:\My Documents\repo";
-        var quoted = $"\"{pathWithSpaces}\"";
-
-        Assert.StartsWith("\"", quoted);
-        Assert.EndsWith("\"", quoted);
-    }
-
-    [Fact]
-    public void GitCommands_HandlesSpecialCharacters()
-    {
-        // Special characters in paths should be handled
-        var specialPath = @"C:\repo's\my-project";
-
-        Assert.Contains("'", specialPath);
-        // Should be able to handle such paths
-        Assert.NotEmpty(specialPath);
-    }
-
-    #endregion
-
-    #region Progress Reporting Tests
-
-    [Fact]
-    public void ProgressMessages_ContainPercentages()
-    {
-        // Progress messages typically contain percentages
-        var exampleMessages = new[]
-        {
-            "Cloning: 25%",
-            "Downloading: 50%",
-            "Receiving objects: 75%",
-            "Resolving deltas: 100%"
-        };
-
-        Assert.All(exampleMessages, msg =>
-        {
-            Assert.Contains("%", msg);
-        });
-    }
-
-    [Theory]
-    [InlineData("Receiving objects: 50% (500/1000)")]
-    [InlineData("Resolving deltas: 100% (100/100)")]
-    public void ProgressMessages_ParseCorrectly(string message)
-    {
-        Assert.Contains("%", message);
-        Assert.Matches(@"\d+%", message);
-    }
-
-    #endregion
+	[Theory]
+	[InlineData("Receiving objects: 50% (5/10)", true)]
+	[InlineData(" remote: Enumerating objects: 12", true)]
+	[InlineData("remote: warning https://user:token@example.test 50%", false)]
+	[InlineData("fatal: Authentication failed 50%", false)]
+	public void IsSafeGitProgressLine_UsesAClosedPhaseAllowlist(string message, bool expected)
+	{
+		Assert.Equal(expected, GitRepositoryService.IsSafeGitProgressLine(message));
+	}
 }

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -157,6 +157,7 @@ public class GitRepositoryServiceUnitTests
 	[InlineData("release/v1.2@beta")]
 	[InlineData("feature.LOCK")]
 	[InlineData("feature/next\u0085checkpoint")]
+	[InlineData("@")]
 	[InlineData("тема/исправление")]
 	public void BranchNameValidator_AcceptsValidUnusualNames(string branchName)
 	{

--- a/Tests/DevProjex.Tests.Unit/GitTrackedPathIndexTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitTrackedPathIndexTests.cs
@@ -128,6 +128,35 @@ public sealed class GitTrackedPathIndexTests
 		Assert.Equal("0", startInfo.Environment["GIT_TERMINAL_PROMPT"]);
 	}
 
+	[Theory]
+	[InlineData(2, true)]
+	[InlineData(5, false)]
+	[InlineData(8, false)]
+	[InlineData(11, false)]
+	public void GitStartFailureCaching_DistinguishesMissingExecutableFromTransientFailures(
+		int nativeErrorCode,
+		bool expectedPermanent)
+	{
+		var exception = new System.ComponentModel.Win32Exception(nativeErrorCode);
+
+		Assert.Equal(
+			expectedPermanent,
+			GitTrackedPathIndexCache.IsPermanentGitStartFailure(exception));
+	}
+
+	[Theory]
+	[InlineData(3)]
+	[InlineData(193)]
+	[InlineData(216)]
+	public void WindowsSpecificGitStartFailures_ArePermanentOnlyOnWindows(int nativeErrorCode)
+	{
+		var exception = new System.ComponentModel.Win32Exception(nativeErrorCode);
+
+		Assert.Equal(
+			OperatingSystem.IsWindows(),
+			GitTrackedPathIndexCache.IsPermanentGitStartFailure(exception));
+	}
+
 	[Fact]
 	public void ExactAndDescendantLookups_NormalizeSeparatorsDeduplicateAndStayInsideRepository()
 	{

--- a/Tests/DevProjex.Tests.Unit/GitTrackedPathIndexTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitTrackedPathIndexTests.cs
@@ -5,6 +5,20 @@ namespace DevProjex.Tests.Unit;
 public sealed class GitTrackedPathIndexTests
 {
 	[Fact]
+	public void GitDirectoryPointer_RejectsActualContentBeyondMaximumAfterLengthProbe()
+	{
+		var bytes = new byte[GitTrackedPathIndexCache.GitFileMaximumLength + 1];
+		Encoding.UTF8.GetBytes("gitdir: metadata", bytes);
+		using var stream = new StaleLengthMemoryStream(bytes, reportedLength: 16);
+
+		var result = GitTrackedPathIndexCache.TryReadGitDirectoryPointer(stream, out var target);
+
+		Assert.False(result);
+		Assert.Empty(target);
+		Assert.Equal(GitTrackedPathIndexCache.GitFileMaximumLength + 1, stream.Position);
+	}
+
+	[Fact]
 	public async Task NullDelimitedReader_WhenRetainedBudgetIsExceeded_AbortsBeforeMaterializingRemainder()
 	{
 		var payload = Encoding.UTF8.GetBytes("first.cs\0second-long-path.cs\0third.cs\0");
@@ -563,5 +577,11 @@ public sealed class GitTrackedPathIndexTests
 			"tracked.tmp");
 
 		Assert.False(evaluation.IsIgnored);
+	}
+
+	private sealed class StaleLengthMemoryStream(byte[] buffer, long reportedLength) :
+		MemoryStream(buffer, writable: false)
+	{
+		public override long Length => reportedLength;
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/GitTrackedPathIndexTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitTrackedPathIndexTests.cs
@@ -59,6 +59,20 @@ public sealed class GitTrackedPathIndexTests
 	}
 
 	[Theory]
+	[InlineData(64, true)]
+	[InlineData(16 * 1024 * 1024, true)]
+	[InlineData(16 * 1024 * 1024 + 1, false)]
+	[InlineData(64 * 1024 * 1024, false)]
+	public void CacheRetentionPolicy_EnforcesTheGlobalRetainedByteBudget(
+		long estimatedRetainedBytes,
+		bool expected)
+	{
+		Assert.Equal(
+			expected,
+			GitTrackedPathIndexCache.CanRetainCacheEntry(estimatedRetainedBytes));
+	}
+
+	[Theory]
 	[InlineData("src/App.cs", true, false, true)]
 	[InlineData("src", false, true, true)]
 	[InlineData("src/Missing.cs", false, false, false)]

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorAcceptanceBenchmarkTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorAcceptanceBenchmarkTests.cs
@@ -35,7 +35,7 @@ public sealed class GitleaksSecretDetectorAcceptanceBenchmarkTests
 		}
 
 		var report = new AcceptanceReport(
-			SchemaVersion: 1,
+			SchemaVersion: 2,
 			CreatedAtUtc: DateTimeOffset.UtcNow,
 			OperatingSystem: RuntimeInformation.OSDescription,
 			Framework: RuntimeInformation.FrameworkDescription,
@@ -64,6 +64,7 @@ public sealed class GitleaksSecretDetectorAcceptanceBenchmarkTests
 	{
 		var timings = new double[cases.Count];
 		var fingerprint = new HashCode();
+		var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
 		var total = Stopwatch.StartNew();
 		for (var index = 0; index < cases.Count; index++)
 		{
@@ -85,7 +86,11 @@ public sealed class GitleaksSecretDetectorAcceptanceBenchmarkTests
 			}
 		}
 		total.Stop();
-		return new AcceptancePass(total.Elapsed.TotalMilliseconds, timings, fingerprint.ToHashCode());
+		return new AcceptancePass(
+			total.Elapsed.TotalMilliseconds,
+			GC.GetAllocatedBytesForCurrentThread() - allocatedBefore,
+			timings,
+			fingerprint.ToHashCode());
 	}
 
 	private static Percentiles Aggregate(IEnumerable<double> samples)
@@ -149,7 +154,11 @@ public sealed class GitleaksSecretDetectorAcceptanceBenchmarkTests
 		bool ShouldMatch);
 
 	private sealed record CorpusCase(string RuleId, string Path, string Content, bool ShouldMatch);
-	private sealed record AcceptancePass(double TotalMilliseconds, double[] FileMilliseconds, int Fingerprint);
+	private sealed record AcceptancePass(
+		double TotalMilliseconds,
+		long AllocatedBytes,
+		double[] FileMilliseconds,
+		int Fingerprint);
 	private sealed record AcceptanceRun(int Run, AcceptancePass Cold, AcceptancePass Warm);
 	private sealed record Percentiles(
 		double MedianMilliseconds,

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -161,6 +161,16 @@ public sealed class GitleaksSecretDetectorTests
 		Assert.DoesNotContain(findings, match => match.RuleId == "generic-api-key");
 	}
 
+	[Theory]
+	[InlineData("", 0d)]
+	[InlineData("aaaa", 0d)]
+	[InlineData("abcd", 2d)]
+	[InlineData("\u0430\u0431\u0430\u0431", 1d)]
+	public void ShannonEntropy_PreservesAsciiAndUnicodeResults(string value, double expected)
+	{
+		Assert.Equal(expected, GitleaksSecretDetector.CalculateShannonEntropy(value), precision: 12);
+	}
+
 	[Fact]
 	public void Detect_UserSecretsIdFastAllowlist_PreservesARealGenericFindingInTheSameFile()
 	{

--- a/Tests/DevProjex.Tests.Unit/IgnoreRulesServiceCacheAndLimitsTests.cs
+++ b/Tests/DevProjex.Tests.Unit/IgnoreRulesServiceCacheAndLimitsTests.cs
@@ -103,6 +103,29 @@ public sealed class IgnoreRulesServiceCacheAndLimitsTests
 	}
 
 	[Fact]
+	public void InvalidateCaches_FromFileSystemRootEvictsDescendantGitIgnoreMatcher()
+	{
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile(".gitignore", "*.cache\n");
+		temp.CreateFile("artifact.cache", "ignored");
+		var service = CreateServiceWithSmartIgnore([]);
+		var before = service.Build(temp.Path, [IgnoreOptionId.UseGitIgnore]);
+		Assert.True(before.IsGitIgnored(
+			Path.Combine(temp.Path, "artifact.cache"),
+			isDirectory: false,
+			"artifact.cache"));
+
+		service.InvalidateCaches(Path.GetPathRoot(temp.Path)!);
+		var after = service.Build(temp.Path, [IgnoreOptionId.UseGitIgnore]);
+
+		Assert.NotSame(before.GitIgnoreMatcher, after.GitIgnoreMatcher);
+		Assert.True(after.IsGitIgnored(
+			Path.Combine(temp.Path, "artifact.cache"),
+			isDirectory: false,
+			"artifact.cache"));
+	}
+
+	[Fact]
 	public void Build_GitIgnoreRewriteWithSameLengthAndTimestamp_InvalidatesMatcher()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -353,6 +353,23 @@ public sealed class InfrastructureJsonPersistenceTests
 	}
 
 	[Fact]
+	public void JsonStorePersistence_BoundedJsonParseRejectsContentThatGrewAfterLengthProbe()
+	{
+		var bytes = Encoding.UTF8.GetBytes("{\"value\":1}overflow");
+		using var stream = new StaleLengthMemoryStream(bytes, reportedLength: 11);
+
+		var result = JsonStorePersistence.TryParseDocumentWithinSizeLimit(
+			stream,
+			maximumDocumentBytes: 11,
+			default,
+			out var document);
+
+		Assert.False(result);
+		Assert.Null(document);
+		Assert.Equal(12, stream.Position);
+	}
+
+	[Fact]
 	public void JsonStorePersistence_ContainsFutureDocument_ProtectsDocumentBeyondExplicitLimit()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -377,6 +377,24 @@ public sealed class InfrastructureJsonPersistenceTests
 	}
 
 	[Fact]
+	public void CrossProcessFileLock_BoundedWaitTimesOutAndDoesNotPoisonTheSidecar()
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "settings.json");
+		var timeout = TimeSpan.FromMilliseconds(75);
+		var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+		using (CrossProcessFileLock.Acquire(fileSet, TimeSpan.Zero))
+		{
+			Assert.ThrowsAny<IOException>(() => CrossProcessFileLock.Acquire(fileSet, timeout));
+		}
+		stopwatch.Stop();
+
+		Assert.True(stopwatch.Elapsed >= timeout, $"Lock wait ended after {stopwatch.Elapsed}.");
+		using var reacquired = CrossProcessFileLock.Acquire(fileSet, TimeSpan.Zero);
+		Assert.NotNull(reacquired);
+	}
+
+	[Fact]
 	public void CrossProcessFileLock_DisposeReleasesSidecarLockForNextWriter()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -385,6 +385,29 @@ public sealed class InfrastructureJsonPersistenceTests
 		Assert.True(protectedDocument);
 	}
 
+	[Theory]
+	[InlineData("schemaVersion", null)]
+	[InlineData("defaultsRevision", 1)]
+	public void JsonStorePersistence_ContainsFutureDocument_ProtectsVersionBeyondInt32(
+		string propertyName,
+		int? currentDefaultsRevision)
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "settings.json");
+		Directory.CreateDirectory(fileSet.DirectoryPath);
+		var json = propertyName == "schemaVersion"
+			? """{ "schemaVersion": 2147483648 }"""
+			: """{ "schemaVersion": 1, "defaultsRevision": 2147483648 }""";
+		File.WriteAllText(fileSet.PrimaryPath, json);
+
+		var protectedDocument = JsonStorePersistence.ContainsFutureDocument(
+			fileSet,
+			currentSchemaVersion: 1,
+			currentDefaultsRevision);
+
+		Assert.True(protectedDocument);
+	}
+
 	[Fact]
 	public void JsonStorePersistence_TryWriteAtomic_CommitsPrimaryMirrorsBackupAndLeavesNoTempFiles()
 	{

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -349,6 +349,7 @@ public sealed class InfrastructureJsonPersistenceTests
 
 		Assert.False(result);
 		Assert.Empty(text);
+		Assert.Equal(11, stream.Position);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -337,6 +337,21 @@ public sealed class InfrastructureJsonPersistenceTests
 	}
 
 	[Fact]
+	public void JsonStorePersistence_BoundedReadRejectsContentThatGrewAfterLengthProbe()
+	{
+		var bytes = Encoding.UTF8.GetBytes("0123456789overflow");
+		using var stream = new StaleLengthMemoryStream(bytes, reportedLength: 10);
+
+		var result = JsonStorePersistence.TryReadAllTextWithinSizeLimit(
+			stream,
+			maximumDocumentBytes: 10,
+			out var text);
+
+		Assert.False(result);
+		Assert.Empty(text);
+	}
+
+	[Fact]
 	public void JsonStorePersistence_ContainsFutureDocument_ProtectsDocumentBeyondExplicitLimit()
 	{
 		using var temp = new TemporaryDirectory();
@@ -527,6 +542,12 @@ public sealed class InfrastructureJsonPersistenceTests
 	{
 		var primaryPath = Path.Combine(temp.Path, "appdata", fileName);
 		return new JsonStoreFileSet(primaryPath, $"{primaryPath}.bak", $"{primaryPath}.lock");
+	}
+
+	private sealed class StaleLengthMemoryStream(byte[] buffer, long reportedLength) :
+		MemoryStream(buffer, writable: false)
+	{
+		public override long Length => reportedLength;
 	}
 
 	private sealed record TestDocument(string Name, int Count);

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -313,6 +313,48 @@ public sealed class InfrastructureJsonPersistenceTests
 	}
 
 	[Fact]
+	public void JsonStorePersistence_TryReadNormalized_RejectsDocumentBeyondExplicitLimit()
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "settings.json");
+		Directory.CreateDirectory(fileSet.DirectoryPath);
+		using (var stream = new FileStream(fileSet.PrimaryPath, FileMode.CreateNew, FileAccess.Write))
+			stream.SetLength(257);
+
+		var result = JsonStorePersistence.TryReadNormalized(
+			fileSet.PrimaryPath,
+			JsonOptions,
+			static () => new TestDocument("default", 0),
+			static document => document,
+			out var document,
+			out var requiresRewrite,
+			maximumDocumentBytes: 256);
+
+		Assert.False(result);
+		Assert.False(requiresRewrite);
+		Assert.Equal(new TestDocument("default", 0), document);
+		Assert.Equal(257, new FileInfo(fileSet.PrimaryPath).Length);
+	}
+
+	[Fact]
+	public void JsonStorePersistence_ContainsFutureDocument_ProtectsDocumentBeyondExplicitLimit()
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "settings.json");
+		Directory.CreateDirectory(fileSet.DirectoryPath);
+		using (var stream = new FileStream(fileSet.PrimaryPath, FileMode.CreateNew, FileAccess.Write))
+			stream.SetLength(257);
+
+		var protectedDocument = JsonStorePersistence.ContainsFutureDocument(
+			fileSet,
+			currentSchemaVersion: 1,
+			maximumDocumentBytes: 256);
+
+		Assert.True(protectedDocument);
+		Assert.Equal(257, new FileInfo(fileSet.PrimaryPath).Length);
+	}
+
+	[Fact]
 	public void JsonStorePersistence_TryWriteAtomic_CommitsPrimaryMirrorsBackupAndLeavesNoTempFiles()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -354,6 +354,37 @@ public sealed class InfrastructureJsonPersistenceTests
 		Assert.Equal(257, new FileInfo(fileSet.PrimaryPath).Length);
 	}
 
+	[Theory]
+	[InlineData("utf16-le")]
+	[InlineData("utf16-be")]
+	[InlineData("utf32-le")]
+	[InlineData("utf32-be")]
+	public void JsonStorePersistence_ContainsFutureDocument_DetectsUnicodeSchema(string encodingName)
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "settings.json");
+		Directory.CreateDirectory(fileSet.DirectoryPath);
+		Encoding encoding = encodingName switch
+		{
+			"utf16-le" => new UnicodeEncoding(false, true, true),
+			"utf16-be" => new UnicodeEncoding(true, true, true),
+			"utf32-le" => new UTF32Encoding(false, true, true),
+			"utf32-be" => new UTF32Encoding(true, true, true),
+			_ => throw new ArgumentOutOfRangeException(nameof(encodingName))
+		};
+		File.WriteAllText(
+			fileSet.PrimaryPath,
+			"""{ "schemaVersion": 2, "name": "future" }""",
+			encoding);
+
+		var protectedDocument = JsonStorePersistence.ContainsFutureDocument(
+			fileSet,
+			currentSchemaVersion: 1,
+			maximumDocumentBytes: 256);
+
+		Assert.True(protectedDocument);
+	}
+
 	[Fact]
 	public void JsonStorePersistence_TryWriteAtomic_CommitsPrimaryMirrorsBackupAndLeavesNoTempFiles()
 	{

--- a/Tests/DevProjex.Tests.Unit/MarkedSecretsMatcherMemoryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/MarkedSecretsMatcherMemoryTests.cs
@@ -6,11 +6,15 @@ public sealed class MarkedSecretsMatcherMemoryTests(ITestOutputHelper output)
 {
 	private const string MarkedValue = "persistent-secret-value";
 
-	[Fact(Timeout = 15_000)]
+	[Fact(Timeout = 45_000)]
 	public void NewlineDenseMaximumFile_UsesBoundedPositionIndexMemory()
 	{
 		var content = new string('\n', checked((int)SecretRedactionOutputPreparer.MaximumScannableFileBytes));
 		var matcher = CreateMatcher();
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var memoryMeasurementBudget = new SecretFileInspectionBudget(
+			TimeSpan.FromSeconds(30),
+			cancellationToken);
 		var legacyAllocated = MeasureLegacyPositionIndexAllocations(content);
 		GC.Collect();
 		GC.WaitForPendingFinalizers();
@@ -20,7 +24,9 @@ public sealed class MarkedSecretsMatcherMemoryTests(ITestOutputHelper output)
 		var findings = matcher.Match(
 			"config.env",
 			content,
-			TestContext.Current.CancellationToken);
+			transformMap: null,
+			memoryMeasurementBudget,
+			cancellationToken);
 		var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
 		output.WriteLine(
 			"16 MiB newline index: legacy={0:N0} B, bitsets+match={1:N0} B",

--- a/Tests/DevProjex.Tests.Unit/OutputRootPathPresentationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/OutputRootPathPresentationTests.cs
@@ -1,3 +1,4 @@
+using DevProjex.Application.Compression;
 using DevProjex.Application.Secrets;
 
 namespace DevProjex.Tests.Unit;
@@ -46,6 +47,37 @@ public sealed class OutputRootPathPresentationTests
 	}
 
 	[Fact]
+	public void CaptureRedactionDecision_PreservesKeepAcrossEquivalentProjectRootAliases()
+	{
+		using var project = new TemporaryDirectory();
+		using var session = SecretRedactionSession.CreateWithPrivateData(
+			new EmptyDetector(),
+			new EmptyDetector());
+		var initialContext = new ContentTransformationContext(
+			null,
+			new SecretRedactionContext(
+				project.Path,
+				session,
+				SecretRedactionFeatures.PrivateData));
+		var initial = Assert.IsType<OutputPathRedactionDecision>(
+			OutputRootPathPresentation.CaptureRedactionDecision(initialContext));
+		Assert.True(session.ToggleKeepAsIs(initial.OccurrenceId));
+		var aliasedContext = initialContext with
+		{
+			Redaction = initialContext.Redaction! with
+			{
+				ProjectRoot = project.Path + Path.DirectorySeparatorChar
+			}
+		};
+
+		var aliased = Assert.IsType<OutputPathRedactionDecision>(
+			OutputRootPathPresentation.CaptureRedactionDecision(aliasedContext));
+
+		Assert.Equal(initial.OccurrenceId, aliased.OccurrenceId);
+		Assert.True(aliased.Keep);
+	}
+
+	[Fact]
 	public void RelativeContentHeaderMapper_IsStablePerRootAndProducesPortablePaths()
 	{
 		using var project = new TemporaryDirectory();
@@ -56,5 +88,13 @@ public sealed class OutputRootPathPresentationTests
 
 		Assert.Same(first, second);
 		Assert.Equal("src/Program.cs", first(file));
+	}
+
+	private sealed class EmptyDetector : ISecretDetector
+	{
+		public IReadOnlyList<DetectedSecret> Detect(
+			string repositoryRelativePath,
+			string content,
+			CancellationToken cancellationToken = default) => [];
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/PathUtilityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/PathUtilityTests.cs
@@ -42,6 +42,15 @@ public sealed class PathUtilityTests
 	}
 
 	[Fact]
+	public void IsPathInside_FileSystemRootContainsDescendant()
+	{
+		var rootPath = Path.GetPathRoot(Path.GetTempPath())!;
+		var descendant = Path.Combine(rootPath, "DevProjex", "workspace");
+
+		Assert.True(PathUtility.IsPathInside(descendant, rootPath));
+	}
+
+	[Fact]
 	public void IsPathInside_ReturnsFalse_ForPrefixTrapSibling()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/PersistentSecretIdentityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/PersistentSecretIdentityTests.cs
@@ -386,6 +386,22 @@ public sealed class PersistentSecretIdentityTests
 	}
 
 	[Fact]
+	public void StableLengthProbe_RejectsKeyFileThatGrewAfterOpening()
+	{
+		using var stream = new StaleLengthMemoryStream(
+			[1, 2, 3, 4, 5],
+			reportedLength: 4);
+		stream.Position = 4;
+
+		var stable = PersistentSecretIdentityProvider.HasStableLengthAfterRead(
+			stream,
+			expectedLength: 4);
+
+		Assert.False(stable);
+		Assert.Equal(5, stream.Position);
+	}
+
+	[Fact]
 	public async Task Provider_DoesNotTouchStorageUntilAnIdentityIsRequired()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -660,6 +676,12 @@ public sealed class PersistentSecretIdentityTests
 		public void MoveUtcBackward(TimeSpan duration) => _utcNow -= duration;
 
 		public void AdvanceMonotonic(TimeSpan duration) => _timestamp += duration.Ticks;
+	}
+
+	private sealed class StaleLengthMemoryStream(byte[] buffer, long reportedLength) :
+		MemoryStream(buffer, writable: false)
+	{
+		public override long Length => reportedLength;
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/PersistentSecretIdentityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/PersistentSecretIdentityTests.cs
@@ -497,6 +497,40 @@ public sealed class PersistentSecretIdentityTests
 	}
 
 	[Fact]
+	public async Task TransientRetryCooldown_UsesMonotonicTimeAcrossUtcClockAdjustments()
+	{
+		using var workspace = new TemporaryDirectory();
+		var appData = workspace.CreateFolder("app-data");
+		var pathAvailable = false;
+		var timeProvider = new IndependentTimeProvider(
+			new DateTimeOffset(2026, 8, 20, 3, 0, 0, TimeSpan.Zero));
+		using var provider = new PersistentSecretIdentityProvider(
+			() => pathAvailable
+				? appData
+				: throw new System.Security.SecurityException("Storage is temporarily unavailable."),
+			TimeSpan.FromMilliseconds(30),
+			TimeSpan.FromSeconds(1),
+			timeProvider);
+
+		Assert.Equal(
+			PersistentSecretIdentityAvailability.TemporarilyUnavailable,
+			await provider.EnsureAvailableAsync(TestContext.Current.CancellationToken));
+		pathAvailable = true;
+		timeProvider.MoveUtcForward(TimeSpan.FromDays(1));
+		Assert.Equal(
+			PersistentSecretIdentityAvailability.TemporarilyUnavailable,
+			await provider.EnsureAvailableAsync(TestContext.Current.CancellationToken));
+		Assert.Equal(1, provider.InitializationAttemptCount);
+		timeProvider.MoveUtcBackward(TimeSpan.FromDays(2));
+		timeProvider.AdvanceMonotonic(TimeSpan.FromSeconds(2));
+
+		Assert.Equal(
+			PersistentSecretIdentityAvailability.Ready,
+			await provider.EnsureAvailableAsync(TestContext.Current.CancellationToken));
+		Assert.Equal(2, provider.InitializationAttemptCount);
+	}
+
+	[Fact]
 	public async Task ConcurrentFirstUse_PerformsOneInitialization()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -608,6 +642,24 @@ public sealed class PersistentSecretIdentityTests
 				return;
 			}
 		}
+	}
+
+	private sealed class IndependentTimeProvider(DateTimeOffset utcNow) : TimeProvider
+	{
+		private DateTimeOffset _utcNow = utcNow;
+		private long _timestamp;
+
+		public override DateTimeOffset GetUtcNow() => _utcNow;
+
+		public override long GetTimestamp() => _timestamp;
+
+		public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+		public void MoveUtcForward(TimeSpan duration) => _utcNow += duration;
+
+		public void MoveUtcBackward(TimeSpan duration) => _utcNow -= duration;
+
+		public void AdvanceMonotonic(TimeSpan duration) => _timestamp += duration.Ticks;
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/PersistentSecretMarkStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/PersistentSecretMarkStoreTests.cs
@@ -45,6 +45,25 @@ public sealed class PersistentSecretMarkStoreTests
 	}
 
 	[Fact]
+	public async Task OversizedStore_IsRejectedAsInvalidWithoutMutation()
+	{
+		using var temporary = new TemporaryDirectory();
+		var project = temporary.CreateFolder("project");
+		var directory = temporary.CreateFolder("DevProjex");
+		var primaryPath = Path.Combine(directory, "project-secret-marks.json");
+		using (var stream = new FileStream(primaryPath, FileMode.CreateNew, FileAccess.Write))
+			stream.SetLength(ProjectProfileStorageLimits.MaximumJsonBytes + 1);
+		var store = new PersistentSecretMarkStore(() => temporary.Path);
+
+		var load = await store.LoadAsync(project, TestContext.Current.CancellationToken);
+		var add = await store.AddAsync(project, Mark(FirstHash, 12), TestContext.Current.CancellationToken);
+
+		Assert.Equal(PersistentSecretMarkStoreStatus.InvalidStorage, load.Status);
+		Assert.Equal(PersistentSecretMarkStoreStatus.InvalidStorage, add.Status);
+		Assert.Equal(ProjectProfileStorageLimits.MaximumJsonBytes + 1, new FileInfo(primaryPath).Length);
+	}
+
+	[Fact]
 	public async Task IndependentStores_AddDistinctMarks_PreserveBothDeltas()
 	{
 		using var temporary = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
@@ -592,6 +592,38 @@ public sealed class ProjectProfileStoreAdditionalTests
 		}
 	}
 
+	[Fact]
+	public void TrySaveProfile_ExtremeCallerTimestamp_CannotBypassNormalizedRevisionOrdering()
+	{
+		var tempRoot = CreateTempDirectory();
+		try
+		{
+			var store = CreateStore(tempRoot);
+			var projectPath = Path.Combine(tempRoot, "RepoA");
+			var currentProfile = new ProjectSelectionProfile(
+				SelectedRootFolders: ["current"],
+				SelectedExtensions: [".cs"],
+				SelectedIgnoreOptions: [IgnoreOptionId.DotFiles]);
+			var staleProfile = new ProjectSelectionProfile(
+				SelectedRootFolders: ["stale"],
+				SelectedExtensions: [".txt"],
+				SelectedIgnoreOptions: [IgnoreOptionId.EmptyFiles]);
+			var currentRevision = DateTimeOffset.UtcNow.AddHours(1);
+
+			Assert.True(store.TrySaveProfile(projectPath, currentProfile, currentRevision));
+			Assert.True(store.TrySaveProfile(projectPath, staleProfile, DateTimeOffset.MaxValue));
+			Assert.True(store.TryLoadProfile(projectPath, out var loaded));
+			Assert.Contains("current", loaded.SelectedRootFolders);
+			Assert.DoesNotContain("stale", loaded.SelectedRootFolders);
+			Assert.Contains(".cs", loaded.SelectedExtensions);
+			Assert.DoesNotContain(".txt", loaded.SelectedExtensions);
+		}
+		finally
+		{
+			Directory.Delete(tempRoot, recursive: true);
+		}
+	}
+
 	[Theory]
 	[InlineData("RepoTrailingSlash")]
 	[InlineData("RepoTrailingAltSlash")]

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
@@ -553,6 +553,45 @@ public sealed class ProjectProfileStoreAdditionalTests
 		}
 	}
 
+	[Fact]
+	public void TrySaveProfile_ExtremePersistedTimestamp_DoesNotBlockLaterRevision()
+	{
+		var tempRoot = CreateTempDirectory();
+		try
+		{
+			var store = CreateStore(tempRoot);
+			var projectPath = Path.Combine(tempRoot, "RepoA");
+			var original = new ProjectSelectionProfile(
+				SelectedRootFolders: ["src"],
+				SelectedExtensions: [".cs"],
+				SelectedIgnoreOptions: [IgnoreOptionId.DotFiles]);
+			var replacement = new ProjectSelectionProfile(
+				SelectedRootFolders: ["docs"],
+				SelectedExtensions: [".md"],
+				SelectedIgnoreOptions: [IgnoreOptionId.UseGitIgnore]);
+			Assert.True(store.TrySaveProfile(projectPath, original));
+			var storagePath = store.GetPath();
+			var document = System.Text.Json.Nodes.JsonNode.Parse(File.ReadAllText(storagePath))!;
+			var profile = document["profiles"]![PathUtility.Normalize(projectPath)]!;
+			profile["updatedUtc"] = DateTimeOffset.MaxValue;
+			File.WriteAllText(storagePath, document.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+			Assert.True(store.TrySaveProfile(
+				projectPath,
+				replacement,
+				DateTimeOffset.UtcNow.AddMinutes(1)));
+			Assert.True(store.TryLoadProfile(projectPath, out var loaded));
+			Assert.Contains("docs", loaded.SelectedRootFolders);
+			Assert.DoesNotContain("src", loaded.SelectedRootFolders);
+			Assert.Contains(".md", loaded.SelectedExtensions);
+			Assert.DoesNotContain(".cs", loaded.SelectedExtensions);
+		}
+		finally
+		{
+			Directory.Delete(tempRoot, recursive: true);
+		}
+	}
+
 	[Theory]
 	[InlineData("RepoTrailingSlash")]
 	[InlineData("RepoTrailingAltSlash")]

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
@@ -575,11 +575,24 @@ public sealed class ProjectProfileStoreAdditionalTests
 			var profile = document["profiles"]![PathUtility.Normalize(projectPath)]!;
 			profile["updatedUtc"] = DateTimeOffset.MaxValue;
 			File.WriteAllText(storagePath, document.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+			var applyRevision = DateTimeOffset.UtcNow;
 
 			Assert.True(store.TrySaveProfile(
 				projectPath,
 				replacement,
-				DateTimeOffset.UtcNow.AddMinutes(1)));
+				applyRevision));
+			using (var persistedDocument = JsonDocument.Parse(File.ReadAllBytes(storagePath)))
+			{
+				var persistedProfile = persistedDocument.RootElement
+					.GetProperty("profiles")
+					.GetProperty(PathUtility.Normalize(projectPath));
+				Assert.Equal(applyRevision, persistedProfile.GetProperty("updatedUtc").GetDateTimeOffset());
+				Assert.Equal(
+					["docs"],
+					persistedProfile.GetProperty("selectedRootFolders")
+						.EnumerateArray()
+						.Select(static value => value.GetString()));
+			}
 			Assert.True(store.TryLoadProfile(projectPath, out var loaded));
 			Assert.Contains("docs", loaded.SelectedRootFolders);
 			Assert.DoesNotContain("src", loaded.SelectedRootFolders);

--- a/Tests/DevProjex.Tests.Unit/ProjectRootFactsProviderTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectRootFactsProviderTests.cs
@@ -91,6 +91,44 @@ public sealed class ProjectRootFactsProviderTests
 	}
 
 	[Fact]
+	public void Get_TrailingSeparatorAliasSharesCacheEntry()
+	{
+		var rootPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+		var buildCount = 0;
+		var provider = new ProjectRootFactsProvider(
+			cacheTtl: TimeSpan.FromMinutes(5),
+			cacheLimit: 4,
+			utcNowProvider: null,
+			factsBuilder: path => CreateFacts(path, $"build-{++buildCount}.marker"));
+
+		var first = provider.Get(rootPath);
+		var alias = provider.Get(rootPath + Path.DirectorySeparatorChar);
+
+		Assert.Same(first, alias);
+		Assert.Equal(1, buildCount);
+	}
+
+	[Fact]
+	public void Get_WhenClockMovesBackward_DoesNotExtendCacheLifetime()
+	{
+		var rootPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+		var now = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc);
+		var buildCount = 0;
+		var provider = new ProjectRootFactsProvider(
+			cacheTtl: TimeSpan.FromMinutes(5),
+			cacheLimit: 4,
+			utcNowProvider: () => now,
+			factsBuilder: path => CreateFacts(path, $"build-{++buildCount}.marker"));
+
+		var first = provider.Get(rootPath);
+		now = now.AddMinutes(-10);
+		var afterClockRollback = provider.Get(rootPath);
+
+		Assert.NotSame(first, afterClockRollback);
+		Assert.Equal(2, buildCount);
+	}
+
+	[Fact]
 	public void TryGetFileSignature_SameLengthAndTimestampButDifferentContent_ChangesFingerprint()
 	{
 		using var temp = new TemporaryDirectory();
@@ -170,6 +208,26 @@ public sealed class ProjectRootFactsProviderTests
 		var unrelatedAfterInvalidation = provider.Get(unrelated.Path);
 		Assert.Same(unrelatedBeforeInvalidation, unrelatedAfterInvalidation);
 		Assert.False(unrelatedAfterInvalidation.HasMarkerFile("pyproject.toml"));
+	}
+
+	[Fact]
+	public void Invalidate_FromFileSystemRoot_RemovesDescendantSnapshot()
+	{
+		var fileSystemRoot = Path.GetPathRoot(Path.GetTempPath())!;
+		var descendant = Path.Combine(fileSystemRoot, "DevProjex", "Tests", Guid.NewGuid().ToString("N"));
+		var buildCount = 0;
+		var provider = new ProjectRootFactsProvider(
+			cacheTtl: TimeSpan.FromMinutes(5),
+			cacheLimit: 4,
+			utcNowProvider: null,
+			factsBuilder: path => CreateFacts(path, $"build-{++buildCount}.marker"));
+
+		var initial = provider.Get(descendant);
+		provider.Invalidate(fileSystemRoot, includeDescendants: true);
+		var refreshed = provider.Get(descendant);
+
+		Assert.NotSame(initial, refreshed);
+		Assert.Equal(2, buildCount);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/ProjectRootFactsProviderTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectRootFactsProviderTests.cs
@@ -167,6 +167,20 @@ public sealed class ProjectRootFactsProviderTests
 	}
 
 	[Fact]
+	public void ContentFingerprint_RejectsFileThatGrewAfterMetadataProbe()
+	{
+		using var stream = new StaleLengthMemoryStream(
+			Encoding.UTF8.GetBytes("root-length-overflow"),
+			reportedLength: 4);
+
+		var exception = Assert.Throws<IOException>(() =>
+			ProjectRootFactsProvider.ComputeContentFingerprint(stream, expectedLength: 4));
+
+		Assert.Contains("changed", exception.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Equal(5, stream.Position);
+	}
+
+	[Fact]
 	public void HasMatchingFileMetadata_ReportsContentRewriteOnlyWhenMetadataChanges()
 	{
 		using var temp = new TemporaryDirectory();
@@ -449,6 +463,12 @@ public sealed class ProjectRootFactsProviderTests
 			files: [new ProjectRootFileFact(markerName, Path.GetExtension(markerName))],
 			directories: [],
 			gitIgnoreSignature: null);
+
+	private sealed class StaleLengthMemoryStream(byte[] buffer, long reportedLength) :
+		MemoryStream(buffer, writable: false)
+	{
+		public override long Length => reportedLength;
+	}
 
 	[Fact]
 	public void HasGitIgnoreFile_RejectsReparseFileAndAcceptsRegularFile()

--- a/Tests/DevProjex.Tests.Unit/ProjectScopeDiscoveryServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectScopeDiscoveryServiceTests.cs
@@ -20,6 +20,28 @@ public sealed class ProjectScopeDiscoveryServiceTests
 	}
 
 	[Fact]
+	public void Discover_WhenClockMovesBackward_DoesNotReuseStaleScopeTopology()
+	{
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile("package.json", "{}");
+		var now = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc);
+		var discovery = new ProjectScopeDiscoveryService(
+			new SmartIgnoreService([]),
+			utcNowProvider: () => now);
+		var initial = discovery.Discover(temp.Path, selectedRootFolders: null);
+		Assert.Single(initial.Scopes);
+
+		temp.CreateFile("nested/pyproject.toml", "[project]\nname = \"nested\"\n");
+		now = now.AddMinutes(-10);
+		var afterClockRollback = discovery.Discover(temp.Path, selectedRootFolders: null);
+
+		Assert.NotSame(initial, afterClockRollback);
+		Assert.Contains(
+			afterClockRollback.Scopes,
+			scope => ScopeEndsWith(scope, "nested"));
+	}
+
+	[Fact]
 	public async Task Discover_InvalidatedWhileFactsAreBuilding_DoesNotPublishStaleTopology()
 	{
 		using var buildStarted = new ManualResetEventSlim();

--- a/Tests/DevProjex.Tests.Unit/ProjectScopeDiscoveryServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectScopeDiscoveryServiceTests.cs
@@ -3,6 +3,23 @@ namespace DevProjex.Tests.Unit;
 public sealed class ProjectScopeDiscoveryServiceTests
 {
 	[Fact]
+	public void Invalidate_TrailingSeparatorAliasRefreshesCanonicalScope()
+	{
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile("source.txt", "plain");
+		var discovery = CreateDiscovery();
+		var initial = discovery.Discover(temp.Path, selectedRootFolders: null);
+		Assert.False(initial.HasAnyGitIgnore);
+
+		temp.CreateFile(".gitignore", "*.cache\n");
+		discovery.Invalidate(temp.Path + Path.DirectorySeparatorChar);
+		var refreshed = discovery.Discover(temp.Path, selectedRootFolders: null);
+
+		Assert.True(refreshed.HasAnyGitIgnore);
+		Assert.NotSame(initial, refreshed);
+	}
+
+	[Fact]
 	public async Task Discover_InvalidatedWhileFactsAreBuilding_DoesNotPublishStaleTopology()
 	{
 		using var buildStarted = new ManualResetEventSlim();

--- a/Tests/DevProjex.Tests.Unit/RecentProjectsStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RecentProjectsStoreTests.cs
@@ -393,6 +393,37 @@ public sealed class RecentProjectsStoreTests
 		Assert.Equal(JsonStorePersistence.SmallDocumentMaximumBytes + 1, new FileInfo(filePath).Length);
 	}
 
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void FutureSchemaInPrimaryOrBackup_IsPreservedAndBlocksPersistence(bool useBackup)
+	{
+		using var temp = new TemporaryDirectory();
+		var store = new RecentProjectsStore(() => temp.Path);
+		var primaryPath = store.GetPath();
+		var futurePath = useBackup ? primaryPath + ".bak" : primaryPath;
+		const string futureJson = """
+		{
+		  "schemaVersion": 999,
+		  "recentFolders": [],
+		  "recentRepositories": [],
+		  "futureHistory": { "keep": true }
+		}
+		""";
+		Directory.CreateDirectory(Path.GetDirectoryName(primaryPath)!);
+		File.WriteAllText(futurePath, futureJson);
+
+		var loaded = store.Load();
+		var updated = store.AddRepository(loaded, "https://github.com/example/new-repository");
+
+		Assert.Empty(loaded.RecentRepositories);
+		Assert.Single(updated.RecentRepositories);
+		Assert.False(store.TryPersist(updated));
+		Assert.True(store.EnsureStorageExists());
+		Assert.Equal(futureJson, File.ReadAllText(futurePath));
+		Assert.Equal(!useBackup, File.Exists(primaryPath));
+	}
+
 	[Fact]
 	public void Load_RemovesApplicationStateDirectory_FromLegacyData()
 	{

--- a/Tests/DevProjex.Tests.Unit/RecentProjectsStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RecentProjectsStoreTests.cs
@@ -599,6 +599,43 @@ public sealed class RecentProjectsStoreTests
 	}
 
 	[Fact]
+	public void ExtremePersistedTimestamps_DoNotBreakRemovalOrReopening()
+	{
+		using var temp = new TemporaryDirectory();
+		var store = new RecentProjectsStore(() => temp.Path);
+		var folderPath = temp.CreateFolder("Workspace");
+		const string repositoryUrl = "https://github.com/example/repository";
+		var state = new RecentProjectsDb
+		{
+			RecentFolders =
+			[
+				new RecentFolderEntry
+				{
+					Path = folderPath,
+					OpenedUtc = DateTimeOffset.MaxValue
+				}
+			],
+			RecentRepositories =
+			[
+				new RecentRepositoryEntry
+				{
+					Url = repositoryUrl,
+					OpenedUtc = DateTimeOffset.MaxValue
+				}
+			]
+		};
+
+		state = store.RemoveFolder(state, folderPath);
+		state = store.RemoveRepository(state, repositoryUrl);
+		state = store.AddFolder(state, folderPath);
+		state = store.AddRepository(state, repositoryUrl);
+		var reloaded = store.Load();
+
+		Assert.Equal(PathUtility.Normalize(folderPath), Assert.Single(reloaded.RecentFolders).Path);
+		Assert.Equal(repositoryUrl, Assert.Single(reloaded.RecentRepositories).Url);
+	}
+
+	[Fact]
 	public void TryPersist_ExcessRemovalHistory_IsBoundedToNewestSixtyFourEntries()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/RecentProjectsStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RecentProjectsStoreTests.cs
@@ -1,4 +1,5 @@
 using DevProjex.Infrastructure.RecentProjects;
+using DevProjex.Infrastructure.Persistence;
 
 namespace DevProjex.Tests.Unit;
 
@@ -372,6 +373,24 @@ public sealed class RecentProjectsStoreTests
 		Assert.Empty(loaded.RecentFolders);
 		Assert.Empty(loaded.RecentRepositories);
 		Assert.Equal(invalidJson, File.ReadAllText(filePath));
+	}
+
+	[Fact]
+	public void Load_OversizedPrimary_ReturnsDefaultWithoutMaterializingOrDestroyingFile()
+	{
+		using var temp = new TemporaryDirectory();
+		var store = new RecentProjectsStore(() => temp.Path);
+		var filePath = store.GetPath();
+		Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+		using (var stream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write))
+			stream.SetLength(JsonStorePersistence.SmallDocumentMaximumBytes + 1);
+
+		var loaded = store.Load();
+
+		Assert.Equal(3, loaded.SchemaVersion);
+		Assert.Empty(loaded.RecentFolders);
+		Assert.Empty(loaded.RecentRepositories);
+		Assert.Equal(JsonStorePersistence.SmallDocumentMaximumBytes + 1, new FileInfo(filePath).Length);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -717,6 +717,28 @@ public class RepoCacheServiceTests : IDisposable
 		Assert.Equal(original, File.ReadAllBytes(indexPath));
 	}
 
+	[Fact]
+	public async Task FutureCacheIndexWithLegacyGitBackup_DoesNotMoveRepositoryDuringMigration()
+	{
+		const string repositoryUrl = "https://github.com/example/future-legacy-index.git";
+		var repositoryPath = _service.CreateRepositoryDirectory(repositoryUrl);
+		Directory.CreateDirectory(Path.Combine(repositoryPath, ".git"));
+		_service.RecordIndexedRepository(repositoryUrl, repositoryPath, "main", "1234567");
+		var indexPath = Path.Combine(_testCacheRoot, "cache-index.json");
+		Assert.True(File.Exists($"{indexPath}.bak"));
+		File.WriteAllText(indexPath, """{"schemaVersion":3,"entries":[],"future":"preserve"}""");
+		var original = File.ReadAllBytes(indexPath);
+
+		using var session = await _service.TryAcquireRepositorySessionAsync(
+			repositoryUrl,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Null(session);
+		Assert.True(Directory.Exists(repositoryPath));
+		Assert.True(Directory.Exists(Path.Combine(repositoryPath, ".git")));
+		Assert.Equal(original, File.ReadAllBytes(indexPath));
+	}
+
     [Fact]
     public void FindIndexedRepository_IgnoresEntriesWithMissingRequiredStrings()
     {

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -369,6 +369,51 @@ public class RepoCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public void CollectGarbage_SaturatedIndexedSizeStillEvictsEveryOversizedEntry()
+    {
+        const string firstUrl = "https://github.com/example/oversized-first.git";
+        const string secondUrl = "https://github.com/example/oversized-second.git";
+        var firstPath = _service.CreateRepositoryDirectory(firstUrl);
+        var secondPath = _service.CreateRepositoryDirectory(secondUrl);
+        var lastUsedUtc = DateTimeOffset.UtcNow;
+        WriteCacheIndex(
+            _testCacheRoot,
+            [
+                new RepositoryCacheIndexEntry(
+                    RepositoryUrlUtility.GetComparisonKey(firstUrl),
+                    firstUrl,
+                    firstPath,
+                    null,
+                    null,
+                    lastUsedUtc,
+                    RepositoryCacheEntryState.Ready,
+                    long.MaxValue,
+                    RepositoryCacheContentKind.Zip),
+                new RepositoryCacheIndexEntry(
+                    RepositoryUrlUtility.GetComparisonKey(secondUrl),
+                    secondUrl,
+                    secondPath,
+                    null,
+                    null,
+                    lastUsedUtc,
+                    RepositoryCacheEntryState.Ready,
+                    long.MaxValue,
+                    RepositoryCacheContentKind.Zip)
+            ]);
+        var service = new RepoCacheService(
+            _testCacheRoot,
+            new RepositoryCachePolicy(1, TimeSpan.FromDays(60)),
+            TimeProvider.System,
+            new GitWorktreeManager());
+
+        service.CollectGarbage();
+
+        Assert.Empty(service.ListIndexedRepositories());
+        Assert.False(Directory.Exists(firstPath));
+        Assert.False(Directory.Exists(secondPath));
+    }
+
+    [Fact]
     public void LocalRepositoryCacheIdentityUsesPlatformPathCaseSemantics()
     {
         var sourceRoot = Path.Combine(Path.GetTempPath(), "DevProjex", "SourceIdentity");

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -332,6 +332,43 @@ public class RepoCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public void FindIndexedRepository_FutureTimestampCannotOverrideValidDuplicate()
+    {
+        const string repositoryUrl = "https://github.com/example/timestamp.git";
+        var corruptPath = _service.CreateRepositoryDirectory(repositoryUrl);
+        var validPath = _service.CreateRepositoryDirectory(repositoryUrl);
+        var identity = RepositoryUrlUtility.GetComparisonKey(repositoryUrl);
+        var validTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1);
+        WriteCacheIndex(
+            _testCacheRoot,
+            [
+                new RepositoryCacheIndexEntry(
+                    identity,
+                    repositoryUrl,
+                    corruptPath,
+                    "corrupt",
+                    null,
+                    DateTimeOffset.MaxValue,
+                    RepositoryCacheEntryState.Ready,
+                    ContentKind: RepositoryCacheContentKind.Zip),
+                new RepositoryCacheIndexEntry(
+                    identity,
+                    repositoryUrl,
+                    validPath,
+                    "valid",
+                    null,
+                    validTimestamp,
+                    RepositoryCacheEntryState.Ready,
+                    ContentKind: RepositoryCacheContentKind.Zip)
+            ]);
+
+        var entry = Assert.IsType<RepositoryCacheIndexEntry>(_service.FindIndexedRepository(repositoryUrl));
+
+        Assert.Equal(validPath, entry.LocalPath, PathComparer.Default);
+        Assert.Equal(validTimestamp, entry.LastOpenedUtc);
+    }
+
+    [Fact]
     public async Task ListIndexedRepositories_LegacyCatalogEntryCanBeOpenedByPathOffline()
     {
         var currentBase = Path.Combine(_testCacheRoot, "open-current");

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -665,6 +665,39 @@ public class RepoCacheServiceTests : IDisposable
         Assert.Equal("main", indexed.Branch);
     }
 
+	[Fact]
+	public void OversizedCacheIndex_IsNotReadOrReplacedByMetadataUpdates()
+	{
+		const string repositoryUrl = "https://github.com/example/oversized-index.git";
+		Directory.CreateDirectory(_testCacheRoot);
+		var indexPath = Path.Combine(_testCacheRoot, "cache-index.json");
+		using (var stream = new FileStream(indexPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+			stream.SetLength(RepoCacheService.MaximumCacheIndexBytes + 1);
+		var repositoryPath = _service.CreateRepositoryDirectory(repositoryUrl);
+
+		Assert.Null(_service.FindIndexedRepository(repositoryUrl));
+		_service.RecordIndexedRepository(repositoryUrl, repositoryPath, "main", "1234567");
+
+		Assert.Equal(RepoCacheService.MaximumCacheIndexBytes + 1, new FileInfo(indexPath).Length);
+		Assert.Null(_service.FindIndexedRepository(repositoryUrl));
+	}
+
+	[Fact]
+	public void FutureCacheIndex_IsNotDowngradedByMetadataUpdates()
+	{
+		const string repositoryUrl = "https://github.com/example/future-index.git";
+		Directory.CreateDirectory(_testCacheRoot);
+		var indexPath = Path.Combine(_testCacheRoot, "cache-index.json");
+		File.WriteAllText(indexPath, """{"schemaVersion":3,"entries":[],"future":"preserve"}""");
+		var original = File.ReadAllBytes(indexPath);
+		var repositoryPath = _service.CreateRepositoryDirectory(repositoryUrl);
+
+		_service.RecordIndexedRepository(repositoryUrl, repositoryPath, "main", "1234567");
+
+		Assert.Equal(original, File.ReadAllBytes(indexPath));
+		Assert.Null(_service.FindIndexedRepository(repositoryUrl));
+	}
+
     [Fact]
     public void FindIndexedRepository_IgnoresEntriesWithMissingRequiredStrings()
     {

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -445,6 +445,33 @@ public class RepoCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public void LegacyLocalRepositoryIdentityIsNormalizedWhenIndexIsRead()
+    {
+        var sourcePath = Path.Combine(_testCacheRoot, "source", "legacy.git");
+        var repositoryUrl = new Uri(sourcePath).AbsoluteUri;
+        var cachePath = _service.CreateRepositoryDirectory(repositoryUrl);
+        var legacyIdentity = RepositoryUrlUtility.Normalize(repositoryUrl)[..^4];
+        WriteCacheIndex(
+            _testCacheRoot,
+            [
+                new RepositoryCacheIndexEntry(
+                    legacyIdentity,
+                    repositoryUrl,
+                    cachePath,
+                    "main",
+                    null,
+                    DateTimeOffset.UtcNow,
+                    RepositoryCacheEntryState.Ready,
+                    ContentKind: RepositoryCacheContentKind.Zip)
+            ]);
+
+        var entry = Assert.IsType<RepositoryCacheIndexEntry>(_service.FindIndexedRepository(repositoryUrl));
+
+        Assert.Equal(RepositoryUrlUtility.GetComparisonKey(repositoryUrl), entry.Identity);
+        Assert.Equal(cachePath, entry.LocalPath, PathComparer.Default);
+    }
+
+    [Fact]
     public async Task ListIndexedRepositories_LegacyCatalogEntryCanBeOpenedByPathOffline()
     {
         var currentBase = Path.Combine(_testCacheRoot, "open-current");

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -507,9 +507,6 @@ public class RepoCacheServiceTests : IDisposable
 
         var validEntry = Assert.IsType<RepositoryCacheIndexEntry>(_service.FindIndexedRepository(validUrl));
         Assert.Equal(validPath, validEntry.LocalPath, PathComparer.Default);
-        Assert.DoesNotContain(
-            _service.ListIndexedRepositories(),
-            entry => string.Equals(entry.RepositoryUrl, invalidUrl, StringComparison.Ordinal));
         Assert.True(Directory.Exists(validPath));
         Assert.True(File.Exists(Path.Combine(validPath, "payload.txt")));
     }

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -698,6 +698,25 @@ public class RepoCacheServiceTests : IDisposable
 		Assert.Null(_service.FindIndexedRepository(repositoryUrl));
 	}
 
+	[Fact]
+	public async Task FutureCacheIndexWithCurrentBackup_IsNotDowngradedBySessionMetadata()
+	{
+		const string repositoryUrl = "https://github.com/example/future-session-index.git";
+		var repositoryPath = _service.CreateRepositoryDirectory(repositoryUrl);
+		_service.RecordIndexedRepository(repositoryUrl, repositoryPath, "main", "1234567");
+		var indexPath = Path.Combine(_testCacheRoot, "cache-index.json");
+		Assert.True(File.Exists($"{indexPath}.bak"));
+		File.WriteAllText(indexPath, """{"schemaVersion":3,"entries":[],"future":"preserve"}""");
+		var original = File.ReadAllBytes(indexPath);
+
+		using var session = await _service.TryAcquireRepositorySessionAsync(
+			repositoryUrl,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Null(session);
+		Assert.Equal(original, File.ReadAllBytes(indexPath));
+	}
+
     [Fact]
     public void FindIndexedRepository_IgnoresEntriesWithMissingRequiredStrings()
     {

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -472,6 +472,49 @@ public class RepoCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public void CollectGarbage_OverlongFileUrlEntryDoesNotDiscardValidIndexEntries()
+    {
+        const string validUrl = "https://github.com/example/valid.git";
+        var validPath = _service.CreateRepositoryDirectory(validUrl);
+        var invalidPath = _service.CreateRepositoryDirectory("invalid");
+        File.WriteAllText(Path.Combine(validPath, "payload.txt"), "valid");
+        File.WriteAllText(Path.Combine(invalidPath, "payload.txt"), "invalid");
+        var invalidUrl = $"file:///C:/{new string('a', 40_000)}";
+        WriteCacheIndex(
+            _testCacheRoot,
+            [
+                new RepositoryCacheIndexEntry(
+                    "invalid",
+                    invalidUrl,
+                    invalidPath,
+                    null,
+                    null,
+                    DateTimeOffset.UtcNow,
+                    RepositoryCacheEntryState.Ready,
+                    ContentKind: RepositoryCacheContentKind.Zip),
+                new RepositoryCacheIndexEntry(
+                    RepositoryUrlUtility.GetComparisonKey(validUrl),
+                    validUrl,
+                    validPath,
+                    "main",
+                    null,
+                    DateTimeOffset.UtcNow,
+                    RepositoryCacheEntryState.Ready,
+                    ContentKind: RepositoryCacheContentKind.Zip)
+            ]);
+
+        _service.CollectGarbage();
+
+        var validEntry = Assert.IsType<RepositoryCacheIndexEntry>(_service.FindIndexedRepository(validUrl));
+        Assert.Equal(validPath, validEntry.LocalPath, PathComparer.Default);
+        Assert.DoesNotContain(
+            _service.ListIndexedRepositories(),
+            entry => string.Equals(entry.RepositoryUrl, invalidUrl, StringComparison.Ordinal));
+        Assert.True(Directory.Exists(validPath));
+        Assert.True(File.Exists(Path.Combine(validPath, "payload.txt")));
+    }
+
+    [Fact]
     public async Task ListIndexedRepositories_LegacyCatalogEntryCanBeOpenedByPathOffline()
     {
         var currentBase = Path.Combine(_testCacheRoot, "open-current");

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -369,6 +369,37 @@ public class RepoCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public void LocalRepositoryCacheIdentityUsesPlatformPathCaseSemantics()
+    {
+        var sourceRoot = Path.Combine(Path.GetTempPath(), "DevProjex", "SourceIdentity");
+        var upperUrl = new Uri(Path.Combine(sourceRoot, "Repo.git")).AbsoluteUri;
+        var lowerUrl = new Uri(Path.Combine(sourceRoot, "repo.git")).AbsoluteUri;
+        var upperCachePath = PublishZip(_service, upperUrl);
+        var lowerCachePath = PublishZip(_service, lowerUrl);
+        _service.RecordIndexedRepository(upperUrl, upperCachePath, "upper");
+        _service.RecordIndexedRepository(lowerUrl, lowerCachePath, "lower");
+
+        var entries = _service.ListIndexedRepositories();
+
+        if (OperatingSystem.IsWindows())
+        {
+            var entry = Assert.Single(entries);
+            Assert.Equal(lowerCachePath, entry.LocalPath, PathComparer.Default);
+            return;
+        }
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(
+            upperCachePath,
+            Assert.IsType<RepositoryCacheIndexEntry>(_service.FindIndexedRepository(upperUrl)).LocalPath,
+            PathComparer.Default);
+        Assert.Equal(
+            lowerCachePath,
+            Assert.IsType<RepositoryCacheIndexEntry>(_service.FindIndexedRepository(lowerUrl)).LocalPath,
+            PathComparer.Default);
+    }
+
+    [Fact]
     public async Task ListIndexedRepositories_LegacyCatalogEntryCanBeOpenedByPathOffline()
     {
         var currentBase = Path.Combine(_testCacheRoot, "open-current");

--- a/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
@@ -5,7 +5,7 @@ namespace DevProjex.Tests.Unit;
 public sealed class RepositoryCacheIsolationTests : IDisposable
 {
 	private const string RepositoryUrl = "https://github.com/example/isolation.git";
-	private static readonly TimeSpan BackgroundOperationTimeout = TimeSpan.FromSeconds(15);
+	private static readonly TimeSpan BackgroundOperationTimeout = TimeSpan.FromSeconds(30);
 	private readonly string _cacheRoot = Path.Combine(
 		Path.GetTempPath(),
 		"DevProjex",
@@ -188,6 +188,81 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 			TestContext.Current.CancellationToken);
 		Assert.True(service.FindIndexedRepository(RepositoryUrl)!.ApproximateSizeBytes > initialSize);
 		Assert.True(Directory.Exists(basePath));
+	}
+
+	[Fact]
+	public async Task RepositorySizeRefresh_RequestDuringCompletedEnumeration_CoalescesOneFreshPass()
+	{
+		using var firstSizeCalculated = new ManualResetEventSlim();
+		using var allowFirstRefreshCommit = new ManualResetEventSlim();
+		using var secondRefreshStarted = new ManualResetEventSlim();
+		using var allowSecondRefresh = new ManualResetEventSlim();
+		var refreshCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var refreshCount = 0;
+		var hooks = new RepoCacheTestHooks
+		{
+			BeforeRepositorySizeRefresh = _ =>
+			{
+				var pass = Interlocked.Increment(ref refreshCount);
+				if (pass != 2)
+					return;
+				secondRefreshStarted.Set();
+				Assert.True(allowSecondRefresh.Wait(BackgroundOperationTimeout));
+			},
+			AfterRepositorySizeCalculated = _ =>
+			{
+				if (Volatile.Read(ref refreshCount) != 1)
+					return;
+				firstSizeCalculated.Set();
+				Assert.True(allowFirstRefreshCommit.Wait(BackgroundOperationTimeout));
+			},
+			AfterRepositorySizeRefresh = _ => refreshCompleted.TrySetResult()
+		};
+		var service = CreateService(new FakeWorktreeManager(supported: true), hooks: hooks);
+		_ = Publish(service, RepositoryUrl, RepositoryCacheContentKind.Git, "main");
+		var sessions = new List<IRepositoryCacheSession>();
+		try
+		{
+			sessions.Add(Assert.IsAssignableFrom<IRepositoryCacheSession>(
+				await service.TryAcquireRepositorySessionAsync(
+					RepositoryUrl,
+					"main",
+					TestContext.Current.CancellationToken)));
+			sessions.Add(Assert.IsAssignableFrom<IRepositoryCacheSession>(
+				await service.TryAcquireRepositorySessionAsync(
+					RepositoryUrl,
+					"main",
+					TestContext.Current.CancellationToken)));
+			Assert.True(firstSizeCalculated.Wait(
+				BackgroundOperationTimeout,
+				TestContext.Current.CancellationToken));
+
+			sessions.Add(Assert.IsAssignableFrom<IRepositoryCacheSession>(
+				await service.TryAcquireRepositorySessionAsync(
+					RepositoryUrl,
+					"main",
+					TestContext.Current.CancellationToken)));
+			allowFirstRefreshCommit.Set();
+			Assert.True(secondRefreshStarted.Wait(
+				BackgroundOperationTimeout,
+				TestContext.Current.CancellationToken));
+			var staleSize = service.FindIndexedRepository(RepositoryUrl)!.ApproximateSizeBytes;
+
+			allowSecondRefresh.Set();
+			await refreshCompleted.Task.WaitAsync(
+				BackgroundOperationTimeout,
+				TestContext.Current.CancellationToken);
+
+			Assert.Equal(2, Volatile.Read(ref refreshCount));
+			Assert.True(service.FindIndexedRepository(RepositoryUrl)!.ApproximateSizeBytes > staleSize);
+		}
+		finally
+		{
+			allowFirstRefreshCommit.Set();
+			allowSecondRefresh.Set();
+			foreach (var session in sessions)
+				session.Dispose();
+		}
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics;
+
 namespace DevProjex.Tests.Unit;
 
 public sealed class RepositoryCacheIsolationTests : IDisposable
 {
 	private const string RepositoryUrl = "https://github.com/example/isolation.git";
+	private static readonly TimeSpan BackgroundOperationTimeout = TimeSpan.FromSeconds(15);
 	private readonly string _cacheRoot = Path.Combine(
 		Path.GetTempPath(),
 		"DevProjex",
@@ -131,7 +134,7 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 			TestContext.Current.CancellationToken);
 		Assert.NotNull(reopened);
 		await worktrees.RemovalStarted.Task.WaitAsync(
-			TimeSpan.FromSeconds(2),
+			BackgroundOperationTimeout,
 			TestContext.Current.CancellationToken);
 		Assert.Equal(0, worktrees.RemovedCount);
 
@@ -606,8 +609,8 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 
 	private static async Task WaitUntilAsync(Func<bool> condition)
 	{
-		var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-		while (!condition() && DateTime.UtcNow < timeout)
+		var stopwatch = Stopwatch.StartNew();
+		while (!condition() && stopwatch.Elapsed < BackgroundOperationTimeout)
 			await Task.Delay(20, TestContext.Current.CancellationToken);
 		Assert.True(condition(), "The asynchronous repository cleanup did not complete in time.");
 	}

--- a/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
@@ -275,7 +275,7 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 					RepositoryUrl,
 					cancellationToken: TestContext.Current.CancellationToken)));
 			Assert.True(collectionStarted.Wait(
-				TimeSpan.FromSeconds(2),
+				TimeSpan.FromSeconds(15),
 				TestContext.Current.CancellationToken));
 
 			for (var index = 0; index < 5; index++)

--- a/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
@@ -266,7 +266,7 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 	}
 
 	[Fact]
-	public async Task WorktreeCleanup_MultipleOpensWhileFirstCleanupIsBlocked_SchedulesOneTaskPerBasePath()
+	public async Task WorktreeCleanup_MultipleOpensWhileFirstCleanupIsBlocked_CoalescesOnePendingRepeat()
 	{
 		using var cleanupStarted = new ManualResetEventSlim();
 		using var allowCleanup = new ManualResetEventSlim();
@@ -293,7 +293,7 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 					"main",
 					TestContext.Current.CancellationToken)));
 			Assert.True(cleanupStarted.Wait(
-				TimeSpan.FromSeconds(2),
+				BackgroundOperationTimeout,
 				TestContext.Current.CancellationToken));
 
 			for (var index = 0; index < 3; index++)
@@ -307,8 +307,8 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 
 			Assert.Equal(1, Volatile.Read(ref cleanupCount));
 			allowCleanup.Set();
-			await Task.Delay(100, TestContext.Current.CancellationToken);
-			Assert.Equal(1, Volatile.Read(ref cleanupCount));
+			await WaitUntilAsync(() => Volatile.Read(ref cleanupCount) == 2);
+			Assert.Equal(2, Volatile.Read(ref cleanupCount));
 		}
 		finally
 		{

--- a/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
@@ -130,7 +130,7 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 			RepositoryUrl,
 			"main",
 			TestContext.Current.CancellationToken).WaitAsync(
-			TimeSpan.FromSeconds(2),
+			BackgroundOperationTimeout,
 			TestContext.Current.CancellationToken);
 		Assert.NotNull(reopened);
 		await worktrees.RemovalStarted.Task.WaitAsync(

--- a/Tests/DevProjex.Tests.Unit/RepositoryUrlUtilityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryUrlUtilityTests.cs
@@ -55,6 +55,32 @@ public sealed class RepositoryUrlUtilityTests
 		Assert.Equal(repositoryUrl.TrimEnd('/'), display);
 	}
 
+	[Fact]
+	public void LocalRepositoryIdentityUsesPlatformPathCaseSemantics()
+	{
+		var upperPath = Path.Combine(Path.GetTempPath(), "DevProjex", "CaseIdentity", "Repo.git");
+		var lowerPath = Path.Combine(Path.GetTempPath(), "DevProjex", "CaseIdentity", "repo.git");
+		var upperUri = new Uri(upperPath).AbsoluteUri;
+		var lowerUri = new Uri(lowerPath).AbsoluteUri;
+
+		Assert.Equal(
+			OperatingSystem.IsWindows(),
+			RepositoryUrlUtility.AreEquivalent(upperUri, lowerUri));
+		Assert.Equal(
+			OperatingSystem.IsWindows(),
+			RepositoryUrlUtility.AreEquivalent(upperPath, lowerPath));
+	}
+
+	[Fact]
+	public void LocalRepositoryIdentityStillIgnoresGitSuffix()
+	{
+		var repositoryPath = Path.Combine(Path.GetTempPath(), "DevProjex", "LocalIdentity", "repo");
+
+		Assert.True(RepositoryUrlUtility.AreEquivalent(
+			new Uri(repositoryPath).AbsoluteUri,
+			new Uri(repositoryPath + ".git").AbsoluteUri));
+	}
+
 	[Theory]
 	[InlineData("")]
 	[InlineData("-uploader")]

--- a/Tests/DevProjex.Tests.Unit/SecretOccurrenceIdentityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SecretOccurrenceIdentityTests.cs
@@ -8,6 +8,33 @@ public sealed class SecretOccurrenceIdentityTests
 	private const string Secret = "canonical-secret-value";
 
 	[Fact]
+	public void KeepAsIs_SurvivesEquivalentProjectRootAlias()
+	{
+		using var workspace = new TemporaryDirectory();
+		var path = workspace.CreateFile("config.txt", Secret);
+		using var session = new SecretRedactionSession(new ExactSecretDetector());
+		var initial = session.BeginOutput(workspace.Path, [path]).CreatePlan(
+			path,
+			Secret,
+			ContentTransformMap.Identity,
+			TestContext.Current.CancellationToken);
+		var initialSpan = Assert.Single(initial.Spans);
+		Assert.True(session.ToggleKeepAsIs(initialSpan.OccurrenceId));
+
+		var aliased = session.BeginOutput(
+			workspace.Path + Path.DirectorySeparatorChar,
+			[path]).CreatePlan(
+			path,
+			Secret,
+			ContentTransformMap.Identity,
+			TestContext.Current.CancellationToken);
+		var aliasedSpan = Assert.Single(aliased.Spans);
+
+		Assert.Equal(initialSpan.OccurrenceId, aliasedSpan.OccurrenceId);
+		Assert.Equal(SecretPreviewSpanState.KeptAsIs, aliasedSpan.State);
+	}
+
+	[Fact]
 	public void KeepAsIs_UsesCanonicalSourceCoordinateAcrossAllTransformationCombinations()
 	{
 		const string source = "body-prefix\ncomment-prefix\n\nTOKEN=" + Secret + "\n";

--- a/Tests/DevProjex.Tests.Unit/SecretRedactionCacheTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SecretRedactionCacheTests.cs
@@ -218,6 +218,31 @@ public sealed class SecretRedactionCacheTests
 	}
 
 	[Fact]
+	public void EquivalentProjectRootAliasesReuseDetectionCacheAndSnapshotIdentity()
+	{
+		using var workspace = new TemporaryDirectory();
+		var path = workspace.CreateFile("src/config.env", $"token={Secret}\n");
+		var content = File.ReadAllText(path);
+		var metadata = SecretFileMetadata.Capture(path);
+		var detector = new CountingDetector();
+		using var session = new SecretRedactionSession(detector);
+		var firstScope = session.BeginOutput(workspace.Path, [path]);
+		firstScope.Analyze(path, content, metadata, TestContext.Current.CancellationToken);
+		var first = firstScope.Complete();
+
+		var aliasScope = session.BeginOutput(
+			workspace.Path + Path.DirectorySeparatorChar,
+			[path]);
+		var reused = aliasScope.TryAnalyzeCached(path);
+		var alias = aliasScope.Complete();
+
+		Assert.True(reused);
+		Assert.Equal(first.SelectionKey, alias.SelectionKey);
+		Assert.Equal(1, detector.CallCount);
+		Assert.Equal(1, session.GetCacheDiagnostics().DetectionRuns);
+	}
+
+	[Fact]
 	public async Task DiscoveryCacheMode_ReusesValidatedContentWithoutWeakeningStrictRevalidation()
 	{
 		using var workspace = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/SecretRedactionTempDirectoryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SecretRedactionTempDirectoryTests.cs
@@ -50,6 +50,20 @@ public sealed class SecretRedactionTempDirectoryTests
 	}
 
 	[Fact]
+	public void Initialize_WhenLeaseCreationFails_RemovesThePartialDirectory()
+	{
+		using var root = new TemporaryDirectory();
+		var partialPath = root.CreateFolder("partial");
+		File.WriteAllText(
+			Path.Combine(partialPath, SecretRedactionTempDirectory.LeaseFileName),
+			"occupied");
+
+		Assert.Throws<IOException>(() => SecretRedactionTempDirectory.Initialize(partialPath));
+
+		Assert.False(Directory.Exists(partialPath));
+	}
+
+	[Fact]
 	public void Scavenger_RemovesOnlyStaleUnleasedOwnedDirectory()
 	{
 		using var root = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/SecretRedactionTempDirectoryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SecretRedactionTempDirectoryTests.cs
@@ -116,6 +116,23 @@ public sealed class SecretRedactionTempDirectoryTests
 	}
 
 	[Fact]
+	public void OwnerMarkerRead_RejectsContentThatGrewAfterLengthProbe()
+	{
+		using var root = new TemporaryDirectory();
+		using var owned = SecretRedactionTempDirectory.Create(root.Path);
+		var ownerBytes = File.ReadAllBytes(
+			Path.Combine(owned.Path, SecretRedactionTempDirectory.OwnerFileName));
+		using var stream = new StaleLengthMemoryStream(
+			[.. ownerBytes, (byte)'x'],
+			reportedLength: ownerBytes.Length);
+
+		var valid = SecretRedactionTempDirectory.HasExpectedOwnerMarker(stream);
+
+		Assert.False(valid);
+		Assert.Equal(ownerBytes.Length + 1, stream.Position);
+	}
+
+	[Fact]
 	public void Scavenger_IgnoresOwnedDirectoryWithMalformedIdentifier()
 	{
 		using var root = new TemporaryDirectory();
@@ -183,4 +200,10 @@ public sealed class SecretRedactionTempDirectoryTests
 		File.SetLastWriteTimeUtc(
 			Path.Combine(directory, SecretRedactionTempDirectory.OwnerFileName),
 			now - SecretRedactionTempDirectory.MinimumScavengeAge - TimeSpan.FromHours(1));
+
+	private sealed class StaleLengthMemoryStream(byte[] buffer, long reportedLength) :
+		MemoryStream(buffer, writable: false)
+	{
+		public override long Length => reportedLength;
+	}
 }

--- a/Tests/DevProjex.Tests.Unit/SelectionRefreshEngineTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SelectionRefreshEngineTests.cs
@@ -16,6 +16,45 @@ public sealed class SelectionRefreshEngineTests
 	}
 
 	[Fact]
+	public void ComputeFullRefreshSnapshot_AvailabilityIoFailureUsesMeasuredFallback()
+	{
+		var scanner = new DotFolderNoiseScanner();
+		var localization = new LocalizationService(CreateCatalog(), AppLanguage.En);
+		var engine = new SelectionRefreshEngine(
+			new ScanOptionsUseCase(LegacyWorkspaceScannerTestAdapter.Adapt(scanner)),
+			new FilterOptionSelectionService(),
+			new IgnoreOptionsService(localization),
+			BuildIgnoreRules,
+			static (_, _) => throw new IOException("transient availability failure"));
+
+		var snapshot = engine.ComputeFullRefreshSnapshot(
+			CreateDefaultsContext(),
+			CancellationToken.None);
+
+		Assert.Contains(
+			snapshot.IgnoreOptions,
+			static option => option.Id == IgnoreOptionId.DotFolders && option.IsChecked);
+	}
+
+	[Fact]
+	public void ComputeFullRefreshSnapshot_UnexpectedAvailabilityFailurePropagates()
+	{
+		var scanner = new DotFolderNoiseScanner();
+		var localization = new LocalizationService(CreateCatalog(), AppLanguage.En);
+		var engine = new SelectionRefreshEngine(
+			new ScanOptionsUseCase(LegacyWorkspaceScannerTestAdapter.Adapt(scanner)),
+			new FilterOptionSelectionService(),
+			new IgnoreOptionsService(localization),
+			BuildIgnoreRules,
+			static (_, _) => throw new InvalidOperationException("unexpected availability failure"));
+
+		var exception = Assert.Throws<InvalidOperationException>(() =>
+			engine.ComputeFullRefreshSnapshot(CreateDefaultsContext(), CancellationToken.None));
+
+		Assert.Equal("unexpected availability failure", exception.Message);
+	}
+
+	[Fact]
 	public void ComputeLiveRefreshSnapshot_NewFileOptionState_PerformsOneWorkspaceScan()
 	{
 		var scanner = CreateCountingWorkspaceScanner(out var scanCount);

--- a/Tests/DevProjex.Tests.Unit/ThemeSettingsStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ThemeSettingsStoreTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using DevProjex.Infrastructure.Persistence;
 using DevProjex.Infrastructure.ThemePresets;
 
 namespace DevProjex.Tests.Unit;
@@ -204,6 +205,23 @@ public sealed class ThemeSettingsStoreTests
         Assert.Equal("Dark.Acrylic", loaded.SelectedPreset);
         Assert.False(store.TrySave(loaded));
         Assert.Equal(originalJson, File.ReadAllText(store.GetPath()));
+    }
+
+    [Fact]
+    public void OversizedDocument_IsPreservedAndRejectsWrites()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new ThemeSettingsStore(() => temp.Path);
+        var path = store.GetPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write))
+            stream.SetLength(JsonStorePersistence.SmallDocumentMaximumBytes + 1);
+
+        var loaded = store.LoadForStartup(TimeSpan.FromSeconds(1));
+
+        Assert.Equal("Dark.Acrylic", loaded.SelectedPreset);
+        Assert.False(store.TrySave(loaded));
+        Assert.Equal(JsonStorePersistence.SmallDocumentMaximumBytes + 1, new FileInfo(path).Length);
     }
 
     [Theory]

--- a/Tests/DevProjex.Tests.Unit/TreeSitterAnalysisDiagnosticsTests.cs
+++ b/Tests/DevProjex.Tests.Unit/TreeSitterAnalysisDiagnosticsTests.cs
@@ -6,6 +6,8 @@ namespace DevProjex.Tests.Unit;
 
 public sealed class TreeSitterAnalysisDiagnosticsTests
 {
+	private static readonly TimeSpan CoordinationTimeout = TimeSpan.FromSeconds(30);
+
 	[Fact]
 	public void BlankLineCollection_RemainsInsideTheExistingEditShapingPhaseSchema()
 	{
@@ -378,7 +380,7 @@ public sealed class TreeSitterAnalysisDiagnosticsTests
 				TestContext.Current.CancellationToken),
 			TestContext.Current.CancellationToken);
 		await observer.Reached.WaitAsync(
-			TimeSpan.FromSeconds(5),
+			CoordinationTimeout,
 			TestContext.Current.CancellationToken);
 
 		diagnosticsA.Dispose();
@@ -386,7 +388,7 @@ public sealed class TreeSitterAnalysisDiagnosticsTests
 		using var diagnosticsB = compressor.BeginAnalysisDiagnostics();
 		observer.Release();
 		_ = await analysisTask.WaitAsync(
-			TimeSpan.FromSeconds(5),
+			CoordinationTimeout,
 			TestContext.Current.CancellationToken);
 		var frozenAfterCompletion = diagnosticsA.Capture();
 
@@ -441,7 +443,7 @@ public sealed class TreeSitterAnalysisDiagnosticsTests
 			if (phase != targetPhase)
 				return;
 			_reached.TrySetResult();
-			if (!_release.Wait(TimeSpan.FromSeconds(5)))
+			if (!_release.Wait(CoordinationTimeout))
 				throw new TimeoutException("The diagnostics freeze test did not release analysis.");
 		}
 

--- a/Tests/DevProjex.Tests.Unit/UserSettingsStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/UserSettingsStoreTests.cs
@@ -284,6 +284,26 @@ public sealed class UserSettingsStoreTests
     }
 
     [Fact]
+    public void FutureSchemaWithUtf16Bom_IsNeverOverwrittenByOlderApplication()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new UserSettingsStore(() => temp.Path);
+        var path = store.GetPath();
+        const string futureJson = """
+        { "schemaVersion": 999, "futureProperty": "keep-me" }
+        """;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, futureJson, new UnicodeEncoding(false, true, true));
+        var originalBytes = File.ReadAllBytes(path);
+
+        var loaded = store.LoadForStartup(TimeSpan.FromSeconds(1));
+        loaded.ViewSettings = loaded.ViewSettings with { IsCompactMode = true };
+
+        Assert.False(store.TrySave(loaded));
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+    }
+
+    [Fact]
     public void OversizedDocument_IsPreservedAndRejectsWrites()
     {
         using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/UserSettingsStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/UserSettingsStoreTests.cs
@@ -1,3 +1,4 @@
+using DevProjex.Infrastructure.Persistence;
 using DevProjex.Infrastructure.ThemePresets;
 
 namespace DevProjex.Tests.Unit;
@@ -280,6 +281,24 @@ public sealed class UserSettingsStoreTests
 
         Assert.False(store.TryPersistViewSettings(loaded));
         Assert.Equal(futureJson, File.ReadAllText(store.GetPath()));
+    }
+
+    [Fact]
+    public void OversizedDocument_IsPreservedAndRejectsWrites()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new UserSettingsStore(() => temp.Path);
+        var path = store.GetPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write))
+            stream.SetLength(JsonStorePersistence.SmallDocumentMaximumBytes + 1);
+
+        var loaded = store.LoadForStartup(TimeSpan.FromSeconds(1));
+        Assert.False(loaded.ViewSettings.IsCompactMode);
+        loaded.ViewSettings = loaded.ViewSettings with { IsCompactMode = true };
+
+        Assert.False(store.TrySave(loaded));
+        Assert.Equal(JsonStorePersistence.SmallDocumentMaximumBytes + 1, new FileInfo(path).Length);
     }
 
     [Theory]

--- a/Tests/DevProjex.Tests.Unit/ZipDownloadServiceInternalHelpersTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ZipDownloadServiceInternalHelpersTests.cs
@@ -6,8 +6,11 @@ public sealed class ZipDownloadServiceInternalHelpersTests
 	[InlineData("nul", true)]
 	[InlineData("CON.txt", true)]
 	[InlineData("com1.tar.gz", true)]
+	[InlineData("COM\u00B9.txt", true)]
+	[InlineData("lpt\u00B2", true)]
 	[InlineData("AUX", true)]
 	[InlineData("COM10", false)]
+	[InlineData("COM\u2074", false)]
 	[InlineData("console.log", false)]
 	[InlineData("nullable.cs", false)]
 	public void IsWindowsReservedDeviceName_ClassifiesBaseComponent(string component, bool expected)


### PR DESCRIPTION
## Summary
- stabilize the Git process-tree cancellation fixture under loaded CI runners
- continue with focused backend reliability and coverage improvements

## Validation
- Release build: 0 warnings
- GitRepositoryServiceCancellationTests: 10 consecutive runs, 20/20 passed

Tracks #191.