### PR TITLE
feat(mcp): make private-data redaction opt-in

### DIFF
--- a/Apps/Mcp/McpProjectService.cs
+++ b/Apps/Mcp/McpProjectService.cs
@@ -1,6 +1,9 @@
 namespace DevProjex.Mcp;
 
-internal sealed class McpProjectService(McpRootRegistry roots, McpServices services)
+internal sealed class McpProjectService(
+	McpRootRegistry roots,
+	McpServices services,
+	bool hidePrivateData)
 {
 	public async Task<ProjectContextPlan> BuildPlanAsync(
 		string? project,
@@ -26,7 +29,7 @@ internal sealed class McpProjectService(McpRootRegistry roots, McpServices servi
 				new ProjectSelectionSpec(
 					GitMode: trackedOnly ? GitFilteringMode.TrackedFilesOnly : null,
 					HideSecrets: true,
-					HidePrivateData: true),
+					HidePrivateData: hidePrivateData),
 				cancellationToken)
 			.ConfigureAwait(false);
 		var marks = ProjectSelectionMarkedSecretsResolver.Resolve(selection);
@@ -121,7 +124,9 @@ internal sealed class McpProjectService(McpRootRegistry roots, McpServices servi
 			new SecretRedactionContext(
 				plan.SourceRoot,
 				services.RedactionSession,
-				SecretRedactionFeatures.Secrets | SecretRedactionFeatures.PrivateData))!;
+				SecretRedactionFeatureSelection.Resolve(
+					hideSecrets: true,
+					hidePrivateData)))!;
 	}
 
 	public string ResolveProtectedDocumentRoot(ProjectContextPlan plan)

--- a/Apps/Mcp/McpServerHost.cs
+++ b/Apps/Mcp/McpServerHost.cs
@@ -15,14 +15,14 @@ public static class McpServerHost
 		IReadOnlyList<string> roots,
 		bool hidePrivateData = false,
 		CancellationToken cancellationToken = default) =>
