### PR TITLE
feat(mcp): report progress for long-running tools

### DIFF
--- a/Application/Context/ProjectContextDocumentService.cs
+++ b/Application/Context/ProjectContextDocumentService.cs
@@ -103,7 +103,8 @@ public sealed class ProjectContextDocumentService(
 		Stream destination,
 		CancellationToken cancellationToken = default,
 		bool plain = false,
-		bool useUnifiedContentHeaders = false)
+		bool useUnifiedContentHeaders = false,
+		IProgress<ProjectCopyExportProgress>? writeProgress = null)
 	{
 		_ = await WriteCompleteWithReportAsync(
 				plan,
@@ -112,7 +113,8 @@ public sealed class ProjectContextDocumentService(
 				destination,
 				cancellationToken,
 				plain,
-				useUnifiedContentHeaders)
+				useUnifiedContentHeaders,
+				writeProgress)
 			.ConfigureAwait(false);
 	}
 
@@ -123,7 +125,8 @@ public sealed class ProjectContextDocumentService(
 		Stream destination,
 		CancellationToken cancellationToken = default,
 		bool plain = false,
-		bool useUnifiedContentHeaders = false)
+		bool useUnifiedContentHeaders = false,
+		IProgress<ProjectCopyExportProgress>? writeProgress = null)
 	{
 		ArgumentNullException.ThrowIfNull(plan);
 		ArgumentNullException.ThrowIfNull(destination);
@@ -147,7 +150,8 @@ public sealed class ProjectContextDocumentService(
 					cancellationToken,
 					plain,
 					useUnifiedContentHeaders,
-					effectivePathRedaction)
+					effectivePathRedaction,
+					writeProgress)
 				.ConfigureAwait(false);
 		}
 		using var cancellationDestination = new CancellationBoundWriteStream(
@@ -164,6 +168,7 @@ public sealed class ProjectContextDocumentService(
 						plain,
 						effectivePathRedaction,
 						contentPathMapper,
+						writeProgress,
 						cancellationToken)
 					.ConfigureAwait(false);
 				break;
@@ -175,6 +180,7 @@ public sealed class ProjectContextDocumentService(
 						plain,
 						effectivePathRedaction,
 						contentPathMapper,
+						writeProgress,
 						cancellationToken)
 					.ConfigureAwait(false);
 				break;
@@ -185,6 +191,7 @@ public sealed class ProjectContextDocumentService(
 						cancellationDestination,
 						effectivePathRedaction,
 						contentPathMapper,
+						writeProgress,
 						cancellationToken)
 					.ConfigureAwait(false);
 				break;
@@ -195,6 +202,7 @@ public sealed class ProjectContextDocumentService(
 						cancellationDestination,
 						effectivePathRedaction,
 						contentPathMapper,
+						writeProgress,
 						cancellationToken)
 					.ConfigureAwait(false);
 				break;
@@ -202,6 +210,41 @@ public sealed class ProjectContextDocumentService(
 				throw new ArgumentOutOfRangeException(nameof(format), format, null);
 		}
 		return ProjectContextWriteResult.Empty;
+	}
+
+	public async Task WritePreparedCompleteAsync(
+		ProjectContextPlan plan,
+		ProjectContextView view,
+		ProjectContextDocumentFormat format,
+		Stream destination,
+		PreparedSecretRedactionOutput prepared,
+		CancellationToken cancellationToken = default,
+		bool plain = false,
+		bool useUnifiedContentHeaders = false,
+		IProgress<ProjectCopyExportProgress>? writeProgress = null)
+	{
+		ArgumentNullException.ThrowIfNull(prepared);
+		var pathRedaction = outputPathRedactionDecision ??
+		                    OutputRootPathPresentation.CaptureRedactionDecision(
+			                    CreateTransformationContext(plan));
+		var analyzer = new PreparedSecretFileContentAnalyzer(contentAnalyzer, prepared);
+		var service = new ProjectContextDocumentService(
+			treeExportService,
+			analyzer,
+			omissionMessageProvider,
+			secretRedactionSession: null,
+			codeCompressionSession: null,
+			outputPathRedactionDecision: pathRedaction);
+		await service.WriteCompleteAsync(
+				plan,
+				view,
+				format,
+				destination,
+				cancellationToken,
+				plain,
+				useUnifiedContentHeaders,
+				writeProgress)
+			.ConfigureAwait(false);
 	}
 
 	// One gate for both transformations: whichever is enabled, the document is built from prepared
@@ -271,7 +314,8 @@ public sealed class ProjectContextDocumentService(
 		CancellationToken cancellationToken,
 		bool plain,
 		bool useUnifiedContentHeaders,
-		OutputPathRedactionDecision? pathRedaction)
+		OutputPathRedactionDecision? pathRedaction,
+		IProgress<ProjectCopyExportProgress>? writeProgress)
 	{
 		var context = CreateTransformationContext(plan)!;
 		var preparer = new SecretRedactionOutputPreparer(contentAnalyzer);
@@ -293,7 +337,8 @@ public sealed class ProjectContextDocumentService(
 				destination,
 				cancellationToken,
 				plain,
-				useUnifiedContentHeaders)
+				useUnifiedContentHeaders,
+				writeProgress)
 			.ConfigureAwait(false);
 		return new ProjectContextWriteResult(prepared.UnscannableFiles);
 	}
@@ -305,6 +350,7 @@ public sealed class ProjectContextDocumentService(
 		bool plain,
 		OutputPathRedactionDecision? pathRedaction,
 		Func<string, string>? contentPathMapper,
+		IProgress<ProjectCopyExportProgress>? writeProgress,
 		CancellationToken cancellationToken)
 	{
 		await using var writer = CreateStreamWriter(destination);
@@ -374,6 +420,7 @@ public sealed class ProjectContextDocumentService(
 					}
 				}
 				hasOutput = true;
+				ReportProgress(writeProgress, index + 1, plan.IncludedFiles.Count);
 			}
 		}
 
