### PR TITLE
Harden release lifecycle and large-data paths

### DIFF
--- a/Application/Preview/FileBackedPreviewTextDocument.cs
+++ b/Application/Preview/FileBackedPreviewTextDocument.cs
@@ -14,7 +14,7 @@ public sealed class FileBackedPreviewTextDocument(
 {
     private static readonly UTF8Encoding Utf8WithoutBom = new(encoderShouldEmitUTF8Identifier: false);
 
-    private readonly object _sync = new();
+	private readonly SemaphoreSlim _streamGate = new(1, 1);
     private FileStream? _stream = new(
         storagePath,
         FileMode.Open,
@@ -41,6 +41,41 @@ public sealed class FileBackedPreviewTextDocument(
         ThrowIfDisposed();
         return ReadTextRange(0, fileLength, trimTrailingLineEnding: false);
     }
+
+	public async ValueTask WriteToAsync(
+		Stream destination,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(destination);
+		if (!destination.CanWrite)
+			throw new InvalidOperationException("Target stream must be writable.");
+
+		await _streamGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			ThrowIfDisposed();
+			var stream = _stream!;
+			stream.Seek(0, SeekOrigin.Begin);
+			var buffer = new byte[PreviewTextStreamWriter.BufferSizeBytes];
+			while (true)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				var bytesRead = await stream
+					.ReadAsync(buffer, cancellationToken)
+					.ConfigureAwait(false);
+				if (bytesRead == 0)
+					break;
+
+				await destination
+					.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken)
+					.ConfigureAwait(false);
+			}
+		}
+		finally
+		{
+			_streamGate.Release();
+		}
+	}
 
     public string GetLineText(int lineNumber)
     {
@@ -85,11 +120,16 @@ public sealed class FileBackedPreviewTextDocument(
 
         _disposed = true;
 
-        lock (_sync)
+		_streamGate.Wait();
+		try
         {
             _stream?.Dispose();
             _stream = null;
         }
+		finally
+		{
+			_streamGate.Release();
+		}
 
         try
         {
@@ -104,7 +144,8 @@ public sealed class FileBackedPreviewTextDocument(
 
     private int ReadBytes(long startOffset, byte[] buffer, int byteCount)
     {
-        lock (_sync)
+		_streamGate.Wait();
+		try
         {
             ThrowIfDisposed();
 
@@ -123,6 +164,10 @@ public sealed class FileBackedPreviewTextDocument(
 
             return totalBytesRead;
         }
+		finally
+		{
+			_streamGate.Release();
+		}
     }
 
     private string ReadTextRange(

--- a/Application/Preview/IPreviewTextDocument.cs
+++ b/Application/Preview/IPreviewTextDocument.cs
@@ -20,4 +20,9 @@ public interface IPreviewTextDocument : IDisposable
     string GetLineText(int lineNumber);
 
     string GetLineRangeText(int firstLine, int lastLine);
+
+	ValueTask WriteToAsync(
+		Stream destination,
+		CancellationToken cancellationToken = default) =>
+		PreviewTextStreamWriter.WriteAsync(destination, GetFullText(), cancellationToken);
 }

--- a/Application/Preview/InMemoryPreviewTextDocument.cs
+++ b/Application/Preview/InMemoryPreviewTextDocument.cs
@@ -30,6 +30,11 @@ public sealed class InMemoryPreviewTextDocument : IPreviewTextDocument
 
     public string GetFullText() => _text;
 
+	public ValueTask WriteToAsync(
+		Stream destination,
+		CancellationToken cancellationToken = default) =>
+		PreviewTextStreamWriter.WriteAsync(destination, _text, cancellationToken);
+
     public string GetLineText(int lineNumber)
     {
         if (_text.Length == 0)

--- a/Application/Preview/PreviewTextStreamWriter.cs
+++ b/Application/Preview/PreviewTextStreamWriter.cs
@@ -1,0 +1,41 @@
+namespace DevProjex.Application.Preview;
+
+internal static class PreviewTextStreamWriter
+{
+	internal const int BufferSizeBytes = 80 * 1024;
+	private const int MaximumCharactersPerChunk = BufferSizeBytes / 4;
+	private static readonly UTF8Encoding Utf8WithoutBom = new(encoderShouldEmitUTF8Identifier: false);
+
+	public static async ValueTask WriteAsync(
+		Stream destination,
+		string content,
+		CancellationToken cancellationToken)
+	{
+		var encoder = Utf8WithoutBom.GetEncoder();
+		var buffer = new byte[BufferSizeBytes];
+		var offset = 0;
+		while (offset < content.Length)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var characterCount = Math.Min(MaximumCharactersPerChunk, content.Length - offset);
+			var flush = offset + characterCount == content.Length;
+			encoder.Convert(
+				content.AsSpan(offset, characterCount),
+				buffer,
+				flush,
+				out var charactersUsed,
+				out var bytesUsed,
+				out _);
+			if (charactersUsed == 0)
+				throw new EncoderFallbackException("UTF-8 encoder did not consume the input chunk.");
+
+			offset += charactersUsed;
+			if (bytesUsed > 0)
+			{
+				await destination
+					.WriteAsync(buffer.AsMemory(0, bytesUsed), cancellationToken)
+					.ConfigureAwait(false);
+			}
+		}
+	}
+}

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -3091,12 +3091,26 @@ internal sealed class SecretFileRedactionPlan(
 	public async ValueTask WriteToAsync(
 		TextWriter destination,
 		string content,
+		CancellationToken cancellationToken) =>
+		await WriteToAsync(destination, content, content.Length, cancellationToken)
+			.ConfigureAwait(false);
+
+	public async ValueTask WriteToAsync(
+		TextWriter destination,
+		string content,
+		int sourceLength,
 		CancellationToken cancellationToken)
 	{
+		ArgumentOutOfRangeException.ThrowIfNegative(sourceLength);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(sourceLength, content.Length);
 		var sourceOffset = 0;
 		foreach (var replacement in Replacements)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
+			if (replacement.SourceStart >= sourceLength)
+				break;
+			if (replacement.SourceEnd > sourceLength)
+				throw new InvalidOperationException("A redaction span crosses the requested output boundary.");
 			await destination.WriteAsync(
 					content.AsMemory(sourceOffset, replacement.SourceStart - sourceOffset),
 					cancellationToken)
@@ -3115,6 +3129,8 @@ internal sealed class SecretFileRedactionPlan(
 			}
 			sourceOffset = replacement.SourceEnd;
 		}
-		await destination.WriteAsync(content.AsMemory(sourceOffset), cancellationToken).ConfigureAwait(false);
+		await destination.WriteAsync(
+			content.AsMemory(sourceOffset, sourceLength - sourceOffset),
+			cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/Application/Services/FileContentAnalyzer.cs
+++ b/Application/Services/FileContentAnalyzer.cs
@@ -8,6 +8,12 @@ using DevProjex.Application.Diagnostics;
 
 namespace DevProjex.Application.Services;
 
+public delegate FileStream FileContentReadStreamOpener(
+	string path,
+	int bufferSize,
+	FileShare fileShare,
+	bool asynchronous);
+
 /// <summary>
 /// Analyzes file content to determine if it's text or binary.
 ///
@@ -73,14 +79,14 @@ public sealed class FileContentAnalyzer :
 		bigEndian: true,
 		byteOrderMark: true,
 		throwOnInvalidCharacters: true);
-	private readonly Func<string, int, FileShare, bool, FileStream> _openSequentialRead;
+	private readonly FileContentReadStreamOpener _openSequentialRead;
 
 	public FileContentAnalyzer()
 		: this(OpenSequentialRead)
 	{
 	}
 
-	internal FileContentAnalyzer(Func<string, int, FileShare, bool, FileStream> openSequentialRead)
+	public FileContentAnalyzer(FileContentReadStreamOpener openSequentialRead)
 	{
 		ArgumentNullException.ThrowIfNull(openSequentialRead);
 		_openSequentialRead = openSequentialRead;

--- a/Application/Services/SelectedContentExportService.cs
+++ b/Application/Services/SelectedContentExportService.cs
@@ -65,6 +65,39 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 			displayRootPath,
 			outputPathRedaction);
 
+	public async Task WriteAsync(
+		Stream destination,
+		IEnumerable<string> filePaths,
+		CancellationToken cancellationToken,
+		Func<string, string>? displayPathMapper,
+		ContentTransformationContext? transformationContext = null,
+		string? displayRootPath = null,
+		OutputPathRedactionDecision? outputPathRedaction = null)
+	{
+		ArgumentNullException.ThrowIfNull(destination);
+		if (!destination.CanWrite)
+			throw new InvalidOperationException("Target stream must be writable.");
+
+		await using var writer = new StreamWriter(
+			destination,
+			new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+			bufferSize: 20 * 1024,
+			leaveOpen: true);
+		var output = new StreamingSelectedContentOutput(writer);
+		_ = await BuildCoreAsync(
+			filePaths,
+			cancellationToken,
+			displayPathMapper,
+			maxFileCount: null,
+			maxFileSizeForFullRead: null,
+			maxOutputCharacters: null,
+			transformationContext,
+			publishCompressionSnapshot: true,
+			displayRootPath,
+			outputPathRedaction,
+			output).ConfigureAwait(false);
+	}
+
 	public async Task<string> BuildBoundedPreviewAsync(
 		IEnumerable<string> filePaths,
 		int maxFileCount,
@@ -102,7 +135,8 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 		ContentTransformationContext? transformationContext,
 		bool publishCompressionSnapshot,
 		string? displayRootPath = null,
-		OutputPathRedactionDecision? outputPathRedaction = null)
+		OutputPathRedactionDecision? outputPathRedaction = null,
+		SelectedContentOutput? destination = null)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
 
@@ -132,7 +166,7 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 		using var transformationScope = transformationContext?.BeginOutput(files, cancellationToken);
 		var redactionScope = transformationScope?.Redaction;
 
-		var sb = new StringBuilder();
+		var output = destination ?? new MaterializedSelectedContentOutput();
 		bool anyWritten = false;
 
 		var processedFileCount = 0;
@@ -230,14 +264,16 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 			processedFileCount++;
 			if (!anyWritten && !string.IsNullOrWhiteSpace(displayRootPath))
 			{
-				sb.AppendLine($"{SingleLineTextEscaping.Escape(displayRootPath)}:");
-				AppendClipboardBlankLine(sb);
-				AppendClipboardBlankLine(sb);
+				await output.AppendLineAsync(
+					$"{SingleLineTextEscaping.Escape(displayRootPath)}:",
+					cancellationToken).ConfigureAwait(false);
+				await AppendClipboardBlankLineAsync(output, cancellationToken).ConfigureAwait(false);
+				await AppendClipboardBlankLineAsync(output, cancellationToken).ConfigureAwait(false);
 			}
 			if (anyWritten)
 			{
-				AppendClipboardBlankLine(sb);
-				AppendClipboardBlankLine(sb);
+				await AppendClipboardBlankLineAsync(output, cancellationToken).ConfigureAwait(false);
+				await AppendClipboardBlankLineAsync(output, cancellationToken).ConfigureAwait(false);
 			}
 
 			anyWritten = true;
@@ -246,16 +282,18 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 				.ResolvePath(rawDisplayPath, outputPathRedaction)
 				.Text;
 			displayPath = SingleLineTextEscaping.Escape(displayPath);
-			sb.AppendLine($"{displayPath}:");
-			AppendClipboardBlankLine(sb);
+			await output.AppendLineAsync($"{displayPath}:", cancellationToken).ConfigureAwait(false);
+			await AppendClipboardBlankLineAsync(output, cancellationToken).ConfigureAwait(false);
 
 			if (content.IsEmpty)
 			{
-				sb.AppendLine(NoContentMarker);
+				await output.AppendLineAsync(NoContentMarker, cancellationToken).ConfigureAwait(false);
 			}
 			else if (content.IsWhitespaceOnly)
 			{
-				sb.AppendLine($"{WhitespaceMarkerPrefix}{content.SizeBytes}{WhitespaceMarkerSuffix}");
+				await output.AppendLineAsync(
+					$"{WhitespaceMarkerPrefix}{content.SizeBytes}{WhitespaceMarkerSuffix}",
+					cancellationToken).ConfigureAwait(false);
 			}
 			else
 			{
@@ -268,19 +306,25 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 					sourceLength--;
 				if (redactionPlan is null)
 				{
-					sb.Append(transformedText.AsSpan(0, sourceLength));
-					sb.AppendLine();
+					await output.AppendAsync(
+						transformedText.AsMemory(0, sourceLength),
+						cancellationToken).ConfigureAwait(false);
+					await output.AppendLineAsync(string.Empty, cancellationToken).ConfigureAwait(false);
 				}
 				else
 				{
-					redactionPlan.AppendTo(sb, transformedText, sourceLength);
-					sb.AppendLine();
+					await output.AppendRedactedAsync(
+						redactionPlan,
+						transformedText,
+						sourceLength,
+						cancellationToken).ConfigureAwait(false);
+					await output.AppendLineAsync(string.Empty, cancellationToken).ConfigureAwait(false);
 				}
 			}
 
-			if (maxOutputCharacters is { } characterLimit && sb.Length >= characterLimit)
+			if (maxOutputCharacters is { } characterLimit && output.Length >= characterLimit)
 			{
-				sb.Length = characterLimit;
+				output.Truncate(characterLimit);
 				break;
 			}
 		}
@@ -296,7 +340,8 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 		}
 		if (publishCompressionSnapshot)
 			transformationScope?.Compression?.Complete();
-		var textOutput = anyWritten ? sb.ToString().TrimEnd('\r', '\n') : string.Empty;
+		await output.CompleteAsync(cancellationToken).ConfigureAwait(false);
+		var textOutput = anyWritten ? output.GetMaterializedText() : string.Empty;
 
 		return new SelectedContentExportResult(textOutput, snapshot);
 	}
@@ -358,5 +403,128 @@ public sealed class SelectedContentExportService(IFileContentAnalyzer contentAna
 		}
 	}
 
-	private static void AppendClipboardBlankLine(StringBuilder sb) => sb.AppendLine(ClipboardBlankLine);
+	private static ValueTask AppendClipboardBlankLineAsync(
+		SelectedContentOutput output,
+		CancellationToken cancellationToken) =>
+		output.AppendLineAsync(ClipboardBlankLine, cancellationToken);
+
+	private abstract class SelectedContentOutput
+	{
+		public abstract int Length { get; }
+		public abstract ValueTask AppendAsync(
+			ReadOnlyMemory<char> value,
+			CancellationToken cancellationToken);
+
+		public async ValueTask AppendLineAsync(
+			string value,
+			CancellationToken cancellationToken)
+		{
+			if (value.Length > 0)
+				await AppendAsync(value.AsMemory(), cancellationToken).ConfigureAwait(false);
+			await AppendAsync(Environment.NewLine.AsMemory(), cancellationToken).ConfigureAwait(false);
+		}
+
+		public abstract ValueTask AppendRedactedAsync(
+			SecretFileRedactionPlan plan,
+			string content,
+			int sourceLength,
+			CancellationToken cancellationToken);
+		public abstract void Truncate(int length);
+		public abstract ValueTask CompleteAsync(CancellationToken cancellationToken);
+		public abstract string GetMaterializedText();
+	}
+
+	private sealed class MaterializedSelectedContentOutput : SelectedContentOutput
+	{
+		private readonly StringBuilder _builder = new();
+		public override int Length => _builder.Length;
+
+		public override ValueTask AppendAsync(
+			ReadOnlyMemory<char> value,
+			CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			_builder.Append(value.Span);
+			return ValueTask.CompletedTask;
+		}
+
+		public override ValueTask AppendRedactedAsync(
+			SecretFileRedactionPlan plan,
+			string content,
+			int sourceLength,
+			CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			plan.AppendTo(_builder, content, sourceLength);
+			return ValueTask.CompletedTask;
+		}
+
+		public override void Truncate(int length) => _builder.Length = length;
+		public override ValueTask CompleteAsync(CancellationToken cancellationToken) =>
+			ValueTask.CompletedTask;
+		public override string GetMaterializedText() => _builder.ToString().TrimEnd('\r', '\n');
+	}
+
+	private sealed class StreamingSelectedContentOutput(TextWriter writer) : SelectedContentOutput
+	{
+		private readonly TrailingLineEndingTextWriter _output = new(writer);
+		public override int Length => _output.Length;
+
+		public override ValueTask AppendAsync(
+			ReadOnlyMemory<char> value,
+			CancellationToken cancellationToken) =>
+			new(_output.WriteAsync(value, cancellationToken));
+
+		public override ValueTask AppendRedactedAsync(
+			SecretFileRedactionPlan plan,
+			string content,
+			int sourceLength,
+			CancellationToken cancellationToken) =>
+			plan.WriteToAsync(_output, content, sourceLength, cancellationToken);
+
+		public override void Truncate(int length) =>
+			throw new NotSupportedException("Streaming output cannot be truncated.");
+		public override ValueTask CompleteAsync(CancellationToken cancellationToken) =>
+			_output.CompleteAsync(cancellationToken);
+		public override string GetMaterializedText() => string.Empty;
+	}
+
+	private sealed class TrailingLineEndingTextWriter(TextWriter inner) : TextWriter
+	{
+		private readonly StringBuilder _trailing = new(2);
+		public override Encoding Encoding => inner.Encoding;
+		public int Length { get; private set; }
+
+		public override async Task WriteAsync(
+			ReadOnlyMemory<char> buffer,
+			CancellationToken cancellationToken = default)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var contentLength = buffer.Length;
+			while (contentLength > 0 && buffer.Span[contentLength - 1] is '\r' or '\n')
+				contentLength--;
+
+			if (contentLength > 0)
+			{
+				if (_trailing.Length > 0)
+				{
+					await inner.WriteAsync(
+						_trailing.ToString().AsMemory(),
+						cancellationToken).ConfigureAwait(false);
+					_trailing.Clear();
+				}
+				await inner.WriteAsync(buffer[..contentLength], cancellationToken).ConfigureAwait(false);
+			}
+
+			if (contentLength < buffer.Length)
+				_trailing.Append(buffer.Span[contentLength..]);
+			Length = checked(Length + buffer.Length);
+		}
+
+		public async ValueTask CompleteAsync(CancellationToken cancellationToken)
+		{
+			_trailing.Clear();
+			await inner.FlushAsync(cancellationToken).ConfigureAwait(false);
+		}
+	}
 }