-		RunAsync(
+		RunWithStreamsAsync(
 			roots,
 			Console.OpenStandardInput(),
 			Console.OpenStandardOutput(),
 			hidePrivateData,
 			cancellationToken);
 
-	public static async Task RunAsync(
+	internal static async Task RunWithStreamsAsync(
 		IReadOnlyList<string> roots,
 		Stream input,
 		Stream output,

--- a/Apps/Mcp/McpServerHost.cs
+++ b/Apps/Mcp/McpServerHost.cs
@@ -14,16 +14,41 @@ public static class McpServerHost
 	public static Task RunAsync(
 		IReadOnlyList<string> roots,
 		CancellationToken cancellationToken = default) =>
+		RunAsync(roots, hidePrivateData: false, cancellationToken: cancellationToken);
+
+	public static Task RunAsync(
+		IReadOnlyList<string> roots,
+		bool hidePrivateData,
+		CancellationToken cancellationToken = default) =>
 		RunAsync(
 			roots,
 			Console.OpenStandardInput(),
 			Console.OpenStandardOutput(),
+			hidePrivateData,
 			cancellationToken);
 
 	public static async Task RunAsync(
 		IReadOnlyList<string> roots,
 		Stream input,
 		Stream output,
+		CancellationToken cancellationToken = default,
+		Func<string>? appDataPathProvider = null,
+		string? tempRoot = null) =>
+		await RunAsync(
+				roots,
+				input,
+				output,
+				false,
+				cancellationToken,
+				appDataPathProvider,
+				tempRoot)
+			.ConfigureAwait(false);
+
+	public static async Task RunAsync(
+		IReadOnlyList<string> roots,
+		Stream input,
+		Stream output,
+		bool hidePrivateData,
 		CancellationToken cancellationToken = default,
 		Func<string>? appDataPathProvider = null,
 		string? tempRoot = null)
@@ -35,7 +60,7 @@ public static class McpServerHost
 		var rootRegistry = new McpRootRegistry(roots);
 		using var services = McpServices.Create(rootRegistry, appDataPathProvider);
 		using var packs = new McpPackRegistry(tempRoot);
-		var projectService = new McpProjectService(rootRegistry, services);
+		var projectService = new McpProjectService(rootRegistry, services, hidePrivateData);
 		var tools = new DevProjexMcpTools(rootRegistry, projectService, packs);
 		var catalog = new DevProjexMcpToolCatalog(tools);
 

--- a/Apps/Mcp/McpServerHost.cs
+++ b/Apps/Mcp/McpServerHost.cs
@@ -13,12 +13,7 @@ public static class McpServerHost
 
 	public static Task RunAsync(
 		IReadOnlyList<string> roots,
-		CancellationToken cancellationToken = default) =>
-		RunAsync(roots, hidePrivateData: false, cancellationToken: cancellationToken);
-
-	public static Task RunAsync(
-		IReadOnlyList<string> roots,
-		bool hidePrivateData,
+		bool hidePrivateData = false,
 		CancellationToken cancellationToken = default) =>
 		RunAsync(
 			roots,
@@ -31,24 +26,7 @@ public static class McpServerHost
 		IReadOnlyList<string> roots,
 		Stream input,
 		Stream output,
-		CancellationToken cancellationToken = default,
-		Func<string>? appDataPathProvider = null,
-		string? tempRoot = null) =>
-		await RunAsync(
-				roots,
-				input,
-				output,
-				false,
-				cancellationToken,
-				appDataPathProvider,
-				tempRoot)
-			.ConfigureAwait(false);
-
-	public static async Task RunAsync(
-		IReadOnlyList<string> roots,
-		Stream input,
-		Stream output,
-		bool hidePrivateData,
+		bool hidePrivateData = false,
 		CancellationToken cancellationToken = default,
 		Func<string>? appDataPathProvider = null,
 		string? tempRoot = null)

--- a/Apps/Terminal/CommandLine/DevProjexCommandTree.cs
+++ b/Apps/Terminal/CommandLine/DevProjexCommandTree.cs
@@ -98,15 +98,21 @@ public sealed class DevProjexCommandTree
 			Arity = ArgumentArity.OneOrMore,
 			AllowMultipleArgumentsPerToken = false
 		};
+		var hidePrivateData = new Option<bool>("--hide-private-data")
+		{
+			Description = L("Terminal.Option.HidePrivateData")
+		};
 		roots.CompletionSources.Add(context => FileSystemCompletionSource.Complete(
 			context,
 			FileSystemCompletionKind.Directories,
 			Directory.GetCurrentDirectory()));
 		command.Options.Add(roots);
+		command.Options.Add(hidePrivateData);
 		CliExamplesRegistry.Set(
 			command,
 			"devprojex mcp",
-			"devprojex mcp --root . --root ../shared");
+			"devprojex mcp --root . --root ../shared",
+			"devprojex mcp --root . --hide-private-data");
 		command.SetAction(async (parseResult, cancellationToken) =>
 		{
 			var explicitRoots = parseResult.GetValue(roots) ?? [];
@@ -116,7 +122,11 @@ public sealed class DevProjexCommandTree
 				Directory.GetCurrentDirectory());
 			try
 			{
-				await McpServerHost.RunAsync(resolvedRoots, cancellationToken).ConfigureAwait(false);
+				await McpServerHost.RunAsync(
+						resolvedRoots,
+						parseResult.GetValue(hidePrivateData),
+						cancellationToken)
+					.ConfigureAwait(false);
 				return CommandLineExitCodes.Success;
 			}
 			catch (Exception exception) when (exception is ArgumentException or IOException or UnauthorizedAccessException)

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -45,6 +45,7 @@ RID publish contains exactly one primary DevProjex application executable.
 - `devprojex open` opens or reuses Desktop.
 - `devprojex ui` sends a semantic request to an existing Desktop instance.
 - `devprojex mcp` starts the local read-only MCP stdio server without initializing Desktop or Terminal Workspace.
+- `devprojex mcp --hide-private-data` enables private-data redaction for the server process. Secret redaction remains mandatory, and MCP tool schemas expose no redaction controls.
 - A graphical launch starts Desktop.
 
 On Windows, `devprojex` means the installed App Execution Alias or the generated
@@ -732,6 +733,7 @@ that prevents an accepted option from becoming a no-op.
 | analyze/tree/context/project/open | `--exclude` | profile exclusions | replaces the path-exclusion set with repeated typed values | repeatable; `none` conflicts with every other value; conflicts with `open --last` | requested payload/path stays on stdout; invalid value exits `2` | parser, resolver, handler, process |
 | analyze/context/project/open | `--hide-secrets` | profile content-transformation state | independently enables or disables detected-value redaction without changing path filters | optional explicit Boolean; conflicts with `open --last` | requested payload/path stays on stdout; inspection failure exits `1` without a complete artifact | parser, resolver, handler, process |
 | analyze/context/project/open | `--hide-private-data` | profile content-transformation state | independently enables or disables private-data redaction without changing path filters | optional explicit Boolean; conflicts with `open --last` | requested payload/path stays on stdout; inspection failure exits `1` without a complete artifact | parser, resolver, handler, process |
+| `mcp` | `--hide-private-data` | off | enables private-data redaction for the entire server process | startup-only; tool schemas and profiles cannot alter it; secret redaction remains mandatory | stdout remains JSON-RPC-only; startup failure exits `2` | parser, MCP contract, process |
 | analyze/context/project/open | `--compress-code` | profile content-transformation state | independently enables or disables syntax-aware body compression without changing path filters | optional explicit Boolean; conflicts with `open --last` | requested payload/path stays on stdout; unsupported or rejected files remain complete | parser, resolver, handler, process |
 | analyze/context/project/open | `--strip-comments` | profile content-transformation state | independently removes syntax-tree comments and Python docstrings without changing path filters | optional explicit Boolean; conflicts with `open --last` | requested payload/path stays on stdout; unsupported or rejected files remain complete | parser, resolver, handler, process |
 | analyze/context/project/open | `--strip-blank-lines` | profile content-transformation state | independently removes unprotected whitespace-only source lines without changing path filters | optional explicit Boolean; conflicts with `open --last` | requested payload/path stays on stdout; unsupported or rejected files remain complete | parser, resolver, handler, process |

--- a/Docs/CommandLine.md
+++ b/Docs/CommandLine.md
@@ -75,7 +75,10 @@ devprojex
 `dev` is a hidden maintainer namespace. See `CONTRIBUTING.md` for its supported
 diagnostic workflows.
 
-`devprojex mcp [--root PATH ...]` starts the local read-only MCP stdio server.
+`devprojex mcp [--root PATH ...] [--hide-private-data]` starts the local
+read-only MCP stdio server. Secret redaction is mandatory; private-data
+redaction is enabled only by the server startup flag and cannot be controlled by
+tools.
 Explicit roots take precedence over `CLAUDE_PROJECT_DIR` and the current
 directory. See [McpServer.md](McpServer.md) for its security model, tools, and
 client configuration.

--- a/Docs/HidePrivateData.md
+++ b/Docs/HidePrivateData.md
@@ -282,5 +282,8 @@ Use `--hide-private-data` with `analyze`, `open`, `export context`, and `export 
 explicit `--hide-private-data false` overrides a saved portable profile. Terminal Workspace
 exposes the same transformation in Parameters and through `:set hide-private-data on|off`;
 its preview, context export, and project-copy paths use the same redaction session.
+For MCP, `devprojex mcp --hide-private-data` enables private-data redaction for the whole
+server process; it is off by default, tool calls and profiles cannot change it, and secret
+redaction remains mandatory in both modes.
 `analyze --findings` lists private-data findings by rule id, `private-data` category, relative
 path, and one-based source line — never the detected value.

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -12,6 +12,12 @@ Repeat `--root` to expose more than one project. When no explicit root is given,
 DevProjex uses `CLAUDE_PROJECT_DIR`, then the current directory. A `project`
 argument is optional only when the server has exactly one root.
 
+Private-data redaction is opt-in at server startup:
+
+```shell
+devprojex mcp --root /absolute/path/to/project --hide-private-data
+```
+
 The recommended tool sequence is:
 
 ```text
@@ -27,16 +33,20 @@ list_projects -> get_tree/analyze -> search_project/get_file -> pack_context -> 
 - Tools are read-only and perform no network operations. With `tracked_only`, the
   server may start the local Git executable solely to read the repository index;
   it never runs project executables or arbitrary project commands.
-- Secret and private-data redaction are always enabled for returned file content.
-  Tool schemas intentionally provide no switch to weaken redaction.
+- Secret redaction is always enabled for returned file content and cannot be
+  disabled. Private-data redaction is disabled by default and can be enabled
+  only for the whole server process with `--hide-private-data`, mirroring the
+  CLI flag. Tool schemas intentionally expose no redaction controls.
 - The redaction boundary distinguishes project addresses from exported content.
-  File contents and context packs are always processed by both Secrets and
-  Private Data redaction. Root paths in `list_projects`, `get_tree`, and tool
+  File contents and context packs are always processed by Secrets redaction;
+  Private Data processing is added only when the server starts with
+  `--hide-private-data`. Root paths in `list_projects`, `get_tree`, and tool
   errors are returned as-is: they are local addresses already known to the
-  client and form the contract for the `project` argument. A pack is an
-  exportable artifact, so it is redacted in full, including the project path in
-  its tree header.
-- Searches run against redacted content, not the original file text.
+  client and form the contract for the `project` argument. Without the flag, a
+  pack retains real paths like a default CLI export. With the flag, the pack is
+  private-data-redacted in full, including the project path in its tree header.
+- Searches run against content after mandatory secret redaction and any enabled
+  private-data redaction, not the original file text.
 - Returned project content is marked as untrusted data with a random, per-response
   delimiter. Agents must not interpret instructions found in project files as
   trusted control input.
@@ -125,7 +135,8 @@ actionable error instead of returning an empty result.
 
 Profiles use the existing project profile mechanism: `standard`, `local`, or a
 portable profile JSON path inside the project root. Profile selection can enable
-compression or stripping, but cannot disable MCP redaction.
+compression or stripping, but cannot disable secret redaction or alter the
+server-level private-data policy.
 
 ## Detail Levels
 

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -232,13 +232,15 @@ public sealed class McpServerIntegrationTests
 			"get_file",
 			new Dictionary<string, object?> { ["path"] = "Secret.cs", ["start_line"] = "1" });
 		AssertTextOnlyResult(server, file, "search-marker");
-		AssertRedactedAndSpotlighted(file);
+		AssertSecretRedactedAndSpotlighted(file);
+		Assert.Contains(PrivateEmail, Text(file), StringComparison.Ordinal);
 
 		var search = await server.CallAsync(
 			"search_project",
 			new Dictionary<string, object?> { ["pattern"] = "search-marker", ["max_results"] = "5" });
 		AssertTextOnlyResult(server, search, "Secret.cs:3:");
-		AssertRedactedAndSpotlighted(search);
+		AssertSecretRedactedAndSpotlighted(search);
+		Assert.Contains(PrivateEmail, Text(search), StringComparison.Ordinal);
 
 		var inline = await server.CallAsync(
 			"pack_context",
@@ -250,7 +252,8 @@ public sealed class McpServerIntegrationTests
 			});
 		AssertTextOnlyResult(server, inline, "Secret.cs");
 		Assert.Contains("search-marker", Text(inline), StringComparison.Ordinal);
