### PR TITLE
Package ready-to-run Linux and macOS release artifacts

### DIFF
--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -1,0 +1,39 @@
+# Installation
+
+Choose the artifact that matches your operating system and CPU architecture from the
+GitHub release page.
+
+## Windows
+
+- Download and run `DevProjex.v<version>.win-x64.exe` or
+  `DevProjex.v<version>.win-arm64.exe`.
+- Install with WinGet: `winget install Avazbek22.DevProjex`.
+- Install the packaged version from Microsoft Store when it is available in your
+  region.
+
+## Linux
+
+The archive preserves the executable permission. Replace `<version>` and
+`<architecture>` (`x64` or `arm64`) before running:
+
+```bash
+curl -L "https://github.com/Avazbek22/DevProjex/releases/download/v<version>/DevProjex.v<version>.linux-<architecture>.tar.gz" | tar xz
+./DevProjex
+```
+
+Move `DevProjex` to a directory on `PATH` if you want a system-wide command.
+
+## macOS
+
+DevProjex requires macOS 14 or newer. Replace `<version>` and `<architecture>` (`x64`
+or `arm64`) before running:
+
+```bash
+curl -L "https://github.com/Avazbek22/DevProjex/releases/download/v<version>/DevProjex.v<version>.osx-<architecture>.app.tar.gz" | tar xz
+mv DevProjex.app /Applications/
+```
+
+The current bundle is unsigned and not notarized. For a browser download, start it
+the first time with **right-click -> Open** and confirm the prompt. `curl` does not
+normally attach the macOS quarantine attribute that browsers add, but the same
+right-click flow remains the safest first-launch fallback.

--- a/Packaging/MacOS/Info.plist.template
+++ b/Packaging/MacOS/Info.plist.template
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>DevProjex</string>
+    <key>CFBundleDisplayName</key>
+    <string>DevProjex</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.devprojex.app</string>
+    <key>CFBundleVersion</key>
+    <string>YOUR_RELEASE_VERSION</string>
+    <key>CFBundleShortVersionString</key>
+    <string>YOUR_RELEASE_VERSION</string>
+    <key>CFBundleExecutable</key>
+    <string>DevProjex</string>
+    <key>CFBundleIconFile</key>
+    <string>app.icns</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/Packaging/MacOS/README.md
+++ b/Packaging/MacOS/README.md
@@ -7,65 +7,42 @@ This folder contains information for packaging DevProjex on macOS.
 Icon PNGs are located in `Assets/AppIcon/MacOS/AppIconSet/`:
 - 16.png, 32.png, 64.png, 128.png, 256.png, 512.png, 1024.png
 
-## Generating app.icns
+## Official Release Artifact
 
-The `.icns` file is required for macOS application bundles. It must be generated on macOS using `iconutil`.
+`Scripts/release-all.ps1` builds the official unsigned macOS artifacts:
 
-### Option 1: Using the provided script (macOS only)
-
-```bash
-./Scripts/generate-app-icns.sh
+```powershell
+./Scripts/release-all.ps1 -Version 5.1 -GitHubArtifactsOnly
 ```
 
-This will create `Assets/AppIcon/MacOS/app.icns`.
+The resulting files are named `DevProjex.v<version>.osx-<architecture>.app.tar.gz`.
+Each archive contains one Finder-ready `DevProjex.app` bundle:
 
-### Option 2: Manual generation (macOS only)
-
-```bash
-# Create iconset directory with proper naming
-mkdir -p Assets/AppIcon/MacOS/app.iconset
-
-cp Assets/AppIcon/MacOS/AppIconSet/16.png   Assets/AppIcon/MacOS/app.iconset/icon_16x16.png
-cp Assets/AppIcon/MacOS/AppIconSet/32.png   Assets/AppIcon/MacOS/app.iconset/icon_16x16@2x.png
-cp Assets/AppIcon/MacOS/AppIconSet/32.png   Assets/AppIcon/MacOS/app.iconset/icon_32x32.png
-cp Assets/AppIcon/MacOS/AppIconSet/64.png   Assets/AppIcon/MacOS/app.iconset/icon_32x32@2x.png
-cp Assets/AppIcon/MacOS/AppIconSet/128.png  Assets/AppIcon/MacOS/app.iconset/icon_128x128.png
-cp Assets/AppIcon/MacOS/AppIconSet/256.png  Assets/AppIcon/MacOS/app.iconset/icon_128x128@2x.png
-cp Assets/AppIcon/MacOS/AppIconSet/256.png  Assets/AppIcon/MacOS/app.iconset/icon_256x256.png
-cp Assets/AppIcon/MacOS/AppIconSet/512.png  Assets/AppIcon/MacOS/app.iconset/icon_256x256@2x.png
-cp Assets/AppIcon/MacOS/AppIconSet/512.png  Assets/AppIcon/MacOS/app.iconset/icon_512x512.png
-cp Assets/AppIcon/MacOS/AppIconSet/1024.png Assets/AppIcon/MacOS/app.iconset/icon_512x512@2x.png
-
-# Generate icns
-iconutil -c icns Assets/AppIcon/MacOS/app.iconset -o Assets/AppIcon/MacOS/app.icns
-
-# Cleanup
-rm -rf Assets/AppIcon/MacOS/app.iconset
+```text
+DevProjex.app/
+└── Contents/
+    ├── Info.plist
+    ├── MacOS/
+    │   └── DevProjex
+    └── Resources/
+        └── app.icns
 ```
 
-### Option 3: Cross-platform using png2icns (Node.js)
+The release script generates `app.icns` deterministically from the committed PNGs,
+fills `Packaging/MacOS/Info.plist.template` with the release version, preserves Unix
+permissions in a deterministic ustar archive, and verifies the result with both its
+own reader and `tar -tvf`. No macOS tools, Node.js packages, or network downloads are
+used during bundle assembly.
 
-```bash
-npm install -g png2icns
-png2icns Assets/AppIcon/MacOS/app.icns \
-    Assets/AppIcon/MacOS/AppIconSet/16.png \
-    Assets/AppIcon/MacOS/AppIconSet/32.png \
-    Assets/AppIcon/MacOS/AppIconSet/128.png \
-    Assets/AppIcon/MacOS/AppIconSet/256.png \
-    Assets/AppIcon/MacOS/AppIconSet/512.png \
-    Assets/AppIcon/MacOS/AppIconSet/1024.png
-```
+The raw RID publish directory must still contain exactly one file named `DevProjex`.
+It is an intermediate validation boundary and is not uploaded as the macOS release
+artifact. DevProjex targets .NET 10 and therefore requires macOS 14 or newer.
 
-## Raw Portable Publish and an Unprepared App Bundle
+## Reference Manual Bundle Recipe
 
-Release validation produces one raw self-contained `DevProjex` executable. It is
-the portable artifact used for CLI/TUI and advanced direct GUI launch, but it is
-not a prepared Finder distribution.
-
-The following maintainer example wraps that executable in an unprepared `.app`.
-The current release scripts do not build, sign, notarize, or execute this bundle,
-so do not present the example output as an official macOS distribution. DevProjex
-targets .NET 10 and therefore requires macOS 14 or newer.
+The following recipe documents the bundle layout for maintainers. Normal releases
+must use `release-all.ps1` so the icon, metadata, permissions, and validation remain
+reproducible.
 
 ```bash
 # Build for macOS
@@ -88,7 +65,8 @@ mkdir -p "DevProjex.app/Contents/Resources"
 # Copy executable
 cp ./publish/osx-x64/DevProjex "DevProjex.app/Contents/MacOS/DevProjex"
 
-# Copy icon
+# Generate or copy a valid app.icns into the bundle
+./Scripts/generate-app-icns.sh
 cp Assets/AppIcon/MacOS/app.icns "DevProjex.app/Contents/Resources/app.icns"
 
 # Create Info.plist (example - customize as needed)
@@ -122,10 +100,8 @@ cat > "DevProjex.app/Contents/Info.plist" << 'EOF'
 EOF
 ```
 
-The raw publish directory must contain exactly one file named `DevProjex`; that is
-the artifact checked by release validation. The subsequent `.app` also contains
-bundle metadata and an icon and is not the one-file portable artifact. Native
-libraries can be extracted by the .NET single-file host at startup; set
+This manual output is unsigned and not notarized. Native libraries can be extracted
+by the .NET single-file host at startup; set
 `DOTNET_BUNDLE_EXTRACT_BASE_DIR` to a private writable directory if the process
 has no usable home directory.
 

--- a/Scripts/release-all.ps1
+++ b/Scripts/release-all.ps1
@@ -7,7 +7,7 @@
     1) asks for a version in 2-4 segment format (4.6 / 4.7.1 / 4.7.1.0)
     2) copies repo to a temporary isolated workspace
     3) builds GitHub artifacts in Release mode