@@ -387,6 +434,7 @@ public sealed class ProjectContextDocumentService(
 		bool plain,
 		OutputPathRedactionDecision? pathRedaction,
 		Func<string, string>? contentPathMapper,
+		IProgress<ProjectCopyExportProgress>? writeProgress,
 		CancellationToken cancellationToken)
 	{
 		await using var writer = CreateStreamWriter(destination);
@@ -427,6 +475,7 @@ public sealed class ProjectContextDocumentService(
 
 		if (IncludesContent(view))
 		{
+			var processedFiles = 0;
 			foreach (var path in plan.IncludedFiles)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
@@ -471,6 +520,7 @@ public sealed class ProjectContextDocumentService(
 					await WriteLineAsync(writer, null, cancellationToken).ConfigureAwait(false);
 					await writer.WriteAsync(fence.AsMemory(), cancellationToken).ConfigureAwait(false);
 				}
+				ReportProgress(writeProgress, ++processedFiles, plan.IncludedFiles.Count);
 			}
 		}
 
@@ -483,6 +533,7 @@ public sealed class ProjectContextDocumentService(
 		Stream destination,
 		OutputPathRedactionDecision? pathRedaction,
 		Func<string, string>? contentPathMapper,
+		IProgress<ProjectCopyExportProgress>? writeProgress,
 		CancellationToken cancellationToken)
 	{
 		using var writer = new Utf8JsonWriter(destination, new JsonWriterOptions
@@ -509,6 +560,7 @@ public sealed class ProjectContextDocumentService(
 		writer.WriteStartArray("files");
 		if (IncludesContent(view))
 		{
+			var processedFiles = 0;
 			foreach (var path in plan.IncludedFiles)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
@@ -547,6 +599,7 @@ public sealed class ProjectContextDocumentService(
 						isFinalSegment: true);
 				}
 				writer.WriteEndObject();
+				ReportProgress(writeProgress, ++processedFiles, plan.IncludedFiles.Count);
 			}
 		}
 		writer.WriteEndArray();
@@ -562,6 +615,7 @@ public sealed class ProjectContextDocumentService(
 		Stream destination,
 		OutputPathRedactionDecision? pathRedaction,
 		Func<string, string>? contentPathMapper,
+		IProgress<ProjectCopyExportProgress>? writeProgress,
 		CancellationToken cancellationToken)
 	{
 		using var writer = XmlWriter.Create(destination, new XmlWriterSettings
@@ -591,6 +645,7 @@ public sealed class ProjectContextDocumentService(
 		writer.WriteStartElement("files");
 		if (IncludesContent(view))
 		{
+			var processedFiles = 0;
 			foreach (var path in plan.IncludedFiles)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
@@ -632,6 +687,7 @@ public sealed class ProjectContextDocumentService(
 					writer.WriteEndElement();
 				}
 				writer.WriteEndElement();
+				ReportProgress(writeProgress, ++processedFiles, plan.IncludedFiles.Count);
 			}
 		}
 		writer.WriteEndElement();
@@ -652,6 +708,23 @@ public sealed class ProjectContextDocumentService(
 		writer.WriteEndDocument();
 		await writer.FlushAsync()
 			.ConfigureAwait(false);
+	}
+
+	private static void ReportProgress(
+		IProgress<ProjectCopyExportProgress>? progress,
+		int processedFiles,
+		int totalFiles)
+	{
+		if (progress is null)
+			return;
+		var percentage = totalFiles == 0
+			? 100d
+			: Math.Clamp(processedFiles * 100d / totalFiles, 0d, 100d);
+		progress.Report(new ProjectCopyExportProgress(
+			processedFiles,
+			totalFiles,
+			BytesWritten: 0,
+			Percentage: percentage));
 	}
 
 	private static ContextFileDocument CreateCompleteFileDocument(

--- a/Application/Secrets/SecretRedactionOutputPreparer.cs
+++ b/Application/Secrets/SecretRedactionOutputPreparer.cs
@@ -48,17 +48,34 @@ public sealed class SecretRedactionOutputPreparer
 			captureEffectiveFindings: false,
 			cancellationToken);
 
+	public Task<PreparedSecretRedactionOutput> PrepareAsync(
+		ContentTransformationContext context,
+		IReadOnlyList<string> orderedFilePaths,
+		IProgress<ProjectCopyExportProgress> progress,
+		CancellationToken cancellationToken = default) =>
+		PrepareAsync(
+			context,
+			orderedFilePaths,
+			captureEffectiveFindings: false,
+			cancellationToken,
+			progress);
+
 	public async Task<PreparedSecretRedactionOutput> PrepareAsync(
 		ContentTransformationContext context,
 		IReadOnlyList<string> orderedFilePaths,
 		bool captureEffectiveFindings,
-		CancellationToken cancellationToken = default)
+		CancellationToken cancellationToken = default,
+		IProgress<ProjectCopyExportProgress>? progress = null)
 	{
 		ArgumentNullException.ThrowIfNull(context);
 		ArgumentNullException.ThrowIfNull(orderedFilePaths);
 		if (context is { Compression: not null, Redaction: null })
 		{
-			return await PrepareCompressionOnlyAsync(context, orderedFilePaths, cancellationToken)
+			return await PrepareCompressionOnlyAsync(
+					context,
+					orderedFilePaths,
+					progress,
+					cancellationToken)
 				.ConfigureAwait(false);
 		}
 
@@ -88,6 +105,9 @@ public sealed class SecretRedactionOutputPreparer
 				}
 			}
 		}
+		var processedFiles = preparedFiles.Count;
+		if (processedFiles > 0)
+			ReportProgress(progress, processedFiles, orderedFilePaths.Count);
 		try
 		{
 			await foreach (var prepared in PrepareOrderedTransformationEntriesAsync(
@@ -98,98 +118,112 @@ public sealed class SecretRedactionOutputPreparer
 			                   requiredInspectionScope).ConfigureAwait(false))
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				var sourcePath = prepared.SourcePath;
-				var result = prepared.ReadResult;
-				var metadataAfterRead = prepared.Metadata;
-
-				switch (result.Classification)
+				var completed = false;
+				try
 				{
-					case FileContentClassification.Binary:
-						scope?.AnalyzeBinary(sourcePath, metadataAfterRead);
-						preparedFiles[sourcePath] = PreparedSecretFile.Binary(sourcePath);
-						continue;
-					case FileContentClassification.TooLarge:
-					case FileContentClassification.UnsupportedEncoding:
-						// A per-file inspection limitation degrades that file, not the whole run.
-						// Redaction cannot promise anything about text it never decoded or fully read,
-						// so every output withholds the content and reports the exact reason.
-						if (scope is not null &&
-						    scope.GetContentInspectionMode(sourcePath) != SecretContentInspectionMode.None)
-						{
-							scope.AnalyzeUnscannable(sourcePath, metadataAfterRead, result.Classification);
-							preparedFiles[sourcePath] = PreparedSecretFile.Unscannable(
-								sourcePath,
-								result.Classification);
-							unscannableFiles.Add(new UnscannableFile(sourcePath, result.Classification));
+					var sourcePath = prepared.SourcePath;
+					var result = prepared.ReadResult;
+					var metadataAfterRead = prepared.Metadata;
+
+					switch (result.Classification)
+					{
+						case FileContentClassification.Binary:
+							scope?.AnalyzeBinary(sourcePath, metadataAfterRead);
+							preparedFiles[sourcePath] = PreparedSecretFile.Binary(sourcePath);
+							completed = true;
 							continue;
-						}
+						case FileContentClassification.TooLarge:
+						case FileContentClassification.UnsupportedEncoding:
+							// A per-file inspection limitation degrades that file, not the whole run.
+							// Redaction cannot promise anything about text it never decoded or fully read,
+							// so every output withholds the content and reports the exact reason.
+							if (scope is not null &&
+							    scope.GetContentInspectionMode(sourcePath) != SecretContentInspectionMode.None)
+							{
+								scope.AnalyzeUnscannable(sourcePath, metadataAfterRead, result.Classification);
+								preparedFiles[sourcePath] = PreparedSecretFile.Unscannable(
+									sourcePath,
+									result.Classification);
+								unscannableFiles.Add(new UnscannableFile(sourcePath, result.Classification));
+								completed = true;
+								continue;
+							}
 
-						// Compression has no redaction promise to break, and detector policy may
-						// exclude this path before content inspection. In both cases the original
-						// remains the authoritative unchanged output.
-						preparedFiles[sourcePath] = PreparedSecretFile.Unchanged(sourcePath);
-						continue;
-					case FileContentClassification.Text:
-						break;
-					default:
-						throw new SecretDetectionException(
-							$"Hide Secrets could not inspect '{sourcePath}' ({result.Classification}).");
-				}
+							// Compression has no redaction promise to break, and detector policy may
+							// exclude this path before content inspection. In both cases the original
+							// remains the authoritative unchanged output.
+							preparedFiles[sourcePath] = PreparedSecretFile.Unchanged(sourcePath);
+							completed = true;
+							continue;
+						case FileContentClassification.Text:
+							break;
+						default:
+							throw new SecretDetectionException(
+								$"Hide Secrets could not inspect '{sourcePath}' ({result.Classification}).");
+					}
 
-				var content = result.Content ??
-				              throw new SecretDetectionException(
-					              $"Hide Secrets received no text for '{sourcePath}'.");
-				// Compression first: the redaction plan, its spans and its counts all describe the
-				// text that actually leaves, not the text on disk.
-				var compressed = prepared.Compression;
-				var transformedText = compressed.Text;
-				var plan = scope?.CreatePlan(
-					sourcePath,
-					transformedText,
-					compressed.Map,
-					prepared.Metadata,
-					compressed.Map.IsIdentity
-						? prepared.SourceFingerprint
-						: null,
-					cancellationToken);
-				var redactions = plan?.Spans
-					.Where(static span => span.State == SecretPreviewSpanState.Redacted)
-					.Select(static span => new PreparedSecretSpan(span.Start, span.Length))
-					.ToArray() ?? [];
-				IReadOnlyList<EffectiveRedactionFinding> findings = plan is null || !captureEffectiveFindings
-					? []
-					: BuildEffectiveFindings(plan.Spans, content.Content, compressed.Map);
-				if (ReferenceEquals(transformedText, content.Content) && redactions.Length == 0)
-				{
-					preparedFiles[sourcePath] = findings.Count == 0
-						? PreparedSecretFile.Unchanged(sourcePath)
-						: new PreparedSecretFile(
-							sourcePath,
-							sourcePath,
-							FileContentClassification.Text,
-							result.Encoding,
-							[],
-							findings);
-					continue;
-				}
-
-				var encoding = result.Encoding ?? TextFileEncoding.Utf8;
-				workingDirectory ??= CreateWorkingDirectory();
-				var preparedPath = Path.Combine(workingDirectory.Path, $"{prepared.Index:D8}.redacted.txt");
-				await WritePreparedTextAsync(
-						preparedPath,
+					var content = result.Content ??
+					              throw new SecretDetectionException(
+						              $"Hide Secrets received no text for '{sourcePath}'.");
+					// Compression first: the redaction plan, its spans and its counts all describe the
+					// text that actually leaves, not the text on disk.
+					var compressed = prepared.Compression;
+					var transformedText = compressed.Text;
+					var plan = scope?.CreatePlan(
+						sourcePath,
 						transformedText,
-						plan,
-						ResolveEncoding(encoding),
-						cancellationToken)
-					.ConfigureAwait(false);
-				preparedFiles[sourcePath] = new PreparedSecretFile(
-					sourcePath,
-					preparedPath,
-					FileContentClassification.Text,
-					encoding,
-					redactions,
-					findings);
+						compressed.Map,
+						prepared.Metadata,
+						compressed.Map.IsIdentity
+							? prepared.SourceFingerprint
+							: null,
+						cancellationToken);
+					var redactions = plan?.Spans
+						.Where(static span => span.State == SecretPreviewSpanState.Redacted)
+						.Select(static span => new PreparedSecretSpan(span.Start, span.Length))
+						.ToArray() ?? [];
+					IReadOnlyList<EffectiveRedactionFinding> findings = plan is null || !captureEffectiveFindings
+						? []
+						: BuildEffectiveFindings(plan.Spans, content.Content, compressed.Map);
+					if (ReferenceEquals(transformedText, content.Content) && redactions.Length == 0)
+					{
+						preparedFiles[sourcePath] = findings.Count == 0
+							? PreparedSecretFile.Unchanged(sourcePath)
+							: new PreparedSecretFile(
+								sourcePath,
+								sourcePath,
+								FileContentClassification.Text,
+								result.Encoding,
+								[],
+								findings);
+						completed = true;
+						continue;
+					}
+
+					var encoding = result.Encoding ?? TextFileEncoding.Utf8;
+					workingDirectory ??= CreateWorkingDirectory();
+					var preparedPath = Path.Combine(workingDirectory.Path, $"{prepared.Index:D8}.redacted.txt");
+					await WritePreparedTextAsync(
+							preparedPath,
+							transformedText,
+							plan,
+							ResolveEncoding(encoding),
+							cancellationToken)
+						.ConfigureAwait(false);
+					preparedFiles[sourcePath] = new PreparedSecretFile(
+						sourcePath,
+						preparedPath,
+						FileContentClassification.Text,
+						encoding,
+						redactions,
+						findings);
+					completed = true;
+				}
+				finally
+				{
+					if (completed)
+						ReportProgress(progress, ++processedFiles, orderedFilePaths.Count);
+				}
 			}
 
 			var snapshot = scope?.Complete(
@@ -480,6 +514,7 @@ public sealed class SecretRedactionOutputPreparer
 	private async Task<PreparedSecretRedactionOutput> PrepareCompressionOnlyAsync(
 		ContentTransformationContext context,
 		IReadOnlyList<string> orderedFilePaths,
+		IProgress<ProjectCopyExportProgress>? progress,
 		CancellationToken cancellationToken)
 	{
 		var workingDirectory = new Lazy<SecretRedactionTempDirectory>(
@@ -498,6 +533,7 @@ public sealed class SecretRedactionOutputPreparer
 		}
 
 		using var transformationScope = context.BeginOutput(orderedFilePaths);
+		var processedFiles = 0;
 		try
 		{
 			if (parallelWork.Count > 0)
@@ -519,6 +555,10 @@ public sealed class SecretRedactionOutputPreparer
 							workingDirectory,
 							workItem,
 							token).ConfigureAwait(false);
+						ReportProgress(
+							progress,
+							Interlocked.Increment(ref processedFiles),
+							orderedFilePaths.Count);
 					}).ConfigureAwait(false);
 			}
 