-		AssertRedactedAndSpotlighted(inline);
+		AssertSecretRedactedAndSpotlighted(inline);
+		Assert.Contains(PrivateEmail, Text(inline), StringComparison.Ordinal);
 
 		var stored = await server.CallAsync(
 			"pack_context",
@@ -267,7 +270,7 @@ public sealed class McpServerIntegrationTests
 			"read_pack",
 			new Dictionary<string, object?> { ["pack_id"] = packId, ["start_line"] = "1" });
 		AssertTextOnlyResult(server, page, "Large.cs");
-		AssertRedactedAndSpotlighted(page);
+		AssertSecretRedactedAndSpotlighted(page);
 
 		var expired = await server.CallAsync(
 			"read_pack",
@@ -356,8 +359,11 @@ public sealed class McpServerIntegrationTests
 		AssertSpotlighted(result);
 	}
 
-	[Fact]
-	public async Task StoredPackTreePreviewRedactsLocalUserSegment()
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task StoredPackUsesServerPrivateDataPolicyForTreePreviewAndPackBody(
+		bool hidePrivateData)
 	{
 		var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 		if (string.IsNullOrWhiteSpace(userProfile))
@@ -377,25 +383,136 @@ public sealed class McpServerIntegrationTests
 				string.Join('\n', Enumerable.Range(0, 1_500).Select(static index =>
 					$"    private const string Value{index:D4} = \"{new string('x', 48)}\";")) +
 				"\n}\n");
-			await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+			await using var server = await McpTestServer.StartAsync(
+				project,
+				workspace.Path,
+				hidePrivateData);
 
 			var result = await server.CallAsync(
 				"pack_context",
 				new Dictionary<string, object?>
 				{
-					["view"] = "content",
+					["view"] = "tree-content",
 					["format"] = "text"
 				});
 