--- a/Application/Services/TextFileExportService.cs
+++ b/Application/Services/TextFileExportService.cs
@@ -2,13 +2,46 @@ namespace DevProjex.Application.Services;
 
 public sealed class TextFileExportService
 {
-	private static readonly UTF8Encoding Utf8WithoutBom = new(encoderShouldEmitUTF8Identifier: false);
-
 	public async Task WriteAsync(Stream stream, string content, CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(stream);
 		ArgumentNullException.ThrowIfNull(content);
+		PrepareDestination(stream);
 
+		await AppendAsync(stream, content, cancellationToken).ConfigureAwait(false);
+		await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task AppendAsync(
+		Stream stream,
+		string content,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+		ArgumentNullException.ThrowIfNull(content);
+		if (!stream.CanWrite)
+			throw new InvalidOperationException("Target stream must be writable.");
+
+		await PreviewTextStreamWriter
+			.WriteAsync(stream, content, cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	public async Task WriteAsync(
+		Stream stream,
+		IPreviewTextDocument document,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(stream);
+		ArgumentNullException.ThrowIfNull(document);
+		PrepareDestination(stream);
+
+		await document.WriteToAsync(stream, cancellationToken).ConfigureAwait(false);
+		await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	private static void PrepareDestination(Stream stream)
+	{
 		if (!stream.CanWrite)
 			throw new InvalidOperationException("Target stream must be writable.");
 
@@ -18,9 +51,5 @@ public sealed class TextFileExportService
 			stream.SetLength(0);
 			stream.Position = 0;
 		}
-
-		await using var writer = new StreamWriter(stream, Utf8WithoutBom, bufferSize: 4096, leaveOpen: true);
-		await writer.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
-		await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/Apps/Avalonia/Coordinators/PreviewSearchInteractionController.cs
+++ b/Apps/Avalonia/Coordinators/PreviewSearchInteractionController.cs
@@ -287,7 +287,7 @@ internal sealed class PreviewSearchInteractionController : IDisposable
 		var query = _viewModel.PreviewSearchQuery;
 		var document = _previewTextControl.Document;
 		if (!_viewModel.PreviewSearchVisible ||
-		    string.IsNullOrWhiteSpace(query) ||
+		    !PreviewSearchIndex.CanSearch(query) ||
 		    document is null)
 		{
 			return;

--- a/Apps/Avalonia/Coordinators/PreviewSurfaceController.cs
+++ b/Apps/Avalonia/Coordinators/PreviewSurfaceController.cs
@@ -71,6 +71,7 @@ internal sealed class PreviewSurfaceController : IDisposable
 	private bool _previewMarkerScrollBarAllowAutoHide;
 	private bool _previewMarkerScrollBarInteractionActive;
 	private bool _previewMarkerRailPointerOver;
+	private Point? _previewMarkerPointerPosition;
     private double _stickyHeaderScrollBarInset = -1;
 	private Vector? _pendingRedactionViewportOffset;
 	private PersistentSecretMarkId? _pendingMarkedSecretId;
@@ -195,6 +196,7 @@ internal sealed class PreviewSurfaceController : IDisposable
 		object? sender,
 		PointerEventArgs e)
 	{
+		_previewMarkerPointerPosition = e.GetPosition(_window);
 		UpdatePreviewMarkerRailPointerState(IsPointerWithinPreviewScrollBar(e));
 		if (ReferenceEquals(_previewMarkerDragPointer, e.Pointer) &&
 		    e.GetCurrentPoint(_controls.TextScrollViewer).Properties.IsLeftButtonPressed)
@@ -212,12 +214,7 @@ internal sealed class PreviewSurfaceController : IDisposable
 			return;
 		}
 
-		var markerTarget = _controls.MarkerBar.FindTargetAt(e.GetPosition(_controls.MarkerBar));
-		SetPreviewMarkerCursor(
-			markerTarget is not null || _previewMarkerRailPointerOver
-				? e.Source as InputElement
-				: null,
-			isDragging: markerTarget is null && _previewMarkerRailPointerOver);
+		RefreshPreviewMarkerCursor();
 	}
 
 	private void OnPreviewMarkerPointerReleased(
@@ -229,12 +226,8 @@ internal sealed class PreviewSurfaceController : IDisposable
 
 		UpdatePreviewMarkerRailPointerState(IsPointerWithinPreviewScrollBar(e));
 		EndPreviewMarkerDrag(releaseCapture: true);
-		var markerTarget = _controls.MarkerBar.FindTargetAt(e.GetPosition(_controls.MarkerBar));
-		SetPreviewMarkerCursor(
-			markerTarget is not null || _previewMarkerRailPointerOver
-				? e.Source as InputElement
-				: null,
-			isDragging: markerTarget is null && _previewMarkerRailPointerOver);
+		_previewMarkerPointerPosition = e.GetPosition(_window);
+		RefreshPreviewMarkerCursor();
 		e.Handled = true;
 	}
 
@@ -341,8 +334,33 @@ internal sealed class PreviewSurfaceController : IDisposable
 		object? sender,
 		PointerEventArgs e)
 	{
+		_previewMarkerPointerPosition = null;
 		UpdatePreviewMarkerRailPointerState(pointerOver: false);
 		SetPreviewMarkerCursor(null);
+	}
+
+	private void RefreshPreviewMarkerCursor()
+	{
+		if (_previewMarkerDragPointer is not null)
+		{
+			SetPreviewMarkerCursor(_controls.TextScrollViewer, isDragging: true);
+			return;
+		}
+
+		if (_previewMarkerPointerPosition is not { } pointerPosition ||
+		    _window.TranslatePoint(pointerPosition, _controls.MarkerBar) is not { } markerPosition)
+		{
+			SetPreviewMarkerCursor(null);
+			return;
+		}
+
+		var markerTarget = _controls.MarkerBar.FindTargetAt(markerPosition);
+		var cursorTarget = markerTarget is not null || _previewMarkerRailPointerOver
+			? _window.InputHitTest(pointerPosition) as InputElement
+			: null;
+		SetPreviewMarkerCursor(
+			cursorTarget,
+			isDragging: markerTarget is null && _previewMarkerRailPointerOver);
 	}
 
 	private void SetPreviewMarkerCursor(
@@ -381,8 +399,11 @@ internal sealed class PreviewSurfaceController : IDisposable
 
     private void OnTextScrollViewerLayoutUpdated(object? sender, EventArgs e)
     {
-        if (!_disposed)
-            UpdateStickyHeaderScrollBarInset();
+		if (_disposed)
+			return;
+
+		UpdateStickyHeaderScrollBarInset();
+		RefreshPreviewMarkerCursor();
     }
 
 	private async void OnManualSecretMarkRejected(

--- a/Apps/Avalonia/Coordinators/ProjectProfilePersistenceCoordinator.cs
+++ b/Apps/Avalonia/Coordinators/ProjectProfilePersistenceCoordinator.cs
@@ -2,6 +2,15 @@ using DevProjex.Application.Models;
 
 namespace DevProjex.Avalonia.Coordinators;
 
+public readonly record struct ProjectProfileFlushResult(
+	bool GateAcquired,
+	int Attempted,
+	int Saved,
+	int Remaining)
+{
+	public bool Succeeded => GateAcquired && Remaining == 0;
+}
+
 public sealed class ProjectProfilePersistenceCoordinator(
     MainWindowViewModel viewModel,
     SelectionSyncCoordinator selectionCoordinator,
@@ -184,7 +193,8 @@ public sealed class ProjectProfilePersistenceCoordinator(
 			_ => ProjectProfileLookupStatus.InvalidStorage
 		};
 
-    public void FlushPending() => _pendingWrites.Flush(CanPersistNormalizedPath);
+	public ProjectProfileFlushResult FlushPending(TimeSpan timeout) =>
+		_pendingWrites.Flush(timeout, CanPersistNormalizedPath);
 
     private bool IsApplicable(string? currentPath)
     {
@@ -283,6 +293,7 @@ public sealed class ProjectProfilePersistenceCoordinator(
 
 internal sealed class PendingProjectProfileWriteQueue(IProjectProfileStore profileStore)
 {
+	private static readonly TimeSpan DefaultFlushTimeout = TimeSpan.FromSeconds(5);
     private readonly Dictionary<string, PendingProfileWrite> _pending =
         new(PathComparer.Default);
 
@@ -346,7 +357,7 @@ internal sealed class PendingProjectProfileWriteQueue(IProjectProfileStore profi
 		DateTimeOffset updatedUtc,
 		Func<string, bool>? canPersist)
 	{
-		FlushCore(canPersist);
+		FlushCore(canPersist, DefaultFlushTimeout);
         var normalizedPath = Path.GetFullPath(projectPath);
 		if (canPersist is not null && !canPersist(normalizedPath))
 			return;
@@ -361,12 +372,24 @@ internal sealed class PendingProjectProfileWriteQueue(IProjectProfileStore profi
             updatedUtc);
     }
 
-	public void Flush(Func<string, bool>? canPersist = null)
+	public void Flush(Func<string, bool>? canPersist = null) =>
+		_ = Flush(DefaultFlushTimeout, canPersist);
+
+	public ProjectProfileFlushResult Flush(
+		TimeSpan timeout,
+		Func<string, bool>? canPersist = null)
 	{
-		_gate.Wait();
+		ArgumentOutOfRangeException.ThrowIfLessThan(timeout, TimeSpan.Zero);
+		var startedTimestamp = Stopwatch.GetTimestamp();
+		if (!_gate.Wait(timeout))
+			return new ProjectProfileFlushResult(false, 0, 0, -1);
+
 		try
 		{
-			FlushCore(canPersist);
+			var remaining = timeout - Stopwatch.GetElapsedTime(startedTimestamp);
+			if (remaining < TimeSpan.Zero)
+				remaining = TimeSpan.Zero;
+			return FlushCore(canPersist, remaining);
 		}
 		finally
 		{
@@ -374,23 +397,31 @@ internal sealed class PendingProjectProfileWriteQueue(IProjectProfileStore profi
 		}
 	}
 
-	private void FlushCore(Func<string, bool>? canPersist)
+	private ProjectProfileFlushResult FlushCore(
+		Func<string, bool>? canPersist,
+		TimeSpan lockTimeout)
 	{
-        foreach (var (path, pending) in _pending.ToArray())
-        {
-			if (canPersist is not null && !canPersist(path))
-				continue;
-            if (!profileStore.TrySaveProfile(
-                    path,
-                    ProjectSelectionProfileBuilder.Clone(pending.Profile),
-                    pending.UpdatedUtc))
-            {
-                continue;
-            }
+		var requests = _pending
+			.Where(entry => canPersist is null || canPersist(entry.Key))
+			.Select(static entry => new ProjectProfileSaveRequest(
+				entry.Key,
+				ProjectSelectionProfileBuilder.Clone(entry.Value.Profile),
+				entry.Value.UpdatedUtc))
+			.ToArray();
+		if (requests.Length == 0)
+			return new ProjectProfileFlushResult(true, 0, 0, _pending.Count);
 
-            _pending.Remove(path);
-        }
-    }
+		var result = profileStore.TrySaveProfilesWithResult(requests, lockTimeout);
+		var savedPaths = result.SavedProjectPaths.ToHashSet(PathComparer.Default);
+		foreach (var path in savedPaths)
+			_pending.Remove(path);
+
+		return new ProjectProfileFlushResult(
+			true,
+			requests.Length,
+			savedPaths.Count,
+			_pending.Count);
+	}
 
     private sealed record PendingProfileWrite(
         ProjectSelectionProfile Profile,

--- a/Apps/Avalonia/Coordinators/ProjectTextOutputPipeline.cs
+++ b/Apps/Avalonia/Coordinators/ProjectTextOutputPipeline.cs
@@ -3,7 +3,9 @@ namespace DevProjex.Avalonia.Coordinators;
 internal sealed class ProjectTextOutputPipeline(
     TreeExportService treeExport,
     SelectedContentExportService contentExport,
-    TreeAndContentExportService treeAndContentExport)
+	TreeAndContentExportService treeAndContentExport,
+	PreviewDocumentBuilder previewDocumentBuilder,
+	TextFileExportService textFileExport)
 {
     public Task<ProjectTextOutputResult> BuildAsync(
         ProjectTextOutputMode mode,
@@ -20,6 +22,114 @@ internal sealed class ProjectTextOutputPipeline(
             () => BuildOnWorkerAsync(mode, effectiveSnapshot, cancellationToken),
             cancellationToken);
     }
+
+	public Task<ProjectTextDocumentOutputResult> BuildDocumentAsync(
+		ProjectTextOutputMode mode,
+		ProjectTextOutputSnapshot snapshot,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(snapshot);
+		cancellationToken.ThrowIfCancellationRequested();
+		var effectiveSnapshot = NormalizeSelection(snapshot);
+		return Task.Run(
+			() => BuildDocumentOnWorkerAsync(mode, effectiveSnapshot, cancellationToken),
+			cancellationToken);
+	}
+
+	private async Task<ProjectTextDocumentOutputResult> BuildDocumentOnWorkerAsync(
+		ProjectTextOutputMode mode,
+		ProjectTextOutputSnapshot snapshot,
+		CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		var outputPathRedaction = OutputRootPathPresentation.CaptureRedactionDecision(
+			snapshot.RedactionContext);
+		if (mode == ProjectTextOutputMode.Tree)
+		{
+			return new ProjectTextDocumentOutputResult(
+				previewDocumentBuilder.CreateDocument(
+					BuildTree(snapshot, cancellationToken, outputPathRedaction)),
+				CandidateFileCount: 0);
+		}
+
+		if (mode is not (ProjectTextOutputMode.Content or ProjectTextOutputMode.TreeAndContent))
+			throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported project text output mode.");
+
+		var files = ResolveContentFiles(snapshot);
+		var contentDocument = await BuildContentDocumentAsync(
+			files,
+			snapshot,
+			mode == ProjectTextOutputMode.Content
+				? snapshot.PathPresentation?.MapFilePath
+				: TreeAndContentExportService.CreateRelativeContentHeaderPathMapper(
+					snapshot.RootPath),
+			outputPathRedaction,
+			cancellationToken).ConfigureAwait(false);
+		if (mode == ProjectTextOutputMode.Content)
+		{
+			return new ProjectTextDocumentOutputResult(
+				contentDocument,
+				files.Count);
+		}
+
+		using (contentDocument)
+		{
+			var tree = BuildTree(snapshot, cancellationToken, outputPathRedaction);
+			if (contentDocument.CharacterCount == 0)
+			{
+				return new ProjectTextDocumentOutputResult(
+					previewDocumentBuilder.CreateDocument(tree),
+					CandidateFileCount: 0);
+			}
+
+			var trimmedTree = tree.TrimEnd('\r', '\n');
+			var separator = string.Concat(
+				Environment.NewLine,
+				"\u00A0",
+				Environment.NewLine,
+				"\u00A0",
+				Environment.NewLine);
+			var combined = await previewDocumentBuilder.CreateDocumentAsync(
+				async (stream, writeCancellationToken) =>
+				{
+					await textFileExport.AppendAsync(
+						stream,
+						trimmedTree,
+						writeCancellationToken).ConfigureAwait(false);
+					await textFileExport.AppendAsync(
+						stream,
+						separator,
+						writeCancellationToken).ConfigureAwait(false);
+					await contentDocument
+						.WriteToAsync(stream, writeCancellationToken)
+						.ConfigureAwait(false);
+				},
+				cancellationToken).ConfigureAwait(false);
+			return new ProjectTextDocumentOutputResult(combined, CandidateFileCount: 0);
+		}
+	}
+
+	private async Task<IPreviewTextDocument> BuildContentDocumentAsync(
+		IReadOnlyList<string> files,
+		ProjectTextOutputSnapshot snapshot,
+		Func<string, string>? displayPathMapper,
+		OutputPathRedactionDecision? outputPathRedaction,
+		CancellationToken cancellationToken)
+	{
+		if (files.Count == 0)
+			return previewDocumentBuilder.CreateInMemory(string.Empty);
+
+		return await previewDocumentBuilder.CreateDocumentAsync(
+			(stream, writeCancellationToken) => contentExport.WriteAsync(
+				stream,
+				files,
+				writeCancellationToken,
+				displayPathMapper,
+				snapshot.RedactionContext,
+				displayRootPath: null,
+				outputPathRedaction),
+			cancellationToken).ConfigureAwait(false);
+	}
 
     private async Task<ProjectTextOutputResult> BuildOnWorkerAsync(
         ProjectTextOutputMode mode,
@@ -171,6 +281,13 @@ internal sealed record ProjectTextOutputSnapshot(
 internal sealed record ProjectTextOutputResult(
     string Content,
     int CandidateFileCount);
+
+internal sealed record ProjectTextDocumentOutputResult(
+	IPreviewTextDocument Document,
+	int CandidateFileCount) : IDisposable
+{
+	public void Dispose() => Document.Dispose();
+}
 
 internal enum ProjectTextOutputMode
 {

--- a/Apps/Avalonia/MainWindow.Composition.cs
+++ b/Apps/Avalonia/MainWindow.Composition.cs
@@ -1042,7 +1042,9 @@ public partial class MainWindow
         _textOutputPipeline = new ProjectTextOutputPipeline(
             _treeExport,
             _contentExport,
-            services.TreeAndContentExportService);
+			services.TreeAndContentExportService,
+			_previewDocumentBuilder,
+			_textFileExport);
         _selectionCoordinator = new SelectionSyncCoordinator(
             _viewModel,
             _scanOptions,

--- a/Apps/Avalonia/MainWindow.TextOutput.cs
+++ b/Apps/Avalonia/MainWindow.TextOutput.cs
@@ -105,12 +105,12 @@ public partial class MainWindow
                 return;
 
             var snapshot = CaptureProjectTextOutputSnapshot();
-            var result = await PrepareProjectTextOutputAsync(mode, snapshot);
+            using var result = await PrepareProjectTextDocumentOutputAsync(mode, snapshot);
             if (!await EnsureProjectTextOutputAvailableAsync(mode, snapshot, result))
                 return;
 
             var saved = await TryExportTextToFileAsync(
-                result.Content,
+				result.Document,
                 snapshot.RootPath,
                 suggestedFileName,
                 dialogTitle,
@@ -122,7 +122,7 @@ public partial class MainWindow
             _sessionMetrics.RecordFileExport(
                 metricsKind,
                 GetMetricsTreeFormat(mode, snapshot),
-                result.Content.Length,
+				(int)Math.Min(int.MaxValue, result.Document.CharacterCount),
                 success: true);
             _toastService.Show(_localization[toastKey]);
         }
@@ -181,15 +181,53 @@ public partial class MainWindow
         }
     }
 
+	private async Task<ProjectTextDocumentOutputResult> PrepareProjectTextDocumentOutputAsync(
+		ProjectTextOutputMode mode,
+		ProjectTextOutputSnapshot snapshot)
+	{
+		_metrics.CancelBackgroundCalculation();
+		var statusOperationId = BeginOutputPreparationStatus();
+		try
+		{
+			var cancellationToken = _windowLifetimeCts?.Token ?? CancellationToken.None;
+			return await _textOutputPipeline.BuildDocumentAsync(mode, snapshot, cancellationToken);
+		}
+		finally
+		{
+			CompleteStatusOperation(ref statusOperationId);
+		}
+	}
+
     private async Task<bool> EnsureProjectTextOutputAvailableAsync(
         ProjectTextOutputMode mode,
         ProjectTextOutputSnapshot snapshot,
         ProjectTextOutputResult result)
+		=> await EnsureProjectTextOutputAvailableAsync(
+			mode,
+			snapshot,
+			result.CandidateFileCount,
+			!string.IsNullOrWhiteSpace(result.Content));
+
+	private async Task<bool> EnsureProjectTextOutputAvailableAsync(
+		ProjectTextOutputMode mode,
+		ProjectTextOutputSnapshot snapshot,
+		ProjectTextDocumentOutputResult result) =>
+		await EnsureProjectTextOutputAvailableAsync(
+			mode,
+			snapshot,
+			result.CandidateFileCount,
+			result.Document.CharacterCount > 0);
+
+	private async Task<bool> EnsureProjectTextOutputAvailableAsync(
+		ProjectTextOutputMode mode,
+		ProjectTextOutputSnapshot snapshot,
+		int candidateFileCount,
+		bool hasContent)
     {
         if (mode != ProjectTextOutputMode.Content)
             return true;
 
-        if (result.CandidateFileCount == 0)
+        if (candidateFileCount == 0)
         {
             var messageKey = snapshot.SelectedPaths.Count > 0
                 ? "Msg.NoCheckedFiles"
@@ -198,7 +236,7 @@ public partial class MainWindow
             return false;
         }
 
-        if (!string.IsNullOrWhiteSpace(result.Content))
+		if (hasContent)
             return true;
 
         await ShowInfoAsync(_localization["Msg.NoTextContent"]);
@@ -252,14 +290,14 @@ public partial class MainWindow
     }
 
     private async Task<bool> TryExportTextToFileAsync(
-        string content,
+		IPreviewTextDocument document,
         string sourceRootPath,
         string suggestedFileName,
         string dialogTitle,
         string defaultExtension,
         IReadOnlyList<FilePickerFileType> fileTypeChoices)
     {
-        if (StorageProvider is null || string.IsNullOrWhiteSpace(content))
+		if (StorageProvider is null || document.CharacterCount == 0)
             return false;
 
         var windowLifetime = _windowLifetimeCts;
@@ -323,7 +361,7 @@ public partial class MainWindow
                     (stream, writeCancellationToken) =>
                         _textFileExport.WriteAsync(
                             stream,
-                            content,
+							document,
                             writeCancellationToken),
                     cancellationToken,
                     path => ProjectCopyExportService.ResolveDestinationOutsideProject(

--- a/Apps/Avalonia/MainWindow.axaml.cs
+++ b/Apps/Avalonia/MainWindow.axaml.cs
@@ -11,6 +11,7 @@ public partial class MainWindow : Window
 {
     private const double BranchMenuItemHeight = 32;
     private const double TreeFontMenuItemHeight = 32;
+	private static readonly TimeSpan ShutdownPersistenceBudget = TimeSpan.FromSeconds(10);
 
     internal enum TerminalCommandPostInstallUiAction
     {
@@ -995,7 +996,8 @@ public partial class MainWindow : Window
         // Give persistence one last synchronous chance before the process exits.
         // This protects against transient IO failures that would otherwise make the UI look correct
         // during the session but leave no durable snapshot for the next launch.
-        _appearanceSettings.PersistPendingChanges();
+		var startedTimestamp = Stopwatch.GetTimestamp();
+		_appearanceSettings.PersistPendingChanges();
 
         if (_recentProjectsDb.RecentFolders.Count > 0 ||
             _recentProjectsDb.RecentFolderRemovals.Count > 0 ||
@@ -1004,7 +1006,16 @@ public partial class MainWindow : Window
             _recentProjectsStore.TryPersist(_recentProjectsDb);
         }
 
-        _projectProfiles.FlushPending();
+		var remaining = ShutdownPersistenceBudget - Stopwatch.GetElapsedTime(startedTimestamp);
+		if (remaining < TimeSpan.Zero)
+			remaining = TimeSpan.Zero;
+		var result = _projectProfiles.FlushPending(remaining);
+		if (!result.Succeeded)
+		{
+			Trace.TraceWarning(
+				$"Project profile shutdown persistence was incomplete: " +
+				$"attempted={result.Attempted}, saved={result.Saved}, remaining={result.Remaining}.");
+		}
     }
 
     private async Task<bool> TryOpenFolderAsync(

--- a/Apps/Avalonia/Services/PreviewSearchIndex.cs
+++ b/Apps/Avalonia/Services/PreviewSearchIndex.cs
@@ -11,7 +11,26 @@ internal readonly record struct PreviewSearchResult(
 
 internal static class PreviewSearchIndex
 {
+	internal const int MinimumQueryLength = 2;
 	internal const int MaximumMatches = 10_000;
+
+	public static bool CanSearch(string? query)
+	{
+		if (string.IsNullOrWhiteSpace(query) ||
+		    query.AsSpan().IndexOfAny('\r', '\n') >= 0)
+		{
+			return false;
+		}
+
+		var runeCount = 0;
+		foreach (var _ in query.EnumerateRunes())
+		{
+			if (++runeCount == MinimumQueryLength)
+				return true;
+		}
+
+		return false;
+	}
 
 	public static PreviewSearchResult Find(
 		IPreviewTextDocument document,
@@ -19,8 +38,7 @@ internal static class PreviewSearchIndex
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(document);
-		if (string.IsNullOrWhiteSpace(query) ||
-		    query.AsSpan().IndexOfAny('\r', '\n') >= 0)
+		if (!CanSearch(query))
 		{
 			return new PreviewSearchResult([], IsCapped: false);
 		}

--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -222,7 +222,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	  "type": "object",
 	  "properties": {
 	    {{ProjectProperty}},
-	    "pattern": { "type": "string", "minLength": 1, "description": "A .NET regular expression evaluated against redacted text with a 2-second timeout." },
+	    "pattern": { "type": "string", "minLength": 1, "maxLength": 4096, "description": "A .NET regular expression evaluated against redacted text with a 2-second timeout." },
 	    {{IncludeProperty}},
 	    {{ExcludeProperty}},
 	    {{TrackedOnlyProperty}},

--- a/Apps/Mcp/McpRootJailFileStreamOpener.cs
+++ b/Apps/Mcp/McpRootJailFileStreamOpener.cs
@@ -1,0 +1,172 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace DevProjex.Mcp;
+
+internal sealed class McpRootJailFileStreamOpener(McpRootRegistry roots)
+{
+	private const int DarwinGetPath = 50;
+	private const int DarwinPathBufferLength = 1024;
+
+	public FileStream OpenRead(
+		string path,
+		int bufferSize,
+		FileShare fileShare,
+		bool asynchronous)
+	{
+		UnixFileTypeInspector.EnsureRegularFile(path);
+		var lexicalRoot = roots.FindLexicalRoot(path);
+		var stream = new FileStream(
+			path,
+			FileMode.Open,
+			FileAccess.Read,
+			fileShare,
+			bufferSize,
+			FileOptions.SequentialScan |
+			(asynchronous ? FileOptions.Asynchronous : FileOptions.None));
+		try
+		{
+			if (lexicalRoot is not null)
+			{
+				var openedPath = ResolveOpenedPath(stream.SafeFileHandle);
+				roots.EnsureOpenedPathIsWithin(lexicalRoot, path, openedPath);
+			}
+			return stream;
+		}
+		catch
+		{
+			stream.Dispose();
+			throw;
+		}
+	}
+
+	internal static string ResolveOpenedPath(SafeFileHandle handle)
+	{
+		ArgumentNullException.ThrowIfNull(handle);
+		if (handle.IsInvalid || handle.IsClosed)
+			throw new IOException("The opened project file handle is unavailable.");
+		if (OperatingSystem.IsWindows())
+			return ResolveWindowsPath(handle);
+		if (OperatingSystem.IsLinux())
+			return ResolveLinuxPath(handle);
+		if (OperatingSystem.IsMacOS())
+			return ResolveDarwinPath(handle);
+		throw new PlatformNotSupportedException("MCP root-jail file reads require Windows, Linux, or macOS.");
+	}
+
+	private static string ResolveWindowsPath(SafeFileHandle handle)
+	{
+		var capacity = 512;
+		while (capacity <= 32_768)
+		{
+			var path = new StringBuilder(capacity);
+			var length = GetFinalPathNameByHandle(handle, path, (uint)path.Capacity, 0);
+			if (length == 0)
+				throw NativeFailure("The final Windows path of an opened project file could not be resolved.");
+			if (length < path.Capacity)
+				return NormalizeWindowsPath(path.ToString());
+			capacity = checked((int)length + 1);
+		}
+		throw new IOException("The final Windows path of an opened project file is too long.");
+	}
+
+	private static string NormalizeWindowsPath(string path)
+	{
+		const string uncPrefix = @"\\?\UNC\";
+		const string extendedPrefix = @"\\?\";
+		if (path.StartsWith(uncPrefix, StringComparison.OrdinalIgnoreCase))
+			path = @"\\" + path[uncPrefix.Length..];
+		else if (path.StartsWith(extendedPrefix, StringComparison.OrdinalIgnoreCase))
+			path = path[extendedPrefix.Length..];
+		return Path.GetFullPath(path);
+	}
+
+	private static string ResolveLinuxPath(SafeFileHandle handle)
+	{
+		var descriptor = handle.DangerousGetHandle().ToInt32();
+		var descriptorPath = $"/proc/self/fd/{descriptor}";
+		for (var capacity = 1024; capacity <= 32_768; capacity *= 2)
+		{
+			var bytes = new byte[capacity];
+			var length = ReadLink(descriptorPath, bytes, (nuint)bytes.Length);
+			if (length < 0)
+				throw NativeFailure("The final Linux path of an opened project file could not be resolved.");
+			if (length < bytes.Length)
+				return Path.GetFullPath(Encoding.UTF8.GetString(bytes, 0, checked((int)length)));
+		}
+		throw new IOException("The final Linux path of an opened project file is too long.");
+	}
+
+	private static string ResolveDarwinPath(SafeFileHandle handle)
+	{
+		var descriptor = handle.DangerousGetHandle().ToInt32();
+		var pathBuffer = new byte[DarwinPathBufferLength];
+		var pinned = GCHandle.Alloc(pathBuffer, GCHandleType.Pinned);
+		try
+		{
+			var result = ReadDarwinPath(descriptor, pinned.AddrOfPinnedObject());
+			if (result != 0)
+				throw NativeFailure("The final macOS path of an opened project file could not be resolved.");
+		}
+		finally
+		{
+			pinned.Free();
+		}
+
+		var terminator = Array.IndexOf(pathBuffer, (byte)0);
+		if (terminator <= 0)
+			throw new IOException("The final macOS path of an opened project file is invalid.");
+		return Path.GetFullPath(Encoding.UTF8.GetString(pathBuffer, 0, terminator));
+	}
+
+	private static int ReadDarwinPath(int descriptor, IntPtr pathBuffer)
+	{
+		if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+		{
+			// Darwin ARM64 passes fcntl's variadic path pointer in its ABI stack slot.
+			return DarwinFcntlArm64(
+				descriptor,
+				DarwinGetPath,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				pathBuffer);
+		}
+		return DarwinFcntl(descriptor, DarwinGetPath, pathBuffer);
+	}
+
+	private static IOException NativeFailure(string message) =>
+		new(message, new Win32Exception(Marshal.GetLastPInvokeError()));
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+	private static extern uint GetFinalPathNameByHandle(
+		SafeFileHandle handle,
+		StringBuilder path,
+		uint pathLength,
+		uint flags);
+
+	[DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
+	private static extern nint ReadLink(
+		[MarshalAs(UnmanagedType.LPUTF8Str)] string path,
+		byte[] buffer,
+		nuint bufferSize);
+
+	[DllImport("libSystem.B.dylib", EntryPoint = "fcntl", SetLastError = true)]
+	private static extern int DarwinFcntl(int descriptor, int command, IntPtr pathBuffer);
+
+	[DllImport("libSystem.B.dylib", EntryPoint = "fcntl", SetLastError = true)]
+	private static extern int DarwinFcntlArm64(
+		int descriptor,
+		int command,
+		nint register2,
+		nint register3,
+		nint register4,
+		nint register5,
+		nint register6,
+		nint register7,
+		IntPtr pathBuffer);
+}

--- a/Apps/Mcp/McpRootRegistry.cs
+++ b/Apps/Mcp/McpRootRegistry.cs
@@ -95,6 +95,31 @@ public sealed class McpRootRegistry
 		return physical;
 	}
 
+	internal string? FindLexicalRoot(string path)
+	{
+		string fullPath;
+		try
+		{
+			fullPath = Path.GetFullPath(path);
+		}
+		catch (Exception exception) when (
+			exception is ArgumentException or NotSupportedException or PathTooLongException)
+		{
+			return null;
+		}
+
+		return _roots
+			.Where(root => IsWithin(root, fullPath))
+			.OrderByDescending(static root => root.Length)
+			.FirstOrDefault();
+	}
+
+	internal void EnsureOpenedPathIsWithin(string projectRoot, string requestedPath, string openedPath)
+	{
+		if (!IsWithin(projectRoot, Path.GetFullPath(openedPath)))
+			throw RootViolation(requestedPath);
+	}
+
 	public static string ResolvePhysicalExistingPath(string path, bool requireDirectory)
 	{
 		var fullPath = Path.GetFullPath(path);

--- a/Apps/Mcp/McpSearchRegex.cs
+++ b/Apps/Mcp/McpSearchRegex.cs
@@ -2,11 +2,19 @@ namespace DevProjex.Mcp;
 
 internal sealed class McpSearchRegex
 {
+	internal const int MaximumPatternLength = 4096;
 	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(2);
 	private readonly Regex _regex;
 
 	public McpSearchRegex(string pattern, bool ignoreCase, TimeSpan? timeout = null)
 	{
+		ArgumentNullException.ThrowIfNull(pattern);
+		if (pattern.Length > MaximumPatternLength)
+		{
+			throw new McpToolException(
+				McpErrorCodes.InvalidPattern,
+				$"{McpErrorCodes.InvalidPattern}: pattern must be at most {MaximumPatternLength} characters; shorten it and retry.");
+		}
 		try
 		{
 			_regex = new Regex(

--- a/Apps/Mcp/McpServerHost.cs
+++ b/Apps/Mcp/McpServerHost.cs
@@ -33,7 +33,7 @@ public static class McpServerHost
 		ArgumentNullException.ThrowIfNull(output);
 
 		var rootRegistry = new McpRootRegistry(roots);
-		using var services = McpServices.Create(appDataPathProvider);
+		using var services = McpServices.Create(rootRegistry, appDataPathProvider);
 		using var packs = new McpPackRegistry(tempRoot);
 		var projectService = new McpProjectService(rootRegistry, services);
 		var tools = new DevProjexMcpTools(rootRegistry, projectService, packs);

--- a/Apps/Mcp/McpServices.cs
+++ b/Apps/Mcp/McpServices.cs
@@ -36,8 +36,11 @@ internal sealed class McpServices : IDisposable
 	public CodeCompressionSession CompressionSession { get; }
 	public SecretRedactionOutputPreparer OutputPreparer { get; }
 
-	public static McpServices Create(Func<string>? appDataPathProvider = null)
+	public static McpServices Create(
+		McpRootRegistry roots,
+		Func<string>? appDataPathProvider = null)
 	{
+		ArgumentNullException.ThrowIfNull(roots);
 		var localization = new LocalizationService(new JsonLocalizationCatalog(), AppLanguage.En);
 		var scanner = new FileSystemScanner();
 		var treeBuilder = new TreeBuilder();
@@ -57,7 +60,8 @@ internal sealed class McpServices : IDisposable
 			new DartArtifactsIgnoreRule()
 		]);
 		var treeExport = new TreeExportService();
-		var contentAnalyzer = new FileContentAnalyzer();
+		var guardedFileOpener = new McpRootJailFileStreamOpener(roots);
+		var contentAnalyzer = new FileContentAnalyzer(guardedFileOpener.OpenRead);
 		var resolvedDataPath = appDataPathProvider ??
 		                       DevProjex.Infrastructure.Persistence.UserDataPathResolver.GetConfigurationRoot;
 		var profileStore = new ProjectProfileStore(resolvedDataPath);

--- a/Apps/Terminal/Tui/TerminalWorkspaceController.cs
+++ b/Apps/Terminal/Tui/TerminalWorkspaceController.cs
@@ -10,6 +10,7 @@ public sealed class TerminalWorkspaceController(
 	TerminalServices services,
 	ITerminalEnvironment environment)
 {
+	internal const long MaximumClipboardPayloadBytes = 256L * 1024 * 1024;
 	private const string TrackedIndexUnavailableCode = "DPX-GIT-TRACKED-INDEX-UNAVAILABLE";
 	private static readonly ProjectContextDocumentLimits PreviewLimits = new();
 
@@ -435,7 +436,7 @@ public sealed class TerminalWorkspaceController(
 			cancellationToken);
 	}
 
-	public async Task<string> BuildCopyPayloadAsync(
+	public async Task<string?> BuildCopyPayloadAsync(
 		TerminalWorkspaceState state,
 		ProjectContextView view,
 		ProjectContextDocumentFormat format,
@@ -448,7 +449,15 @@ public sealed class TerminalWorkspaceController(
 				format,
 				cancellationToken)
 			.ConfigureAwait(false);
-		return PreviewClipboardPayloadBuilder.BuildFullDocumentPayload(document);
+		return MaterializeCopyPayload(document);
+	}
+
+	internal static string? MaterializeCopyPayload(IPreviewTextDocument document)
+	{
+		ArgumentNullException.ThrowIfNull(document);
+		return document.CharacterCount > MaximumClipboardPayloadBytes / sizeof(char)
+			? null
+			: PreviewClipboardPayloadBuilder.BuildFullDocumentPayload(document);
 	}
 
 	private async Task<IPreviewTextDocument> BuildInteractivePreviewAsync(

--- a/Apps/Terminal/Tui/TerminalWorkspaceSession.Actions.cs
+++ b/Apps/Terminal/Tui/TerminalWorkspaceSession.Actions.cs
@@ -929,6 +929,9 @@ internal sealed partial class TerminalWorkspaceSession
 
 	private void ShowActionPalette()
 	{
+		if (_operationProgress is not null)
+			return;
+
 		var registry = _screen == TerminalWorkspaceScreen.Welcome
 			? null
 			: BuildWorkspaceActionRegistry();
@@ -1286,6 +1289,11 @@ internal sealed partial class TerminalWorkspaceSession
 						format,
 						token)
 					.ConfigureAwait(false);
+				if (payload is null)
+				{
+					throw new TerminalWorkspaceOperationException(
+						"DPX-TUI-CLIPBOARD-PAYLOAD-TOO-LARGE");
+				}
 				var clipboardResult = await InvokeAsync(() => _clipboardWriter.Write(payload))
 					.ConfigureAwait(false);
 				if (!clipboardResult.IsSuccess)

--- a/Apps/Terminal/Tui/TerminalWorkspaceSession.Commands.cs
+++ b/Apps/Terminal/Tui/TerminalWorkspaceSession.Commands.cs
@@ -374,6 +374,7 @@ internal sealed partial class TerminalWorkspaceSession
 	{
 		if (_screen != TerminalWorkspaceScreen.Workspace ||
 			_layoutMode == TerminalWorkspaceLayoutMode.TooSmall ||
+			_operationProgress is not null ||
 			_commandLine is null)
 		{
 			return;

--- a/Apps/Terminal/Tui/TerminalWorkspaceSession.cs
+++ b/Apps/Terminal/Tui/TerminalWorkspaceSession.cs
@@ -1912,6 +1912,11 @@ internal sealed partial class TerminalWorkspaceSession : IDisposable
 			return;
 		if (_commandLine?.IsEditing == true)
 			return;
+		if (_operationProgress is not null && IsOverlayActivationKey(key))
+		{
+			key.Handled = true;
+			return;
+		}
 		if (_screen == TerminalWorkspaceScreen.Workspace &&
 			_layoutMode != TerminalWorkspaceLayoutMode.TooSmall &&
 			TerminalWorkspaceCommandKey.IsActivation(key))
@@ -1994,6 +1999,12 @@ internal sealed partial class TerminalWorkspaceSession : IDisposable
 		if (_screen == TerminalWorkspaceScreen.Workspace)
 			HandleWorkspaceKey(key);
 	}
+
+	private static bool IsOverlayActivationKey(Key key) =>
+		TerminalWorkspaceCommandKey.IsActivation(key) ||
+		key == Key.F1 ||
+		key == new Key('?') ||
+		key == Key.P.WithCtrl;
 
 	private void HandleWelcomeKey(Key key)
 	{
@@ -4173,6 +4184,9 @@ internal sealed partial class TerminalWorkspaceSession : IDisposable
 
 	private void ShowHelp(bool welcome)
 	{
+		if (_operationProgress is not null)
+			return;
+
 		var contextualBody = _activePane switch
 		{
 			TerminalWorkspacePane.Preview => L("Terminal.Tui.Help.Preview"),

--- a/Docs/CLI-Profiles.md
+++ b/Docs/CLI-Profiles.md
@@ -38,6 +38,12 @@ maps by retaining their selected values as checked entries; all other rows use c
 defaults consistently across surfaces. Explicit CLI fields are exact for that invocation
 and never mutate the stored maps.
 
+Desktop batches pending local-profile snapshots under one project-profile store lock
+when the window closes. The batch retains the existing atomic file-replacement format
+and has a ten-second shutdown budget; if contention outlives that budget, the last
+durable profile data remains intact and the unsaved snapshots are logged rather than
+blocking application exit indefinitely.
+
 The Hide Secrets content-transformation state is stored separately from path
 Exclusions and remains off in the built-in `standard` profile. Individual
 keep-as-is decisions are session-only: profiles never store secret fingerprints,

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -21,7 +21,9 @@ list_projects -> get_tree/analyze -> search_project/get_file -> pack_context -> 
 ## Security Model
 
 - Every exposed project is pinned when the process starts. Canonical path and
-  symbolic-link checks reject access outside those roots.
+  symbolic-link checks reject access outside those roots. Content files are
+  opened before their final handle path is validated, and the validated handle
+  is the one read, so a path swap cannot escape the root jail.
 - Tools are read-only and perform no network operations. With `tracked_only`, the
   server may start the local Git executable solely to read the repository index;
   it never runs project executables or arbitrary project commands.
@@ -62,7 +64,7 @@ The tool order is stable.
 | `analyze` | `project?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `detail?`, `tracked_only?` | File, character, and token metrics plus the ten largest files by tokens. Metrics reflect the effective detail level. |
 | `pack_context` | `project?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `detail?`, `tracked_only?`, `view?`, `format?` | Exact DevProjex context pipeline. Inline through 50,000 characters; otherwise returns a session-scoped `pack_id` and tree. |
 | `read_pack` | `pack_id`, `start_line?`, `end_line?` | Inclusive, 1-based range; at most 1,000 lines or 50,000 characters per call. Call `pack_context` again after server restart. |
-| `search_project` | `project?`, `pattern`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `context_lines?`, `ignore_case?`, `max_results?` | Grep-style redacted matches. Regex timeout is 2 seconds; `max_results` cannot exceed 200, and oversized text responses are explicitly truncated with a narrowing hint. |
+| `search_project` | `project?`, `pattern`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `context_lines?`, `ignore_case?`, `max_results?` | Grep-style redacted matches. Regex patterns are limited to 4,096 characters and a 2-second timeout; `max_results` cannot exceed 200, and oversized text responses are explicitly truncated with a narrowing hint. |
 | `get_file` | `project?`, `path`, `start_line?`, `end_line?` | Redacted text from one effective file; at most 1,000 lines or 50,000 characters. |
 
 ## Result Contract

--- a/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
+++ b/Infrastructure/FileSystem/GitTrackedPathIndexCache.cs
@@ -222,13 +222,19 @@ internal static class GitTrackedPathIndexCache
 			await GitRepositoryService
 				.WaitForExitOrTerminateAsync(process, timeoutSource.Token)
 				.ConfigureAwait(false);
+			if (!await GitProcessOutputReader
+				    .WaitForCompletionAfterExitAsync(process, trackedPathsTask, errorDrainTask)
+				    .ConfigureAwait(false))
+			{
+				return null;
+			}
 			trackedPaths = await trackedPathsTask.ConfigureAwait(false);
 			await errorDrainTask.ConfigureAwait(false);
 		}
 		catch (OperationCanceledException)
 		{
 			await GitProcessOutputReader
-				.ObserveCompletionAsync(trackedPathsTask, errorDrainTask)
+				.ObserveAfterTerminationAsync(process, trackedPathsTask, errorDrainTask)
 				.ConfigureAwait(false);
 			throw;
 		}

--- a/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
+++ b/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
@@ -305,7 +305,7 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 		{
 		}
 		GitProcessOutputReader
-			.ObserveCompletionAsync(output, error)
+			.ObserveAfterTerminationAsync(process, output, error)
 			.GetAwaiter()
 			.GetResult();
 	}

--- a/Infrastructure/Git/GitProcessOutputReader.cs
+++ b/Infrastructure/Git/GitProcessOutputReader.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using DevProjex.Infrastructure.Processes;
 
 namespace DevProjex.Infrastructure.Git;
@@ -5,6 +6,7 @@ namespace DevProjex.Infrastructure.Git;
 internal static class GitProcessOutputReader
 {
 	internal const int MaximumOutputCharacters = 1024 * 1024;
+	private static readonly TimeSpan OutputDrainTimeout = TimeSpan.FromSeconds(2);
 
 	internal static async Task<GitProcessOutput> ReadAsync(
 		TextReader reader,
@@ -20,6 +22,88 @@ internal static class GitProcessOutputReader
 	internal static async Task ObserveCompletionAsync(params Task[] readers)
 	{
 		await BoundedTextReader.ObserveCompletionAsync(readers).ConfigureAwait(false);
+	}
+
+	internal static Task<bool> WaitForCompletionAfterExitAsync(
+		Process process,
+		params Task[] readers) =>
+		WaitForCompletionAfterExitAsync(
+			() => CloseRedirectedReaders(process),
+			OutputDrainTimeout,
+			readers);
+
+	internal static Task ObserveAfterTerminationAsync(
+		Process process,
+		params Task[] readers) =>
+		ObserveAfterTerminationAsync(
+			() => CloseRedirectedReaders(process),
+			OutputDrainTimeout,
+			readers);
+
+	internal static async Task<bool> WaitForCompletionAfterExitAsync(
+		Action closeReaders,
+		TimeSpan timeout,
+		params Task[] readers)
+	{
+		ArgumentNullException.ThrowIfNull(closeReaders);
+		if (timeout <= TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(timeout));
+
+		try
+		{
+			await Task.WhenAll(readers).WaitAsync(timeout).ConfigureAwait(false);
+			return true;
+		}
+		catch (TimeoutException)
+		{
+			closeReaders();
+			await ObserveBoundedAsync(timeout, readers).ConfigureAwait(false);
+			return false;
+		}
+	}
+
+	internal static async Task ObserveAfterTerminationAsync(
+		Action closeReaders,
+		TimeSpan timeout,
+		params Task[] readers)
+	{
+		ArgumentNullException.ThrowIfNull(closeReaders);
+		if (timeout <= TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(timeout));
+
+		closeReaders();
+		await ObserveBoundedAsync(timeout, readers).ConfigureAwait(false);
+	}
+
+	private static async Task ObserveBoundedAsync(TimeSpan timeout, Task[] readers)
+	{
+		try
+		{
+			await ObserveCompletionAsync(readers).WaitAsync(timeout).ConfigureAwait(false);
+		}
+		catch (TimeoutException)
+		{
+			// The primary process is already gone. A descendant may still own a copied pipe
+			// handle, so cleanup must not retain a repository lock indefinitely.
+		}
+	}
+
+	private static void CloseRedirectedReaders(Process process)
+	{
+		ArgumentNullException.ThrowIfNull(process);
+		TryDispose(process.StandardOutput);
+		TryDispose(process.StandardError);
+	}
+
+	private static void TryDispose(IDisposable reader)
+	{
+		try
+		{
+			reader.Dispose();
+		}
+		catch (Exception exception) when (exception is IOException or InvalidOperationException)
+		{
+		}
 	}
 }
 

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -826,13 +826,15 @@ public sealed class GitRepositoryService : IGitRepositoryService
         try
         {
             await WaitForExitOrTerminateAsync(process, cancellationToken);
-            await Task.WhenAll(outputPump, errorPump).ConfigureAwait(false);
+            _ = await GitProcessOutputReader
+                .WaitForCompletionAfterExitAsync(process, outputPump, errorPump)
+                .ConfigureAwait(false);
             progressObserver?.ThrowIfFaulted();
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             await GitProcessOutputReader
-                .ObserveCompletionAsync(outputPump, errorPump)
+                .ObserveAfterTerminationAsync(process, outputPump, errorPump)
                 .ConfigureAwait(false);
             throw;
         }

--- a/Infrastructure/Git/GitWorktreeManager.cs
+++ b/Infrastructure/Git/GitWorktreeManager.cs
@@ -392,7 +392,12 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 			await GitRepositoryService
 				.WaitForExitOrTerminateAsync(process, cancellationToken)
 				.ConfigureAwait(false);
-			await Task.WhenAll(outputTask, errorTask).ConfigureAwait(false);
+			if (!await GitProcessOutputReader
+				    .WaitForCompletionAfterExitAsync(process, outputTask, errorTask)
+				    .ConfigureAwait(false))
+			{
+				return new GitProcessResult(-1, string.Empty, "Git process output did not close after exit.");
+			}
 			var output = await outputTask.ConfigureAwait(false);
 			var error = await errorTask.ConfigureAwait(false);
 			return output.ExceededLimit || error.ExceededLimit
@@ -402,7 +407,7 @@ internal sealed class GitWorktreeManager : IGitWorktreeManager
 		catch (OperationCanceledException)
 		{
 			await GitProcessOutputReader
-				.ObserveCompletionAsync(outputTask, errorTask)
+				.ObserveAfterTerminationAsync(process, outputTask, errorTask)
 				.ConfigureAwait(false);
 
 			throw;

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -1432,7 +1432,12 @@ public sealed class RepoCacheService : IRepoCacheService
 			await GitRepositoryService
 				.WaitForExitOrTerminateAsync(process, cancellationToken)
 				.ConfigureAwait(false);
-			await Task.WhenAll(output, error).ConfigureAwait(false);
+			if (!await GitProcessOutputReader
+				    .WaitForCompletionAfterExitAsync(process, output, error)
+				    .ConfigureAwait(false))
+			{
+				return null;
+			}
 			var standardOutput = await output.ConfigureAwait(false);
 			var standardError = await error.ConfigureAwait(false);
 			return process.ExitCode == 0 &&
@@ -1444,7 +1449,7 @@ public sealed class RepoCacheService : IRepoCacheService
 		catch (OperationCanceledException)
 		{
 			await GitProcessOutputReader
-				.ObserveCompletionAsync(output, error)
+				.ObserveAfterTerminationAsync(process, output, error)
 				.ConfigureAwait(false);
 			throw;
 		}

--- a/Infrastructure/Persistence/CrossProcessFileLock.cs
+++ b/Infrastructure/Persistence/CrossProcessFileLock.cs
@@ -48,12 +48,14 @@ internal static class CrossProcessFileLock
                     FileShare.None);
                 return new HeldLock(stream);
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-				if (Stopwatch.GetElapsedTime(startedTimestamp) >= timeout)
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+			{
+				var elapsed = Stopwatch.GetElapsedTime(startedTimestamp);
+				if (elapsed >= timeout)
                     throw;
 
-                Thread.Sleep(RetryDelay);
+				var remaining = timeout - elapsed;
+				Thread.Sleep(remaining < RetryDelay ? remaining : RetryDelay);
             }
         }
     }

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -91,6 +91,96 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		ProjectSelectionProfile profile) =>
 		TrySaveProfileWithResult(localProjectPath, profile, DateTimeOffset.UtcNow);
 
+	public ProjectProfileBatchSaveResult TrySaveProfilesWithResult(
+		IReadOnlyList<ProjectProfileSaveRequest> requests,
+		TimeSpan lockTimeout)
+	{
+		ArgumentNullException.ThrowIfNull(requests);
+		ArgumentOutOfRangeException.ThrowIfLessThan(lockTimeout, TimeSpan.Zero);
+		if (requests.Count == 0)
+			return new ProjectProfileBatchSaveResult([]);
+
+		var preparedByPath = new Dictionary<string, PreparedProfileWrite>(PathComparer.Default);
+		foreach (var request in requests)
+		{
+			if (!TryNormalizePath(request.LocalProjectPath, out var normalizedPath))
+				continue;
+
+			var normalizedUpdatedUtc = NormalizeProfileTimestamp(request.UpdatedUtc);
+			var persistedProfile = ToPersistedProfile(
+				request.Profile,
+				normalizedUpdatedUtc,
+				out var wasTruncated);
+			if (wasTruncated)
+				continue;
+
+			if (!preparedByPath.TryGetValue(normalizedPath, out var previous) ||
+			    previous.UpdatedUtc <= normalizedUpdatedUtc)
+			{
+				preparedByPath[normalizedPath] = new PreparedProfileWrite(
+					normalizedPath,
+					persistedProfile,
+					normalizedUpdatedUtc);
+			}
+		}
+
+		if (preparedByPath.Count == 0)
+			return new ProjectProfileBatchSaveResult([]);
+
+		var startedTimestamp = Stopwatch.GetTimestamp();
+		if (!Monitor.TryEnter(_sync, lockTimeout))
+			return new ProjectProfileBatchSaveResult([]);
+
+		try
+		{
+			var remaining = lockTimeout - Stopwatch.GetElapsedTime(startedTimestamp);
+			if (remaining < TimeSpan.Zero)
+				remaining = TimeSpan.Zero;
+			var fileSet = GetFileSet();
+			if (!CrossProcessFileLock.TryAcquire(fileSet, remaining, out var heldLock))
+				return new ProjectProfileBatchSaveResult([]);
+
+			using var _ = heldLock;
+			if (HasOversizedDocument(fileSet) ||
+			    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
+			{
+				return new ProjectProfileBatchSaveResult([]);
+			}
+
+			var db = LoadInternal(fileSet, persistRecovery: false);
+			db.SchemaVersion = CurrentSchemaVersion;
+			var alreadySaved = new List<string>();
+			var changedPaths = new List<string>();
+			foreach (var write in preparedByPath.Values)
+			{
+				if (db.Profiles.TryGetValue(write.NormalizedPath, out var existing) &&
+				    existing is not null &&
+				    existing.UpdatedUtc > write.UpdatedUtc)
+				{
+					alreadySaved.Add(write.NormalizedPath);
+					continue;
+				}
+
+				db.Profiles[write.NormalizedPath] = write.Profile;
+				changedPaths.Add(write.NormalizedPath);
+			}
+
+			if (changedPaths.Count == 0)
+				return new ProjectProfileBatchSaveResult(alreadySaved);
+
+			PruneProfiles(db);
+			if (!TrySaveInternal(fileSet, db))
+				return new ProjectProfileBatchSaveResult(alreadySaved);
+
+			alreadySaved.AddRange(changedPaths.Where(db.Profiles.ContainsKey));
+			return new ProjectProfileBatchSaveResult(alreadySaved);
+		}
+		finally
+		{
+			Monitor.Exit(_sync);
+		}
+	}
+
 	private ProjectProfileSaveResult TrySaveProfileWithResult(
 		string localProjectPath,
 		ProjectSelectionProfile profile,
@@ -307,11 +397,13 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 			path,
 			ProjectProfileStorageLimits.MaximumJsonBytes);
 
-	private ProjectProfileDb LoadInternal(JsonStoreFileSet fileSet)
+	private ProjectProfileDb LoadInternal(
+		JsonStoreFileSet fileSet,
+		bool persistRecovery = true)
 	{
 		if (TryLoadFromPath(fileSet.PrimaryPath, out var primaryDb, out var primaryRequiresRewrite))
 		{
-			if (primaryRequiresRewrite)
+			if (primaryRequiresRewrite && persistRecovery)
 				TrySaveInternal(fileSet, primaryDb);
 
 			return primaryDb;
@@ -320,7 +412,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		// Recover from the last known-good snapshot when the primary profile document becomes unreadable.
 		if (TryLoadFromPath(fileSet.BackupPath, out var backupDb, out _))
 		{
-			TrySaveInternal(fileSet, backupDb);
+			if (persistRecovery)
+				TrySaveInternal(fileSet, backupDb);
 			return backupDb;
 		}
 
@@ -531,6 +624,11 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		timestamp <= DateTimeOffset.UnixEpoch || timestamp > MaximumSafeProfileTimestamp
 			? DateTimeOffset.UnixEpoch.AddTicks(1)
 			: timestamp;
+
+	private sealed record PreparedProfileWrite(
+		string NormalizedPath,
+		PersistedProjectProfile Profile,
+		DateTimeOffset UpdatedUtc);
 
 	private static ProjectSelectionProfile ToProfile(
 		PersistedProjectProfile profile,

--- a/Infrastructure/TerminalCommands/TerminalCommandSetupService.cs
+++ b/Infrastructure/TerminalCommands/TerminalCommandSetupService.cs
@@ -63,6 +63,7 @@ public sealed class TerminalCommandSetupService(TerminalCommandSetupServiceOptio
 	private const int MaximumLauncherValidationOutputCharacters = 64 * 1024;
 	internal const int MaximumShellProfileBytes = 8 * 1024 * 1024;
 	private static readonly TimeSpan LauncherValidationTimeout = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan LauncherOutputDrainTimeout = TimeSpan.FromSeconds(2);
 	// Cover lock-free probes and writes within one process; the named mutex still protects separate processes.
 	private static readonly object ProcessSetupSync = new();
 
@@ -1467,10 +1468,7 @@ public sealed class TerminalCommandSetupService(TerminalCommandSetupServiceOptio
 				outputCancellation.Cancel();
 				TryKillProcess(process);
 				_ = process.WaitForExit(1000);
-				BoundedTextReader
-					.ObserveCompletionAsync(standardOutput, standardError)
-					.GetAwaiter()
-					.GetResult();
+				ObserveValidationReaders(process, standardOutput, standardError);
 				return new TerminalCommandValidationResult(false, "The terminal launcher validation timed out.");
 			}
 			if (standardOutput.Result.ExceededLimit || standardError.Result.ExceededLimit)
@@ -1490,7 +1488,7 @@ public sealed class TerminalCommandSetupService(TerminalCommandSetupServiceOptio
 		{
 			outputCancellation?.Cancel();
 			TryKillProcess(process);
-			ObserveValidationReaders(standardOutput, standardError);
+			ObserveValidationReaders(process, standardOutput, standardError);
 			return new TerminalCommandValidationResult(false, ex.Message);
 		}
 		finally
@@ -1511,6 +1509,7 @@ public sealed class TerminalCommandSetupService(TerminalCommandSetupServiceOptio
 	}
 
 	private static void ObserveValidationReaders(
+		Process? process,
 		Task<BoundedTextReadResult>? standardOutput,
 		Task<BoundedTextReadResult>? standardError)
 	{
@@ -1522,10 +1521,35 @@ public sealed class TerminalCommandSetupService(TerminalCommandSetupServiceOptio
 		if (readers.Count == 0)
 			return;
 
-		BoundedTextReader
-			.ObserveCompletionAsync(readers.ToArray())
-			.GetAwaiter()
-			.GetResult();
+		TryDisposeValidationReader(process, standardOutput: true);
+		TryDisposeValidationReader(process, standardOutput: false);
+		try
+		{
+			BoundedTextReader
+				.ObserveCompletionAsync(readers.ToArray())
+				.WaitAsync(LauncherOutputDrainTimeout)
+				.GetAwaiter()
+				.GetResult();
+		}
+		catch (TimeoutException)
+		{
+		}
+	}
+
+	private static void TryDisposeValidationReader(Process? process, bool standardOutput)
+	{
+		if (process is null)
+			return;
+		try
+		{
+			if (standardOutput)
+				process.StandardOutput.Dispose();
+			else
+				process.StandardError.Dispose();
+		}
+		catch (Exception exception) when (exception is IOException or InvalidOperationException)
+		{
+		}
 	}
 
 	private static SetupLockLease AcquireSetupLock(string commandPath)

--- a/Kernel/Abstractions/IProjectProfileStore.cs
+++ b/Kernel/Abstractions/IProjectProfileStore.cs
@@ -10,6 +10,21 @@ public interface IProjectProfileStore
 		string localProjectPath,
 		ProjectSelectionProfile profile) =>
 		new(TrySaveProfile(localProjectPath, profile), WasTruncated: false);
+	ProjectProfileBatchSaveResult TrySaveProfilesWithResult(
+		IReadOnlyList<ProjectProfileSaveRequest> requests,
+		TimeSpan lockTimeout)
+	{
+		ArgumentNullException.ThrowIfNull(requests);
+		ArgumentOutOfRangeException.ThrowIfLessThan(lockTimeout, TimeSpan.Zero);
+		var savedPaths = new List<string>(requests.Count);
+		foreach (var request in requests)
+		{
+			if (TrySaveProfile(request.LocalProjectPath, request.Profile, request.UpdatedUtc))
+				savedPaths.Add(request.LocalProjectPath);
+		}
+
+		return new ProjectProfileBatchSaveResult(savedPaths);
+	}
 	ProjectProfileLookupResult LookupProfile(string localProjectPath, TimeSpan lockTimeout)
 	{
 		return TryLoadProfile(localProjectPath, out var profile)

--- a/Kernel/Models/ProjectProfileBatchSave.cs
+++ b/Kernel/Models/ProjectProfileBatchSave.cs
@@ -1,0 +1,9 @@
+namespace DevProjex.Kernel.Models;
+
+public sealed record ProjectProfileSaveRequest(
+	string LocalProjectPath,
+	ProjectSelectionProfile Profile,
+	DateTimeOffset UpdatedUtc);
+
+public sealed record ProjectProfileBatchSaveResult(
+	IReadOnlyList<string> SavedProjectPaths);

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -163,6 +163,34 @@ public sealed class McpServerIntegrationTests
 	}
 
 	[Fact]
+	public async Task GetFileRejectsAProjectFileReplacedByAnOutsideSymlink()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var sourcePath = Path.Combine(project, "source.txt");
+		var outsidePath = Path.Combine(workspace.Path, "outside.txt");
+		File.WriteAllText(outsidePath, "outside content");
+		File.WriteAllText(sourcePath, "inside content");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		File.Delete(sourcePath);
+		CreateFileAliasOrSkip(sourcePath, outsidePath);
+		try
+		{
+			var result = await server.CallAsync(
+				"get_file",
+				new Dictionary<string, object?> { ["path"] = "source.txt" });
+
+			Assert.True(result.IsError);
+			Assert.Contains(McpErrorCodes.RootViolation, Text(result), StringComparison.Ordinal);
+		}
+		finally
+		{
+			File.Delete(sourcePath);
+		}
+	}
+
+	[Fact]
 	public async Task ToolCallsExposeTextAndStructuredPayloadsAccordingToSchemaContract()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -850,6 +878,19 @@ public sealed class McpServerIntegrationTests
 			{
 			}
 			Assert.Skip("Windows junction creation is unavailable.");
+		}
+	}
+
+	private static void CreateFileAliasOrSkip(string linkPath, string targetPath)
+	{
+		try
+		{
+			File.CreateSymbolicLink(linkPath, targetPath);
+		}
+		catch (Exception exception) when (
+			exception is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+		{
+			Assert.Skip($"File symbolic links are unavailable: {exception.GetType().Name}.");
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -105,6 +105,9 @@ public sealed class McpServerIntegrationTests
 		var searchBoolean = tools.Single(static tool => tool.Name == "search_project")
 			.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("ignore_case");
 		Assert.Equal(2, searchBoolean.GetProperty("oneOf").GetArrayLength());
+		var searchPattern = tools.Single(static tool => tool.Name == "search_project")
+			.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("pattern");
+		Assert.Equal(4096, searchPattern.GetProperty("maxLength").GetInt32());
 		foreach (var name in new[] { "analyze", "pack_context" })
 		{
 			var detail = tools.Single(tool => tool.Name == name)
@@ -244,6 +247,26 @@ public sealed class McpServerIntegrationTests
 		Assert.True(expired.IsError);
 		Assert.Null(expired.StructuredContent);
 		Assert.Contains(McpErrorCodes.PackExpired, Text(expired), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SearchProjectRejectsPatternsLongerThanTheSchemaLimitAtRuntime()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(Path.Combine(project, "source.txt"), "content");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = new string('x', McpSearchRegex.MaximumPatternLength + 1)
+			});
+
+		Assert.True(result.IsError);
+		Assert.Contains(McpErrorCodes.InvalidPattern, Text(result), StringComparison.Ordinal);
+		Assert.Contains("4096", Text(result), StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal.ProgressHost/DelayedWriteStream.cs
+++ b/Tests/DevProjex.Tests.Terminal.ProgressHost/DelayedWriteStream.cs
@@ -1,0 +1,59 @@
+namespace DevProjex.Tests.Terminal.ProgressHost;
+
+internal sealed class DelayedWriteStream(
+	Stream inner,
+	string cancelPath,
+	CancellationTokenSource cancellation) : Stream
+{
+	public override bool CanRead => false;
+	public override bool CanSeek => inner.CanSeek;
+	public override bool CanWrite => true;
+	public override long Length => inner.Length;
+	public override long Position
+	{
+		get => inner.Position;
+		set => inner.Position = value;
+	}
+
+	public override void Flush() => inner.Flush();
+	public override Task FlushAsync(CancellationToken cancellationToken) =>
+		inner.FlushAsync(cancellationToken);
+	public override int Read(byte[] buffer, int offset, int count) =>
+		throw new NotSupportedException();
+	public override long Seek(long offset, SeekOrigin origin) =>
+		inner.Seek(offset, origin);
+	public override void SetLength(long value) => inner.SetLength(value);
+	public override void Write(byte[] buffer, int offset, int count) =>
+		inner.Write(buffer, offset, count);
+
+	public override async ValueTask WriteAsync(
+		ReadOnlyMemory<byte> buffer,
+		CancellationToken cancellationToken = default)
+	{
+		CancelWhenRequested(cancellationToken);
+		await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+		CancelWhenRequested(cancellationToken);
+		await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+	}
+
+	private void CancelWhenRequested(CancellationToken cancellationToken)
+	{
+		if (!File.Exists(cancelPath))
+			return;
+		cancellation.Cancel();
+		cancellationToken.ThrowIfCancellationRequested();
+	}
+
+	protected override void Dispose(bool disposing)
+	{
+		if (disposing)
+			inner.Dispose();
+		base.Dispose(disposing);
+	}
+
+	public override async ValueTask DisposeAsync()
+	{
+		await inner.DisposeAsync().ConfigureAwait(false);
+		GC.SuppressFinalize(this);
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs
+++ b/Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs
@@ -99,9 +99,11 @@ internal static class Program
 			destinationFile,
 			cancelPath,
 			cancellation);
+		var pendingReadyPath = readyPath + ".pending";
 		await File.WriteAllTextAsync(
-			readyPath,
+			pendingReadyPath,
 			Environment.WorkingSet.ToString(CultureInfo.InvariantCulture));
+		File.Move(pendingReadyPath, readyPath);
 
 		try
 		{

--- a/Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs
+++ b/Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using DevProjex.Application.Preview;
 using DevProjex.Application.Services;
 using DevProjex.Kernel;
 using DevProjex.Kernel.Models;
@@ -24,6 +25,19 @@ internal static class Program
 		{
 			_ = Console.In.ReadToEnd();
 			Console.Out.Write("eof");
+			return CommandLineExitCodes.Success;
+		}
+		if (args is ["--file-backed-export", var sourcePath, var destinationPath,
+		    var readyPath, var cancelPath, var outcomePath])
+		{
+			RunFileBackedExportAsync(
+					sourcePath,
+					destinationPath,
+					readyPath,
+					cancelPath,
+					outcomePath)
+				.GetAwaiter()
+				.GetResult();
 			return CommandLineExitCodes.Success;
 		}
 
@@ -57,6 +71,50 @@ internal static class Program
 			.RunAsync(args, cancellation.Token)
 			.GetAwaiter()
 			.GetResult();
+	}
+
+	private static async Task RunFileBackedExportAsync(
+		string sourcePath,
+		string destinationPath,
+		string readyPath,
+		string cancelPath,
+		string outcomePath)
+	{
+		var sourceLength = new FileInfo(sourcePath).Length;
+		using var document = new FileBackedPreviewTextDocument(
+			sourcePath,
+			[0],
+			sourceLength,
+			maxLineLength: 0,
+			characterCount: sourceLength);
+		await using var destinationFile = new FileStream(
+			destinationPath,
+			FileMode.CreateNew,
+			FileAccess.Write,
+			FileShare.Read,
+			bufferSize: 64 * 1024,
+			FileOptions.Asynchronous | FileOptions.SequentialScan);
+		using var cancellation = new CancellationTokenSource();
+		await using var destination = new DelayedWriteStream(
+			destinationFile,
+			cancelPath,
+			cancellation);
+		await File.WriteAllTextAsync(
+			readyPath,
+			Environment.WorkingSet.ToString(CultureInfo.InvariantCulture));
+
+		try
+		{
+			await new TextFileExportService().WriteAsync(
+				destination,
+				document,
+				cancellation.Token);
+			await File.WriteAllTextAsync(outcomePath, "completed");
+		}
+		catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+		{
+			await File.WriteAllTextAsync(outcomePath, "canceled");
+		}
 	}
 
 	private static int RunSignalCheckpointProtocol()

--- a/Tests/DevProjex.Tests.Terminal/GeneratedCompletionNativeShellIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/GeneratedCompletionNativeShellIntegrationTests.cs
@@ -493,7 +493,10 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 			probePath,
 			shellExecutable));
 
-		var result = await RunProcessAsync(startInfo, cancellationToken);
+		var result = await RunProcessAsync(
+			startInfo,
+			cancellationToken,
+			processTimeout: TimeSpan.FromSeconds(45));
 		if (result.ExitCode == 0)
 			return;
 

--- a/Tests/DevProjex.Tests.Terminal/TerminalProgressPtyTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalProgressPtyTests.cs
@@ -73,6 +73,14 @@ public sealed class TerminalProgressPtyTests
 		Assert.Contains("Esc or Ctrl+C", active, StringComparison.Ordinal);
 		Assert.False(terminal.HasExited);
 
+		await terminal.SendAsync(":\u001bOP\u0010", TestContext.Current.CancellationToken);
+		await Task.Delay(150, TestContext.Current.CancellationToken);
+		var gated = terminal.CaptureScreen();
+		Assert.Contains("Esc or Ctrl+C", gated, StringComparison.Ordinal);
+		Assert.DoesNotContain("Filter actions:", gated, StringComparison.Ordinal);
+		Assert.DoesNotContain(":set", gated, StringComparison.Ordinal);
+		Assert.DoesNotContain("ACTION PALETTE", gated, StringComparison.Ordinal);
+
 		await terminal.SendCtrlCAsync(TestContext.Current.CancellationToken);
 		await terminal.WaitForScreenAsync(
 			"Operation canceled",
@@ -80,6 +88,14 @@ public sealed class TerminalProgressPtyTests
 			cancellationToken: TestContext.Current.CancellationToken);
 		Assert.False(Directory.Exists(destination));
 		Assert.False(terminal.HasExited);
+		await terminal.WaitForScreenAsync(
+			"> CONTEXT PREVIEW",
+			cancellationToken: TestContext.Current.CancellationToken);
+		await terminal.SendAsync(":", TestContext.Current.CancellationToken);
+		await terminal.WaitForScreenAsync(
+			":set",
+			cancellationToken: TestContext.Current.CancellationToken);
+		await terminal.SendEscapeAsync(TestContext.Current.CancellationToken);
 		await terminal.WaitForScreenAsync(
 			"> CONTEXT PREVIEW",
 			cancellationToken: TestContext.Current.CancellationToken);

--- a/Tests/DevProjex.Tests.Terminal/TerminalPtyHarness.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalPtyHarness.cs
@@ -80,6 +80,15 @@ internal sealed class TerminalPtyHarness : IAsyncDisposable
 	}
 
 	public bool HasExited => _exit.Task.IsCompleted;
+	public long PeakWorkingSetBytes
+	{
+		get
+		{
+			using var process = Process.GetProcessById(_process.ProcessId);
+			process.Refresh();
+			return process.PeakWorkingSet64;
+		}
+	}
 	public string RawOutput => CaptureRawOutput();
 	public int Columns
 	{

--- a/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceCommandLinePtyTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceCommandLinePtyTests.cs
@@ -25,6 +25,33 @@ public sealed class TerminalWorkspaceCommandLinePtyTests
 		await QuitAsync(terminal);
 	}
 
+	[Fact(Timeout = 240_000)]
+	public async Task CopyCommandRejectsAnOversizedDocumentBeforeStringMaterialization()
+	{
+		using var project = CreateOversizedCopyProject();
+		await using var terminal = await StartAsync(project.Path, columns: 120, rows: 30);
+		await terminal.WaitForScreenAsync(
+			"PROJECT TREE",
+			timeout: TimeSpan.FromSeconds(45),
+			cancellationToken: TestContext.Current.CancellationToken);
+		var peakBefore = terminal.PeakWorkingSetBytes;
+		var stopwatch = Stopwatch.StartNew();
+
+		await terminal.SendAsync(":copy content text\r", TestContext.Current.CancellationToken);
+		var result = await terminal.WaitForScreenAsync(
+			"Use :export instead",
+			timeout: TimeSpan.FromSeconds(75),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains("too large", result, StringComparison.OrdinalIgnoreCase);
+		Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(75));
+		Assert.True(
+			terminal.PeakWorkingSetBytes - peakBefore < 192L * 1024 * 1024,
+			"The copy path allocated memory proportional to the oversized UTF-16 payload.");
+		Assert.False(terminal.HasExited);
+		await QuitAsync(terminal);
+	}
+
 	[Fact(Timeout = 120_000)]
 	public async Task AnalyzeCommandPublishesEveryMetricOnOneResultLine()
 	{
@@ -664,6 +691,32 @@ public sealed class TerminalWorkspaceCommandLinePtyTests
 			"src/App.cs",
 			"const string ApiKey = \"ghp_a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL\";");
 		project.WriteFile("readme.md", "# Command line test");
+		return project;
+	}
+
+	private static TemporaryDirectory CreateOversizedCopyProject()
+	{
+		var project = new TemporaryDirectory();
+		project.WriteFile("global.json", "{}");
+		var path = Path.Combine(project.Path, "oversized.txt");
+		var targetBytes = TerminalWorkspaceController.MaximumClipboardPayloadBytes /
+		                  sizeof(char) + 1024;
+		var buffer = Enumerable.Repeat((byte)'x', 80 * 1024).ToArray();
+		for (var index = 4095; index < buffer.Length; index += 4096)
+			buffer[index] = (byte)'\n';
+		using var stream = new FileStream(
+			path,
+			FileMode.CreateNew,
+			FileAccess.Write,
+			FileShare.None,
+			buffer.Length,
+			FileOptions.SequentialScan);
+		for (long written = 0; written < targetBytes;)
+		{
+			var count = (int)Math.Min(buffer.Length, targetBytes - written);
+			stream.Write(buffer, 0, count);
+			written += count;
+		}
 		return project;
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs
@@ -895,6 +895,17 @@ public sealed class TerminalWorkspaceContractTests
 	}
 
 	[Fact]
+	public void CopyPayloadRejectsAnOversizedDocumentBeforeReadingItsText()
+	{
+		using var document = new NonMaterializablePreviewDocument(
+			TerminalWorkspaceController.MaximumClipboardPayloadBytes / sizeof(char) + 1);
+
+		var payload = TerminalWorkspaceController.MaterializeCopyPayload(document);
+
+		Assert.Null(payload);
+	}
+
+	[Fact]
 	public async Task RefreshSelectsANewFileAndPreservesAnExplicitlyClearedFile()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -1087,5 +1098,22 @@ public sealed class TerminalWorkspaceContractTests
 	private sealed class SynchronousProgress<T>(Action<T> report) : IProgress<T>
 	{
 		public void Report(T value) => report(value);
+	}
+
+	private sealed class NonMaterializablePreviewDocument(long characterCount) : IPreviewTextDocument
+	{
+		public int LineCount => 1;
+		public int MaxLineLength => 1;
+		public long CharacterCount => characterCount;
+		public IReadOnlyList<PreviewDocumentSection> Sections => [];
+
+		public string GetFullText() => throw new InvalidOperationException("Text must not be materialized.");
+		public string GetLineText(int lineNumber) =>
+			throw new InvalidOperationException("Text must not be materialized.");
+		public string GetLineRangeText(int firstLine, int lastLine) =>
+			throw new InvalidOperationException("Text must not be materialized.");
+		public void Dispose()
+		{
+		}
 	}
 }

--- a/Tests/DevProjex.Tests.UI/MainWindowHelpSearchUiTests.cs
+++ b/Tests/DevProjex.Tests.UI/MainWindowHelpSearchUiTests.cs
@@ -104,7 +104,7 @@ public sealed class MainWindowHelpSearchUiTests
             help.SearchBoxControl.Text = "no-such-help-search-result-4f22";
             await UiTestDriver.WaitForConditionAsync(
                 window,
-                () => help.SearchMatchCount == 0,
+                () => help.SearchMatchCount == 0 && matchSummary.IsVisible,
                 "empty help search result");
             Assert.True(previousButton.IsEnabled);
             Assert.True(nextButton.IsEnabled);

--- a/Tests/DevProjex.Tests.UI/MainWindowPreviewMarkerUiTests.cs
+++ b/Tests/DevProjex.Tests.UI/MainWindowPreviewMarkerUiTests.cs
@@ -110,9 +110,11 @@ public sealed class MainWindowPreviewMarkerUiTests
 				() => stickyHeader.Margin.Right > 0.1 &&
 				      scrollViewer.AllowAutoHide == originalViewerAllowAutoHide &&
 				      !verticalScrollBar.AllowAutoHide &&
-				      !horizontalScrollBar.IsExpanded,
+					      !horizontalScrollBar.IsExpanded,
 				"scrollbar hover to move the sticky path away and keep the rail active");
 			await UiTestDriver.WaitForSettledFramesAsync(frameCount: 3);
+			window.MouseMove(railPoint, RawInputModifiers.None);
+			await UiTestDriver.WaitForSettledFramesAsync(frameCount: 1);
 			window.MouseMove(markerPoint, RawInputModifiers.None);
 			await UiTestDriver.WaitForConditionAsync(
 				window,

--- a/Tests/DevProjex.Tests.UI/MainWindowRepositoryCacheUiTests.cs
+++ b/Tests/DevProjex.Tests.UI/MainWindowRepositoryCacheUiTests.cs
@@ -269,7 +269,7 @@ public sealed class MainWindowRepositoryCacheUiTests(UiWorkspaceFixture workspac
 				await UiTestDriver.WaitForSettledFramesAsync(frameCount: 2);
 				var deleteButton = await OpenAndFindDeleteButtonAsync(window, comboBox, removed);
 
-				await UiTestDriver.ClickAsync(window, deleteButton);
+				await UiTestDriver.RaiseButtonClickAsync(deleteButton);
 				await UiTestDriver.WaitForConditionAsync(
 					window,
 					() => viewModel.CachedRepositories.Count == 1,

--- a/Tests/DevProjex.Tests.Unit/Avalonia/PreviewSearchIndexTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/PreviewSearchIndexTests.cs
@@ -75,14 +75,31 @@ public sealed class PreviewSearchIndexTests
 	[Theory]
 	[InlineData("")]
 	[InlineData("   ")]
+	[InlineData("x")]
+	[InlineData("🙂")]
 	[InlineData("two\nlines")]
-	public void Find_RejectsEmptyOrMultilineQueryWithoutReadingDocument(string query)
+	public void Find_RejectsShortOrMultilineQueryWithoutReadingDocument(string query)
 	{
 		using var document = new TrackingDocument(["two lines"]);
 
 		var result = PreviewSearchIndex.Find(
 			document,
 			query,
+			TestContext.Current.CancellationToken);
+
+		Assert.Empty(result.Matches);
+		Assert.False(result.IsCapped);
+		Assert.Equal(0, document.LineReadCount);
+	}
+
+	[Fact]
+	public void Find_OneCharacterQueryDoesNotScanLargeDocument()
+	{
+		using var document = new RepeatedLineDocument(1_000_000, "x");
+
+		var result = PreviewSearchIndex.Find(
+			document,
+			"x",
 			TestContext.Current.CancellationToken);
 
 		Assert.Empty(result.Matches);

--- a/Tests/DevProjex.Tests.Unit/Avalonia/ProjectTextOutputPipelineTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/ProjectTextOutputPipelineTests.cs
@@ -1,4 +1,5 @@
 using DevProjex.Application.Compression;
+using DevProjex.Application.Preview;
 using DevProjex.Application.Secrets;
 using DevProjex.Infrastructure.Secrets;
 
@@ -6,6 +7,53 @@ namespace DevProjex.Tests.Unit.Avalonia;
 
 public sealed class ProjectTextOutputPipelineTests
 {
+	[Theory]
+	[InlineData((int)ProjectTextOutputMode.Content)]
+	[InlineData((int)ProjectTextOutputMode.TreeAndContent)]
+	public async Task BuildDocumentAsync_LargeFileBackedOutputMatchesLegacyBytes(int modeValue)
+	{
+		using var project = new TemporaryDirectory();
+		var sourceFile = Path.Combine(project.Path, "large.txt");
+		var content = string.Concat(
+			Enumerable.Repeat("ASCII\r\nПривет🙂\rline\n", 32_000)) +
+			"tail";
+		await File.WriteAllTextAsync(
+			sourceFile,
+			content,
+			new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+			TestContext.Current.CancellationToken);
+		var root = DirectoryNode(project.Path, FileNode(sourceFile));
+		var snapshot = CreateSnapshot(
+			project.Path,
+			root,
+			new HashSet<string>(PathComparer.Default));
+		var pipeline = CreatePipeline();
+		var mode = (ProjectTextOutputMode)modeValue;
+
+		var legacy = await pipeline.BuildAsync(
+			mode,
+			snapshot,
+			TestContext.Current.CancellationToken);
+		using var streamed = await pipeline.BuildDocumentAsync(
+			mode,
+			snapshot,
+			TestContext.Current.CancellationToken);
+		Assert.IsType<FileBackedPreviewTextDocument>(streamed.Document);
+		await using var legacyBytes = new MemoryStream();
+		await using var streamedBytes = new MemoryStream();
+		var writer = new TextFileExportService();
+		await writer.WriteAsync(
+			legacyBytes,
+			legacy.Content,
+			TestContext.Current.CancellationToken);
+		await writer.WriteAsync(
+			streamedBytes,
+			streamed.Document,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(legacyBytes.ToArray(), streamedBytes.ToArray());
+	}
+
 	[Fact]
 	public async Task BuildAsync_ContentUsesTheOriginalPerFilePathFormat()
 	{
@@ -224,7 +272,9 @@ public sealed class ProjectTextOutputPipelineTests
         return new ProjectTextOutputPipeline(
             treeExport,
             contentExport,
-            new TreeAndContentExportService(treeExport, contentExport));
+			new TreeAndContentExportService(treeExport, contentExport),
+			new PreviewDocumentBuilder(new FileContentAnalyzer()),
+			new TextFileExportService());
     }
 
     private static ProjectTextOutputSnapshot CreateSnapshot(

--- a/Tests/DevProjex.Tests.Unit/DevProjex.Tests.Unit.csproj
+++ b/Tests/DevProjex.Tests.Unit/DevProjex.Tests.Unit.csproj
@@ -18,6 +18,9 @@
     <ProjectReference Include="..\..\Apps\Mcp\DevProjex.Mcp.csproj" />
     <ProjectReference Include="..\..\Apps\Avalonia\DevProjex.Avalonia.csproj" />
     <ProjectReference Include="..\..\Kernel\Kernel.csproj" />
+    <ProjectReference
+      Include="..\DevProjex.Tests.Terminal.ProgressHost\DevProjex.Tests.Terminal.ProgressHost.csproj"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/DevProjex.Tests.Unit/FileBackedExportProcessTests.cs
+++ b/Tests/DevProjex.Tests.Unit/FileBackedExportProcessTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class FileBackedExportProcessTests
+{
+	[Fact]
+	public async Task LargeFileBackedExport_CancelsQuicklyWithoutProportionalWorkingSetGrowth()
+	{
+		using var temporary = new TemporaryDirectory();
+		var sourcePath = Path.Combine(temporary.Path, "large.preview");
+		var destinationPath = Path.Combine(temporary.Path, "export.txt");
+		var readyPath = Path.Combine(temporary.Path, "ready.txt");
+		var cancelPath = Path.Combine(temporary.Path, "cancel");
+		var outcomePath = Path.Combine(temporary.Path, "outcome.txt");
+		const long sourceLength = 300L * 1024 * 1024;
+		await using (var source = new FileStream(sourcePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+			source.SetLength(sourceLength);
+
+		using var process = Process.Start(CreateStartInfo(
+			sourcePath,
+			destinationPath,
+			readyPath,
+			cancelPath,
+			outcomePath));
+		Assert.NotNull(process);
+		try
+		{
+			await WaitForFileAsync(readyPath, process!, TestContext.Current.CancellationToken);
+			var baselineWorkingSet = long.Parse(
+				await File.ReadAllTextAsync(readyPath, TestContext.Current.CancellationToken),
+				CultureInfo.InvariantCulture);
+			var peakWorkingSet = baselineWorkingSet;
+			await Task.Delay(150, TestContext.Current.CancellationToken);
+			var cancellationStarted = Stopwatch.StartNew();
+			await File.WriteAllTextAsync(cancelPath, string.Empty, TestContext.Current.CancellationToken);
+			while (!process!.HasExited)
+			{
+				try
+				{
+					process.Refresh();
+					peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
+				}
+				catch (InvalidOperationException) when (process.HasExited)
+				{
+					break;
+				}
+				await Task.Delay(10, TestContext.Current.CancellationToken);
+			}
+			cancellationStarted.Stop();
+
+			Assert.Equal(0, process.ExitCode);
+			Assert.Equal("canceled", await File.ReadAllTextAsync(
+				outcomePath,
+				TestContext.Current.CancellationToken));
+			Assert.InRange(cancellationStarted.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+			Assert.InRange(peakWorkingSet - baselineWorkingSet, 0, 64L * 1024 * 1024);
+			Assert.InRange(new FileInfo(destinationPath).Length, 1, sourceLength - 1);
+		}
+		finally
+		{
+			if (!File.Exists(cancelPath))
+				await File.WriteAllTextAsync(
+					cancelPath,
+					string.Empty,
+					TestContext.Current.CancellationToken);
+			if (!process!.HasExited)
+			{
+				using var exitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+				try
+				{
+					await process.WaitForExitAsync(exitTimeout.Token);
+				}
+				catch (OperationCanceledException)
+				{
+					process.Kill(entireProcessTree: true);
+					await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+				}
+			}
+		}
+	}
+
+	private static ProcessStartInfo CreateStartInfo(
+		string sourcePath,
+		string destinationPath,
+		string readyPath,
+		string cancelPath,
+		string outcomePath)
+	{
+		var executableName = OperatingSystem.IsWindows()
+			? "DevProjex.Tests.Terminal.ProgressHost.exe"
+			: "DevProjex.Tests.Terminal.ProgressHost";
+		var executablePath = Path.Combine(
+			FindRepositoryRoot(),
+			"Tests",
+			"DevProjex.Tests.Terminal.ProgressHost",
+			"bin",
+			ResolveConfiguration(),
+			"net10.0",
+			executableName);
+		if (!File.Exists(executablePath))
+			throw new FileNotFoundException("Build the process test host before running this test.", executablePath);
+
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = executablePath,
+			UseShellExecute = false,
+			CreateNoWindow = true
+		};
+		startInfo.ArgumentList.Add("--file-backed-export");
+		startInfo.ArgumentList.Add(sourcePath);
+		startInfo.ArgumentList.Add(destinationPath);
+		startInfo.ArgumentList.Add(readyPath);
+		startInfo.ArgumentList.Add(cancelPath);
+		startInfo.ArgumentList.Add(outcomePath);
+		return startInfo;
+	}
+
+	private static string ResolveConfiguration()
+	{
+		var segments = AppContext.BaseDirectory
+			.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+			.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		return segments.Contains("Release", StringComparer.OrdinalIgnoreCase)
+			? "Release"
+			: "Debug";
+	}
+
+	private static string FindRepositoryRoot()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null)
+		{
+			if (File.Exists(Path.Combine(directory.FullName, "DevProjex.sln")))
+				return directory.FullName;
+			directory = directory.Parent;
+		}
+		throw new DirectoryNotFoundException("The repository root could not be resolved.");
+	}
+
+	private static async Task WaitForFileAsync(
+		string path,
+		Process process,
+		CancellationToken cancellationToken)
+	{
+		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeout.CancelAfter(TimeSpan.FromSeconds(10));
+		while (!File.Exists(path))
+		{
+			if (process.HasExited)
+				throw new InvalidOperationException($"Export helper exited with code {process.ExitCode}.");
+			await Task.Delay(20, timeout.Token);
+		}
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/FileBackedExportProcessTests.cs
+++ b/Tests/DevProjex.Tests.Unit/FileBackedExportProcessTests.cs
@@ -26,10 +26,10 @@ public sealed class FileBackedExportProcessTests
 		Assert.NotNull(process);
 		try
 		{
-			await WaitForFileAsync(readyPath, process!, TestContext.Current.CancellationToken);
-			var baselineWorkingSet = long.Parse(
-				await File.ReadAllTextAsync(readyPath, TestContext.Current.CancellationToken),
-				CultureInfo.InvariantCulture);
+			var baselineWorkingSet = await WaitForReadyWorkingSetAsync(
+				readyPath,
+				process!,
+				TestContext.Current.CancellationToken);
 			var peakWorkingSet = baselineWorkingSet;
 			await Task.Delay(150, TestContext.Current.CancellationToken);
 			var cancellationStarted = Stopwatch.StartNew();
@@ -138,17 +138,23 @@ public sealed class FileBackedExportProcessTests
 		throw new DirectoryNotFoundException("The repository root could not be resolved.");
 	}
 
-	private static async Task WaitForFileAsync(
+	private static async Task<long> WaitForReadyWorkingSetAsync(
 		string path,
 		Process process,
 		CancellationToken cancellationToken)
 	{
 		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 		timeout.CancelAfter(TimeSpan.FromSeconds(10));
-		while (!File.Exists(path))
+		while (true)
 		{
 			if (process.HasExited)
 				throw new InvalidOperationException($"Export helper exited with code {process.ExitCode}.");
+			if (File.Exists(path))
+			{
+				var content = await File.ReadAllTextAsync(path, timeout.Token);
+				if (long.TryParse(content, NumberStyles.None, CultureInfo.InvariantCulture, out var workingSet))
+					return workingSet;
+			}
 			await Task.Delay(20, timeout.Token);
 		}
 	}

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -108,6 +108,26 @@ public class GitRepositoryServiceUnitTests
 	}
 
 	[Fact]
+	public async Task ExitedProcessOutputDrainClosesStuckReadersWithinTheBoundedCleanup()
+	{
+		var reader = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var closeCount = 0;
+
+		var drainedNormally = await GitProcessOutputReader.WaitForCompletionAfterExitAsync(
+			() =>
+			{
+				Interlocked.Increment(ref closeCount);
+				reader.TrySetException(new IOException("Pipe closed."));
+			},
+			TimeSpan.FromMilliseconds(50),
+			reader.Task);
+
+		Assert.False(drainedNormally);
+		Assert.Equal(1, closeCount);
+		Assert.True(reader.Task.IsFaulted);
+	}
+
+	[Fact]
 	public async Task WorktreeSupportProbe_FaultedProbeIsRetriedOnNextRequest()
 	{
 		var calls = 0;

--- a/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
@@ -218,7 +218,8 @@ public sealed class McpInfrastructureTests
 		{
 			var candidate = Path.Combine(link, "secret.txt");
 			var registry = new McpRootRegistry([project]);
-			Assert.True(PathComparer.Default.Equals(project, registry.FindLexicalRoot(candidate)));
+			var canonicalProject = registry.ResolveProject(project);
+			Assert.True(PathComparer.Default.Equals(canonicalProject, registry.FindLexicalRoot(candidate)));
 			var opener = new McpRootJailFileStreamOpener(registry);
 
 			var exception = Assert.Throws<McpToolException>(() =>
@@ -229,7 +230,7 @@ public sealed class McpInfrastructureTests
 					asynchronous: false));
 
 			Assert.Equal(McpErrorCodes.RootViolation, exception.Code);
-			Assert.Contains(project, exception.Message, StringComparison.Ordinal);
+			Assert.Contains(canonicalProject, exception.Message, StringComparison.Ordinal);
 		}
 		finally
 		{

--- a/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
@@ -184,6 +184,61 @@ public sealed class McpInfrastructureTests
 	}
 
 	[Fact]
+	public void RootJailFileOpenerReadsAnOrdinaryFileFromTheVerifiedHandle()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateFolder("project");
+		var source = workspace.CreateFile("project/source.txt", "verified content");
+		var registry = new McpRootRegistry([project]);
+		var opener = new McpRootJailFileStreamOpener(registry);
+
+		using var stream = opener.OpenRead(
+			source,
+			bufferSize: 4096,
+			FileShare.Read,
+			asynchronous: false);
+		using var reader = new StreamReader(stream);
+
+		Assert.Equal("verified content", reader.ReadToEnd());
+		Assert.True(PathComparer.Default.Equals(
+			McpRootRegistry.ResolvePhysicalExistingPath(source, requireDirectory: false),
+			McpRootJailFileStreamOpener.ResolveOpenedPath(stream.SafeFileHandle)));
+	}
+
+	[Fact]
+	public void RootJailFileOpenerRejectsAnAncestorSymlinkEscapeAfterLexicalAcceptance()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateFolder("project");
+		var outside = workspace.CreateFolder("outside");
+		workspace.CreateFile("outside/secret.txt", "outside");
+		var link = Path.Combine(project, "alias");
+		CreateDirectoryAliasOrSkip(link, outside);
+		try
+		{
+			var candidate = Path.Combine(link, "secret.txt");
+			var registry = new McpRootRegistry([project]);
+			Assert.True(PathComparer.Default.Equals(project, registry.FindLexicalRoot(candidate)));
+			var opener = new McpRootJailFileStreamOpener(registry);
+
+			var exception = Assert.Throws<McpToolException>(() =>
+				opener.OpenRead(
+					candidate,
+					bufferSize: 4096,
+					FileShare.Read,
+					asynchronous: false));
+
+			Assert.Equal(McpErrorCodes.RootViolation, exception.Code);
+			Assert.Contains(project, exception.Message, StringComparison.Ordinal);
+		}
+		finally
+		{
+			if (Directory.Exists(link))
+				Directory.Delete(link);
+		}
+	}
+
+	[Fact]
 	public void RootRegistryRevalidatesTheImplicitSingleRootAfterFilesystemReplacement()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -483,6 +538,13 @@ public sealed class McpInfrastructureTests
 		var timeout = Assert.Throws<McpToolException>(() => regex.IsMatch(new string('a', 100_000) + "!"));
 		Assert.Equal(McpErrorCodes.InvalidPattern, timeout.Code);
 		Assert.Contains("simplify", timeout.Message, StringComparison.Ordinal);
+
+		var oversized = Assert.Throws<McpToolException>(() =>
+			new McpSearchRegex(
+				new string('x', McpSearchRegex.MaximumPatternLength + 1),
+				ignoreCase: true));
+		Assert.Equal(McpErrorCodes.InvalidPattern, oversized.Code);
+		Assert.Contains("4096", oversized.Message, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
@@ -216,9 +216,9 @@ public sealed class McpInfrastructureTests
 		CreateDirectoryAliasOrSkip(link, outside);
 		try
 		{
-			var candidate = Path.Combine(link, "secret.txt");
 			var registry = new McpRootRegistry([project]);
 			var canonicalProject = registry.ResolveProject(project);
+			var candidate = Path.Combine(canonicalProject, "alias", "secret.txt");
 			Assert.True(PathComparer.Default.Equals(canonicalProject, registry.FindLexicalRoot(candidate)));
 			var opener = new McpRootJailFileStreamOpener(registry);
 

--- a/Tests/DevProjex.Tests.Unit/ProjectCopyExportUiContractTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectCopyExportUiContractTests.cs
@@ -108,7 +108,7 @@ public sealed class ProjectCopyExportUiContractTests
             "Avalonia",
             "MainWindow.TextOutput.cs");
         Assert.Contains(
-            "result.Content,\n                snapshot.RootPath,",
+			"result.Document,\n                snapshot.RootPath,",
             source.ReplaceLineEndings("\n"),
             StringComparison.Ordinal);
         var methodStart = source.IndexOf(

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileShutdownProcessTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileShutdownProcessTests.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class ProjectProfileShutdownProcessTests
+{
+	[Fact]
+	public async Task BatchFlush_WhenAnotherProcessHoldsLock_StaysWithinBudgetAndPreservesPendingData()
+	{
+		using var temporary = new TemporaryDirectory();
+		var firstProject = temporary.CreateFolder("already-saved");
+		var pendingProject = temporary.CreateFolder("pending");
+		var store = new ProjectProfileStore(() => temporary.Path);
+		store.SaveProfile(
+			firstProject,
+			new ProjectSelectionProfile([], [".cs"], []));
+		var persistedBytesBeforeContention = File.ReadAllBytes(store.GetPath());
+		var queue = new PendingProjectProfileWriteQueue(new FailFirstProfileStore(store));
+		queue.Persist(
+			pendingProject,
+			new ProjectSelectionProfile([], [".json"], []),
+			DateTimeOffset.UtcNow);
+		Assert.Equal(1, queue.Count);
+
+		var readyPath = Path.Combine(temporary.Path, "lock.ready");
+		var releasePath = Path.Combine(temporary.Path, "lock.release");
+		using var process = Process.Start(ProfilePersistenceLockProcessHost.CreateStartInfo(
+			store.GetPath() + ".lock",
+			readyPath,
+			releasePath));
+		Assert.NotNull(process);
+		await WaitForFileAsync(readyPath, process!, TestContext.Current.CancellationToken);
+
+		try
+		{
+			var stopwatch = Stopwatch.StartNew();
+			var result = queue.Flush(TimeSpan.FromMilliseconds(300));
+			stopwatch.Stop();
+
+			Assert.True(result.GateAcquired);
+			Assert.Equal(1, result.Attempted);
+			Assert.Equal(0, result.Saved);
+			Assert.Equal(1, result.Remaining);
+			Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+			Assert.Equal(persistedBytesBeforeContention, File.ReadAllBytes(store.GetPath()));
+		}
+		finally
+		{
+			await File.WriteAllTextAsync(
+				releasePath,
+				string.Empty,
+				TestContext.Current.CancellationToken);
+			await process!.WaitForExitAsync(TestContext.Current.CancellationToken);
+		}
+
+		Assert.True(store.TryLoadProfile(firstProject, out var alreadySaved));
+		Assert.Equal([".cs"], alreadySaved.SelectedExtensions);
+		Assert.False(store.TryLoadProfile(pendingProject, out _));
+		var retry = queue.Flush(TimeSpan.FromSeconds(1));
+		Assert.True(retry.Succeeded);
+		Assert.True(store.TryLoadProfile(pendingProject, out var persisted));
+		Assert.Equal([".json"], persisted.SelectedExtensions);
+	}
+
+	private static async Task WaitForFileAsync(
+		string path,
+		Process process,
+		CancellationToken cancellationToken)
+	{
+		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeout.CancelAfter(TimeSpan.FromSeconds(10));
+		while (!File.Exists(path))
+		{
+			if (process.HasExited)
+			{
+				throw new InvalidOperationException(
+					$"Profile lock helper exited with code {process.ExitCode} before acquiring the lock.");
+			}
+
+			await Task.Delay(TimeSpan.FromMilliseconds(20), timeout.Token);
+		}
+	}
+
+	private sealed class FailFirstProfileStore(ProjectProfileStore inner) : IProjectProfileStore
+	{
+		private int _failNextSingleWrite = 1;
+
+		public bool EnsureStorageExists() => inner.EnsureStorageExists();
+
+		public bool TryLoadProfile(string localProjectPath, out ProjectSelectionProfile profile) =>
+			inner.TryLoadProfile(localProjectPath, out profile);
+
+		public bool TrySaveProfile(string localProjectPath, ProjectSelectionProfile profile) =>
+			TrySaveProfile(localProjectPath, profile, DateTimeOffset.UtcNow);
+
+		public bool TrySaveProfile(
+			string localProjectPath,
+			ProjectSelectionProfile profile,
+			DateTimeOffset updatedUtc)
+		{
+			if (Interlocked.Exchange(ref _failNextSingleWrite, 0) == 1)
+				return false;
+
+			return inner.TrySaveProfile(localProjectPath, profile, updatedUtc);
+		}
+
+		public ProjectProfileBatchSaveResult TrySaveProfilesWithResult(
+			IReadOnlyList<ProjectProfileSaveRequest> requests,
+			TimeSpan lockTimeout) =>
+			inner.TrySaveProfilesWithResult(requests, lockTimeout);
+
+		public void SaveProfile(string localProjectPath, ProjectSelectionProfile profile) =>
+			_ = TrySaveProfile(localProjectPath, profile);
+
+		public void ClearAllProfiles() => inner.ClearAllProfiles();
+	}
+}
+
+internal static class ProfilePersistenceLockProcessHost
+{
+	private const string LockPathVariable = "DEVPROJEX_TEST_PROFILE_LOCK_PATH";
+	private const string ReadyPathVariable = "DEVPROJEX_TEST_PROFILE_LOCK_READY";
+	private const string ReleasePathVariable = "DEVPROJEX_TEST_PROFILE_LOCK_RELEASE";
+
+	[ModuleInitializer]
+	internal static void Run()
+	{
+		var lockPath = Environment.GetEnvironmentVariable(LockPathVariable);
+		var readyPath = Environment.GetEnvironmentVariable(ReadyPathVariable);
+		var releasePath = Environment.GetEnvironmentVariable(ReleasePathVariable);
+		if (string.IsNullOrWhiteSpace(lockPath) ||
+		    string.IsNullOrWhiteSpace(readyPath) ||
+		    string.IsNullOrWhiteSpace(releasePath))
+		{
+			return;
+		}
+
+		using (new FileStream(
+			       lockPath,
+			       FileMode.OpenOrCreate,
+			       FileAccess.ReadWrite,
+			       FileShare.None))
+		{
+			File.WriteAllText(readyPath, Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+			while (!File.Exists(releasePath))
+				Thread.Sleep(20);
+		}
+
+		Environment.Exit(0);
+	}
+
+	internal static ProcessStartInfo CreateStartInfo(
+		string lockPath,
+		string readyPath,
+		string releasePath)
+	{
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet",
+			UseShellExecute = false,
+			CreateNoWindow = true
+		};
+		startInfo.ArgumentList.Add(typeof(ProfilePersistenceLockProcessHost).Assembly.Location);
+		startInfo.Environment[LockPathVariable] = lockPath;
+		startInfo.Environment[ReadyPathVariable] = readyPath;
+		startInfo.Environment[ReleasePathVariable] = releasePath;
+		return startInfo;
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileStoreTests.cs
@@ -3,6 +3,35 @@ namespace DevProjex.Tests.Unit;
 public sealed class ProjectProfileStoreTests
 {
 	[Fact]
+	public void TrySaveProfilesWithResult_PersistsEveryProfileInOneBatch()
+	{
+		using var temporary = new TemporaryDirectory();
+		var firstProject = temporary.CreateFolder("first");
+		var secondProject = temporary.CreateFolder("second");
+		var store = CreateStore(temporary.Path);
+		var updatedUtc = DateTimeOffset.UtcNow;
+
+		var result = store.TrySaveProfilesWithResult(
+			[
+				new ProjectProfileSaveRequest(
+					firstProject,
+					new ProjectSelectionProfile([], [".cs"], []),
+					updatedUtc),
+				new ProjectProfileSaveRequest(
+					secondProject,
+					new ProjectSelectionProfile([], [".json"], []),
+					updatedUtc)
+			],
+			TimeSpan.FromSeconds(1));
+
+		Assert.Equal(2, result.SavedProjectPaths.Count);
+		Assert.True(store.TryLoadProfile(firstProject, out var first));
+		Assert.True(store.TryLoadProfile(secondProject, out var second));
+		Assert.Equal([".cs"], first.SelectedExtensions);
+		Assert.Equal([".json"], second.SelectedExtensions);
+	}
+
+	[Fact]
 	public void SelectedPathsRoundTripSignificantWhitespace()
 	{
 		using var temporary = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/TextFileExportServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/TextFileExportServiceTests.cs
@@ -108,7 +108,7 @@ public sealed class TextFileExportServiceTests
 		var service = new TextFileExportService();
 		await using var stream = new MemoryStream();
 
-		await Assert.ThrowsAsync<ArgumentNullException>(() => service.WriteAsync(stream, null!, cancellationToken: TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(() => service.WriteAsync(stream, (string)null!, cancellationToken: TestContext.Current.CancellationToken));
 	}
 
 	[Fact]


### PR DESCRIPTION
Closes the final review decisions for terminal, MCP, GUI lifecycle, and large file-backed exports. Includes the Windows test-host shutdown fix and targeted regression coverage.