@@ -530,6 +570,10 @@ public sealed class SecretRedactionOutputPreparer
 					workingDirectory,
 					workItem,
 					cancellationToken).ConfigureAwait(false);
+				ReportProgress(
+					progress,
+					Interlocked.Increment(ref processedFiles),
+					orderedFilePaths.Count);
 			}
 
 			var preparedFiles = new Dictionary<string, PreparedSecretFile>(
@@ -556,6 +600,23 @@ public sealed class SecretRedactionOutputPreparer
 				workingDirectory.Value.Dispose();
 			throw;
 		}
+	}
+
+	private static void ReportProgress(
+		IProgress<ProjectCopyExportProgress>? progress,
+		int processedFiles,
+		int totalFiles)
+	{
+		if (progress is null)
+			return;
+		var percentage = totalFiles == 0
+			? 100d
+			: Math.Clamp(processedFiles * 100d / totalFiles, 0d, 100d);
+		progress.Report(new ProjectCopyExportProgress(
+			processedFiles,
+			totalFiles,
+			BytesWritten: 0,
+			Percentage: percentage));
 	}
 
 	private async Task<PreparedSecretFile> PrepareCompressedFileAsync(

--- a/Application/Services/ProjectContentMetricsCalculator.cs
+++ b/Application/Services/ProjectContentMetricsCalculator.cs
@@ -6,9 +6,20 @@ public static class ProjectContentMetricsCalculator
 	private const int MaximumConcurrentReads = 4;
 	private const int BatchSize = 1024;
 
+	public static Task<ExportOutputMetrics> CalculateAsync(
+		IFileContentAnalyzer analyzer,
+		IReadOnlyList<string>? orderedFilePaths,
+		CancellationToken cancellationToken = default)
+		=> CalculateAsync(
+			analyzer,
+			orderedFilePaths,
+			progress: null,
+			cancellationToken);
+
 	public static async Task<ExportOutputMetrics> CalculateAsync(
 		IFileContentAnalyzer analyzer,
 		IReadOnlyList<string>? orderedFilePaths,
+		IProgress<ProjectCopyExportProgress>? progress,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(analyzer);
@@ -24,6 +35,7 @@ public static class ProjectContentMetricsCalculator
 		};
 		var accumulator = new ExportOutputMetricsCalculator.OrderedContentMetricsAccumulator();
 		var batchMetrics = new FileContentMetricsResult?[Math.Min(BatchSize, orderedFilePaths.Count)];
+		var processedFiles = 0;
 		for (var batchStart = 0; batchStart < orderedFilePaths.Count; batchStart += batchMetrics.Length)
 		{
 			var batchCount = Math.Min(batchMetrics.Length, orderedFilePaths.Count - batchStart);
@@ -36,6 +48,13 @@ public static class ProjectContentMetricsCalculator
 					batchMetrics[batchIndex] = await analyzer
 						.GetClassifiedMetricsAsync(orderedFilePaths[batchStart + batchIndex], token)
 						.ConfigureAwait(false);
+					var processed = Interlocked.Increment(ref processedFiles);
+					var percentage = processed * 100d / orderedFilePaths.Count;
+					progress?.Report(new ProjectCopyExportProgress(
+						processed,
+						orderedFilePaths.Count,
+						BytesWritten: 0,
+						Percentage: percentage));
 				}).ConfigureAwait(false);
 
 			for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -76,28 +76,63 @@ internal sealed class DevProjexMcpTools(
 	[Description("Measure a redacted project selection and list its ten largest text files by estimated tokens.")]
 	public Task<CallToolResult> Analyze(
 		RequestContext<CallToolRequestParams> request,
+		IProgress<ProgressNotificationValue> progress,
 		CancellationToken cancellationToken) =>
 		RunProjectAsync(async () =>
 		{
+			var operationProgress = new McpProgressReporter(progress);
+			operationProgress.Milestone(1, "selecting files");
 			var arguments = SelectionArguments(request.Params);
 			var detail = McpDetailPolicy.Parse(arguments.OptionalString("detail"));
 			var plan = await BuildSelectionAsync(arguments, cancellationToken).ConfigureAwait(false);
+			operationProgress.Milestone(
+				10,
+				$"scanning files {plan.IncludedFiles.Count}/{plan.IncludedFiles.Count}");
 			var effectiveDetail = projects.ResolveDetail(plan, detail);
-			await using var prepared = await projects.PrepareAsync(plan, detail, cancellationToken).ConfigureAwait(false);
-			var analyzer = projects.CreatePreparedAnalyzer(prepared);
-			var metrics = await ProjectContentMetricsCalculator
-				.CalculateAsync(analyzer, plan.IncludedFiles, cancellationToken)
+			operationProgress.Milestone(11, $"transforming content 0/{plan.IncludedFiles.Count}");
+			await using var prepared = await projects.PrepareAsync(
+					plan,
+					detail,
+					operationProgress.Measure("transforming content", 12, 59),
+					cancellationToken)
 				.ConfigureAwait(false);
+			operationProgress.Milestone(
+				60,
+				$"transforming content {plan.IncludedFiles.Count}/{plan.IncludedFiles.Count}");
+			var analyzer = projects.CreatePreparedAnalyzer(prepared);
+			operationProgress.Milestone(61, $"analyzing content 0/{plan.IncludedFiles.Count}");
+			var metrics = await ProjectContentMetricsCalculator
+				.CalculateAsync(
+					analyzer,
+					plan.IncludedFiles,
+					operationProgress.Measure("analyzing content", 62, 89),
+					cancellationToken)
+				.ConfigureAwait(false);
+			operationProgress.Milestone(
+				90,
+				$"analyzing content {plan.IncludedFiles.Count}/{plan.IncludedFiles.Count}");
 			var largest = new List<FileWeight>();
+			var rankedFiles = 0;
+			var rankingProgress = operationProgress.Measure("ranking files", 91, 98);
 			foreach (var file in plan.IncludedFiles)
 			{
 				var result = await analyzer.GetClassifiedMetricsAsync(file, cancellationToken).ConfigureAwait(false);
+				rankingProgress.Report(new ProjectCopyExportProgress(
+					++rankedFiles,
+					plan.IncludedFiles.Count,
+					BytesWritten: 0,
+					Percentage: plan.IncludedFiles.Count == 0
+						? 100d
+						: rankedFiles * 100d / plan.IncludedFiles.Count));
 				if (result.Metrics is not { } fileMetrics || !result.IsText)
 					continue;
 				largest.Add(new FileWeight(
 					McpProjectService.ToRelative(plan.SourceRoot, file),
 					CodeCompressionSnapshot.EstimateTokens(fileMetrics.CharCount)));
 			}
+			operationProgress.Milestone(
+				99,
+				$"ranking files {plan.IncludedFiles.Count}/{plan.IncludedFiles.Count}");
 			var top = largest
 				.OrderByDescending(static item => item.Tokens)
 				.ThenBy(static item => item.Path, StringComparer.Ordinal)
@@ -112,15 +147,19 @@ internal sealed class DevProjexMcpTools(
 				detail = effectiveDetail.Token,
 				topFiles = top
 			};
+			operationProgress.Milestone(100, "building analysis");
 			return McpToolResults.StructuredSuccess(envelope);
 		});
 
 	[Description("Build an exact redacted DevProjex context export. Large packs expire when this server process exits.")]
 	public Task<CallToolResult> PackContext(
 		RequestContext<CallToolRequestParams> request,
+		IProgress<ProgressNotificationValue> progress,
 		CancellationToken cancellationToken) =>
 		RunProjectAsync(async () =>
 		{
+			var operationProgress = new McpProgressReporter(progress);
+			operationProgress.Milestone(1, "selecting files");
 			var arguments = McpJsonArguments.Create(
 				request.Params,
 				"project",
@@ -134,27 +173,67 @@ internal sealed class DevProjexMcpTools(
 				"tracked_only");
 			var detail = McpDetailPolicy.Parse(arguments.OptionalString("detail"));
 			var plan = await BuildSelectionAsync(arguments, cancellationToken).ConfigureAwait(false);
+			operationProgress.Milestone(
+				10,
+				$"scanning files {plan.IncludedFiles.Count}/{plan.IncludedFiles.Count}");
 			var effectiveDetail = projects.ResolveDetail(plan, detail);
 			plan = projects.ApplyDetail(plan, effectiveDetail);
 			var view = ParseView(arguments.OptionalString("view") ?? "tree-content");
 			var format = ParseFormat(arguments.OptionalString("format") ?? "markdown");
+			var transformedFileCount = view == ProjectContextView.Tree ? 0 : plan.IncludedFiles.Count;
+			operationProgress.Milestone(11, $"transforming content 0/{transformedFileCount}");
+			await using var prepared = view == ProjectContextView.Tree
+				? null
+				: await projects.PrepareAsync(
+						plan,
+						McpDetailLevel.Full,
+						operationProgress.Measure("transforming content", 12, 59),
+						cancellationToken)
+					.ConfigureAwait(false);
+			operationProgress.Milestone(
+				60,
+				$"transforming content {transformedFileCount}/{transformedFileCount}");
+			var writtenFileCount = view == ProjectContextView.Tree ? 0 : plan.IncludedFiles.Count;
+			operationProgress.Milestone(61, $"writing pack 0/{writtenFileCount}");
 			var pack = await packs.CreateAsync(
 				async (stream, token) =>
 				{
-					await projects.DocumentService.WriteCompleteAsync(
-						plan,
-						view,
-						format,
-						stream,
-						token,
-						plain: false,
-						useUnifiedContentHeaders: true).ConfigureAwait(false);
+					var writeProgress = operationProgress.Measure("writing pack", 62, 99);
+					if (prepared is null)
+					{
+						await projects.DocumentService.WriteCompleteAsync(
+								plan,
+								view,
+								format,
+								stream,
+								token,
+								plain: false,
+								useUnifiedContentHeaders: true,
+								writeProgress: writeProgress)
+							.ConfigureAwait(false);
+						return;
+					}
+
+					await projects.DocumentService.WritePreparedCompleteAsync(
+							plan,
+							view,
+							format,
+							stream,
+							prepared,
+							token,
+							plain: false,
+							useUnifiedContentHeaders: true,
+							writeProgress)
+						.ConfigureAwait(false);
 				},
 				cancellationToken).ConfigureAwait(false);
 			if (pack.Characters <= MaximumInlinePackCharacters)
 			{
 				var content = await File.ReadAllTextAsync(pack.Path, cancellationToken).ConfigureAwait(false);
 				packs.Remove(pack.Id);
+				operationProgress.Milestone(
+					100,
+					$"writing pack {writtenFileCount}/{writtenFileCount}");
 				return McpToolResults.TextSuccess(McpSpotlight.Wrap(content), advertiseLargeResult: true);
 			}
 
@@ -168,6 +247,9 @@ internal sealed class DevProjexMcpTools(
 			var message = $"Pack stored as '{pack.Id}' ({pack.Characters} characters). " +
 			              "Call read_pack with this pack_id to read ranges, or search_project to locate source content.\n" +
 			              McpSpotlight.Wrap(tree);
+			operationProgress.Milestone(
+				100,
+				$"writing pack {writtenFileCount}/{writtenFileCount}");
 			return McpToolResults.TextSuccess(message, advertiseLargeResult: true);
 		});
 

--- a/Apps/Mcp/GlobalUsings.cs
+++ b/Apps/Mcp/GlobalUsings.cs
@@ -14,6 +14,7 @@ global using DevProjex.Kernel;
 global using DevProjex.Kernel.Abstractions;
 global using DevProjex.Kernel.Contracts;
 global using DevProjex.Kernel.Models;
+global using ModelContextProtocol;
 global using ModelContextProtocol.Protocol;
 global using ModelContextProtocol.Server;
 global using System.Text;

--- a/Apps/Mcp/McpProgressReporter.cs
+++ b/Apps/Mcp/McpProgressReporter.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+
+namespace DevProjex.Mcp;
+
+internal sealed class McpProgressReporter(IProgress<ProgressNotificationValue> destination)
+{
+	private const double Total = 100d;
+	private const double MinimumIntermediateStep = 5d;
+	private static readonly TimeSpan MinimumIntermediateInterval = TimeSpan.FromMilliseconds(250);
+	private readonly object _sync = new();
+	private double _lastProgress;
+	private long _lastReportTimestamp;
+
+	public void Milestone(double progress, string message) =>
+		Report(progress, message, force: true);
+
+	public IProgress<ProjectCopyExportProgress> Measure(
+		string phase,
+		double start,
+		double end) =>
+		new SynchronousProgress<ProjectCopyExportProgress>(value =>
+		{
+			var total = Math.Max(0, value.TotalEntryCount);
+			var processed = Math.Clamp(value.ProcessedEntryCount, 0, total);
+			var fraction = total == 0
+				? 1d
+				: processed / (double)total;
+			var mapped = start + Math.Clamp(fraction, 0d, 1d) * (end - start);
+			Report(mapped, $"{phase} {processed}/{total}", force: false);
+		});
+
+	private void Report(double progress, string message, bool force)
+	{
+		lock (_sync)
+		{
+			var normalized = Math.Clamp(progress, 0d, Total);
+			if (normalized <= _lastProgress)
+				return;
+
+			var now = Stopwatch.GetTimestamp();
+			if (!force &&
+			    (normalized - _lastProgress < MinimumIntermediateStep ||
+			     _lastReportTimestamp != 0 &&
+			     Stopwatch.GetElapsedTime(_lastReportTimestamp, now) < MinimumIntermediateInterval))
+			{
+				return;
+			}
+
+			_lastProgress = normalized;
+			_lastReportTimestamp = now;
+			destination.Report(new ProgressNotificationValue
+			{
+				Progress = (float)normalized,
+				Total = (float)Total,
+				Message = message
+			});
+		}
+	}
+
+	private sealed class SynchronousProgress<T>(Action<T> report) : IProgress<T>
+	{
+		public void Report(T value) => report(value);
+	}
+}

--- a/Apps/Mcp/McpProjectService.cs
+++ b/Apps/Mcp/McpProjectService.cs
@@ -115,12 +115,24 @@ internal sealed class McpProjectService(McpRootRegistry roots, McpServices servi
 				SecretRedactionFeatures.Secrets | SecretRedactionFeatures.PrivateData))!;
 	}
 
-	public async Task<PreparedSecretRedactionOutput> PrepareAsync(
+	public Task<PreparedSecretRedactionOutput> PrepareAsync(
 		ProjectContextPlan plan,
 		McpDetailLevel detail,
 		CancellationToken cancellationToken) =>
+		PrepareAsync(plan, detail, progress: null, cancellationToken);
+
+	public async Task<PreparedSecretRedactionOutput> PrepareAsync(
+		ProjectContextPlan plan,
+		McpDetailLevel detail,
+		IProgress<ProjectCopyExportProgress>? progress,
+		CancellationToken cancellationToken) =>
 		await services.OutputPreparer
-			.PrepareAsync(CreateTransformationContext(plan, detail), plan.IncludedFiles, cancellationToken)
+			.PrepareAsync(
+				CreateTransformationContext(plan, detail),
+				plan.IncludedFiles,
+				captureEffectiveFindings: false,
+				cancellationToken,
+				progress)
 			.ConfigureAwait(false);
 
 	public Task<PreparedSecretRedactionOutput> PrepareAsync(

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -82,6 +82,16 @@ Future tools must declare `outputSchema` only when their useful result is
 genuinely structured and can be returned completely in `structuredContent`.
 Metadata about a text payload is not sufficient reason to add a schema.
 
+## Progress Notifications
+
+`pack_context` and `analyze` report measured selection, content-transformation,
+and output phases through MCP `notifications/progress`. Notifications are sent
+only when the caller supplies a `progressToken` in the request `_meta`; without
+that token the server sends none. `progressToken` is transport metadata, not a
+tool argument, so tool input schemas are unchanged. Progress is monotonic and
+intermediate file-count updates are rate-limited; the other five tools do not
+report progress.
+
 Defaults:
 
 - `pack_context.view`: `tree-content`

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Pipelines;
 using DevProjex.Mcp;
+using ModelContextProtocol;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
@@ -227,6 +228,111 @@ public sealed class McpServerIntegrationTests
 	}
 
 	[Fact]
+	public async Task LongRunningToolsReportOrderedProgressOnlyForRequestedTokens()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		for (var index = 0; index < 8; index++)
+		{
+			File.WriteAllText(
+				Path.Combine(project, $"File{index:D2}.cs"),
+				$"internal static class File{index:D2} {{ public const int Value = {index}; }}\n");
+		}
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var cases = new[]
+		{
+			new ProgressCase(
+				"pack_context",
+				new Dictionary<string, object?>
+				{
+					["view"] = "content",
+					["format"] = "text"
+				},
+				["selecting files", "transforming content", "writing pack"]),
+			new ProgressCase(
+				"analyze",
+				new Dictionary<string, object?>(),
+				["selecting files", "transforming content", "analyzing content"])
+		};
+
+		foreach (var testCase in cases)
+		{
+			var progress = new InlineProgress<ProgressNotificationValue>();
+			var firstMessage = server.WireMessageCount;
+			var firstInputMessage = server.InputWireMessageCount;
+			var result = await server.CallAsync(
+				testCase.ToolName,
+				testCase.Arguments,
+				progress);
+
+			Assert.NotEqual(true, result.IsError);
+			var request = Assert.Single(
+				server.GetInputWireMessages(firstInputMessage),
+				static message => message.TryGetProperty("method", out var method) &&
+				                  method.GetString() == RequestMethods.ToolsCall);
+			var requestToken = request.GetProperty("params")
+				.GetProperty("_meta")
+				.GetProperty("progressToken");
+			var messages = server.GetWireMessages(firstMessage);
+			var progressMessages = messages
+				.Select((message, index) => (Message: message, Index: index))
+				.Where(static item =>
+					item.Message.TryGetProperty("method", out var method) &&
+					method.GetString() == NotificationMethods.ProgressNotification)
+				.ToArray();
+			Assert.NotEmpty(progressMessages);
+			var resultIndex = Array.FindIndex(
+				messages,
+				static message => message.TryGetProperty("result", out var wireResult) &&
+				                  wireResult.TryGetProperty("content", out _));
+			Assert.True(resultIndex >= 0, "The tool result was not recorded on the wire.");
+			Assert.All(progressMessages, item => Assert.True(item.Index < resultIndex));
+
+			var values = progressMessages
+				.Select(static item => item.Message.GetProperty("params"))
+				.ToArray();
+			Assert.All(values, value =>
+			{
+				Assert.True(JsonElement.DeepEquals(
+					requestToken,
+					value.GetProperty("progressToken")));
+				Assert.Equal(100f, value.GetProperty("total").GetSingle());
+			});
+			for (var index = 1; index < values.Length; index++)
+			{
+				Assert.True(
+					values[index].GetProperty("progress").GetSingle() >
+					values[index - 1].GetProperty("progress").GetSingle());
+			}
+			foreach (var phase in testCase.ExpectedPhases)
+			{
+				Assert.Contains(
+					values,
+					value => value.GetProperty("message").GetString()!
+						.StartsWith(phase, StringComparison.Ordinal));
+			}
+			Assert.NotEmpty(progress.Values);
+
+			firstMessage = server.WireMessageCount;
+			firstInputMessage = server.InputWireMessageCount;
+			result = await server.CallAsync(testCase.ToolName, testCase.Arguments);
+			Assert.NotEqual(true, result.IsError);
+			request = Assert.Single(
+				server.GetInputWireMessages(firstInputMessage),
+				static message => message.TryGetProperty("method", out var method) &&
+				                  method.GetString() == RequestMethods.ToolsCall);
+			if (request.GetProperty("params").TryGetProperty("_meta", out var requestMeta))
+				Assert.False(requestMeta.TryGetProperty("progressToken", out _));
+			Assert.DoesNotContain(
+				server.GetWireMessages(firstMessage),
+				static message =>
+					message.TryGetProperty("method", out var method) &&
+					method.GetString() == NotificationMethods.ProgressNotification);
+		}
+	}
+
+	[Fact]
 	public async Task DetailSignaturesCompressesMetricsAndContentWithoutWeakeningRedaction()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -442,6 +548,32 @@ public sealed class McpServerIntegrationTests
 	private static string Text(CallToolResult result) =>
 		Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
 
+	private sealed record ProgressCase(
+		string ToolName,
+		IReadOnlyDictionary<string, object?> Arguments,
+		IReadOnlyList<string> ExpectedPhases);
+
+	private sealed class InlineProgress<T> : IProgress<T>
+	{
+		private readonly List<T> _values = [];
+		private readonly object _sync = new();
+
+		public IReadOnlyList<T> Values
+		{
+			get
+			{
+				lock (_sync)
+					return _values.ToArray();
+			}
+		}
+
+		public void Report(T value)
+		{
+			lock (_sync)
+				_values.Add(value);
+		}
+	}
+
 	private static void AssertSpotlighted(CallToolResult result)
 	{
 		var text = Text(result);
@@ -499,6 +631,7 @@ public sealed class McpServerIntegrationTests
 		private readonly Pipe _clientToServer;
 		private readonly Pipe _serverToClient;
 		private readonly Task _serverTask;
+		private readonly RecordingWriteStream _recordingInput;
 		private readonly RecordingReadStream _recordingOutput;
 
 		private McpTestServer(
@@ -506,12 +639,14 @@ public sealed class McpServerIntegrationTests
 			Pipe clientToServer,
 			Pipe serverToClient,
 			Task serverTask,
+			RecordingWriteStream recordingInput,
 			RecordingReadStream recordingOutput)
 		{
 			Client = client;
 			_clientToServer = clientToServer;
 			_serverToClient = serverToClient;
 			_serverTask = serverTask;
+			_recordingInput = recordingInput;
 			_recordingOutput = recordingOutput;
 		}
 
@@ -528,27 +663,58 @@ public sealed class McpServerIntegrationTests
 				TestContext.Current.CancellationToken,
 				() => Path.Combine(sandbox, "app-data"),
 				Path.Combine(sandbox, "temp"));
+			var recordingInput = new RecordingWriteStream(clientToServer.Writer.AsStream());
 			var recordingOutput = new RecordingReadStream(serverToClient.Reader.AsStream());
 			var transport = new StreamClientTransport(
-				clientToServer.Writer.AsStream(),
+				recordingInput,
 				recordingOutput);
 			var client = await McpClient.CreateAsync(
 				transport,
 				clientOptions: null,
 				loggerFactory: null,
 				TestContext.Current.CancellationToken);
-			return new McpTestServer(client, clientToServer, serverToClient, serverTask, recordingOutput);
+			return new McpTestServer(
+				client,
+				clientToServer,
+				serverToClient,
+				serverTask,
+				recordingInput,
+				recordingOutput);
 		}
 
 		public Task<CallToolResult> CallAsync(
 			string name,
-			IReadOnlyDictionary<string, object?>? arguments = null) =>
+			IReadOnlyDictionary<string, object?>? arguments = null,
+			IProgress<ProgressNotificationValue>? progress = null,
+			RequestOptions? options = null) =>
 			Client.CallToolAsync(
 				name,
 				arguments ?? new Dictionary<string, object?>(),
-				progress: null,
-				options: null,
+				progress,
+				options,
 				TestContext.Current.CancellationToken).AsTask();