-			Assert.Contains("Pack stored as '", Text(result), StringComparison.Ordinal);
-			Assert.Contains(protectedProject, Text(result), StringComparison.Ordinal);
-			Assert.DoesNotContain(project, Text(result), StringComparison.Ordinal);
+			var resultText = Text(result);
+			Assert.Contains("Pack stored as '", resultText, StringComparison.Ordinal);
+			var page = await server.CallAsync(
+				"read_pack",
+				new Dictionary<string, object?>
+				{
+					["pack_id"] = ExtractPackId(resultText),
+					["start_line"] = 1
+				});
+			AssertPackPathPolicy(resultText, project, protectedProject, hidePrivateData);
+			AssertPackPathPolicy(Text(page), project, protectedProject, hidePrivateData);
 		}
 		finally
 		{
 			if (Directory.Exists(project))
 				Directory.Delete(project, recursive: true);
 		}
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task ContentToolsAlwaysRedactSecretsAndApplyServerPrivateDataPolicy(
+		bool hidePrivateData)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var sensitiveLines =
+			$"const string Token = \"{Secret}\";\n" +
+			$"contact: {PrivateEmail}\n" +
+			"search-marker\n";
+		File.WriteAllText(Path.Combine(project, "Small.txt"), sensitiveLines);
+		File.WriteAllText(
+			Path.Combine(project, "Large.txt"),
+			sensitiveLines + string.Join('\n', Enumerable.Repeat(new string('x', 80), 1_000)));
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			hidePrivateData);
+
+		var file = await server.CallAsync(
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "Small.txt" });
+		var search = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "search-marker",
+				["context_lines"] = 2
+			});
+		var inlinePack = await server.CallAsync(
+			"pack_context",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "Small.txt" },
+				["view"] = "content",
+				["format"] = "text"
+			});
+		var storedPack = await server.CallAsync(
+			"pack_context",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "Large.txt" },
+				["view"] = "content",
+				["format"] = "text"
+			});
+		var storedPage = await server.CallAsync(
+			"read_pack",
+			new Dictionary<string, object?>
+			{
+				["pack_id"] = ExtractPackId(Text(storedPack)),
+				["start_line"] = 1
+			});
+
+		foreach (var result in new[] { file, search, inlinePack, storedPage })
+		{
+			AssertSecretRedactedAndSpotlighted(result);
+			Assert.Contains("search-marker", Text(result), StringComparison.Ordinal);
+			if (hidePrivateData)
+				Assert.DoesNotContain(PrivateEmail, Text(result), StringComparison.Ordinal);
+			else
+				Assert.Contains(PrivateEmail, Text(result), StringComparison.Ordinal);
+		}
+	}
+
+	[Fact]
+	public async Task DefaultServerPolicyOverridesPrivateDataEnabledByLocalProfile()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "Profiled.txt"),
+			$"token: {Secret}\ncontact: {PrivateEmail}\n");
+		var appData = Path.Combine(workspace.Path, "app-data");
+		new ProjectProfileStore(() => appData).SaveProfile(
+			project,
+			new ProjectSelectionProfile(
+				SelectedRootFolders: [],
+				SelectedExtensions: [".txt"],
+				SelectedIgnoreOptions: [IgnoreOptionId.HidePrivateData],
+				IgnoreOptionStates: new Dictionary<IgnoreOptionId, bool>
+				{
+					[IgnoreOptionId.HidePrivateData] = true
+				}));
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync(
+			"pack_context",
+			new Dictionary<string, object?>
+			{
+				["profile"] = "local",
+				["view"] = "content",
+				["format"] = "text"
+			});
+
+		AssertSecretRedactedAndSpotlighted(result);
+		Assert.Contains(PrivateEmail, Text(result), StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -620,7 +737,7 @@ public sealed class McpServerIntegrationTests
 		Assert.Contains("Calculate", Text(packed), StringComparison.Ordinal);
 		Assert.Contains("private const string Token", Text(packed), StringComparison.Ordinal);
 		Assert.DoesNotContain(bodyMarker, Text(packed), StringComparison.Ordinal);
-		AssertRedactedAndSpotlighted(packed);
+		AssertSecretRedactedAndSpotlighted(packed);
 	}
 
 	[Fact]
@@ -821,11 +938,27 @@ public sealed class McpServerIntegrationTests
 		Assert.DoesNotContain(result.Content, static block => block is EmbeddedResourceBlock);
 	}
 
-	private static void AssertRedactedAndSpotlighted(CallToolResult result)
+	private static void AssertSecretRedactedAndSpotlighted(CallToolResult result)
 	{
 		AssertSpotlighted(result);
 		Assert.DoesNotContain(Secret, Text(result), StringComparison.Ordinal);
-		Assert.DoesNotContain(PrivateEmail, Text(result), StringComparison.Ordinal);
+	}
+
+	private static void AssertPackPathPolicy(
+		string text,
+		string project,
+		string protectedProject,
+		bool hidePrivateData)
+	{
+		if (hidePrivateData)
+		{
+			Assert.Contains(protectedProject, text, StringComparison.Ordinal);
+			Assert.DoesNotContain(project, text, StringComparison.Ordinal);
+			return;
+		}
+
+		Assert.Contains(project, text, StringComparison.Ordinal);
+		Assert.DoesNotContain(protectedProject, text, StringComparison.Ordinal);
 	}
 
 	private static void InitializeGitIndex(string repository, params string[] trackedPaths)
@@ -943,7 +1076,10 @@ public sealed class McpServerIntegrationTests
 
 		public McpClient Client { get; }
 
-		public static async Task<McpTestServer> StartAsync(string project, string sandbox)
+		public static async Task<McpTestServer> StartAsync(
+			string project,
+			string sandbox,
+			bool hidePrivateData = false)
 		{
 			var clientToServer = new Pipe();
 			var serverToClient = new Pipe();
@@ -951,6 +1087,7 @@ public sealed class McpServerIntegrationTests
 				[project],
 				clientToServer.Reader.AsStream(),
 				serverToClient.Writer.AsStream(),
+				hidePrivateData,
 				TestContext.Current.CancellationToken,
 				() => Path.Combine(sandbox, "app-data"),
 				Path.Combine(sandbox, "temp"));

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -490,8 +490,9 @@ public sealed class McpServerIntegrationTests
 			Path.Combine(project, "Profiled.txt"),
 			$"token: {Secret}\ncontact: {PrivateEmail}\n");
 		var appData = Path.Combine(workspace.Path, "app-data");
+		var physicalProject = McpRootRegistry.ResolvePhysicalExistingPath(project, requireDirectory: true);
 		new ProjectProfileStore(() => appData).SaveProfile(
-			project,
+			physicalProject,
 			new ProjectSelectionProfile(
 				SelectedRootFolders: [],
 				SelectedExtensions: [".txt"],

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -30,7 +30,7 @@ public sealed class McpServerIntegrationTests
 		await using var input = new MemoryStream();
 		await using var output = new MemoryStream();
 
-		await McpServerHost.RunAsync(
+		await McpServerHost.RunWithStreamsAsync(
 			[project],
 			input,
 			output,
@@ -581,7 +581,7 @@ public sealed class McpServerIntegrationTests
 		var project = workspace.CreateDirectory("project");
 		File.WriteAllText(
 			Path.Combine(project, "Profiled.txt"),
-			$"token: {Secret}\ncontact: {PrivateEmail}\n");
+			$"token: {Secret}\ncontact: {PrivateEmail}\nprofile-policy-marker\n");
 		var appData = Path.Combine(workspace.Path, "app-data");
 		var physicalProject = McpRootRegistry.ResolvePhysicalExistingPath(project, requireDirectory: true);
 		new ProjectProfileStore(() => appData).SaveProfile(
@@ -609,6 +609,7 @@ public sealed class McpServerIntegrationTests
 			});
 
 		AssertSecretRedactedAndSpotlighted(result);
+		Assert.Contains("profile-policy-marker", Text(result), StringComparison.Ordinal);
 		Assert.Equal(!hidePrivateData, Text(result).Contains(PrivateEmail, StringComparison.Ordinal));
 	}
 
@@ -623,7 +624,7 @@ public sealed class McpServerIntegrationTests
 		var project = workspace.CreateDirectory("project");
 		File.WriteAllText(
 			Path.Combine(project, "Profiled.txt"),
-			$"token: {Secret}\ncontact: {PrivateEmail}\n");
+			$"token: {Secret}\ncontact: {PrivateEmail}\nprofile-policy-marker\n");
 		const string profileName = "portable.json";
 		File.WriteAllText(
 			Path.Combine(project, profileName),
@@ -657,6 +658,7 @@ public sealed class McpServerIntegrationTests
 			});
 
 		AssertSecretRedactedAndSpotlighted(result);
