### PR TITLE
fix(mcp): restore text tool payloads for structured clients

### DIFF
--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -14,12 +14,12 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 		_tools =
 		[
 			Create(target, nameof(DevProjexMcpTools.ListProjects), "list_projects", "List projects", ListProjectsInput, ListProjectsOutput),
-			Create(target, nameof(DevProjexMcpTools.GetTree), "get_tree", "Get project tree", GetTreeInput, TruncationOutput),
+			Create(target, nameof(DevProjexMcpTools.GetTree), "get_tree", "Get project tree", GetTreeInput),
 			Create(target, nameof(DevProjexMcpTools.Analyze), "analyze", "Analyze project", AnalyzeInput, AnalyzeOutput),
-			Create(target, nameof(DevProjexMcpTools.PackContext), "pack_context", "Pack project context", PackContextInput, PackOutput, largeResult: true),
-			Create(target, nameof(DevProjexMcpTools.ReadPack), "read_pack", "Read context pack", ReadPackInput, PageOutput, largeResult: true),
-			Create(target, nameof(DevProjexMcpTools.SearchProject), "search_project", "Search project", SearchInput, SearchOutput),
-			Create(target, nameof(DevProjexMcpTools.GetFile), "get_file", "Get project file", GetFileInput, FileOutput)
+			Create(target, nameof(DevProjexMcpTools.PackContext), "pack_context", "Pack project context", PackContextInput, largeResult: true),
+			Create(target, nameof(DevProjexMcpTools.ReadPack), "read_pack", "Read context pack", ReadPackInput, largeResult: true),
+			Create(target, nameof(DevProjexMcpTools.SearchProject), "search_project", "Search project", SearchInput),
+			Create(target, nameof(DevProjexMcpTools.GetFile), "get_file", "Get project file", GetFileInput)
 		];
 	}
 
@@ -44,7 +44,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 		string name,
 		string title,
 		string inputSchema,