+
+		public int WireMessageCount => GetWireMessages(0).Length;
+		public int InputWireMessageCount => GetInputWireMessages(0).Length;
+
+		public JsonElement[] GetInputWireMessages(int startIndex) =>
+			ParseMessages(_recordingInput.GetRecordedText(), startIndex);
+
+		public JsonElement[] GetWireMessages(int startIndex) =>
+			ParseMessages(_recordingOutput.GetRecordedText(), startIndex);
+
+		private static JsonElement[] ParseMessages(string transcript, int startIndex)
+		{
+			var lines = transcript
+				.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+			var messages = new List<JsonElement>(Math.Max(0, lines.Length - startIndex));
+			for (var index = startIndex; index < lines.Length; index++)
+			{
+				using var document = JsonDocument.Parse(lines[index].TrimEnd('\r'));
+				messages.Add(document.RootElement.Clone());
+			}
+			return messages.ToArray();
+		}
 
 		public JsonElement GetLastToolCallWireResult()
 		{
@@ -574,6 +740,72 @@ public sealed class McpServerIntegrationTests
 			await _clientToServer.Writer.CompleteAsync();
 			await _serverToClient.Reader.CompleteAsync();
 			await _serverTask.WaitAsync(TimeSpan.FromSeconds(10));
+		}
+
+		private sealed class RecordingWriteStream(Stream destination) : Stream
+		{
+			private readonly MemoryStream _recording = new();
+			private readonly object _sync = new();
+
+			public string GetRecordedText()
+			{
+				lock (_sync)
+					return Encoding.UTF8.GetString(_recording.ToArray());
+			}
+
+			public override async ValueTask WriteAsync(
+				ReadOnlyMemory<byte> buffer,
+				CancellationToken cancellationToken = default)
+			{
+				await destination.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+				lock (_sync)
+					_recording.Write(buffer.Span);
+			}
+
+			public override async Task WriteAsync(
+				byte[] buffer,
+				int offset,
+				int count,
+				CancellationToken cancellationToken)
+			{
+				await destination.WriteAsync(buffer.AsMemory(offset, count), cancellationToken)
+					.ConfigureAwait(false);
+				lock (_sync)
+					_recording.Write(buffer, offset, count);
+			}
+
+			public override void Write(byte[] buffer, int offset, int count)
+			{
+				destination.Write(buffer, offset, count);
+				lock (_sync)
+					_recording.Write(buffer, offset, count);
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing)
+				{
+					destination.Dispose();
+					_recording.Dispose();
+				}
+				base.Dispose(disposing);
+			}
+
+			public override bool CanRead => false;
+			public override bool CanSeek => false;
+			public override bool CanWrite => true;
+			public override long Length => throw new NotSupportedException();
+			public override long Position
+			{
+				get => throw new NotSupportedException();
+				set => throw new NotSupportedException();
+			}
+			public override void Flush() => destination.Flush();
+			public override Task FlushAsync(CancellationToken cancellationToken) =>
+				destination.FlushAsync(cancellationToken);
+			public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+			public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+			public override void SetLength(long value) => throw new NotSupportedException();
 		}
 
 		private sealed class RecordingReadStream(Stream source) : Stream

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using DevProjex.Mcp;
+using ModelContextProtocol;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
@@ -60,6 +61,20 @@ public sealed class McpServerProcessTests
 			var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
 			using var textDocument = JsonDocument.Parse(text);
 			Assert.True(JsonElement.DeepEquals(structured, textDocument.RootElement));