+		Assert.Contains("profile-policy-marker", Text(result), StringComparison.Ordinal);
 		Assert.Equal(!hidePrivateData, Text(result).Contains(PrivateEmail, StringComparison.Ordinal));
 	}
 
@@ -1228,7 +1230,7 @@ public sealed class McpServerIntegrationTests
 		{
 			var clientToServer = new Pipe();
 			var serverToClient = new Pipe();
-			var serverTask = McpServerHost.RunAsync(
+			var serverTask = McpServerHost.RunWithStreamsAsync(
 				[project],
 				clientToServer.Reader.AsStream(),
 				serverToClient.Writer.AsStream(),

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -34,9 +34,10 @@ public sealed class McpServerIntegrationTests
 			[project],
 			input,
 			output,
-			TestContext.Current.CancellationToken,
-			() => workspace.CreateDirectory("app-data"),
-			temporaryRoot);
+			hidePrivateData: false,
+			cancellationToken: TestContext.Current.CancellationToken,
+			appDataPathProvider: () => workspace.CreateDirectory("app-data"),
+			tempRoot: temporaryRoot);
 
 		var packRoot = Path.Combine(temporaryRoot, "DevProjex", "mcp");
 		Assert.Empty(Directory.EnumerateDirectories(packRoot));
@@ -481,8 +482,100 @@ public sealed class McpServerIntegrationTests
 		}
 	}
 
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task SearchProjectSearchesTheEffectiveRedactedText(bool hidePrivateData)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "Sensitive.txt"),
+			$"token: {Secret}\ncontact: {PrivateEmail}\n");
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			hidePrivateData);
+
+		var secretSearch = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = Regex.Escape(Secret),
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			});
+		var privateDataSearch = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = Regex.Escape(PrivateEmail),
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			});
+
+		AssertSpotlighted(secretSearch);
+		Assert.DoesNotContain(Secret, Text(secretSearch), StringComparison.Ordinal);
+		Assert.DoesNotContain("Sensitive.txt:", Text(secretSearch), StringComparison.Ordinal);
+		AssertSpotlighted(privateDataSearch);
+		if (hidePrivateData)
+		{
+			Assert.DoesNotContain(PrivateEmail, Text(privateDataSearch), StringComparison.Ordinal);
+			Assert.DoesNotContain("Sensitive.txt:", Text(privateDataSearch), StringComparison.Ordinal);
+		}
+		else
+		{
+			Assert.Contains(PrivateEmail, Text(privateDataSearch), StringComparison.Ordinal);
+			Assert.Contains("Sensitive.txt:2:", Text(privateDataSearch), StringComparison.Ordinal);
+		}
+	}
+
 	[Fact]
-	public async Task DefaultServerPolicyOverridesPrivateDataEnabledByLocalProfile()
+	public async Task AnalyzeMetricsReflectServerPrivateDataPolicy()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var content = string.Join(
+			'\n',
+			Enumerable.Range(0, 100).Select(static index =>
+				$"contact-{index:D3}: alice.smith.long.identity.{index:D3}@company.io")) +
+			"\n";
+		File.WriteAllText(
+			Path.Combine(project, "Contacts.txt"),
+			content);
+
+		JsonElement unmaskedMetrics;
+		await using (var server = await McpTestServer.StartAsync(project, workspace.Path))
+		{
+			var result = await server.CallAsync("analyze");
+			Assert.NotEqual(true, result.IsError);
+			unmaskedMetrics = Assert.IsType<JsonElement>(result.StructuredContent).Clone();
+		}
+
+		JsonElement maskedMetrics;
+		await using (var server = await McpTestServer.StartAsync(project, workspace.Path, hidePrivateData: true))
+		{
+			var result = await server.CallAsync("analyze");
+			Assert.NotEqual(true, result.IsError);
+			maskedMetrics = Assert.IsType<JsonElement>(result.StructuredContent).Clone();
+		}
+
+		Assert.Equal(1, unmaskedMetrics.GetProperty("files").GetInt32());
+		Assert.Equal(1, maskedMetrics.GetProperty("files").GetInt32());
+		Assert.True(
+			maskedMetrics.GetProperty("characters").GetInt64() <
+			unmaskedMetrics.GetProperty("characters").GetInt64());
+		Assert.True(
+			maskedMetrics.GetProperty("tokens").GetInt64() <
+			unmaskedMetrics.GetProperty("tokens").GetInt64());
+	}
+
+	[Theory]
+	[InlineData(false, true)]
+	[InlineData(true, false)]
+	public async Task ServerPrivateDataPolicyOverridesOpposingLocalProfile(
+		bool hidePrivateData,
+		bool profileHidePrivateData)
 	{
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("project");
@@ -496,12 +589,15 @@ public sealed class McpServerIntegrationTests
 			new ProjectSelectionProfile(
 				SelectedRootFolders: [],
 				SelectedExtensions: [".txt"],
-				SelectedIgnoreOptions: [IgnoreOptionId.HidePrivateData],
+				SelectedIgnoreOptions: profileHidePrivateData ? [IgnoreOptionId.HidePrivateData] : [],
 				IgnoreOptionStates: new Dictionary<IgnoreOptionId, bool>
 				{
-					[IgnoreOptionId.HidePrivateData] = true
+					[IgnoreOptionId.HidePrivateData] = profileHidePrivateData
 				}));