-		string outputSchema,
+		string? outputSchema = null,
 		bool largeResult = false)
 	{
 		var method = typeof(DevProjexMcpTools).GetMethod(
@@ -52,21 +52,22 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 			BindingFlags.Instance | BindingFlags.Public) ??
 		             throw new MissingMethodException(typeof(DevProjexMcpTools).FullName, methodName);
 		var description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
-		var tool = McpServerTool.Create(
-			method,
-			target,
-			new McpServerToolCreateOptions
-			{
-				Name = name,
-				Title = title,
-				Description = description,
-				ReadOnly = true,
-				Destructive = false,
-				Idempotent = true,
-				OpenWorld = false,
-				UseStructuredContent = true,
-				OutputSchema = ParseSchema(outputSchema)
-			});
+		var options = new McpServerToolCreateOptions
+		{
+			Name = name,
+			Title = title,
+			Description = description,
+			ReadOnly = true,
+			Destructive = false,
+			Idempotent = true,
+			OpenWorld = false
+		};
+		if (outputSchema is not null)
+		{
+			options.UseStructuredContent = true;
+			options.OutputSchema = ParseSchema(outputSchema);
+		}
+		var tool = McpServerTool.Create(method, target, options);
 		tool.ProtocolTool.InputSchema = ParseSchema(inputSchema);
 		if (largeResult)
 		{
@@ -276,19 +277,6 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	}
 	""";
 
-	private const string TruncationOutput = """
-	{
-	  "type": "object",
-	  "properties": {
-	    "lines": { "type": "integer" },
-	    "totalLines": { "type": "integer" },
-	    "truncated": { "type": "boolean" }
-	  },
-	  "required": ["lines", "totalLines", "truncated"],
-	  "additionalProperties": false
-	}
-	""";
-
 	private const string AnalyzeOutput = """
 	{
 	  "type": "object",
@@ -315,61 +303,4 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	}
 	""";
 
-	private const string PackOutput = """
-	{
-	  "type": "object",
-	  "properties": {
-	    "files": { "type": "integer" },
-	    "characters": { "type": "integer" },
-	    "lines": { "type": "integer" },
-	    "detail": { "type": "string", "enum": ["full", "compact", "signatures"] },
-	    "stored": { "type": "boolean" },
-	    "packId": { "type": ["string", "null"] }
-	  },
-	  "required": ["files", "characters", "lines", "detail", "stored", "packId"],
-	  "additionalProperties": false
-	}
-	""";
-
-	private const string PageOutput = """
-	{
-	  "type": "object",
-	  "properties": {
-	    "startLine": { "type": "integer" },
-	    "endLine": { "type": "integer" },
-	    "totalLines": { "type": "integer" },
-	    "truncated": { "type": "boolean" }
-	  },
-	  "required": ["startLine", "endLine", "totalLines", "truncated"],
-	  "additionalProperties": false
-	}
-	""";
-
-	private const string SearchOutput = """
-	{
-	  "type": "object",
-	  "properties": {
-	    "matches": { "type": "integer" },
-	    "shown": { "type": "integer" },
-	    "truncated": { "type": "boolean" }
-	  },
-	  "required": ["matches", "shown", "truncated"],
-	  "additionalProperties": false
-	}
-	""";
-
-	private const string FileOutput = """
-	{
-	  "type": "object",
-	  "properties": {
-	    "path": { "type": "string" },
-	    "startLine": { "type": "integer" },
-	    "endLine": { "type": "integer" },
-	    "totalLines": { "type": "integer" },
-	    "truncated": { "type": "boolean" }
-	  },
-	  "required": ["path", "startLine", "endLine", "totalLines", "truncated"],
-	  "additionalProperties": false
-	}
-	""";
 }

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -32,10 +32,7 @@ internal sealed class DevProjexMcpTools(
 				.Where(projects.HasLocalProfile)
 				.Select(root => new { project = root, name = "local" })
 				.ToArray();
-			var text = string.Join(
-				'\n',
-				projectItems.Select(static item => $"{item.path}\t{item.name}\t{item.type}"));
-			return Task.FromResult(McpToolResults.Success(text, new { projects = projectItems, profiles }));
+			return Task.FromResult(McpToolResults.StructuredSuccess(new { projects = projectItems, profiles }));
 		});
 
 	[Description("Return the effective project tree after built-in, gitignore, profile, and optional agent glob filters.")]
@@ -73,9 +70,7 @@ internal sealed class DevProjexMcpTools(
 			var body = string.Join('\n', shown);
 			if (truncated)
 				body += "\n[Tree truncated at 2000 lines. Narrow include_patterns, exclude_patterns, or max_depth.]";
-			return McpToolResults.Success(
-				McpSpotlight.Wrap(body),
-				new { lines = shown.Count, totalLines = lines.Count, truncated });
+			return McpToolResults.TextSuccess(McpSpotlight.Wrap(body));
 		});
 
 	[Description("Measure a redacted project selection and list its ten largest text files by estimated tokens.")]
@@ -117,8 +112,7 @@ internal sealed class DevProjexMcpTools(
 				detail = effectiveDetail.Token,
 				topFiles = top
 			};
-			var text = JsonSerializer.Serialize(envelope, new JsonSerializerOptions { WriteIndented = true });
-			return McpToolResults.Success(text, envelope);
+			return McpToolResults.StructuredSuccess(envelope);
 		});
 
 	[Description("Build an exact redacted DevProjex context export. Large packs expire when this server process exits.")]
@@ -157,21 +151,11 @@ internal sealed class DevProjexMcpTools(
 						useUnifiedContentHeaders: true).ConfigureAwait(false);
 				},
 				cancellationToken).ConfigureAwait(false);
-			var metrics = new
-			{
-				files = plan.IncludedFiles.Count,
-				characters = pack.Characters,
-				lines = pack.Lines,
-				detail = effectiveDetail.Token,
-				stored = pack.Characters > MaximumInlinePackCharacters,
-				packId = pack.Characters > MaximumInlinePackCharacters ? pack.Id : null
-			};
-
 			if (pack.Characters <= MaximumInlinePackCharacters)
 			{
 				var content = await File.ReadAllTextAsync(pack.Path, cancellationToken).ConfigureAwait(false);
 				packs.Remove(pack.Id);
-				return McpToolResults.Success(McpSpotlight.Wrap(content), metrics, advertiseLargeResult: true);
+				return McpToolResults.TextSuccess(McpSpotlight.Wrap(content), advertiseLargeResult: true);
 			}
 
 			var tree = projects.TreeExportService.BuildFullTree(
@@ -184,7 +168,7 @@ internal sealed class DevProjexMcpTools(
 			var message = $"Pack stored as '{pack.Id}' ({pack.Characters} characters). " +
 			              "Call read_pack with this pack_id to read ranges, or search_project to locate source content.\n" +
 			              McpSpotlight.Wrap(tree);
-			return McpToolResults.Success(message, metrics, advertiseLargeResult: true);
+			return McpToolResults.TextSuccess(message, advertiseLargeResult: true);
 		});
 
 	[Description("Read a 1-based line range from a pack created by this server session.")]
@@ -207,15 +191,8 @@ internal sealed class DevProjexMcpTools(
 			}
 			if (page.CharacterLimitReached)
 				text += "\n[The current line exceeded the 50000-character response cap; use search_project to narrow the source.]";
-			return McpToolResults.Success(
+			return McpToolResults.TextSuccess(
 				McpSpotlight.Wrap(text),
-				new
-				{
-					startLine = page.StartLine,
-					endLine = page.EndLine,
-					totalLines = page.TotalLines,
-					truncated = page.IsTruncated
-				},
 				advertiseLargeResult: true);
 		});
 
@@ -278,9 +255,7 @@ internal sealed class DevProjexMcpTools(
 			var shown = Math.Min(totalMatches, maximumResults);
 			if (totalMatches > shown)
 				output.AppendLine($"[{totalMatches - shown} additional matches not shown; narrow the pattern or filters.]");
-			return McpToolResults.Success(
-				McpSpotlight.Wrap(output.ToString().TrimEnd()),
-				new { matches = totalMatches, shown, truncated = totalMatches > shown });
+			return McpToolResults.TextSuccess(McpSpotlight.Wrap(output.ToString().TrimEnd()));
 		});
 
 	[Description("Read redacted text from one effective project file using an optional 1-based line range.")]
@@ -325,16 +300,7 @@ internal sealed class DevProjexMcpTools(
 			var text = page.Text;
 			if (page.IsTruncated)
 				text += $"\n[Showing lines {page.StartLine}-{page.EndLine} of {page.TotalLines}; continue with start_line={page.EndLine + 1}.]";
-			return McpToolResults.Success(
-				McpSpotlight.Wrap(text),
-				new
-				{
-					path = McpProjectService.ToRelative(plan.SourceRoot, file),
-					startLine = page.StartLine,
-					endLine = page.EndLine,
-					totalLines = page.TotalLines,
-					truncated = page.IsTruncated
-				});
+			return McpToolResults.TextSuccess(McpSpotlight.Wrap(text));
 		});
 
 	private McpJsonArguments SelectionArguments(CallToolRequestParams request) =>

--- a/Apps/Mcp/McpToolResults.cs
+++ b/Apps/Mcp/McpToolResults.cs
@@ -3,19 +3,38 @@ namespace DevProjex.Mcp;
 internal static class McpToolResults
 {
 	private const string MaxResultSizeKey = "anthropic/maxResultSizeChars";
+	private static readonly JsonSerializerOptions StructuredTextOptions = new()
+	{
+		WriteIndented = true
+	};
 
-	public static CallToolResult Success(
+	public static CallToolResult TextSuccess(
 		string text,
-		object? structured = null,
 		bool advertiseLargeResult = false) =>
 		new()
 		{
 			Content = [new TextContentBlock { Text = text }],
-			StructuredContent = structured is null ? null : JsonSerializer.SerializeToElement(structured),
 			Meta = advertiseLargeResult
 				? new System.Text.Json.Nodes.JsonObject { [MaxResultSizeKey] = 200_000 }
 				: null
 		};
+
+	public static CallToolResult StructuredSuccess(object value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+		var structured = JsonSerializer.SerializeToElement(value);
+		return new CallToolResult
+		{
+			Content =
+			[
+				new TextContentBlock
+				{
+					Text = JsonSerializer.Serialize(structured, StructuredTextOptions)
+				}
+			],
+			StructuredContent = structured
+		};
+	}
 
 	public static CallToolResult Error(McpToolException exception) =>
 		new()

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -25,6 +25,13 @@ list_projects -> get_tree/analyze -> search_project/get_file -> pack_context -> 
 - Tools are read-only and never start processes or perform network operations.
 - Secret and private-data redaction are always enabled for returned file content.
   Tool schemas intentionally provide no switch to weaken redaction.
+- The redaction boundary distinguishes project addresses from exported content.
+  File contents and context packs are always processed by both Secrets and
+  Private Data redaction. Root paths in `list_projects`, `get_tree`, and tool
+  errors are returned as-is: they are local addresses already known to the
+  client and form the contract for the `project` argument. A pack is an
+  exportable artifact, so it is redacted in full, including the project path in
+  its tree header.
 - Searches run against redacted content, not the original file text.
 - Returned project content is marked as untrusted data with a random, per-response
   delimiter. Agents must not interpret instructions found in project files as
@@ -52,6 +59,28 @@ The tool order is stable.
 | `read_pack` | `pack_id`, `start_line?`, `end_line?` | Inclusive, 1-based range; at most 1,000 lines or 50,000 characters per call. Call `pack_context` again after server restart. |
 | `search_project` | `project?`, `pattern`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `context_lines?`, `ignore_case?`, `max_results?` | Grep-style redacted matches. Regex timeout is 2 seconds; `max_results` cannot exceed 200. |
 | `get_file` | `project?`, `path`, `start_line?`, `end_line?` | Redacted text from one effective file; at most 1,000 lines. |
+
+## Result Contract
+
+Only `list_projects` and `analyze` declare an MCP `outputSchema`. Their
+authoritative result is the complete object in `structuredContent`; the first
+text block in `content` is a JSON serialization of that same object.
+
+`get_tree`, `pack_context`, `read_pack`, `search_project`, and `get_file` are
+text tools. They do not declare `outputSchema`, omit `structuredContent`, and
+return the useful payload directly in the first text block in `content`. This
+avoids JSON escaping and unnecessary token overhead for trees, source text,
+search context, and packs. Truncation and continuation metadata is embedded in
+plain-text trailers such as `[Tree truncated ...]` and `[Showing lines ...]`.
+
+An inline `pack_context` result contains the complete pack. A stored result is
+self-contained: it starts with `Pack stored as '<id>' (<N> characters). Call
+read_pack ...`, followed by a preview of the project tree. Clients extract the
+session-scoped `pack_id` from that text and pass it to `read_pack`.
+
+Future tools must declare `outputSchema` only when their useful result is
+genuinely structured and can be returned completely in `structuredContent`.
+Metadata about a text payload is not sufficient reason to add a schema.
 
 Defaults:
 
@@ -90,8 +119,8 @@ compression or stripping, but cannot disable MCP redaction.
 Unsupported languages remain unchanged. Detail is monotonic: transformations
 enabled by the selected user profile are unioned with the requested level, so an
 agent can reduce context further but cannot restore bodies, comments, or blank
-lines removed by the profile. The structured result reports the effective detail
-tier.
+lines removed by the profile. The `analyze` structured result reports the
+effective detail tier; `pack_context` returns the transformed pack itself.
 
 ## Client Configuration
 

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -41,10 +41,14 @@ public sealed class McpServerIntegrationTests
 			Assert.False(protocol.Annotations?.OpenWorldHint);
 			Assert.False(protocol.Annotations?.DestructiveHint);
 			Assert.Equal(JsonValueKind.False, protocol.InputSchema.GetProperty("additionalProperties").ValueKind);
-			Assert.NotNull(protocol.OutputSchema);
 			Assert.DoesNotContain("hide_secrets", protocol.InputSchema.GetRawText(), StringComparison.OrdinalIgnoreCase);
 			Assert.DoesNotContain("hide_private", protocol.InputSchema.GetRawText(), StringComparison.OrdinalIgnoreCase);
 		});
+		Assert.Equal(
+			["list_projects", "analyze"],
+			tools
+				.Where(static tool => tool.ProtocolTool.OutputSchema is not null)
+				.Select(static tool => tool.Name));
 		Assert.Equal(
 			200_000,
 			tools.Single(static tool => tool.Name == "pack_context")
@@ -97,7 +101,7 @@ public sealed class McpServerIntegrationTests
 	}
 
 	[Fact]
-	public async Task ToolsCompleteTheRedactedInlineAndStoredPackWorkflow()
+	public async Task ToolCallsExposeTextAndStructuredPayloadsAccordingToSchemaContract()
 	{
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("project");
@@ -107,26 +111,42 @@ public sealed class McpServerIntegrationTests
 			$"// Contact {PrivateEmail}\nsearch-marker\n");
 		File.WriteAllText(Path.Combine(project, "Large.cs"), "large-marker\n" + new string('x', 60_000));
 		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+		var tools = await server.Client.ListToolsAsync(
+			options: null,
+			TestContext.Current.CancellationToken);
 
 		var projects = await server.CallAsync("list_projects");
-		Assert.Contains(project, Text(projects), PathComparison);
+		var projectsStructured = AssertStructuredResult(
+			server,
+			projects,
+			Assert.IsType<JsonElement>(tools.Single(static tool => tool.Name == "list_projects").ProtocolTool.OutputSchema));
+		var listedProject = projectsStructured.GetProperty("projects")[0].GetProperty("path").GetString();
+		Assert.True(
+			string.Equals(project, listedProject, PathComparison),
+			$"Expected listed project '{project}', got '{listedProject}'.");
 
 		var tree = await server.CallAsync("get_tree", new Dictionary<string, object?> { ["max_depth"] = "10" });
-		Assert.Contains("Secret.cs", Text(tree), StringComparison.Ordinal);
+		AssertTextOnlyResult(server, tree, "Secret.cs");
 		AssertSpotlighted(tree);
 
 		var analysis = await server.CallAsync("analyze");
 		Assert.True(analysis.StructuredContent?.GetProperty("files").GetInt32() >= 2);
+		var analysisStructured = AssertStructuredResult(
+			server,
+			analysis,
+			Assert.IsType<JsonElement>(tools.Single(static tool => tool.Name == "analyze").ProtocolTool.OutputSchema));
+		Assert.True(analysisStructured.GetProperty("files").GetInt32() >= 2);
 
 		var file = await server.CallAsync(
 			"get_file",
 			new Dictionary<string, object?> { ["path"] = "Secret.cs", ["start_line"] = "1" });
+		AssertTextOnlyResult(server, file, "search-marker");
 		AssertRedactedAndSpotlighted(file);
 
 		var search = await server.CallAsync(
 			"search_project",
 			new Dictionary<string, object?> { ["pattern"] = "search-marker", ["max_results"] = "5" });
-		Assert.Contains("Secret.cs:3:", Text(search), StringComparison.Ordinal);
+		AssertTextOnlyResult(server, search, "Secret.cs:3:");
 		AssertRedactedAndSpotlighted(search);
 
 		var inline = await server.CallAsync(
@@ -137,7 +157,8 @@ public sealed class McpServerIntegrationTests
 				["view"] = "content",
 				["format"] = "markdown"
 			});
-		Assert.False(inline.StructuredContent?.GetProperty("stored").GetBoolean());
+		AssertTextOnlyResult(server, inline, "Secret.cs");
+		Assert.Contains("search-marker", Text(inline), StringComparison.Ordinal);
 		AssertRedactedAndSpotlighted(inline);
 
 		var stored = await server.CallAsync(
@@ -147,13 +168,14 @@ public sealed class McpServerIntegrationTests
 				["view"] = "content",
 				["format"] = "text"
 			});
-		Assert.True(stored.StructuredContent?.GetProperty("stored").GetBoolean());
-		var packId = stored.StructuredContent?.GetProperty("packId").GetString();
-		Assert.False(string.IsNullOrWhiteSpace(packId));
+		AssertTextOnlyResult(server, stored, "Pack stored as '");
+		Assert.Contains("Large.cs", Text(stored), StringComparison.Ordinal);
+		var packId = ExtractPackId(Text(stored));
 
 		var page = await server.CallAsync(
 			"read_pack",
-			new Dictionary<string, object?> { ["pack_id"] = packId!, ["start_line"] = "1" });
+			new Dictionary<string, object?> { ["pack_id"] = packId, ["start_line"] = "1" });
+		AssertTextOnlyResult(server, page, "Large.cs");
 		AssertRedactedAndSpotlighted(page);
 
 		var expired = await server.CallAsync(
@@ -162,6 +184,45 @@ public sealed class McpServerIntegrationTests
 		Assert.True(expired.IsError);
 		Assert.Null(expired.StructuredContent);
 		Assert.Contains(McpErrorCodes.PackExpired, Text(expired), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SchemaAwareClientReceivesCompleteTreeFileAndSearchPayloads()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "Sample.cs"),
+			"before-context\nneedle-value\nafter-context\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+		var tools = (await server.Client.ListToolsAsync(
+				options: null,
+				TestContext.Current.CancellationToken))
+			.ToDictionary(static tool => tool.Name, StringComparer.Ordinal);
+
+		var tree = ReadLikeSchemaAwareClient(
+			tools["get_tree"],
+			await server.CallAsync("get_tree"));
+		var file = ReadLikeSchemaAwareClient(
+			tools["get_file"],
+			await server.CallAsync(
+				"get_file",
+				new Dictionary<string, object?> { ["path"] = "Sample.cs" }));
+		var search = ReadLikeSchemaAwareClient(
+			tools["search_project"],
+			await server.CallAsync(
+				"search_project",
+				new Dictionary<string, object?>
+				{
+					["pattern"] = "needle-value",
+					["context_lines"] = 1
+				}));
+
+		Assert.Contains("Sample.cs", tree, StringComparison.Ordinal);
+		Assert.Contains("needle-value", file, StringComparison.Ordinal);
+		Assert.Contains("Sample.cs:2:needle-value", search, StringComparison.Ordinal);
+		Assert.Contains("Sample.cs-1-before-context", search, StringComparison.Ordinal);
+		Assert.Contains("Sample.cs-3-after-context", search, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -210,7 +271,7 @@ public sealed class McpServerIntegrationTests
 		Assert.True(
 			signatures.StructuredContent?.GetProperty("tokens").GetInt64() <
 			full.StructuredContent?.GetProperty("tokens").GetInt64());
-		Assert.Equal("signatures", packed.StructuredContent?.GetProperty("detail").GetString());
+		Assert.Null(packed.StructuredContent);
 		Assert.Contains("Calculate", Text(packed), StringComparison.Ordinal);
 		Assert.Contains("private const string Token", Text(packed), StringComparison.Ordinal);
 		Assert.DoesNotContain(bodyMarker, Text(packed), StringComparison.Ordinal);
@@ -265,6 +326,113 @@ public sealed class McpServerIntegrationTests
 		Assert.True(error.IsError);
 		Assert.Contains(McpErrorCodes.InvalidArguments, Text(error), StringComparison.Ordinal);
 		Assert.Contains("omit tracked_only", Text(error), StringComparison.Ordinal);
+	}
+
+	private static string ReadLikeSchemaAwareClient(McpClientTool tool, CallToolResult result)
+	{
+		if (tool.ProtocolTool.OutputSchema is null)
+		{
+			Assert.Null(result.StructuredContent);
+			return Text(result);
+		}
+
+		Assert.NotNull(result.StructuredContent);
+		return result.StructuredContent.Value.GetRawText();
+	}
+
+	private static string ExtractPackId(string text)
+	{
+		var match = Regex.Match(
+			text,
+			"Pack stored as '([^']+)' \\(\\d+ characters\\)\\.",
+			RegexOptions.CultureInvariant);
+		Assert.True(match.Success, $"Stored pack response did not contain a pack id: {text}");
+		return match.Groups[1].Value;
+	}
+
+	private static void AssertTextOnlyResult(
+		McpTestServer server,
+		CallToolResult result,
+		string expectedPayload)
+	{
+		Assert.NotEqual(true, result.IsError);
+		Assert.Null(result.StructuredContent);
+		Assert.Contains(expectedPayload, Text(result), StringComparison.Ordinal);
+
+		var wireResult = server.GetLastToolCallWireResult();
+		Assert.False(wireResult.TryGetProperty("structuredContent", out _));
+		var block = wireResult.GetProperty("content")[0];
+		Assert.Equal("text", block.GetProperty("type").GetString());
+		Assert.Equal(Text(result), block.GetProperty("text").GetString());
+	}
+
+	private static JsonElement AssertStructuredResult(
+		McpTestServer server,
+		CallToolResult result,
+		JsonElement outputSchema)
+	{
+		Assert.NotEqual(true, result.IsError);
+		Assert.NotNull(result.StructuredContent);
+		var structured = result.StructuredContent.Value;
+		AssertMatchesSchema(structured, outputSchema);
+
+		using var textDocument = JsonDocument.Parse(Text(result));
+		Assert.True(JsonElement.DeepEquals(structured, textDocument.RootElement));
+		var wireResult = server.GetLastToolCallWireResult();
+		Assert.True(wireResult.TryGetProperty("structuredContent", out var wireStructured));
+		Assert.True(JsonElement.DeepEquals(structured, wireStructured));
+		return structured;
+	}
+
+	private static void AssertMatchesSchema(JsonElement value, JsonElement schema, string path = "$")
+	{
+		var expectedType = schema.GetProperty("type").GetString();
+		switch (expectedType)
+		{
+			case "object":
+				Assert.True(value.ValueKind == JsonValueKind.Object, $"{path} must be an object.");
+				var properties = schema.GetProperty("properties");
+				if (schema.TryGetProperty("required", out var required))
+				{
+					foreach (var requiredProperty in required.EnumerateArray())
+					{
+						var name = requiredProperty.GetString()!;
+						Assert.True(value.TryGetProperty(name, out _), $"{path}.{name} is required.");
+					}
+				}
+
+				foreach (var property in value.EnumerateObject())
+				{
+					Assert.True(
+						properties.TryGetProperty(property.Name, out var propertySchema),
+						$"{path}.{property.Name} is not declared by the schema.");
+					AssertMatchesSchema(property.Value, propertySchema, $"{path}.{property.Name}");
+				}
+				break;
+			case "array":
+				Assert.True(value.ValueKind == JsonValueKind.Array, $"{path} must be an array.");
+				var itemSchema = schema.GetProperty("items");
+				var index = 0;
+				foreach (var item in value.EnumerateArray())
+					AssertMatchesSchema(item, itemSchema, $"{path}[{index++}]");
+				break;
+			case "string":
+				Assert.True(value.ValueKind == JsonValueKind.String, $"{path} must be a string.");
+				if (schema.TryGetProperty("enum", out var allowed))
+				{
+					Assert.Contains(
+						value.GetString(),
+						allowed.EnumerateArray().Select(static item => item.GetString()));
+				}
+				break;
+			case "integer":
+				Assert.True(
+					value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out _),
+					$"{path} must be an integer.");
+				break;
+			default:
+				throw new Xunit.Sdk.XunitException($"Unsupported contract schema type '{expectedType}' at {path}.");
+		}
 	}
 
 	private static StringComparison PathComparison =>
@@ -330,17 +498,20 @@ public sealed class McpServerIntegrationTests
 		private readonly Pipe _clientToServer;
 		private readonly Pipe _serverToClient;
 		private readonly Task _serverTask;
+		private readonly RecordingReadStream _recordingOutput;
 
 		private McpTestServer(
 			McpClient client,
 			Pipe clientToServer,
 			Pipe serverToClient,
-			Task serverTask)
+			Task serverTask,
+			RecordingReadStream recordingOutput)
 		{
 			Client = client;
 			_clientToServer = clientToServer;
 			_serverToClient = serverToClient;
 			_serverTask = serverTask;
+			_recordingOutput = recordingOutput;
 		}
 
 		public McpClient Client { get; }
@@ -356,15 +527,16 @@ public sealed class McpServerIntegrationTests
 				TestContext.Current.CancellationToken,
 				() => Path.Combine(sandbox, "app-data"),
 				Path.Combine(sandbox, "temp"));
+			var recordingOutput = new RecordingReadStream(serverToClient.Reader.AsStream());
 			var transport = new StreamClientTransport(
 				clientToServer.Writer.AsStream(),
-				serverToClient.Reader.AsStream());
+				recordingOutput);
 			var client = await McpClient.CreateAsync(
 				transport,
 				clientOptions: null,
 				loggerFactory: null,
 				TestContext.Current.CancellationToken);
-			return new McpTestServer(client, clientToServer, serverToClient, serverTask);
+			return new McpTestServer(client, clientToServer, serverToClient, serverTask, recordingOutput);
 		}
 
 		public Task<CallToolResult> CallAsync(
@@ -377,12 +549,90 @@ public sealed class McpServerIntegrationTests
 				options: null,
 				TestContext.Current.CancellationToken).AsTask();
 
+		public JsonElement GetLastToolCallWireResult()
+		{
+			var messages = _recordingOutput.GetRecordedText()
+				.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+			for (var index = messages.Length - 1; index >= 0; index--)
+			{
+				using var document = JsonDocument.Parse(messages[index].TrimEnd('\r'));
+				if (document.RootElement.TryGetProperty("result", out var result) &&
+				    result.ValueKind == JsonValueKind.Object &&
+				    result.TryGetProperty("content", out _))
+				{
+					return result.Clone();
+				}
+			}
+
+			throw new Xunit.Sdk.XunitException("No tools/call result was recorded on the MCP wire.");
+		}
+
 		public async ValueTask DisposeAsync()
 		{
 			await Client.DisposeAsync();
 			await _clientToServer.Writer.CompleteAsync();
 			await _serverToClient.Reader.CompleteAsync();
 			await _serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+		}
+
+		private sealed class RecordingReadStream(Stream source) : Stream
+		{
+			private readonly MemoryStream _recording = new();
+			private readonly object _sync = new();
+
+			public string GetRecordedText()
+			{
+				lock (_sync)
+					return Encoding.UTF8.GetString(_recording.ToArray());
+			}
+
+			public override async ValueTask<int> ReadAsync(
+				Memory<byte> buffer,
+				CancellationToken cancellationToken = default)
+			{
+				var read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+				if (read > 0)
+				{
+					lock (_sync)
+						_recording.Write(buffer.Span[..read]);
+				}
+				return read;
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				var read = source.Read(buffer, offset, count);
+				if (read > 0)
+				{
+					lock (_sync)
+						_recording.Write(buffer, offset, read);
+				}
+				return read;
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing)
+				{
+					source.Dispose();
+					_recording.Dispose();
+				}
+				base.Dispose(disposing);
+			}
+
+			public override bool CanRead => source.CanRead;
+			public override bool CanSeek => false;
+			public override bool CanWrite => false;
+			public override long Length => throw new NotSupportedException();
+			public override long Position
+			{
+				get => throw new NotSupportedException();
+				set => throw new NotSupportedException();
+			}
+			public override void Flush() => throw new NotSupportedException();
+			public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+			public override void SetLength(long value) => throw new NotSupportedException();
+			public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 		}
 	}
 }

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -121,9 +121,10 @@ public sealed class McpServerIntegrationTests
 			projects,
 			Assert.IsType<JsonElement>(tools.Single(static tool => tool.Name == "list_projects").ProtocolTool.OutputSchema));
 		var listedProject = projectsStructured.GetProperty("projects")[0].GetProperty("path").GetString();
+		var expectedProject = McpRootRegistry.ResolvePhysicalExistingPath(project, requireDirectory: true);
 		Assert.True(
-			string.Equals(project, listedProject, PathComparison),
-			$"Expected listed project '{project}', got '{listedProject}'.");
+			string.Equals(expectedProject, listedProject, PathComparison),
+			$"Expected listed project '{expectedProject}', got '{listedProject}'.");
 
 		var tree = await server.CallAsync("get_tree", new Dictionary<string, object?> { ["max_depth"] = "10" });
 		AssertTextOnlyResult(server, tree, "Secret.cs");

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -51,8 +51,12 @@ public sealed class McpServerProcessTests
 			Assert.NotNull(result.StructuredContent);
 			var structured = result.StructuredContent.Value;
 			var listedProject = structured.GetProperty("projects")[0].GetProperty("path").GetString();
-			Assert.True(string.Equals(project, listedProject, PathComparison));
-			Assert.False(string.Equals(ignoredEnvironmentRoot, listedProject, PathComparison));
+			var expectedProject = McpRootRegistry.ResolvePhysicalExistingPath(project, requireDirectory: true);
+			var expectedIgnoredEnvironmentRoot = McpRootRegistry.ResolvePhysicalExistingPath(
+				ignoredEnvironmentRoot,
+				requireDirectory: true);
+			Assert.True(string.Equals(expectedProject, listedProject, PathComparison));
+			Assert.False(string.Equals(expectedIgnoredEnvironmentRoot, listedProject, PathComparison));
 			var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
 			using var textDocument = JsonDocument.Parse(text);
 			Assert.True(JsonElement.DeepEquals(structured, textDocument.RootElement));

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -48,9 +48,14 @@ public sealed class McpServerProcessTests
 				progress: null,
 				options: null,
 				TestContext.Current.CancellationToken);
+			Assert.NotNull(result.StructuredContent);
+			var structured = result.StructuredContent.Value;
+			var listedProject = structured.GetProperty("projects")[0].GetProperty("path").GetString();
+			Assert.True(string.Equals(project, listedProject, PathComparison));
+			Assert.False(string.Equals(ignoredEnvironmentRoot, listedProject, PathComparison));
 			var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
-			Assert.Contains(project, text, PathComparison);
-			Assert.DoesNotContain(ignoredEnvironmentRoot, text, PathComparison);
+			using var textDocument = JsonDocument.Parse(text);
+			Assert.True(JsonElement.DeepEquals(structured, textDocument.RootElement));
 		}
 
 		process.StandardInput.Close();


### PR DESCRIPTION
## Problem

MCP clients that prefer structuredContent when a tool declares outputSchema, including Claude Code, received only summary metadata from get_tree, pack_context, read_pack, search_project, and get_file. Their useful tree, pack, file, or search payload remained only in content and could be ignored by a conforming client.

## Fix

- Remove outputSchema and structuredContent from the five text-oriented tools so their authoritative payload stays in the first text content block without JSON escaping overhead.
- Keep outputSchema for list_projects and analyze, with the text block serialized from the same complete structuredContent object.
- Keep pack_context self-contained in inline and stored modes, including a text-extractable pack id and tree preview for stored packs.
- Document the MCP result contract and the redaction boundary for project addresses versus exported content.
- Add raw JSON-RPC contract coverage and a schema-aware client regression for tree, file, and contextual search payloads.

## Validation

The branch includes integration and process-level coverage for tools/list and tools/call wire behavior. CI is the final arbiter for this PR.