-    4) builds Microsoft Store package in ReleaseStore mode
+    4) optionally builds the Microsoft Store package in ReleaseStore mode
     5) copies final artifacts back to local publish folders only
 
   The script never writes build artifacts into your working source tree
@@ -23,12 +23,14 @@
 param(
     [string]$Version = "",
     [switch]$ValidateConfigOnly,
-    [switch]$SmokeStoreBuildOnly
+    [switch]$SmokeStoreBuildOnly,
+    [switch]$GitHubArtifactsOnly
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "release-helpers.ps1")
+. (Join-Path $PSScriptRoot "release-archive-helpers.ps1")
 
 $script:IsolatedWorkspaceRoot = $null
 $script:IsolatedRepoRoot = $null
@@ -496,6 +498,24 @@ function Invoke-StoreListingValidationScript([string]$repoRoot) {
     & $validationScriptPath -RepositoryRoot $repoRoot
 }
 
+function Assert-MacPackagingSourceContract([string]$repoRoot) {
+    $iconSetPath = Join-Path $repoRoot "Assets\AppIcon\MacOS\AppIconSet"
+    $pngSignature = [byte[]]@(137, 80, 78, 71, 13, 10, 26, 10)
+    foreach ($fileName in @("16.png", "32.png", "64.png", "128.png", "256.png", "512.png", "1024.png")) {
+        $iconPath = Join-Path $iconSetPath $fileName
+        Assert-Condition (Test-Path -LiteralPath $iconPath -PathType Leaf) "Required macOS icon source was not found: $iconPath"
+        $iconBytes = [System.IO.File]::ReadAllBytes($iconPath)
+        Assert-Condition ($iconBytes.Length -gt $pngSignature.Length) "Required macOS icon source is empty or truncated: $iconPath"
+        for ($index = 0; $index -lt $pngSignature.Length; $index++) {
+            Assert-Condition ($iconBytes[$index] -eq $pngSignature[$index]) "Required macOS icon source is not a PNG file: $iconPath"
+        }
+    }
+
+    $templatePath = Join-Path $repoRoot "Packaging\MacOS\Info.plist.template"
+    Assert-Condition (Test-Path -LiteralPath $templatePath -PathType Leaf) "macOS Info.plist template was not found: $templatePath"
+    [void](Get-MacInfoPlistContent -templatePath $templatePath -version "0.0.1")
+}
+
 function Invoke-ReleaseConfigValidation([string]$repoRoot) {
     $versionInfo = Get-DefaultReleaseVersionInfo -repoRoot $repoRoot
 
@@ -534,6 +554,7 @@ function Invoke-ReleaseConfigValidation([string]$repoRoot) {
     $releaseAllPath = Join-Path $repoRoot "Scripts\release-all.ps1"
     $releaseAllContent = Get-Content -Path $releaseAllPath -Raw
     Assert-Condition ($releaseAllContent.Contains('release-helpers.ps1')) "release-all.ps1 must use release-helpers.ps1 for shared release metadata."
+    Assert-Condition ($releaseAllContent.Contains('release-archive-helpers.ps1')) "release-all.ps1 must use release-archive-helpers.ps1 for portable archives."
 
     $wingetScriptPath = Join-Path $repoRoot "Scripts\winget-update.ps1"
     $wingetScriptContent = Get-Content -Path $wingetScriptPath -Raw
@@ -543,7 +564,8 @@ function Invoke-ReleaseConfigValidation([string]$repoRoot) {
 
     $macReadmePath = Join-Path $repoRoot "Packaging\MacOS\README.md"
     $macReadmeContent = Get-Content -Path $macReadmePath -Raw
-    Assert-Condition ($macReadmeContent.Contains('YOUR_RELEASE_VERSION')) "Packaging/MacOS/README.md must use a release-version placeholder instead of a stale hardcoded example."
+    Assert-Condition ($macReadmeContent.Contains('release-all.ps1')) "Packaging/MacOS/README.md must identify release-all.ps1 as the official bundle builder."
+    Assert-MacPackagingSourceContract -repoRoot $repoRoot
 
     Write-Host "Release configuration is consistent."
     Write-Host "  DisplayVersion      : $($versionInfo.DisplayVersion)"
@@ -689,13 +711,72 @@ function Configure-IsolatedNuGetCache() {
     New-Item -ItemType Directory -Path $isolatedPlugins -Force | Out-Null
 
     # Always use isolated per-run caches to keep local developer environment untouched.
-    $env:NUGET_PACKAGES = $isolatedPackages
+    # NuGetPackageRoot is consumed as an MSBuild directory prefix by Infrastructure.csproj.
+    # Preserve the trailing separator that NuGet's default global-packages path provides.
+    $env:NUGET_PACKAGES = $isolatedPackages + [System.IO.Path]::DirectorySeparatorChar
     $env:NUGET_HTTP_CACHE_PATH = $isolatedHttp
     $env:NUGET_PLUGINS_CACHE_PATH = $isolatedPlugins
 }
 
+function Get-IsolatedWorkspaceSourceSize([string]$sourceRoot) {
+    $rootDirectory = [System.IO.DirectoryInfo]::new([System.IO.Path]::GetFullPath($sourceRoot))
+    $rootExclusions = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in @(".git", ".idea", ".vs", ".codex", ".claude", "artifacts", ".artifacts", "publish", ".release-cache", "TestResults")) {
+        [void]$rootExclusions.Add($name)
+    }
+
+    $directoryExclusions = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in @("bin", "obj", "artifacts", ".artifacts", "publish", ".release-cache", "TestResults")) {
+        [void]$directoryExclusions.Add($name)
+    }
+
+    $pendingDirectories = New-Object 'System.Collections.Generic.Stack[System.IO.DirectoryInfo]'
+    $pendingDirectories.Push($rootDirectory)
+    [long]$totalBytes = 0
+
+    while ($pendingDirectories.Count -gt 0) {
+        $currentDirectory = $pendingDirectories.Pop()
+        foreach ($entry in $currentDirectory.EnumerateFileSystemInfos()) {
+            if ($entry -is [System.IO.DirectoryInfo]) {
+                $isRootChild = [System.StringComparer]::OrdinalIgnoreCase.Equals($currentDirectory.FullName, $rootDirectory.FullName)
+                if (($isRootChild -and $rootExclusions.Contains($entry.Name)) -or
+                    $directoryExclusions.Contains($entry.Name) -or
+                    $entry.Name.StartsWith(".verify-", [System.StringComparison]::OrdinalIgnoreCase) -or
+                    (($entry.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+                    continue
+                }
+
+                $pendingDirectories.Push($entry)
+                continue
+            }
+
+            if ($entry -is [System.IO.FileInfo]) {
+                $totalBytes += $entry.Length
+            }
+        }
+    }
+
+    return $totalBytes
+}
+
+function Assert-IsolatedWorkspaceCapacity([string]$sourceRoot) {
+    [long]$sourceBytes = Get-IsolatedWorkspaceSourceSize -sourceRoot $sourceRoot
+    [long]$buildReserveBytes = 20GB
+    [long]$requiredFreeBytes = ($sourceBytes * 2) + $buildReserveBytes
+    $tempRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($env:TEMP))
+    $drive = New-Object System.IO.DriveInfo($tempRoot)
+
+    Write-Host ("Eligible source size: {0:N2} GiB" -f ($sourceBytes / 1GB))
+    Write-Host ("Temporary drive free: {0:N2} GiB" -f ($drive.AvailableFreeSpace / 1GB))
+    if ($drive.AvailableFreeSpace -lt $requiredFreeBytes) {
+        throw ("Insufficient temporary-drive capacity. At least {0:N2} GiB is required for the isolated source copy and build reserve; {1:N2} GiB is available." -f ($requiredFreeBytes / 1GB), ($drive.AvailableFreeSpace / 1GB))
+    }
+}
+
 function Create-IsolatedWorkspace([string]$sourceRoot) {
     Write-Step "Preparing isolated workspace"
+
+    Assert-IsolatedWorkspaceCapacity -sourceRoot $sourceRoot
 
     $script:IsolatedWorkspaceRoot = Join-Path $env:TEMP ("devprojex-release-work\" + [Guid]::NewGuid().ToString("N"))
     $script:IsolatedRepoRoot = Join-Path $script:IsolatedWorkspaceRoot "repo"
@@ -718,8 +799,19 @@ function Create-IsolatedWorkspace([string]$sourceRoot) {
         (Join-Path $sourceRoot ".vs"),
         (Join-Path $sourceRoot ".codex"),
         (Join-Path $sourceRoot ".claude"),
+        (Join-Path $sourceRoot "artifacts"),
+        (Join-Path $sourceRoot ".artifacts"),
         (Join-Path $sourceRoot "publish"),
-        (Join-Path $sourceRoot ".release-cache")
+        (Join-Path $sourceRoot ".release-cache"),
+        (Join-Path $sourceRoot "TestResults"),
+        "bin",
+        "obj",
+        "artifacts",
+        ".artifacts",
+        "publish",
+        ".release-cache",
+        "TestResults",
+        ".verify-*"
     )
 
     & robocopy @robocopyArgs | Out-Null
@@ -744,6 +836,116 @@ function Create-IsolatedWorkspace([string]$sourceRoot) {
     }
 }
 
+function New-ReleaseArchiveEntry(
+    [string]$name,
+    [int]$mode,
+    [bool]$isDirectory,
+    [string]$sourcePath = "",
+    [byte[]]$bytes = $null
+) {
+    return [pscustomobject]@{
+        Name = $name
+        Mode = $mode
+        IsDirectory = $isDirectory
+        SourcePath = $sourcePath
+        Bytes = $bytes
+    }
+}
+
+function Invoke-ExternalTarValidation([string]$archivePath) {
+    $tarCommand = Get-Command tar -ErrorAction SilentlyContinue
+    if ($null -eq $tarCommand) {
+        throw "tar is required for independent archive validation but was not found in PATH."
+    }
+
+    $tarPath = if (-not [string]::IsNullOrWhiteSpace([string]$tarCommand.Source)) {
+        [string]$tarCommand.Source
+    }
+    else {
+        [string]$tarCommand.Name
+    }
+    Invoke-ExternalCommand `
+        -filePath $tarPath `
+        -arguments @("-tvf", $archivePath) `
+        -failureMessage "External tar validation failed for '$archivePath'"
+}
+
+function Assert-ReleaseArchive(
+    [string]$archivePath,
+    [object[]]$expectedEntries,
+    [string]$version = ""
+) {
+    $plistEntryName = "DevProjex.app/Contents/Info.plist"
+    $captureNames = if ([string]::IsNullOrWhiteSpace($version)) { @() } else { @($plistEntryName) }
+    $actualEntries = @(Read-UstarGzipArchive -archivePath $archivePath -captureEntryNames $captureNames)
+    Assert-Condition ($actualEntries.Count -eq $expectedEntries.Count) "Archive '$archivePath' contains $($actualEntries.Count) entries; expected $($expectedEntries.Count)."
+
+    for ($index = 0; $index -lt $expectedEntries.Count; $index++) {
+        $expected = $expectedEntries[$index]
+        $actual = $actualEntries[$index]
+        Assert-Condition ([System.StringComparer]::Ordinal.Equals([string]$actual.Name, [string]$expected.Name)) "Archive '$archivePath' entry $index must be '$($expected.Name)'. Found: '$($actual.Name)'."
+        Assert-Condition ([int]$actual.Mode -eq [int]$expected.Mode) "Archive '$archivePath' entry '$($actual.Name)' has mode $([System.Convert]::ToString([int]$actual.Mode, 8)); expected $([System.Convert]::ToString([int]$expected.Mode, 8))."
+        Assert-Condition ([bool]$actual.IsDirectory -eq [bool]$expected.IsDirectory) "Archive '$archivePath' entry '$($actual.Name)' has an unexpected type."
+        if (-not [bool]$actual.IsDirectory) {
+            Assert-Condition ([long]$actual.Size -gt 0) "Archive '$archivePath' entry '$($actual.Name)' is empty."
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($version)) {
+        $plistEntry = $actualEntries | Where-Object { $_.Name -eq $plistEntryName } | Select-Object -First 1
+        Assert-Condition ($null -ne $plistEntry -and $null -ne $plistEntry.Bytes) "Archive '$archivePath' does not expose Info.plist for validation."
+        $plistContent = [System.Text.Encoding]::UTF8.GetString($plistEntry.Bytes)
+        Assert-Condition (-not $plistContent.Contains('YOUR_RELEASE_VERSION')) "Archive '$archivePath' contains an unresolved Info.plist version placeholder."
+        [xml]$plistDocument = $plistContent
+        Assert-Condition ((Get-PlistStringValue -document $plistDocument -key 'CFBundleVersion') -eq $version) "Archive '$archivePath' contains the wrong CFBundleVersion."
+        Assert-Condition ((Get-PlistStringValue -document $plistDocument -key 'CFBundleShortVersionString') -eq $version) "Archive '$archivePath' contains the wrong CFBundleShortVersionString."
+    }
+
+    Invoke-ExternalTarValidation -archivePath $archivePath
+}
+
+function New-LinuxReleaseArchive(
+    [string]$binaryPath,
+    [string]$archivePath
+) {
+    $entries = @(
+        (New-ReleaseArchiveEntry -name "DevProjex" -mode 493 -isDirectory $false -sourcePath $binaryPath)
+    )
+    New-UstarGzipArchive -archivePath $archivePath -entries $entries
+    Assert-ReleaseArchive -archivePath $archivePath -expectedEntries $entries
+}
+
+function New-MacReleaseArchive(
+    [string]$repoRoot,
+    [string]$binaryPath,
+    [string]$archivePath,
+    [string]$version,
+    [string]$workDirectory
+) {
+    $iconPath = Join-Path $workDirectory "app.icns"
+    New-DeterministicIcns `
+        -iconSetPath (Join-Path $repoRoot "Assets\AppIcon\MacOS\AppIconSet") `
+        -outputPath $iconPath
+
+    $plistContent = Get-MacInfoPlistContent `
+        -templatePath (Join-Path $repoRoot "Packaging\MacOS\Info.plist.template") `
+        -version $version
+    $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+    $plistBytes = $utf8WithoutBom.GetBytes($plistContent)
+
+    $entries = @(
+        (New-ReleaseArchiveEntry -name "DevProjex.app/" -mode 493 -isDirectory $true),
+        (New-ReleaseArchiveEntry -name "DevProjex.app/Contents/" -mode 493 -isDirectory $true),
+        (New-ReleaseArchiveEntry -name "DevProjex.app/Contents/Info.plist" -mode 420 -isDirectory $false -bytes $plistBytes),
+        (New-ReleaseArchiveEntry -name "DevProjex.app/Contents/MacOS/" -mode 493 -isDirectory $true),
+        (New-ReleaseArchiveEntry -name "DevProjex.app/Contents/MacOS/DevProjex" -mode 493 -isDirectory $false -sourcePath $binaryPath),
+        (New-ReleaseArchiveEntry -name "DevProjex.app/Contents/Resources/" -mode 493 -isDirectory $true),
+        (New-ReleaseArchiveEntry -name "DevProjex.app/Contents/Resources/app.icns" -mode 420 -isDirectory $false -sourcePath $iconPath)
+    )
+    New-UstarGzipArchive -archivePath $archivePath -entries $entries
+    Assert-ReleaseArchive -archivePath $archivePath -expectedEntries $entries -version $version
+}
+
 function Build-GitHubArtifactsInWorkspace(
     [string]$version,
     [string]$configuration,
@@ -760,12 +962,12 @@ function Build-GitHubArtifactsInWorkspace(
     $workDir = Join-Path $releaseDir "_work"
 
     $targets = @(
-        @{ Rid = "win-x64"; Binary = "DevProjex.exe"; Name = "DevProjex.v$version.win-x64.exe" },
-        @{ Rid = "win-arm64"; Binary = "DevProjex.exe"; Name = "DevProjex.v$version.win-arm64.exe" },
-        @{ Rid = "linux-x64"; Binary = "DevProjex"; Name = "DevProjex.v$version.linux-x64.portable" },
-        @{ Rid = "linux-arm64"; Binary = "DevProjex"; Name = "DevProjex.v$version.linux-arm64.portable" },
-        @{ Rid = "osx-x64"; Binary = "DevProjex"; Name = "DevProjex.v$version.osx-x64" },
-        @{ Rid = "osx-arm64"; Binary = "DevProjex"; Name = "DevProjex.v$version.osx-arm64" }
+        @{ Rid = "win-x64"; Binary = "DevProjex.exe"; Kind = "Windows"; Name = "DevProjex.v$version.win-x64.exe" },
+        @{ Rid = "win-arm64"; Binary = "DevProjex.exe"; Kind = "Windows"; Name = "DevProjex.v$version.win-arm64.exe" },
+        @{ Rid = "linux-x64"; Binary = "DevProjex"; Kind = "Linux"; Name = "DevProjex.v$version.linux-x64.tar.gz" },
+        @{ Rid = "linux-arm64"; Binary = "DevProjex"; Kind = "Linux"; Name = "DevProjex.v$version.linux-arm64.tar.gz" },
+        @{ Rid = "osx-x64"; Binary = "DevProjex"; Kind = "MacOS"; Name = "DevProjex.v$version.osx-x64.app.tar.gz" },
+        @{ Rid = "osx-arm64"; Binary = "DevProjex"; Kind = "MacOS"; Name = "DevProjex.v$version.osx-arm64.app.tar.gz" }
     )
 
     if (Test-Path $releaseDir) {
@@ -822,10 +1024,27 @@ function Build-GitHubArtifactsInWorkspace(
         }
 
         $destinationPath = Join-Path $releaseDir ([string]$target.Name)
-        Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
-
-        if ($rid.StartsWith("win-", [System.StringComparison]::OrdinalIgnoreCase)) {
-            Assert-WindowsArtifactVersion -artifactPath $destinationPath -displayVersion $version -storePackageVersion $storePackageVersion
+        switch ([string]$target.Kind) {
+            "Windows" {
+                Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
+                Assert-WindowsArtifactVersion -artifactPath $destinationPath -displayVersion $version -storePackageVersion $storePackageVersion
+            }
+            "Linux" {
+                New-LinuxReleaseArchive -binaryPath $sourcePath -archivePath $destinationPath
+            }
+            "MacOS" {
+                $packageWorkDirectory = Join-Path $workDir "$rid-package"
+                New-Item -ItemType Directory -Path $packageWorkDirectory -Force | Out-Null
+                New-MacReleaseArchive `
+                    -repoRoot $script:IsolatedRepoRoot `
+                    -binaryPath $sourcePath `
+                    -archivePath $destinationPath `
+                    -version $version `
+                    -workDirectory $packageWorkDirectory
+            }
+            default {
+                throw "Unsupported GitHub artifact kind '$($target.Kind)' for $rid."
+            }
         }
     }
 
@@ -835,7 +1054,7 @@ function Build-GitHubArtifactsInWorkspace(
         Where-Object { $_.Name -ne "SHA256SUMS.txt" } |
         Sort-Object Name |
         ForEach-Object {
-            $hash = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToLowerInvariant()
+            $hash = Get-FileSha256Hex -path $_.FullName
             $hashLines += "$hash *$($_.Name)"
         }
 
@@ -1327,7 +1546,11 @@ function Invoke-WackValidationInWorkspace() {
     }
 }
 
-function Publish-ArtifactsToSource([string]$sourceRoot, [string]$version) {
+function Publish-ArtifactsToSource(
+    [string]$sourceRoot,
+    [string]$version,
+    [switch]$GitHubOnly
+) {
     Write-Step "Publishing artifacts to source publish folder"
 
     $isolatedGitHubDir = Join-Path $script:IsolatedRepoRoot "publish\github\v$version"
@@ -1341,6 +1564,13 @@ function Publish-ArtifactsToSource([string]$sourceRoot, [string]$version) {
     }
     New-Item -ItemType Directory -Path $sourceGitHubDir -Force | Out-Null
     Copy-Item -Path (Join-Path $isolatedGitHubDir "*") -Destination $sourceGitHubDir -Recurse -Force
+
+    if ($GitHubOnly) {
+        return @{
+            GitHub = $sourceGitHubDir
+            Store = $null
+        }
+    }
 
     $storeArtifacts = Get-StoreArtifactPaths
     if ($null -eq $storeArtifacts -or $storeArtifacts.Count -eq 0) {
@@ -1475,8 +1705,9 @@ function Cleanup-IsolatedWorkspace() {
 Ensure-DotnetAvailable
 $repoRoot = Get-DevProjexRepoRoot -startPath $PSScriptRoot
 
-if ($ValidateConfigOnly -and $SmokeStoreBuildOnly) {
-    throw "Use either -ValidateConfigOnly or -SmokeStoreBuildOnly, not both."
+if (($ValidateConfigOnly -and $SmokeStoreBuildOnly) -or
+    ($GitHubArtifactsOnly -and ($ValidateConfigOnly -or $SmokeStoreBuildOnly))) {
+    throw "Use only one of -ValidateConfigOnly, -SmokeStoreBuildOnly, or -GitHubArtifactsOnly."
 }
 
 if ($ValidateConfigOnly) {
@@ -1502,8 +1733,13 @@ Write-Host "Version: $resolvedVersion"
 Write-Host "Store package version: $storePackageVersion"
 Write-Host "Build mode  : isolated workspace (local source tree untouched)"
 Write-Host "GitHub build: Release (single-file, self-contained)"
-Write-Host "Store build : ReleaseStore (.msixupload, x64|arm64)"
-Write-Host "Store check : WACK (must pass before artifacts are published)"
+if ($GitHubArtifactsOnly) {
+    Write-Host "Store build : skipped (-GitHubArtifactsOnly)"
+}
+else {
+    Write-Host "Store build : ReleaseStore (.msixupload, x64|arm64)"
+    Write-Host "Store check : WACK (must pass before artifacts are published)"
+}
 Write-Host "Store listing CSV: not modified"
 Write-Step "Validating release config"
 Invoke-ReleaseConfigValidation -repoRoot $repoRoot
@@ -1515,16 +1751,23 @@ try {
     Write-Step "Building GitHub artifacts in isolated workspace"
     Build-GitHubArtifactsInWorkspace -version $resolvedVersion -configuration "Release" -storePackageVersion $storePackageVersion
 
-    Write-Step "Building Microsoft Store package in isolated workspace"
-    Build-StoreArtifactsInWorkspace -displayVersion $resolvedVersion -configuration "ReleaseStore" -platform "x64" -bundlePlatforms "x64|arm64" -packageVersion $storePackageVersion
+    if (-not $GitHubArtifactsOnly) {
+        Write-Step "Building Microsoft Store package in isolated workspace"
+        Build-StoreArtifactsInWorkspace -displayVersion $resolvedVersion -configuration "ReleaseStore" -platform "x64" -bundlePlatforms "x64|arm64" -packageVersion $storePackageVersion
 
-    Invoke-WackValidationInWorkspace
+        Invoke-WackValidationInWorkspace
+    }
 
-    $finalPaths = Publish-ArtifactsToSource -sourceRoot $sourceRoot -version $resolvedVersion
+    $finalPaths = Publish-ArtifactsToSource `
+        -sourceRoot $sourceRoot `
+        -version $resolvedVersion `
+        -GitHubOnly:$GitHubArtifactsOnly
 
     Write-Step "Done"
     Write-Host "GitHub artifacts: $($finalPaths.GitHub)"
-    Write-Host "MS Store artifacts: $($finalPaths.Store)"
+    if (-not $GitHubArtifactsOnly) {
+        Write-Host "MS Store artifacts: $($finalPaths.Store)"
+    }
 }
 finally {
     Restore-NuGetEnvironment

--- a/Scripts/release-archive-helpers.ps1
+++ b/Scripts/release-archive-helpers.ps1
@@ -312,16 +312,60 @@ function Write-BigEndianUInt32([System.IO.Stream]$stream, [uint32]$value) {
     $stream.Write($bytes, 0, $bytes.Length)
 }
 
+function Read-BigEndianUInt32(
+    [byte[]]$bytes,
+    [int]$offset
+) {
+    if ($null -eq $bytes -or $offset -lt 0 -or $bytes.Length -lt ($offset + 4)) {
+        throw "Cannot read a big-endian UInt32 at offset $offset."
+    }
+
+    return [uint32](
+        ([uint32]$bytes[$offset] * 16777216) +
+        ([uint32]$bytes[$offset + 1] * 65536) +
+        ([uint32]$bytes[$offset + 2] * 256) +
+        [uint32]$bytes[$offset + 3])
+}
+
+function Assert-PngDimensions(
+    [byte[]]$payload,
+    [string]$sourcePath,
+    [string]$slotType,
+    [int]$expectedSize
+) {
+    $pngSignature = [byte[]]@(137, 80, 78, 71, 13, 10, 26, 10)
+    if ($null -eq $payload -or $payload.Length -lt 24) {
+        throw "macOS icon source for $slotType is not a complete PNG: $sourcePath"
+    }
+    for ($index = 0; $index -lt $pngSignature.Length; $index++) {
+        if ($payload[$index] -ne $pngSignature[$index]) {
+            throw "macOS icon source for $slotType is not a PNG: $sourcePath"
+        }
+    }
+
+    $ihdrLength = Read-BigEndianUInt32 -bytes $payload -offset 8
+    $ihdrType = [System.Text.Encoding]::ASCII.GetString($payload, 12, 4)
+    if ($ihdrLength -ne 13 -or $ihdrType -ne 'IHDR') {
+        throw "macOS icon source for $slotType has an invalid PNG IHDR: $sourcePath"
+    }
+
+    $width = Read-BigEndianUInt32 -bytes $payload -offset 16
+    $height = Read-BigEndianUInt32 -bytes $payload -offset 20
+    if ($width -ne $expectedSize -or $height -ne $expectedSize) {
+        throw "macOS icon source for $slotType must be ${expectedSize}x${expectedSize}px; found ${width}x${height}px: $sourcePath"
+    }
+}
+
 function New-DeterministicIcns([string]$iconSetPath, [string]$outputPath) {
     $slots = @(
-        [pscustomobject]@{ Type = 'ic07'; File = '128.png' },
-        [pscustomobject]@{ Type = 'ic08'; File = '256.png' },
-        [pscustomobject]@{ Type = 'ic09'; File = '512.png' },
-        [pscustomobject]@{ Type = 'ic10'; File = '1024.png' },
-        [pscustomobject]@{ Type = 'ic11'; File = '32.png' },
-        [pscustomobject]@{ Type = 'ic12'; File = '64.png' },
-        [pscustomobject]@{ Type = 'ic13'; File = '512.png' },
-        [pscustomobject]@{ Type = 'ic14'; File = '1024.png' }
+        [pscustomobject]@{ Type = 'ic07'; File = '128.png'; Size = 128 },
+        [pscustomobject]@{ Type = 'ic08'; File = '256.png'; Size = 256 },
+        [pscustomobject]@{ Type = 'ic09'; File = '512.png'; Size = 512 },
+        [pscustomobject]@{ Type = 'ic10'; File = '1024.png'; Size = 1024 },
+        [pscustomobject]@{ Type = 'ic11'; File = '32.png'; Size = 32 },
+        [pscustomobject]@{ Type = 'ic12'; File = '64.png'; Size = 64 },
+        [pscustomobject]@{ Type = 'ic13'; File = '256.png'; Size = 256 },
+        [pscustomobject]@{ Type = 'ic14'; File = '512.png'; Size = 512 }
     )
 
     $slotPayloads = New-Object 'System.Collections.Generic.List[object]'
@@ -335,6 +379,11 @@ function New-DeterministicIcns([string]$iconSetPath, [string]$outputPath) {
         if ($payload.Length -eq 0) {
             throw "Required macOS icon source is empty: $sourcePath"
         }
+        Assert-PngDimensions `
+            -payload $payload `
+            -sourcePath $sourcePath `
+            -slotType ([string]$slot.Type) `
+            -expectedSize ([int]$slot.Size)
         $slotPayloads.Add([pscustomobject]@{ Type = $slot.Type; Bytes = $payload })
         $totalLength += 8 + $payload.Length
     }

--- a/Scripts/release-archive-helpers.ps1
+++ b/Scripts/release-archive-helpers.ps1
@@ -1,0 +1,418 @@
+Set-StrictMode -Version Latest
+
+$script:UstarBlockSize = 512
+$script:UstarFixedModificationTime = 0
+
+function Get-FileSha256Hex([string]$path) {
+    $stream = [System.IO.File]::OpenRead($path)
+    try {
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hash = $sha256.ComputeHash($stream)
+        }
+        finally {
+            $sha256.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+
+    return ([System.BitConverter]::ToString($hash) -replace '-', '').ToLowerInvariant()
+}
+
+function Set-UstarAsciiField(
+    [byte[]]$header,
+    [int]$offset,
+    [int]$length,
+    [string]$value
+) {
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($value)
+    if ($bytes.Length -gt $length) {
+        throw "USTAR field value is too long: '$value'."
+    }
+
+    [System.Array]::Copy($bytes, 0, $header, $offset, $bytes.Length)
+}
+
+function ConvertTo-UstarOctal([long]$value, [int]$length) {
+    if ($value -lt 0) {
+        throw "USTAR numeric values cannot be negative: $value."
+    }
+
+    $digits = [System.Convert]::ToString($value, 8)
+    if ($digits.Length -gt ($length - 1)) {
+        throw "USTAR numeric value '$value' does not fit in a $length-byte field."
+    }
+
+    return $digits.PadLeft($length - 1, '0') + [char]0
+}
+
+function New-UstarHeader(
+    [string]$name,
+    [int]$mode,
+    [long]$size,
+    [char]$typeFlag
+) {
+    $header = New-Object byte[] $script:UstarBlockSize
+    Set-UstarAsciiField -header $header -offset 0 -length 100 -value $name
+    Set-UstarAsciiField -header $header -offset 100 -length 8 -value (ConvertTo-UstarOctal -value $mode -length 8)
+    Set-UstarAsciiField -header $header -offset 108 -length 8 -value (ConvertTo-UstarOctal -value 0 -length 8)
+    Set-UstarAsciiField -header $header -offset 116 -length 8 -value (ConvertTo-UstarOctal -value 0 -length 8)
+    Set-UstarAsciiField -header $header -offset 124 -length 12 -value (ConvertTo-UstarOctal -value $size -length 12)
+    Set-UstarAsciiField -header $header -offset 136 -length 12 -value (ConvertTo-UstarOctal -value $script:UstarFixedModificationTime -length 12)
+    for ($index = 148; $index -lt 156; $index++) {
+        $header[$index] = 32
+    }
+    Set-UstarAsciiField -header $header -offset 156 -length 1 -value ([string]$typeFlag)
+    Set-UstarAsciiField -header $header -offset 257 -length 6 -value ("ustar" + [char]0)
+    Set-UstarAsciiField -header $header -offset 263 -length 2 -value "00"
+
+    [long]$checksum = 0
+    foreach ($value in $header) {
+        $checksum += $value
+    }
+
+    $checksumDigits = [System.Convert]::ToString($checksum, 8)
+    if ($checksumDigits.Length -gt 6) {
+        throw "USTAR checksum '$checksum' is too large."
+    }
+    Set-UstarAsciiField -header $header -offset 148 -length 8 -value ($checksumDigits.PadLeft(6, '0') + [char]0 + ' ')
+    return $header
+}
+
+function Copy-StreamBytes(
+    [System.IO.Stream]$source,
+    [System.IO.Stream]$destination,
+    [long]$count
+) {
+    $buffer = New-Object byte[] 81920
+    [long]$remaining = $count
+    while ($remaining -gt 0) {
+        $requested = [int][System.Math]::Min([long]$buffer.Length, $remaining)
+        $read = $source.Read($buffer, 0, $requested)
+        if ($read -le 0) {
+            throw "Unexpected end of stream with $remaining byte(s) remaining."
+        }
+        $destination.Write($buffer, 0, $read)
+        $remaining -= $read
+    }
+}
+
+function Skip-StreamBytes([System.IO.Stream]$stream, [long]$count) {
+    $buffer = New-Object byte[] 81920
+    [long]$remaining = $count
+    while ($remaining -gt 0) {
+        $requested = [int][System.Math]::Min([long]$buffer.Length, $remaining)
+        $read = $stream.Read($buffer, 0, $requested)
+        if ($read -le 0) {
+            throw "Unexpected end of archive with $remaining byte(s) remaining."
+        }
+        $remaining -= $read
+    }
+}
+
+function Read-StreamBlock([System.IO.Stream]$stream, [int]$length) {
+    $buffer = New-Object byte[] $length
+    $offset = 0
+    while ($offset -lt $length) {
+        $read = $stream.Read($buffer, $offset, $length - $offset)
+        if ($read -le 0) {
+            throw "Unexpected end of archive while reading a $length-byte block."
+        }
+        $offset += $read
+    }
+    return $buffer
+}
+
+function New-UstarGzipArchive(
+    [string]$archivePath,
+    [object[]]$entries
+) {
+    if ($null -eq $entries -or $entries.Count -eq 0) {
+        throw "At least one USTAR entry is required."
+    }
+
+    $parent = Split-Path -Path $archivePath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    $fileStream = [System.IO.File]::Create($archivePath)
+    try {
+        $gzipStream = New-Object System.IO.Compression.GZipStream(
+            $fileStream,
+            [System.IO.Compression.CompressionMode]::Compress,
+            $true)
+        try {
+            foreach ($entry in $entries) {
+                $name = [string]$entry.Name
+                $mode = [int]$entry.Mode
+                $isDirectory = [bool]$entry.IsDirectory
+                if ([string]::IsNullOrWhiteSpace($name) -or $name.Contains('\')) {
+                    throw "USTAR entry names must be non-empty forward-slash paths: '$name'."
+                }
+                if ([System.Text.Encoding]::ASCII.GetByteCount($name) -gt 100) {
+                    throw "USTAR entry name exceeds the portable 100-byte field: '$name'."
+                }
+                if ($isDirectory -and -not $name.EndsWith('/', [System.StringComparison]::Ordinal)) {
+                    throw "USTAR directory entries must end with '/': '$name'."
+                }
+
+                $sourcePath = [string]$entry.SourcePath
+                $entryBytes = $entry.Bytes
+                [long]$size = 0
+                if (-not $isDirectory) {
+                    if ($null -ne $entryBytes) {
+                        $size = [long]$entryBytes.Length
+                    }
+                    elseif (-not [string]::IsNullOrWhiteSpace($sourcePath) -and (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+                        $size = (Get-Item -LiteralPath $sourcePath).Length
+                    }
+                    else {
+                        throw "USTAR file entry '$name' has no readable source."
+                    }
+                }
+
+                $typeFlag = if ($isDirectory) { [char]'5' } else { [char]'0' }
+                $header = New-UstarHeader -name $name -mode $mode -size $size -typeFlag $typeFlag
+                $gzipStream.Write($header, 0, $header.Length)
+
+                if (-not $isDirectory -and $size -gt 0) {
+                    if ($null -ne $entryBytes) {
+                        $gzipStream.Write($entryBytes, 0, $entryBytes.Length)
+                    }
+                    else {
+                        $sourceStream = [System.IO.File]::OpenRead($sourcePath)
+                        try {
+                            Copy-StreamBytes -source $sourceStream -destination $gzipStream -count $size
+                        }
+                        finally {
+                            $sourceStream.Dispose()
+                        }
+                    }
+
+                    $paddingLength = [int](($script:UstarBlockSize - ($size % $script:UstarBlockSize)) % $script:UstarBlockSize)
+                    if ($paddingLength -gt 0) {
+                        $padding = New-Object byte[] $paddingLength
+                        $gzipStream.Write($padding, 0, $padding.Length)
+                    }
+                }
+            }
+
+            $endBlocks = New-Object byte[] ($script:UstarBlockSize * 2)
+            $gzipStream.Write($endBlocks, 0, $endBlocks.Length)
+        }
+        finally {
+            $gzipStream.Dispose()
+        }
+    }
+    finally {
+        $fileStream.Dispose()
+    }
+}
+
+function ConvertFrom-UstarOctal([byte[]]$header, [int]$offset, [int]$length) {
+    $value = [System.Text.Encoding]::ASCII.GetString($header, $offset, $length).Trim([char]0, ' ')
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return [long]0
+    }
+    return [System.Convert]::ToInt64($value, 8)
+}
+
+function Read-UstarGzipArchive(
+    [string]$archivePath,
+    [string[]]$captureEntryNames = @()
+) {
+    $capturedNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+    foreach ($captureName in $captureEntryNames) {
+        [void]$capturedNames.Add($captureName)
+    }
+
+    $entries = New-Object 'System.Collections.Generic.List[object]'
+    $fileStream = [System.IO.File]::OpenRead($archivePath)
+    try {
+        $gzipStream = New-Object System.IO.Compression.GZipStream(
+            $fileStream,
+            [System.IO.Compression.CompressionMode]::Decompress,
+            $true)
+        try {
+            while ($true) {
+                $header = Read-StreamBlock -stream $gzipStream -length $script:UstarBlockSize
+                $nonZeroHeaderByte = $header | Where-Object { $_ -ne 0 } | Select-Object -First 1
+                if ($null -eq $nonZeroHeaderByte) {
+                    $secondEndBlock = Read-StreamBlock -stream $gzipStream -length $script:UstarBlockSize
+                    if ($null -ne ($secondEndBlock | Where-Object { $_ -ne 0 } | Select-Object -First 1)) {
+                        throw "USTAR archive does not end with two zero blocks: $archivePath"
+                    }
+                    break
+                }
+
+                $storedChecksum = ConvertFrom-UstarOctal -header $header -offset 148 -length 8
+                $checksumHeader = New-Object byte[] $script:UstarBlockSize
+                [System.Array]::Copy($header, $checksumHeader, $header.Length)
+                for ($index = 148; $index -lt 156; $index++) {
+                    $checksumHeader[$index] = 32
+                }
+                [long]$calculatedChecksum = 0
+                foreach ($value in $checksumHeader) {
+                    $calculatedChecksum += $value
+                }
+                if ($storedChecksum -ne $calculatedChecksum) {
+                    throw "USTAR checksum mismatch in '$archivePath'."
+                }
+
+                $name = [System.Text.Encoding]::ASCII.GetString($header, 0, 100).TrimEnd([char]0)
+                $mode = [int](ConvertFrom-UstarOctal -header $header -offset 100 -length 8)
+                $size = ConvertFrom-UstarOctal -header $header -offset 124 -length 12
+                $typeFlag = [char]$header[156]
+                $capturedBytes = $null
+                if ($size -gt 0 -and $capturedNames.Contains($name)) {
+                    if ($size -gt [int]::MaxValue) {
+                        throw "Captured USTAR entry is too large: '$name'."
+                    }
+                    $capturedBytes = Read-StreamBlock -stream $gzipStream -length ([int]$size)
+                }
+                elseif ($size -gt 0) {
+                    Skip-StreamBytes -stream $gzipStream -count $size
+                }
+
+                $paddingLength = [long](($script:UstarBlockSize - ($size % $script:UstarBlockSize)) % $script:UstarBlockSize)
+                if ($paddingLength -gt 0) {
+                    Skip-StreamBytes -stream $gzipStream -count $paddingLength
+                }
+
+                $entries.Add([pscustomobject]@{
+                    Name = $name
+                    Mode = $mode
+                    Size = $size
+                    IsDirectory = ($typeFlag -eq [char]'5')
+                    Bytes = $capturedBytes
+                })
+            }
+        }
+        finally {
+            $gzipStream.Dispose()
+        }
+    }
+    finally {
+        $fileStream.Dispose()
+    }
+
+    return $entries.ToArray()
+}
+
+function Write-BigEndianUInt32([System.IO.Stream]$stream, [uint32]$value) {
+    $bytes = [byte[]]@(
+        (($value -shr 24) -band 0xff),
+        (($value -shr 16) -band 0xff),
+        (($value -shr 8) -band 0xff),
+        ($value -band 0xff)
+    )
+    $stream.Write($bytes, 0, $bytes.Length)
+}
+
+function New-DeterministicIcns([string]$iconSetPath, [string]$outputPath) {
+    $slots = @(
+        [pscustomobject]@{ Type = 'ic07'; File = '128.png' },
+        [pscustomobject]@{ Type = 'ic08'; File = '256.png' },
+        [pscustomobject]@{ Type = 'ic09'; File = '512.png' },
+        [pscustomobject]@{ Type = 'ic10'; File = '1024.png' },
+        [pscustomobject]@{ Type = 'ic11'; File = '32.png' },
+        [pscustomobject]@{ Type = 'ic12'; File = '64.png' },
+        [pscustomobject]@{ Type = 'ic13'; File = '512.png' },
+        [pscustomobject]@{ Type = 'ic14'; File = '1024.png' }
+    )
+
+    $slotPayloads = New-Object 'System.Collections.Generic.List[object]'
+    [uint64]$totalLength = 8
+    foreach ($slot in $slots) {
+        $sourcePath = Join-Path $iconSetPath $slot.File
+        if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+            throw "Required macOS icon source was not found: $sourcePath"
+        }
+        $payload = [System.IO.File]::ReadAllBytes($sourcePath)
+        if ($payload.Length -eq 0) {
+            throw "Required macOS icon source is empty: $sourcePath"
+        }
+        $slotPayloads.Add([pscustomobject]@{ Type = $slot.Type; Bytes = $payload })
+        $totalLength += 8 + $payload.Length
+    }
+    if ($totalLength -gt [uint32]::MaxValue) {
+        throw "Generated ICNS exceeds the 32-bit container limit."
+    }
+
+    $parent = Split-Path -Path $outputPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    $stream = [System.IO.File]::Create($outputPath)
+    try {
+        $signature = [System.Text.Encoding]::ASCII.GetBytes('icns')
+        $stream.Write($signature, 0, $signature.Length)
+        Write-BigEndianUInt32 -stream $stream -value ([uint32]$totalLength)
+        foreach ($slotPayload in $slotPayloads) {
+            $typeBytes = [System.Text.Encoding]::ASCII.GetBytes([string]$slotPayload.Type)
+            $stream.Write($typeBytes, 0, $typeBytes.Length)
+            Write-BigEndianUInt32 -stream $stream -value ([uint32](8 + $slotPayload.Bytes.Length))
+            $stream.Write($slotPayload.Bytes, 0, $slotPayload.Bytes.Length)
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Get-PlistStringValue([xml]$document, [string]$key) {
+    $keyNode = $document.SelectSingleNode("/plist/dict/key[text()='$key']")
+    if ($null -eq $keyNode) {
+        return $null
+    }
+
+    $valueNode = $keyNode.NextSibling
+    while ($null -ne $valueNode -and $valueNode.NodeType -ne [System.Xml.XmlNodeType]::Element) {
+        $valueNode = $valueNode.NextSibling
+    }
+    if ($null -eq $valueNode -or $valueNode.LocalName -ne 'string') {
+        return $null
+    }
+    return [string]$valueNode.InnerText
+}
+
+function Get-MacInfoPlistContent([string]$templatePath, [string]$version) {
+    $template = [System.IO.File]::ReadAllText($templatePath)
+    $placeholder = 'YOUR_RELEASE_VERSION'
+    $placeholderCount = [System.Text.RegularExpressions.Regex]::Matches(
+        $template,
+        [System.Text.RegularExpressions.Regex]::Escape($placeholder)).Count
+    if ($placeholderCount -ne 2) {
+        throw "macOS Info.plist template must contain exactly two $placeholder placeholders. Found: $placeholderCount."
+    }
+    if ($version -notmatch '^\d+(\.\d+){0,3}$') {
+        throw "Invalid macOS bundle version '$version'."
+    }
+
+    $content = $template.Replace($placeholder, $version)
+    [xml]$document = $content
+    $requiredValues = @{
+        CFBundleName = 'DevProjex'
+        CFBundleDisplayName = 'DevProjex'
+        CFBundleIdentifier = 'com.devprojex.app'
+        CFBundleVersion = $version
+        CFBundleShortVersionString = $version
+        CFBundleExecutable = 'DevProjex'
+        CFBundleIconFile = 'app.icns'
+        CFBundlePackageType = 'APPL'
+        LSMinimumSystemVersion = '14.0'
+    }
+    foreach ($requiredValue in $requiredValues.GetEnumerator()) {
+        $actualValue = Get-PlistStringValue -document $document -key ([string]$requiredValue.Key)
+        if ($actualValue -ne [string]$requiredValue.Value) {
+            throw "macOS Info.plist value '$($requiredValue.Key)' must be '$($requiredValue.Value)'. Found: '$actualValue'."
+        }
+    }
+    if ($content.Contains($placeholder)) {
+        throw "macOS Info.plist still contains a release-version placeholder."
+    }
+    return $content
+}

--- a/Tests/DevProjex.Tests.Integration/GitCloneWorkflowTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitCloneWorkflowTests.cs
@@ -294,6 +294,7 @@ public sealed class GitCloneWorkflowTests : IAsyncLifetime, IDisposable
 				Assert.NotNull(reopened);
 			}
 			_cacheService.DeleteRepositoryDirectory(currentCachedRepoPath);
+			await AssertCacheEventuallyDeletedAsync(currentCachedRepoPath);
 			Assert.Null(_cacheService.FindIndexedRepository(TestRepoUrl));
 			currentCachedRepoPath = null;
         }

--- a/Tests/DevProjex.Tests.Integration/ReleaseArchivePackagingIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArchivePackagingIntegrationTests.cs
@@ -31,6 +31,31 @@ public sealed class ReleaseArchivePackagingIntegrationTests
 		}
 	}
 
+	[Fact]
+	public void IcnsHelper_MapsEverySlotAndRejectsMismatchedPngDimensions()
+	{
+		using var workspace = new TemporaryDirectory();
+		var helperPath = Path.Combine(RepoRoot.Value, "Scripts", "release-archive-helpers.ps1");
+		var iconSetPath = Path.Combine(RepoRoot.Value, "Assets", "AppIcon", "MacOS", "AppIconSet");
+		var scriptPath = workspace.CreateFile(
+			"verify-release-icns.ps1",
+			BuildIcnsVerificationScript(helperPath, iconSetPath));
+		var shells = OperatingSystem.IsWindows()
+			? new[] { "powershell", "pwsh" }
+			: new[] { "pwsh" };
+
+		foreach (var shell in shells)
+		{
+			var result = RunPowerShell(shell, scriptPath, workspace.Path);
+			Assert.True(
+				result.ExitCode == 0,
+				$"ICNS verification failed in {shell}.{Environment.NewLine}" +
+				$"STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}" +
+				$"STDERR:{Environment.NewLine}{result.StandardError}");
+			Assert.Contains("icns-contract-ok", result.StandardOutput, StringComparison.Ordinal);
+		}
+	}
+
 	private static string BuildVerificationScript(string helperPath)
 	{
 		var escapedHelperPath = helperPath.Replace("'", "''", StringComparison.Ordinal);
@@ -59,6 +84,61 @@ public sealed class ReleaseArchivePackagingIntegrationTests
 			& tar -tvf $firstArchive
 			if ($LASTEXITCODE -ne 0) { throw "tar -tvf failed with exit code $LASTEXITCODE." }
 			Write-Output 'archive-contract-ok'
+			""";
+	}
+
+	private static string BuildIcnsVerificationScript(string helperPath, string iconSetPath)
+	{
+		var escapedHelperPath = helperPath.Replace("'", "''", StringComparison.Ordinal);
+		var escapedIconSetPath = iconSetPath.Replace("'", "''", StringComparison.Ordinal);
+		return $$"""
+			$ErrorActionPreference = 'Stop'
+			. '{{escapedHelperPath}}'
+			$iconSetPath = '{{escapedIconSetPath}}'
+			$outputPath = Join-Path $PSScriptRoot 'app.icns'
+			New-DeterministicIcns -iconSetPath $iconSetPath -outputPath $outputPath
+			$actual = [System.IO.File]::ReadAllBytes($outputPath)
+			$expected = @(
+			    [pscustomobject]@{ Type = 'ic07'; File = '128.png' },
+			    [pscustomobject]@{ Type = 'ic08'; File = '256.png' },
+			    [pscustomobject]@{ Type = 'ic09'; File = '512.png' },
+			    [pscustomobject]@{ Type = 'ic10'; File = '1024.png' },
+			    [pscustomobject]@{ Type = 'ic11'; File = '32.png' },
+			    [pscustomobject]@{ Type = 'ic12'; File = '64.png' },
+			    [pscustomobject]@{ Type = 'ic13'; File = '256.png' },
+			    [pscustomobject]@{ Type = 'ic14'; File = '512.png' }
+			)
+			$offset = 8
+			foreach ($slot in $expected) {
+			    $type = [System.Text.Encoding]::ASCII.GetString($actual, $offset, 4)
+			    $entryLength = [int](Read-BigEndianUInt32 -bytes $actual -offset ($offset + 4))
+			    $expectedPayload = [System.IO.File]::ReadAllBytes((Join-Path $iconSetPath $slot.File))
+			    if ($type -ne $slot.Type -or $entryLength -ne (8 + $expectedPayload.Length)) {
+			        throw "ICNS slot mismatch for $($slot.Type)."
+			    }
+			    for ($index = 0; $index -lt $expectedPayload.Length; $index++) {
+			        if ($actual[$offset + 8 + $index] -ne $expectedPayload[$index]) {
+			            throw "ICNS payload mismatch for $($slot.Type)."
+			        }
+			    }
+			    $offset += $entryLength
+			}
+			if ($offset -ne $actual.Length) { throw 'ICNS contains unexpected trailing data.' }
+
+			$badIconSetPath = Join-Path $PSScriptRoot 'bad-icon-set'
+			New-Item -ItemType Directory -Path $badIconSetPath -Force | Out-Null
+			Get-ChildItem -LiteralPath $iconSetPath -Filter '*.png' | Copy-Item -Destination $badIconSetPath -Force
+			Copy-Item -LiteralPath (Join-Path $iconSetPath '128.png') -Destination (Join-Path $badIconSetPath '256.png') -Force
+			$rejected = $false
+			try {
+			    New-DeterministicIcns -iconSetPath $badIconSetPath -outputPath (Join-Path $PSScriptRoot 'bad.icns')
+			}
+			catch {
+			    if ($_.Exception.Message -notlike '*ic08*256x256px*128x128px*') { throw }
+			    $rejected = $true
+			}
+			if (-not $rejected) { throw 'Mismatched PNG dimensions were accepted.' }
+			Write-Output 'icns-contract-ok'
 			""";
 	}
 

--- a/Tests/DevProjex.Tests.Integration/ReleaseArchivePackagingIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArchivePackagingIntegrationTests.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using DevProjex.Tests.Integration.Helpers;
+using DevProjex.Tests.Shared.StoreListing;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class ReleaseArchivePackagingIntegrationTests
+{
+	private static readonly Lazy<string> RepoRoot = new(StoreListingPaths.FindRepositoryRoot);
+
+	[Fact]
+	public void UstarHelper_RoundTripsModesAndProducesDeterministicTarGzip()
+	{
+		using var workspace = new TemporaryDirectory();
+		var helperPath = Path.Combine(RepoRoot.Value, "Scripts", "release-archive-helpers.ps1");
+		var scriptPath = workspace.CreateFile("verify-release-archive.ps1", BuildVerificationScript(helperPath));
+		var shells = OperatingSystem.IsWindows()
+			? new[] { "powershell", "pwsh" }
+			: new[] { "pwsh" };
+
+		foreach (var shell in shells)
+		{
+			var result = RunPowerShell(shell, scriptPath, workspace.Path);
+			Assert.True(
+				result.ExitCode == 0,
+				$"Archive verification failed in {shell}.{Environment.NewLine}" +
+				$"STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}" +
+				$"STDERR:{Environment.NewLine}{result.StandardError}");
+			Assert.Contains("archive-contract-ok", result.StandardOutput, StringComparison.Ordinal);
+		}
+	}
+
+	private static string BuildVerificationScript(string helperPath)
+	{
+		var escapedHelperPath = helperPath.Replace("'", "''", StringComparison.Ordinal);
+		return $$"""
+			$ErrorActionPreference = 'Stop'
+			. '{{escapedHelperPath}}'
+			$payloadPath = Join-Path $PSScriptRoot 'DevProjex'
+			[System.IO.File]::WriteAllText($payloadPath, 'release payload')
+			$entries = @(
+			    [pscustomobject]@{ Name = 'bundle/'; Mode = 493; IsDirectory = $true; SourcePath = ''; Bytes = $null },
+			    [pscustomobject]@{ Name = 'bundle/DevProjex'; Mode = 493; IsDirectory = $false; SourcePath = $payloadPath; Bytes = $null },
+			    [pscustomobject]@{ Name = 'bundle/Info.plist'; Mode = 420; IsDirectory = $false; SourcePath = ''; Bytes = [Text.Encoding]::UTF8.GetBytes('plist') }
+			)
+			$firstArchive = Join-Path $PSScriptRoot 'first.tar.gz'
+			$secondArchive = Join-Path $PSScriptRoot 'second.tar.gz'
+			New-UstarGzipArchive -archivePath $firstArchive -entries $entries
+			New-UstarGzipArchive -archivePath $secondArchive -entries $entries
+			$firstHash = Get-FileSha256Hex -path $firstArchive
+			$secondHash = Get-FileSha256Hex -path $secondArchive
+			if ($firstHash -ne $secondHash) { throw 'Archive output is not deterministic.' }
+			$actual = @(Read-UstarGzipArchive -archivePath $firstArchive -captureEntryNames @('bundle/Info.plist'))
+			if ($actual.Count -ne 3) { throw "Unexpected entry count: $($actual.Count)." }
+			if ($actual[0].Name -ne 'bundle/' -or -not $actual[0].IsDirectory -or $actual[0].Mode -ne 493) { throw 'Directory entry mismatch.' }
+			if ($actual[1].Name -ne 'bundle/DevProjex' -or $actual[1].Mode -ne 493 -or $actual[1].Size -le 0) { throw 'Executable entry mismatch.' }
+			if ($actual[2].Name -ne 'bundle/Info.plist' -or $actual[2].Mode -ne 420 -or $actual[2].Size -le 0) { throw 'Metadata entry mismatch.' }
+			& tar -tvf $firstArchive
+			if ($LASTEXITCODE -ne 0) { throw "tar -tvf failed with exit code $LASTEXITCODE." }
+			Write-Output 'archive-contract-ok'
+			""";
+	}
+
+	private static (int ExitCode, string StandardOutput, string StandardError) RunPowerShell(
+		string executable,
+		string scriptPath,
+		string workingDirectory)
+	{
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = executable,
+			WorkingDirectory = workingDirectory,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false
+		};
+		startInfo.ArgumentList.Add("-NoLogo");
+		startInfo.ArgumentList.Add("-NoProfile");
+		if (OperatingSystem.IsWindows() && executable.Equals("powershell", StringComparison.Ordinal))
+		{
+			startInfo.ArgumentList.Add("-ExecutionPolicy");
+			startInfo.ArgumentList.Add("Bypass");
+		}
+		startInfo.ArgumentList.Add("-File");
+		startInfo.ArgumentList.Add(scriptPath);
+
+		try
+		{
+			using var process = Process.Start(startInfo)
+				?? throw new InvalidOperationException($"Could not start {executable}.");
+			var standardOutput = process.StandardOutput.ReadToEnd();
+			var standardError = process.StandardError.ReadToEnd();
+			process.WaitForExit();
+			return (process.ExitCode, standardOutput, standardError);
+		}
+		catch (Win32Exception exception)
+		{
+			throw new InvalidOperationException(
+				$"Required PowerShell executable '{executable}' was not found.",
+				exception);
+		}
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/AppInstances/AppInstancePackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Unit/AppInstances/AppInstancePackagingContractTests.cs
@@ -264,6 +264,22 @@ public sealed class AppInstancePackagingContractTests
 
         Assert.Contains("Rid = \"linux-x64\"", releaseScript, StringComparison.Ordinal);
         Assert.Contains("Rid = \"linux-arm64\"", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("DevProjex.v$version.linux-x64.tar.gz", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("DevProjex.v$version.linux-arm64.tar.gz", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("DevProjex.v$version.osx-x64.app.tar.gz", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("DevProjex.v$version.osx-arm64.app.tar.gz", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("New-UstarGzipArchive", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("Read-UstarGzipArchive", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("-GitHubOnly:$GitHubArtifactsOnly", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("(Join-Path $sourceRoot \"artifacts\")", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("(Join-Path $sourceRoot \".artifacts\")", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("\"bin\"", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("\"obj\"", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("Assert-IsolatedWorkspaceCapacity -sourceRoot $sourceRoot", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("$sourceBytes * 2", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("$isolatedPackages + [System.IO.Path]::DirectorySeparatorChar", releaseScript, StringComparison.Ordinal);
+        Assert.DoesNotContain("linux-x64.portable", releaseScript, StringComparison.Ordinal);
+        Assert.DoesNotContain("linux-arm64.portable", releaseScript, StringComparison.Ordinal);
         Assert.Contains("\"/p:PublishSingleFile=true\"", releaseScript, StringComparison.Ordinal);
         Assert.Contains("\"/p:IncludeNativeLibrariesForSelfExtract=true\"", releaseScript, StringComparison.Ordinal);
         Assert.Contains("\"/p:PublishReadyToRun=true\"", releaseScript, StringComparison.Ordinal);
@@ -332,7 +348,8 @@ public sealed class AppInstancePackagingContractTests
         Assert.Contains($"/Applications/{CommandLineExecutableAliases.DisplayName}.app/Contents/MacOS/{CommandLineExecutableAliases.DisplayName}", readme, StringComparison.Ordinal);
         Assert.Contains("DEVPROJEX_TERMINAL_HOST=1", readme, StringComparison.Ordinal);
         Assert.Contains("<string>14.0</string>", readme, StringComparison.Ordinal);
-        Assert.Contains("unprepared `.app`", readme, StringComparison.Ordinal);
+        Assert.Contains("DevProjex.v<version>.osx-<architecture>.app.tar.gz", readme, StringComparison.Ordinal);
+        Assert.Contains("generates `app.icns` deterministically", readme, StringComparison.Ordinal);
         Assert.Contains("does not modify shell profiles or global environment variables", readme, StringComparison.Ordinal);
         Assert.DoesNotContain(CommandLineExecutableAliases.WindowsStoreAlias, readme, StringComparison.Ordinal);
     }

--- a/Tests/DevProjex.Tests.Unit/Avalonia/TerminalCommandAutomaticPromptGateTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/TerminalCommandAutomaticPromptGateTests.cs
@@ -28,6 +28,8 @@ public sealed class TerminalCommandAutomaticPromptGateTests
 	[InlineData("DevProjex.v.win-x64.exe")]
 	[InlineData("DevProjex.v4.9.5.freebsd-x64")]
 	[InlineData("DevProjex.v4.9.5.win-x64.exe.bak")]
+	[InlineData("DevProjex.v4.9.5.linux-x64.tar.gz")]
+	[InlineData("DevProjex.v4.9.5.osx-arm64.app.tar.gz")]
 	[InlineData("dotnet.exe")]
 	public void ShouldShowAutomaticTerminalCommandPrompt_RejectsNonReleaseExecutableNames(string fileName)
 	{
@@ -40,7 +42,7 @@ public sealed class TerminalCommandAutomaticPromptGateTests
 	}
 
 	[Fact]
-	public void ReleaseScript_EveryPublishedPortableArtifactPassesExecutableIdentityGate()
+	public void ReleaseScript_OnlyDirectExecutableArtifactsPassExecutableIdentityGate()
 	{
 		var scriptPath = Path.Combine(FindRepositoryRoot(), "Scripts", "release-all.ps1");
 		var script = File.ReadAllText(scriptPath);
@@ -52,9 +54,10 @@ public sealed class TerminalCommandAutomaticPromptGateTests
 		foreach (System.Text.RegularExpressions.Match match in matches)
 		{
 			var artifactName = match.Groups["name"].Value.Replace("$version", "4.9.5", StringComparison.Ordinal);
-			Assert.True(
-				CommandLineExecutableAliases.IsPublishedPortableFileName(artifactName),
-				$"Release artifact is not recognized by the automatic terminal setup gate: {artifactName}");
+			var isDirectExecutable = artifactName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
+			Assert.Equal(
+				isDirectExecutable,
+				CommandLineExecutableAliases.IsPublishedPortableFileName(artifactName));
 		}
 	}
 


### PR DESCRIPTION
## Summary
- package Linux binaries as executable-preserving tar.gz archives
- build deterministic macOS app bundles with generated ICNS metadata
- add GitHub-only release mode and archive self-validation

## Validation
- generated and inspected all six GitHub artifacts for version 0.0.1
- verified archive layouts, permissions, plist versions, and checksums
- full Unit, Integration, Terminal, and UI suites
- Release build with zero warnings