-		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			hidePrivateData);
 
 		var result = await server.CallAsync(
 			"pack_context",
@@ -513,7 +609,55 @@ public sealed class McpServerIntegrationTests
 			});
 
 		AssertSecretRedactedAndSpotlighted(result);
-		Assert.Contains(PrivateEmail, Text(result), StringComparison.Ordinal);
+		Assert.Equal(!hidePrivateData, Text(result).Contains(PrivateEmail, StringComparison.Ordinal));
+	}
+
+	[Theory]
+	[InlineData(false, true)]
+	[InlineData(true, false)]
+	public async Task ServerPrivateDataPolicyOverridesOpposingPortableProfile(
+		bool hidePrivateData,
+		bool profileHidePrivateData)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "Profiled.txt"),
+			$"token: {Secret}\ncontact: {PrivateEmail}\n");
+		const string profileName = "portable.json";
+		File.WriteAllText(
+			Path.Combine(project, profileName),
+			JsonSerializer.Serialize(new
+			{
+				schemaVersion = PortableProjectProfileService.CurrentSchemaVersion,
+				kind = PortableProjectProfileService.DocumentKind,
+				selection = new
+				{
+					roots = (string[]?)null,
+					extensions = new[] { ".txt" },
+					selectedPaths = Array.Empty<string>(),
+					gitMode = "none",
+					exclusions = Array.Empty<string>(),
+					hideSecrets = false,
+					hidePrivateData = profileHidePrivateData
+				}
+			}));
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			hidePrivateData);
+
+		var result = await server.CallAsync(
+			"pack_context",
+			new Dictionary<string, object?>
+			{
+				["profile"] = profileName,
+				["view"] = "content",
+				["format"] = "text"
+			});
+
+		AssertSecretRedactedAndSpotlighted(result);
+		Assert.Equal(!hidePrivateData, Text(result).Contains(PrivateEmail, StringComparison.Ordinal));
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal/CompletionReleaseRegressionTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/CompletionReleaseRegressionTests.cs
@@ -30,6 +30,14 @@ public sealed class CompletionReleaseRegressionTests
 	}
 
 	[Fact]
+	public async Task McpCompletionOffersPrivateDataRedactionOption()
+	{
+		var candidates = await CompleteAsync("devprojex mcp --");
+
+		Assert.Contains("--hide-private-data", candidates);
+	}
+
+	[Fact]
 	public async Task OutputKindCompletionContainsOnlyCanonicalValues()
 	{
 		var candidates = await CompleteAsync("devprojex export project . --as ");

--- a/Tests/DevProjex.Tests.Terminal/McpCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpCommandContractTests.cs
@@ -35,6 +35,7 @@ public sealed class McpCommandContractTests
 		Assert.Equal(CommandLineExitCodes.Success, exitCode);
 		Assert.Contains("devprojex mcp", environment.StandardOutput, StringComparison.Ordinal);
 		Assert.Contains("--root", environment.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("--hide-private-data", environment.StandardOutput, StringComparison.Ordinal);
 		Assert.Contains("Run the local read-only MCP stdio server.", environment.StandardOutput, StringComparison.Ordinal);
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -8,13 +8,27 @@ namespace DevProjex.Tests.Terminal;
 
 public sealed class McpServerProcessTests
 {
-	[Fact]
-	public async Task RealProcessSpeaksOnlyJsonRpcAndStopsOnStandardInputEof()
+	private const string Secret = "ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL";
+	private const string PrivateEmail = "alice.smith" + "@company.io";
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task RealProcessAppliesServerRedactionPolicyAndStopsOnStandardInputEof(
+		bool hidePrivateData)
 	{
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("project");
 		var ignoredEnvironmentRoot = workspace.CreateDirectory("environment-root");
-		workspace.WriteFile("project/app.cs", "internal sealed class ProcessMarker {}\n");
+		var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		var privatePath = string.IsNullOrWhiteSpace(userProfile)
+			? string.Empty
+			: Path.Combine(userProfile, "DevProjexMcpProcessProbe", "project");
+		workspace.WriteFile(
+			"project/app.cs",
+			$"internal sealed class ProcessMarker {{ const string Token = \"{Secret}\"; }}\n" +
+			$"// Contact {PrivateEmail}\n" +
+			$"// Project {privatePath}\n");
 		var application = PublishedApplicationLocator.FindApplicationAssembly();
 		var startInfo = new ProcessStartInfo("dotnet")
 		{
@@ -29,6 +43,8 @@ public sealed class McpServerProcessTests
 		startInfo.ArgumentList.Add("mcp");
 		startInfo.ArgumentList.Add("--root");
 		startInfo.ArgumentList.Add(project);
+		if (hidePrivateData)
+			startInfo.ArgumentList.Add("--hide-private-data");
 		startInfo.Environment["CLAUDE_PROJECT_DIR"] = ignoredEnvironmentRoot;
 		startInfo.Environment["DEVPROJEX_INTERNAL_DATA_ROOT"] = workspace.CreateDirectory("data");
 
@@ -62,6 +78,14 @@ public sealed class McpServerProcessTests
 			using var textDocument = JsonDocument.Parse(text);
 			Assert.True(JsonElement.DeepEquals(structured, textDocument.RootElement));
 
+			var file = await client.CallToolAsync(
+				"get_file",
+				new Dictionary<string, object?> { ["path"] = "app.cs" },
+				progress: null,
+				options: null,
+				TestContext.Current.CancellationToken);
+			AssertRedactionPolicy(file, privatePath, hidePrivateData);
+
 			var progress = new InlineProgress<ProgressNotificationValue>();
 			var pack = await client.CallToolAsync(
 				"pack_context",
@@ -74,6 +98,7 @@ public sealed class McpServerProcessTests
 				options: null,
 				TestContext.Current.CancellationToken);
 			Assert.NotEqual(true, pack.IsError);
+			AssertRedactionPolicy(pack, privatePath, hidePrivateData);
 		}
 
 		process.StandardInput.Close();
@@ -98,6 +123,36 @@ public sealed class McpServerProcessTests
 			Assert.Equal("2.0", document.RootElement.GetProperty("jsonrpc").GetString());
 		});
 	}
+
+	private static void AssertRedactionPolicy(
+		CallToolResult result,
+		string project,
+		bool hidePrivateData)
+	{
+		var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+		Assert.NotEqual(true, result.IsError);
+		Assert.Contains("ProcessMarker", text, StringComparison.Ordinal);
+		Assert.DoesNotContain(Secret, text, StringComparison.Ordinal);
+		if (hidePrivateData)
+		{
+			Assert.DoesNotContain(PrivateEmail, text, StringComparison.Ordinal);
+			if (CanRedactLocalUserPath(project))
+				Assert.DoesNotContain(project, text, StringComparison.Ordinal);
+		}
+		else
+		{
+			Assert.Contains(PrivateEmail, text, StringComparison.Ordinal);
+			if (!string.IsNullOrEmpty(project))
+				Assert.Contains(project, text, StringComparison.Ordinal);
+		}
+	}
+
+	private static bool CanRedactLocalUserPath(string path) =>
+		!string.IsNullOrEmpty(path) &&
+		!string.Equals(
+			path,
+			OutputRootPathPresentation.MaskLocalUserSegment(path),
+			StringComparison.Ordinal);
 
 	private static StringComparison PathComparison =>
 		OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -10,6 +10,7 @@ public sealed class McpServerProcessTests
 {
 	private const string Secret = "ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL";
 	private const string PrivateEmail = "alice.smith" + "@company.io";
+	private const string PrivatePath = "/home/alice-smith/DevProjexMcpProcessProbe/project";
 
 	[Theory]
 	[InlineData(false)]
@@ -20,15 +21,11 @@ public sealed class McpServerProcessTests
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("project");
 		var ignoredEnvironmentRoot = workspace.CreateDirectory("environment-root");
-		var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		var privatePath = string.IsNullOrWhiteSpace(userProfile)
-			? string.Empty
-			: Path.Combine(userProfile, "DevProjexMcpProcessProbe", "project");
 		workspace.WriteFile(
 			"project/app.cs",
 			$"internal sealed class ProcessMarker {{ const string Token = \"{Secret}\"; }}\n" +
 			$"// Contact {PrivateEmail}\n" +
-			$"// Project {privatePath}\n");
+			$"// Project {PrivatePath}\n");
 		var application = PublishedApplicationLocator.FindApplicationAssembly();
 		var startInfo = new ProcessStartInfo("dotnet")
 		{
@@ -84,7 +81,7 @@ public sealed class McpServerProcessTests
 				progress: null,
 				options: null,
 				TestContext.Current.CancellationToken);
-			AssertRedactionPolicy(file, privatePath, hidePrivateData);
+			AssertRedactionPolicy(file, hidePrivateData);
 
 			var progress = new InlineProgress<ProgressNotificationValue>();
 			var pack = await client.CallToolAsync(
@@ -98,7 +95,7 @@ public sealed class McpServerProcessTests
 				options: null,
 				TestContext.Current.CancellationToken);
 			Assert.NotEqual(true, pack.IsError);
-			AssertRedactionPolicy(pack, privatePath, hidePrivateData);
+			AssertRedactionPolicy(pack, hidePrivateData);
 		}
 
 		process.StandardInput.Close();