+
+			var progress = new InlineProgress<ProgressNotificationValue>();
+			var pack = await client.CallToolAsync(
+				"pack_context",
+				new Dictionary<string, object?>
+				{
+					["view"] = "content",
+					["format"] = "text"
+				},
+				progress,
+				options: null,
+				TestContext.Current.CancellationToken);
+			Assert.NotEqual(true, pack.IsError);
+			Assert.NotEmpty(progress.Values);
 		}
 
 		process.StandardInput.Close();
@@ -81,6 +96,27 @@ public sealed class McpServerProcessTests
 
 	private static StringComparison PathComparison =>
 		OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+	private sealed class InlineProgress<T> : IProgress<T>
+	{
+		private readonly List<T> _values = [];
+		private readonly object _sync = new();
+
+		public IReadOnlyList<T> Values
+		{
+			get
+			{
+				lock (_sync)
+					return _values.ToArray();
+			}
+		}
+
+		public void Report(T value)
+		{
+			lock (_sync)
+				_values.Add(value);
+		}
+	}
 
 	private sealed class RecordingReadStream(Stream source) : Stream
 	{


### PR DESCRIPTION
## Summary

- report MCP notifications/progress for pack_context and analyze when the caller supplies a progressToken
- bridge measured engine progress through selection, content transformation, analysis, and pack writing phases
- emit deterministic monotonic phase milestones while throttling intermediate file-count updates
- keep the five fast tools and all tool input/output schemas unchanged
- document the progress transport contract

## Verification

- targeted McpServer integration tests
- MCP real-process client test
- Release solution build with zero warnings

CI is the final cross-platform arbiter.