@@ -126,7 +123,6 @@ public sealed class McpServerProcessTests
 
 	private static void AssertRedactionPolicy(
 		CallToolResult result,
-		string project,
 		bool hidePrivateData)
 	{
 		var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
@@ -136,23 +132,14 @@ public sealed class McpServerProcessTests
 		if (hidePrivateData)
 		{
 			Assert.DoesNotContain(PrivateEmail, text, StringComparison.Ordinal);
-			if (CanRedactLocalUserPath(project))
-				Assert.DoesNotContain(project, text, StringComparison.Ordinal);
+			Assert.DoesNotContain(PrivatePath, text, StringComparison.Ordinal);
 		}
 		else
 		{
 			Assert.Contains(PrivateEmail, text, StringComparison.Ordinal);
-			if (!string.IsNullOrEmpty(project))
-				Assert.Contains(project, text, StringComparison.Ordinal);
+			Assert.Contains(PrivatePath, text, StringComparison.Ordinal);
 		}
 	}
-
-	private static bool CanRedactLocalUserPath(string path) =>
-		!string.IsNullOrEmpty(path) &&
-		!string.Equals(
-			path,
-			OutputRootPathPresentation.MaskLocalUserSegment(path),
-			StringComparison.Ordinal);
 
 	private static StringComparison PathComparison =>
 		OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using DevProjex.Application.Services;
 using DevProjex.Mcp;
 using ModelContextProtocol;
 using ModelContextProtocol.Client;
@@ -88,7 +89,7 @@ public sealed class McpServerProcessTests
 				"pack_context",
 				new Dictionary<string, object?>
 				{
-					["view"] = "content",
+					["view"] = "tree-content",
 					["format"] = "text"
 				},
 				progress,
@@ -96,29 +97,55 @@ public sealed class McpServerProcessTests
 				TestContext.Current.CancellationToken);
 			Assert.NotEqual(true, pack.IsError);
 			AssertRedactionPolicy(pack, hidePrivateData);
+			AssertGeneratedRootPathPolicy(pack, expectedProject, hidePrivateData);
 		}
 
 		process.StandardInput.Close();
-		await process.WaitForExitAsync(TestContext.Current.CancellationToken)
-			.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+		var standardOutputEofTask = recordingOutput.DrainToEndAsync(TestContext.Current.CancellationToken);
+		await Task.WhenAll(
+			process.WaitForExitAsync(TestContext.Current.CancellationToken)
+				.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken),
+			standardOutputEofTask
+				.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken));
 		var standardError = await standardErrorTask;
 		Assert.Equal(0, process.ExitCode);
 		Assert.True(string.IsNullOrWhiteSpace(standardError), $"Unexpected stderr: {standardError}");
 
-		var transcript = recordingOutput.GetRecordedText();
-		var messages = transcript.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-		Assert.NotEmpty(messages);
+		var messages = ParseJsonRpcMessages(recordingOutput.GetRecordedText());
 		Assert.Contains(messages, static message =>
 		{
-			using var document = JsonDocument.Parse(message.TrimEnd('\r'));
+			using var document = JsonDocument.Parse(message);
 			return document.RootElement.TryGetProperty("method", out var method) &&
 			       method.GetString() == NotificationMethods.ProgressNotification;
 		});
-		Assert.All(messages, static message =>
+	}
+
+	private static IReadOnlyList<string> ParseJsonRpcMessages(string transcript)
+	{
+		var lines = transcript.Split('\n');
+		var messageCount = lines.Length;
+		if (messageCount > 0 && lines[^1].Length == 0)
+			messageCount--;
+
+		Assert.True(messageCount > 0, "MCP stdout did not contain any JSON-RPC messages.");
+		var messages = new string[messageCount];
+		for (var index = 0; index < messageCount; index++)
 		{
-			using var document = JsonDocument.Parse(message.TrimEnd('\r'));
+			var line = lines[index];
+			var message = line.EndsWith('\r') ? line[..^1] : line;
+			Assert.False(
+				string.IsNullOrWhiteSpace(message),
+				$"MCP stdout contained an empty non-protocol line at index {index}.");
+			Assert.DoesNotContain('\r', message);
+			Assert.StartsWith("{", message, StringComparison.Ordinal);
+			Assert.EndsWith("}", message, StringComparison.Ordinal);
+			using var document = JsonDocument.Parse(message);
+			Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
 			Assert.Equal("2.0", document.RootElement.GetProperty("jsonrpc").GetString());
-		});
+			messages[index] = message;
+		}
+
+		return messages;
 	}
 
 	private static void AssertRedactionPolicy(
@@ -139,6 +166,19 @@ public sealed class McpServerProcessTests
 			Assert.Contains(PrivateEmail, text, StringComparison.Ordinal);
 			Assert.Contains(PrivatePath, text, StringComparison.Ordinal);
 		}
+	}
+
+	private static void AssertGeneratedRootPathPolicy(
+		CallToolResult result,
+		string project,
+		bool hidePrivateData)
+	{
+		var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+		var protectedProject = OutputRootPathPresentation.MaskLocalUserSegment(project);
+		var expectedProject = hidePrivateData ? protectedProject : project;
+		Assert.Contains(expectedProject, text, StringComparison.Ordinal);
+		if (!string.Equals(project, protectedProject, StringComparison.Ordinal))
+			Assert.DoesNotContain(hidePrivateData ? project : protectedProject, text, StringComparison.Ordinal);
 	}
 
 	private static StringComparison PathComparison =>
@@ -167,13 +207,24 @@ public sealed class McpServerProcessTests
 
 	private sealed class RecordingReadStream(Stream source) : Stream
 	{
+		private static readonly Encoding StrictUtf8 = new UTF8Encoding(
+			encoderShouldEmitUTF8Identifier: false,
+			throwOnInvalidBytes: true);
 		private readonly MemoryStream _recording = new();
 		private readonly object _sync = new();
 
 		public string GetRecordedText()
 		{
 			lock (_sync)
-				return Encoding.UTF8.GetString(_recording.ToArray());
+				return StrictUtf8.GetString(_recording.ToArray());
+		}
+
+		public async Task DrainToEndAsync(CancellationToken cancellationToken)
+		{
+			var buffer = new byte[8 * 1024];
+			while (await ReadAsync(buffer, cancellationToken).ConfigureAwait(false) > 0)
+			{
+			}
 		}
 
 		public override async ValueTask<int> ReadAsync(

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -19,8 +19,14 @@ public sealed class McpServerProcessTests
 	public async Task RealProcessAppliesServerRedactionPolicyAndStopsOnStandardInputEof(
 		bool hidePrivateData)
 	{
-		using var workspace = new TemporaryDirectory();
+		var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		if (string.IsNullOrWhiteSpace(userProfile))
+			Assert.Skip("The environment does not expose a user profile directory.");
+		using var workspace = new TemporaryDirectory(userProfile);
 		var project = workspace.CreateDirectory("project");
+		var physicalProject = McpRootRegistry.ResolvePhysicalExistingPath(project, requireDirectory: true);
+		if (OutputRootPathPresentation.MaskLocalUserSegment(physicalProject) == physicalProject)
+			Assert.Skip("The user profile path does not use a supported local-user layout.");
 		var ignoredEnvironmentRoot = workspace.CreateDirectory("environment-root");
 		workspace.WriteFile(
 			"project/app.cs",
@@ -142,6 +148,15 @@ public sealed class McpServerProcessTests
 			using var document = JsonDocument.Parse(message);
 			Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
 			Assert.Equal("2.0", document.RootElement.GetProperty("jsonrpc").GetString());
+			var hasMethod = document.RootElement.TryGetProperty("method", out var method) &&
+			                method.ValueKind == JsonValueKind.String &&
+			                !string.IsNullOrWhiteSpace(method.GetString());
+			var hasId = document.RootElement.TryGetProperty("id", out _);
+			var hasResult = document.RootElement.TryGetProperty("result", out _);
+			var hasError = document.RootElement.TryGetProperty("error", out _);
+			Assert.True(
+				hasMethod ? !hasResult && !hasError : hasId && hasResult != hasError,
+				$"MCP stdout contained an invalid JSON-RPC message at index {index}: {message}");
 			messages[index] = message;
 		}
 
@@ -177,8 +192,7 @@ public sealed class McpServerProcessTests
 		var protectedProject = OutputRootPathPresentation.MaskLocalUserSegment(project);
 		var expectedProject = hidePrivateData ? protectedProject : project;
 		Assert.Contains(expectedProject, text, StringComparison.Ordinal);
-		if (!string.Equals(project, protectedProject, StringComparison.Ordinal))
-			Assert.DoesNotContain(hidePrivateData ? project : protectedProject, text, StringComparison.Ordinal);
+		Assert.DoesNotContain(hidePrivateData ? project : protectedProject, text, StringComparison.Ordinal);
 	}
 
 	private static StringComparison PathComparison =>


### PR DESCRIPTION
## Summary
- keep MCP secret redaction mandatory in every server mode
- make private-data redaction opt-in through the launch-only `--hide-private-data` flag
- preserve tool schemas while aligning packs, files, search, profiles, and normative documentation

## Validation
- MCP integration: 18 passed, 1 platform skip
- MCP terminal/process: 7 passed; both real stdio modes exit cleanly on EOF
- completion contracts: 73 passed, 5 unavailable-shell skips
- full Unit: 10,378 passed, 47 platform skips
- full Integration: 3,355 passed, 62 platform skips
- isolated Release application graph: 0 warnings, 0 errors

The combined local run reached the 10-minute limit while Terminal was still active; UI rebuild was blocked by a pre-existing test process holding its output DLLs. Targeted MCP coverage is fully green.