### PR TITLE
fix(git): respect repository boundaries and local excludes

### DIFF
--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -310,7 +310,9 @@ exports fail with `DPX-EXPORT-RESERVED-NAME` rather than overwrite or duplicate 
 `gitignore` mode reads regular `.gitignore` files reachable in the selected working
 tree. When the selected path is below its owning repository/worktree root, the
 ancestor rule chain from that root through the selected path is applied before
-rules discovered below it. It does not read `.git/info/exclude`, global Git excludes, or symbolic links
+rules discovered below it. Repository-local `info/exclude` is read with lower
+precedence than the root `.gitignore`, resolving `gitdir:` and `commondir` for
+worktrees and submodules. It does not read global Git excludes or symbolic links
 named `.gitignore`; Git itself does not follow a symbolic link when accessing that
 control file. If no regular `.gitignore` exists, the selected mode remains
 `gitignore` with an empty pattern set; the administrative entry named exactly `.git`
@@ -322,6 +324,18 @@ instead of silently including files without complete rule evaluation. Skipping a
 `.gitignore` symbolic link is normal Git-compatible behavior and is not an access
 diagnostic. The reader strips an initial UTF-8 BOM and otherwise decodes as UTF-8;
 UTF-16/UTF-32 BOMs are not auto-detected and reinterpreted as valid rules.
+
+In v5.2 the existing Git modes gain an intentional behavior change: `gitignore`
+reads `info/exclude`, and both `gitignore` and `tracked` treat undeclared embedded
+repositories as opaque directories. Declared initialized submodules own their
+rules and nested declarations recursively; parent rules do not leak inside.
+Without a repository above the scan root, the first repository in each subtree
+becomes an independent owner. A gitlink without a declaration remains embedded;
+a declaration without a boundary remains an ordinary directory. The complete
+source-resolution and ownership specification is in [SmartIgnore.md](SmartIgnore.md).
+To recover the previous embedded-repository visibility, use `--git-mode none`
+(or MCP `--unrestricted` to also disable ordinary exclusions). No new flag,
+checkbox, token, diagnostic code, localization key, or MCP schema is introduced.
 
 Git pattern and tracked-index path comparison use the effective repository
 `core.ignoreCase` value. On macOS, canonical Unicode comparison also follows

--- a/Docs/CommandLine.md
+++ b/Docs/CommandLine.md
@@ -170,7 +170,7 @@ Git modes:
 | Token | Behavior |
 |---|---|
 | `none` | No Git-based filtering |
-| `gitignore` | Respect applicable hierarchical `.gitignore` rules |
+| `gitignore` | Respect hierarchical `.gitignore` and repository-local `info/exclude`, with opaque embedded repositories and independent declared submodules |
 | `tracked` | Include only paths returned from applicable indexes by the installed Git CLI; no readable index fails closed with exit `3` |
 | `staged` | Include files with staged changes |
 | `changes` | Include staged, unstaged, and untracked files; ignored untracked files remain excluded |
@@ -198,6 +198,15 @@ loads but a nested index does not, that nested scope is excluded and reported wi
 `DPX-GIT-TRACKED-INDEX-PARTIAL`. If none load, commands report
 `DPX-GIT-TRACKED-INDEX-UNAVAILABLE`; they never reinterpret `tracked` as `gitignore`.
 An absent `.gitignore` is an active empty rule set, not a fallback to `none`.
+Repository-local `info/exclude` has lower priority than the root `.gitignore`;
+worktrees resolve it through `gitdir:` and `commondir`. Global excludes are not
+read. In `gitignore` and `tracked`, a nested repository is opaque unless its
+path is declared in its owner's `.gitmodules`; initialized declared submodules
+use their own rules, recursively. Without an owning repository, the first
+repository in each subtree is independent. See [SmartIgnore.md](SmartIgnore.md)
+for the complete ownership, source-resolution, and fail-closed specification.
+This changes v5.2 visibility without adding options: use `--git-mode none` to
+traverse embedded repositories and ignore local exclusion rules.
 The administrative path named exactly `.git` remains excluded; `.github` and other
 `.git*` names are not treated as Git metadata.
 

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -32,6 +32,12 @@ and is intentionally rejected at server startup. `off` is accepted as an input
 alias for the canonical `none` token.
 
 Without a Git flag the baseline is `gitignore`, the standard profile's mode.
+It includes repository-local `info/exclude` and treats undeclared embedded
+repositories as opaque; initialized declared submodules own their rules
+recursively. Worktrees resolve the shared exclude file through `commondir`.
+These rule sources are read as files without starting Git. Global excludes
+remain outside the contract. See [SmartIgnore.md](SmartIgnore.md) for the full
+specification; `--unrestricted` restores embedded-repository visibility.
 
 The exclusion baseline is deliberately narrower than the desktop standard set.
 A server started without exclusion flags runs with `smart-ignore` and

--- a/Docs/SmartIgnore.md
+++ b/Docs/SmartIgnore.md
@@ -88,7 +88,7 @@ Smart Ignore and Git filtering solve different problems. Smart Ignore recognizes
 | Mode | Behavior |
 |---|---|
 | `none` | Does not apply Git-based filtering. |
-| `gitignore` | Applies reachable hierarchical `.gitignore` rules. |
+| `gitignore` | Applies repository-local ignore rules and repository boundaries, following the working-tree view of `git status`. |
 | `tracked` | Includes only paths returned by applicable Git indexes. |
 | `staged` | Includes files with staged changes. |
 | `changes` | Includes staged, unstaged, and non-ignored untracked files. |
@@ -104,19 +104,29 @@ Git mode never changes Smart Ignore or an ordinary exclusion.
 
 ### `.gitignore` mode
 
-The `.gitignore` implementation supports nested rule scopes, negations, and ancestor rules from the owning repository or worktree root to the selected folder. An ignored directory is still traversed when a later negation may expose a descendant.
+The `.gitignore` implementation supports nested rule scopes, negations, and ancestor rules from the owning repository or worktree root to the selected folder. An ignored directory is still traversed when a later applicable negation may expose a descendant. Tracked files retain the existing index override.
+
+The owning repository is the nearest physical `.git` boundary at the selected root or above it. When opening a folder of projects with no owning repository, the first boundary reached in each subtree becomes its owner: sibling repositories are independent. Opening a worktree or a subdirectory inside a repository starts with that repository's root rule chain.
+
+A deeper directory with its own `.git` boundary is opaque unless its portable relative path is declared by `path = ...` in a `[submodule "..."]` section of the owner's `.gitmodules`. An opaque embedded repository is one untracked directory, as in `git status`: its files are never selected or recursively enumerated in `gitignore` or `tracked`. This includes manually cloned repositories, vendored clones, and worktrees nested inside an owning repository. It contributes one directory to the existing GitIgnore controller impact; `empty-folders` determines whether an empty node remains visible. A gitlink without a `.gitmodules` declaration is also embedded, even if the parent index records it.
+
+A declared path with its own boundary is a submodule and becomes the owner of its subtree. Its own `.gitignore`, `info/exclude`, and recursive `.gitmodules` apply; parent ignore patterns do not apply inside it. In `tracked`, only applicable owners and declared submodules supply indexes. A declared but uninitialized path without a boundary remains an ordinary directory, including an empty directory. `.gitmodules` is read once per owner per scan with the UTF-8 and source-size limits of `.gitignore`, and at most 8,192 distinct paths. Paths use `/`, may be quoted, and must be relative without empty, `.` or `..` segments; `url` and `branch` do not influence selection. An unreadable or invalid declaration cannot authorize traversal of a nested repository.
+
+Repository-local `info/exclude` is loaded before the root `.gitignore`, at the same root scope with lower precedence. A root negation overrides it, including `notes/` in `info/exclude` with `!notes/keep.md` in the root `.gitignore`. For a normal repository the source is `<root>/.git/info/exclude`. A `.git` file resolves its `gitdir:` target relative to the repository root; if that directory has `commondir`, its target is resolved relative to the Git directory and `<common-directory>/info/exclude` is read. Without `commondir`, including the usual submodule layout, the source is `<git-directory>/info/exclude`. Missing sources are empty. These sources and submodule declarations are read directly from files, without Git commands.
 
 The following boundaries are intentional:
 
-- an absent `.gitignore` is an active empty rule set, not a fallback to `none`;
+- an absent `.gitignore` contributes no patterns and never falls back to `none`; repository boundaries and other applicable sources still apply;
 - the administrative entry named exactly `.git` remains excluded in every Git filtering mode, including `none`;
 - names such as `.github` and `.git-owned` are ordinary paths;
-- `.git/info/exclude` and global Git excludes are not read;
+- global Git excludes (`core.excludesFile`) are not read;
 - a symbolic link named `.gitignore` is not followed;
-- an unreadable `.gitignore` scope fails closed and produces the existing partial-access diagnostic instead of silently including uncertain paths;
+- an unreadable `.gitignore` or `info/exclude` scope fails closed and produces the existing partial-access diagnostic instead of silently including uncertain paths;
 - an initial UTF-8 BOM is supported; UTF-16 and UTF-32 files are not reinterpreted as valid rule sources.
 
 Repository-backed pattern comparison follows the effective Git `core.ignoreCase` value. On macOS, canonical Unicode comparison also follows `core.precomposeUnicode`. A standalone `.gitignore` outside a repository uses the host filesystem comparison policy.
+
+`none` and MCP `--unrestricted` expose files inside embedded repositories, subject to the ordinary selection and filesystem safety rules. The `.git` administrative area and reparse points remain excluded in every mode. This v5.2 behavior change adds no checkbox, option, exclusion token, diagnostic code, or MCP schema field; use `--git-mode none` to restore traversal of embedded repositories.
 
 ### Tracked-files-only mode
 

--- a/Infrastructure/FileSystem/FileSystemScanner.cs
+++ b/Infrastructure/FileSystem/FileSystemScanner.cs
@@ -1125,7 +1125,12 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 					directoryGitIgnoreCandidateContext,
 					cancellationToken,
 					loadSession: gitIgnoreLoadSession);
-				if (IsActiveGitIgnoreReadFailure(rules, gitIgnoreLoadStatus))
+				if (directoryGitIgnoreCandidateContext.IsOpaqueRepository(dir))
+					gitIgnoreImpactCount++;
+				if (directoryGitIgnoreContext.IsOpaqueRepository(dir) && gitIgnoreLoadStatus != GitIgnoreMatcherLoadStatus.ReadFailure)
+					continue;
+				if (IsActiveGitIgnoreReadFailure(rules, gitIgnoreLoadStatus) ||
+				    directoryGitIgnoreContext.IsOpaqueRepository(dir) && gitIgnoreLoadStatus == GitIgnoreMatcherLoadStatus.ReadFailure)
 				{
 					directories.Add(new DirectoryScanNode(
 						dir,
@@ -2820,11 +2825,6 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 						cancellationToken,
 						captureFiles);
 					directoryFiles = captureFiles ? directoryBatch.Files : null;
-					if (!string.IsNullOrWhiteSpace(directoryBatch.GitMetadataPath))
-					{
-						discoveredGitRepositoryRoots.Add(facts.FullPath);
-						gitEvidence = new GitWorkspaceEvidence(HasRepositoryBoundary: true);
-					}
 					(gitIgnoreContext, gitIgnoreCandidateContext, var gitIgnoreLoadStatus) = EnterGitIgnoreScope(
 						facts.FullPath,
 						facts.RelativePath,
@@ -2836,7 +2836,21 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 						discoveredGitIgnoreMatchers,
 						discoveredGitTrackedPathIndexes,
 						gitIgnoreLoadSession);
-					if (IsActiveGitIgnoreReadFailure(effectiveRules, gitIgnoreLoadStatus))
+					if (!string.IsNullOrWhiteSpace(directoryBatch.GitMetadataPath) &&
+					    !gitIgnoreCandidateContext.IsOpaqueRepository(facts.FullPath))
+					{
+						discoveredGitRepositoryRoots.Add(facts.FullPath);
+						gitEvidence = new GitWorkspaceEvidence(HasRepositoryBoundary: true);
+					}
+					if (gitIgnoreCandidateContext.IsOpaqueRepository(facts.FullPath))
+						directControllerImpactCounts = new IgnoreControllerImpactCounts(GitIgnore: 1);
+					if (gitIgnoreContext.IsOpaqueRepository(facts.FullPath))
+					{
+						directoryFiles = [];
+						canTraverseChildren = false;
+					}
+					if (IsActiveGitIgnoreReadFailure(effectiveRules, gitIgnoreLoadStatus) ||
+					    gitIgnoreContext.IsOpaqueRepository(facts.FullPath) && gitIgnoreLoadStatus == GitIgnoreMatcherLoadStatus.ReadFailure)
 					{
 							directories.Add(new EffectiveIgnoreScanNode(
 								facts.FullPath,
@@ -3838,19 +3852,10 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 		GitIgnoreMatcherLoadSession? loadSession = null)
 	{
 		loadSession ??= new GitIgnoreMatcherLoadSession();
-		var activeContainsScope = activeContext.ContainsScope(directoryPath);
-		var candidateContainsScope = candidateContext.ContainsScope(directoryPath);
-		ScopedGitIgnoreMatcher? scopedMatcher = null;
-		var loadStatus = GitIgnoreMatcherLoadStatus.NotFound;
-		if (!string.IsNullOrWhiteSpace(gitIgnorePath))
-		{
-			var loadResult = loadSession.LoadWithCancellation(
-				directoryPath,
-				gitIgnorePath,
-				cancellationToken);
-			scopedMatcher = loadResult.Matcher;
-			loadStatus = loadResult.Status;
-		}
+		var loadResult = loadSession.LoadScope(directoryPath, gitIgnorePath, gitMetadataPath,
+			gitMetadataPath is null ? null : activeContext.GetOwningRepository(directoryPath), cancellationToken);
+		var scopedMatcher = loadResult.Matcher;
+		var loadStatus = loadResult.Status;
 
 		var requiresTrackedPathIndex =
 			activeContext.RequiresTrackedPathIndex ||
@@ -3858,7 +3863,7 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 			scopedMatcher is not null &&
 			!ReferenceEquals(scopedMatcher.Matcher, GitIgnoreMatcher.Empty);
 		var reachedRepositoryBoundary = !string.IsNullOrWhiteSpace(gitMetadataPath);
-		if (requiresTrackedPathIndex && (reachedRepositoryBoundary || scopedMatcher is not null))
+		if (scopedMatcher?.IsOpaqueRepository != true && requiresTrackedPathIndex && (reachedRepositoryBoundary || scopedMatcher is not null))
 		{
 			GitTrackedPathIndex? trackedPathIndex = null;
 			var loadedTrackedPathIndex = reachedRepositoryBoundary
@@ -3903,12 +3908,8 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 
 		discoveredMatchers?.Add(scopedMatcher);
 		return (
-			activeContainsScope
-				? activeContext
-				: activeContext.WithScope(scopedMatcher, directoryRelativePath),
-			candidateContainsScope
-				? candidateContext
-				: candidateContext.WithScope(scopedMatcher, directoryRelativePath),
+			activeContext.WithScope(scopedMatcher, directoryRelativePath),
+			candidateContext.WithScope(scopedMatcher, directoryRelativePath),
 			loadStatus);
 	}
 

--- a/Infrastructure/FileSystem/FileSystemScanner.cs
+++ b/Infrastructure/FileSystem/FileSystemScanner.cs
@@ -3852,6 +3852,8 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 		GitIgnoreMatcherLoadSession? loadSession = null)
 	{
 		loadSession ??= new GitIgnoreMatcherLoadSession();
+		if (candidateContext.IsOpaqueRepository(directoryPath))
+			return (activeContext, candidateContext, GitIgnoreMatcherLoadStatus.NotFound);
 		var loadResult = loadSession.LoadScope(directoryPath, gitIgnorePath, gitMetadataPath,
 			gitMetadataPath is null ? null : activeContext.GetOwningRepository(directoryPath), cancellationToken);
 		var scopedMatcher = loadResult.Matcher;

--- a/Infrastructure/FileSystem/FileSystemScanner.cs
+++ b/Infrastructure/FileSystem/FileSystemScanner.cs
@@ -1125,7 +1125,8 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 					directoryGitIgnoreCandidateContext,
 					cancellationToken,
 					loadSession: gitIgnoreLoadSession);
-				if (directoryGitIgnoreCandidateContext.IsOpaqueRepository(dir))
+				if (directoryGitIgnoreCandidateContext.IsOpaqueRepository(dir) &&
+				    PathComparer.Default.Equals(directoryGitIgnoreCandidateContext.GetOwningRepository(dir), dir))
 					gitIgnoreImpactCount++;
 				if (directoryGitIgnoreContext.IsOpaqueRepository(dir) && gitIgnoreLoadStatus != GitIgnoreMatcherLoadStatus.ReadFailure)
 					continue;
@@ -1165,7 +1166,7 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 							sd.RelativePath,
 							isDirectory: true,
 							sd.Name);
-					if (directoryGitIgnoreCandidate.IsIgnored)
+					if (directoryGitIgnoreCandidate.IsIgnored && !directoryGitIgnoreCandidateContext.IsOpaqueRepository(dir))
 						gitIgnoreImpactCount++;
 					if (ShouldSkipDirectoryByName(sd.Name, sd.FullPath, sd.IsHidden, rules, directoryGitIgnore))
 						continue;
@@ -1256,7 +1257,7 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 								: directoryGitIgnoreCandidateContext
 									.Evaluate(file.FullPath, file.RelativePath, isDirectory: false, file.Name)
 									.IsIgnored;
-							if (fileGitIgnoreCandidate)
+							if (fileGitIgnoreCandidate && !directoryGitIgnoreCandidateContext.IsOpaqueRepository(dir))
 								localState.GitIgnoreImpactCount++;
 							if (ShouldSkipFileByName(
 								    file.Name,
@@ -2843,7 +2844,10 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 						gitEvidence = new GitWorkspaceEvidence(HasRepositoryBoundary: true);
 					}
 					if (gitIgnoreCandidateContext.IsOpaqueRepository(facts.FullPath))
-						directControllerImpactCounts = new IgnoreControllerImpactCounts(GitIgnore: 1);
+						directControllerImpactCounts = PathComparer.Default.Equals(
+							gitIgnoreCandidateContext.GetOwningRepository(facts.FullPath), facts.FullPath)
+							? new IgnoreControllerImpactCounts(GitIgnore: 1)
+							: IgnoreControllerImpactCounts.Empty;
 					if (gitIgnoreContext.IsOpaqueRepository(facts.FullPath))
 					{
 						directoryFiles = [];
@@ -3267,6 +3271,14 @@ public sealed partial class FileSystemScanner : IFileSystemScanner, IFileSystemS
 			if (visibilityState.BaseFinalVisible != visibilityState.EmptyFoldersFinalVisible)
 				effectiveCounts.EmptyFolders++;
 
+			// An opaque repository contributes its boundary once, even when the disabled
+			// GitIgnore filter lets the inventory enumerate its descendants.
+			if (node.GitIgnoreCandidateContext.IsOpaqueRepository(node.Path))
+			{
+				if (PathComparer.Default.Equals(node.GitIgnoreCandidateContext.GetOwningRepository(node.Path), node.Path))
+					controllerImpactCounts = controllerImpactCounts.Add(new IgnoreControllerImpactCounts(GitIgnore: 1));
+				continue;
+			}
 			controllerImpactCounts = controllerImpactCounts.Add(node.DirectControllerImpactCounts);
 			var smartIgnoreBaselineFiles = effectiveRules.IsGitIgnoreTraversalEnabled
 				? metrics.GitIgnoreVisibleFiles

--- a/Infrastructure/FileSystem/GitIgnoreAncestorScopeBootstrapper.cs
+++ b/Infrastructure/FileSystem/GitIgnoreAncestorScopeBootstrapper.cs
@@ -49,13 +49,22 @@ internal static class GitIgnoreAncestorScopeBootstrapper
 		foreach (var scopePath in scopePaths)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			var loadResult = loadSession.LoadWithCancellation(
+			var loadResult = PathComparer.Default.Equals(scopePath, repositoryRootPath)
+				? loadSession.LoadRepositoryScope(scopePath, Path.Combine(scopePath, ".git"),
+					Path.Combine(scopePath, ".gitignore"), cancellationToken)
+				: loadSession.LoadWithCancellation(
 				scopePath,
 				Path.Combine(scopePath, ".gitignore"),
 				cancellationToken);
 			lastStatus = loadResult.Status;
 			if (loadResult.Status == GitIgnoreMatcherLoadStatus.ReadFailure)
 			{
+				if (loadResult.Matcher is { IsRepositoryBoundary: true } boundary)
+				{
+					activeContext = activeContext.WithAncestorScope(boundary, normalizedScanRoot);
+					candidateContext = candidateContext.WithAncestorScope(boundary, normalizedScanRoot);
+					discoveredMatchers?.Add(boundary);
+				}
 				return new GitIgnoreAncestorScopeBootstrapResult(
 					activeContext,
 					candidateContext,

--- a/Infrastructure/FileSystem/GitIgnoreMatcherFileCache.cs
+++ b/Infrastructure/FileSystem/GitIgnoreMatcherFileCache.cs
@@ -15,6 +15,10 @@ internal static class GitIgnoreMatcherFileCache
 	private static readonly LinkedList<CacheEntry> CacheLru = new();
 	private static long _retainedSourceBytes;
 
+	// Linked worktrees share info/exclude, but each parsed matcher owns a different root.
+	internal static string CreateCacheKey(string scopeRootPath, string sourcePath) =>
+		string.Concat(Path.GetFullPath(scopeRootPath), "\0", sourcePath);
+
 	public static GitIgnoreMatcherLoadResult Load(
 		string scopeRootPath,
 		string gitIgnorePath,
@@ -86,9 +90,10 @@ internal static class GitIgnoreMatcherFileCache
 			}
 
 			var normalizedPath = Path.GetFullPath(gitIgnorePath);
+			var cacheKey = CreateCacheKey(scopeRootPath, normalizedPath);
 			lock (CacheSync)
 			{
-				if (Cache.TryGetValue(normalizedPath, out var cachedNode) &&
+				if (Cache.TryGetValue(cacheKey, out var cachedNode) &&
 				    cachedNode.Value.SourceLengthBytes == source.LengthBytes &&
 				    string.Equals(
 					    cachedNode.Value.ContentFingerprint,
@@ -110,18 +115,19 @@ internal static class GitIgnoreMatcherFileCache
 			var scopedMatcher = new ScopedGitIgnoreMatcher(Path.GetFullPath(scopeRootPath), matcher);
 			lock (CacheSync)
 			{
-				Remove(normalizedPath);
+				Remove(cacheKey);
 				// Source length is a stable proxy for the parsed matcher's footprint. A single
 				// pathological source is still usable, but is never retained by the process cache.
 				if (source.LengthBytes <= MaximumRetainedSourceBytes)
 				{
 					var entry = new CacheEntry(
 						normalizedPath,
+						scopedMatcher.ScopeRootPath,
 						source.LengthBytes,
 						source.ContentFingerprint,
 						comparisonSemantics,
 						scopedMatcher);
-					Cache[normalizedPath] = CacheLru.AddFirst(entry);
+					Cache[cacheKey] = CacheLru.AddFirst(entry);
 					_retainedSourceBytes += source.LengthBytes;
 					TrimCache();
 				}
@@ -184,7 +190,7 @@ internal static class GitIgnoreMatcherFileCache
 		while ((Cache.Count > CacheLimit || _retainedSourceBytes > MaximumRetainedSourceBytes) &&
 		       CacheLru.Last is { } leastRecentlyUsed)
 		{
-			Remove(leastRecentlyUsed.Value.Path);
+			Remove(CreateCacheKey(leastRecentlyUsed.Value.ScopeRootPath, leastRecentlyUsed.Value.Path));
 		}
 	}
 
@@ -199,6 +205,7 @@ internal static class GitIgnoreMatcherFileCache
 
 	private sealed record CacheEntry(
 		string Path,
+		string ScopeRootPath,
 		long SourceLengthBytes,
 		string ContentFingerprint,
 		GitPathComparisonSemantics ComparisonSemantics,

--- a/Infrastructure/FileSystem/GitIgnoreMatcherLoadSession.cs
+++ b/Infrastructure/FileSystem/GitIgnoreMatcherLoadSession.cs
@@ -114,9 +114,11 @@ internal sealed class GitIgnoreMatcherLoadSession
 			if (matcher.IsRepositoryBoundary)
 				continue;
 			string sourcePath;
+			string cacheKey;
 			try
 			{
 				sourcePath = Path.GetFullPath(Path.Combine(matcher.ScopeRootPath, ".gitignore"));
+				cacheKey = GitIgnoreMatcherFileCache.CreateCacheKey(matcher.ScopeRootPath, sourcePath);
 			}
 			catch (Exception exception) when (exception is
 			       NotSupportedException or
@@ -126,14 +128,14 @@ internal sealed class GitIgnoreMatcherLoadSession
 				continue;
 			}
 
-			if (_loads.ContainsKey(sourcePath))
+			if (_loads.ContainsKey(cacheKey))
 				continue;
 
 			// Rules created for this operation already own the parsed matcher. Seeding keeps
 			// later traversal from revalidating the same source while preserving the exact
 			// matcher instance and typed load result for every parallel consumer.
 			_loads.TryAdd(
-				sourcePath,
+				cacheKey,
 				new Lazy<GitIgnoreMatcherLoadResult>(
 					() => GitIgnoreMatcherLoadResult.Loaded(matcher),
 					LazyThreadSafetyMode.ExecutionAndPublication));
@@ -152,9 +154,11 @@ internal sealed class GitIgnoreMatcherLoadSession
 		IgnorePipelineDiagnostics.RecordGitIgnoreLoadRequest();
 
 		string normalizedPath;
+		string cacheKey;
 		try
 		{
 			normalizedPath = Path.GetFullPath(gitIgnorePath);
+			cacheKey = GitIgnoreMatcherFileCache.CreateCacheKey(scopeRootPath, normalizedPath);
 		}
 		catch (Exception exception) when (exception is
 		       NotSupportedException or
@@ -164,28 +168,28 @@ internal sealed class GitIgnoreMatcherLoadSession
 			return Execute(scopeRootPath, gitIgnorePath, cancellationToken);
 		}
 
-		if (_loads.TryGetValue(normalizedPath, out var cached))
+		if (_loads.TryGetValue(cacheKey, out var cached))
 		{
 			IgnorePipelineDiagnostics.RecordGitIgnoreLoadReuse();
 			cancellationToken.ThrowIfCancellationRequested();
-			return GetValueOrRemoveCanceled(normalizedPath, cached);
+			return GetValueOrRemoveCanceled(cacheKey, cached);
 		}
 
 		var candidate = new Lazy<GitIgnoreMatcherLoadResult>(
 			() => Execute(scopeRootPath, normalizedPath, cancellationToken),
 			LazyThreadSafetyMode.ExecutionAndPublication);
-		var selected = _loads.GetOrAdd(normalizedPath, candidate);
+		var selected = _loads.GetOrAdd(cacheKey, candidate);
 		if (!ReferenceEquals(selected, candidate))
 			IgnorePipelineDiagnostics.RecordGitIgnoreLoadReuse();
 
 		if (cancellationToken.IsCancellationRequested)
 		{
 			if (ReferenceEquals(selected, candidate))
-				RemoveExact(normalizedPath, selected);
+				RemoveExact(cacheKey, selected);
 			cancellationToken.ThrowIfCancellationRequested();
 		}
 
-		return GetValueOrRemoveCanceled(normalizedPath, selected);
+		return GetValueOrRemoveCanceled(cacheKey, selected);
 	}
 
 	private GitIgnoreMatcherLoadResult GetValueOrRemoveCanceled(

--- a/Infrastructure/FileSystem/GitIgnoreMatcherLoadSession.cs
+++ b/Infrastructure/FileSystem/GitIgnoreMatcherLoadSession.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using DevProjex.Application.Diagnostics;
+using DevProjex.Infrastructure.Git;
 
 namespace DevProjex.Infrastructure.FileSystem;
 
@@ -12,6 +13,79 @@ internal sealed class GitIgnoreMatcherLoadSession
 	private readonly ConcurrentDictionary<string, Lazy<GitIgnoreMatcherLoadResult>> _loads =
 		new(ProjectTreePathIdentity.CanonicalComparer);
 	private readonly Func<string, string, CancellationToken, GitIgnoreMatcherLoadResult> _loader;
+	private readonly ConcurrentDictionary<string, Lazy<GitIgnoreMatcherLoadResult>> _repositoryScopes =
+		new(ProjectTreePathIdentity.CanonicalComparer);
+	private readonly ConcurrentDictionary<string, Lazy<GitSubmoduleManifest>> _submodules =
+		new(ProjectTreePathIdentity.CanonicalComparer);
+
+	public GitIgnoreMatcherLoadResult LoadScope(string directoryPath, string? gitIgnorePath,
+		string? gitMetadataPath, string? owner, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		if (string.IsNullOrWhiteSpace(gitMetadataPath))
+			return string.IsNullOrWhiteSpace(gitIgnorePath) ? GitIgnoreMatcherLoadResult.NotFound :
+				LoadWithCancellation(directoryPath, gitIgnorePath, cancellationToken);
+		if (owner is not null && !PathComparer.Default.Equals(directoryPath, owner))
+		{
+			var manifest = GetOrLoad(_submodules, owner, () => GitSubmoduleManifest.Read(owner, cancellationToken));
+			if (manifest.ReadFailed)
+				return RepositoryFailure(directoryPath, opaque: true);
+			if (!manifest.Paths.Contains(PathUtility.GetPortableRelativePath(owner, directoryPath)))
+				return GitIgnoreMatcherLoadResult.Loaded(new ScopedGitIgnoreMatcher(directoryPath, GitIgnoreMatcher.Empty)
+				{
+					IsRepositoryBoundary = true,
+					IsOpaqueRepository = true
+				});
+		}
+		return LoadRepositoryScope(directoryPath, gitMetadataPath, gitIgnorePath, cancellationToken);
+	}
+
+	public GitIgnoreMatcherLoadResult LoadRepositoryScope(
+		string repositoryRoot, string gitMetadataPath, string? gitIgnorePath, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		return GetOrLoad(_repositoryScopes, repositoryRoot, () =>
+		{
+			try
+			{
+				if (!GitLocalConfigSemanticsReader.TryResolveGitDirectory(repositoryRoot, gitMetadataPath, out var gitDirectory) ||
+				    !GitLocalConfigSemanticsReader.TryResolveCommonDirectory(gitDirectory, out var commonDirectory))
+					return RepositoryFailure(repositoryRoot);
+				var exclude = LoadWithCancellation(repositoryRoot, Path.Combine(commonDirectory, "info", "exclude"), cancellationToken);
+				var ignore = LoadWithCancellation(repositoryRoot, gitIgnorePath ?? Path.Combine(repositoryRoot, ".gitignore"), cancellationToken);
+				if (exclude.Status == GitIgnoreMatcherLoadStatus.ReadFailure || ignore.Status == GitIgnoreMatcherLoadStatus.ReadFailure)
+					return RepositoryFailure(repositoryRoot);
+				return GitIgnoreMatcherLoadResult.Loaded(new ScopedGitIgnoreMatcher(repositoryRoot,
+					GitIgnoreMatcher.Combine(exclude.Matcher?.Matcher ?? GitIgnoreMatcher.Empty,
+						ignore.Matcher?.Matcher ?? GitIgnoreMatcher.Empty)) { IsRepositoryBoundary = true });
+			}
+			catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or
+			       System.Security.SecurityException or ArgumentException or NotSupportedException)
+			{
+				return RepositoryFailure(repositoryRoot);
+			}
+		});
+	}
+
+	private static GitIgnoreMatcherLoadResult RepositoryFailure(string root, bool opaque = false) =>
+		new(GitIgnoreMatcherLoadStatus.ReadFailure, new ScopedGitIgnoreMatcher(root, GitIgnoreMatcher.Empty)
+		{
+			IsRepositoryBoundary = true, IsOpaqueRepository = opaque
+		});
+
+	private static T GetOrLoad<T>(ConcurrentDictionary<string, Lazy<T>> cache, string path, Func<T> loader)
+	{
+		var load = cache.GetOrAdd(path, _ => new Lazy<T>(loader, LazyThreadSafetyMode.ExecutionAndPublication));
+		try
+		{
+			return load.Value;
+		}
+		catch (OperationCanceledException)
+		{
+			cache.TryRemove(new KeyValuePair<string, Lazy<T>>(path, load));
+			throw;
+		}
+	}
 
 	public GitIgnoreMatcherLoadSession()
 		: this(static (scopeRootPath, gitIgnorePath, cancellationToken) =>
@@ -37,6 +111,8 @@ internal sealed class GitIgnoreMatcherLoadSession
 	{
 		foreach (var matcher in matchers)
 		{
+			if (matcher.IsRepositoryBoundary)
+				continue;
 			string sourcePath;
 			try
 			{

--- a/Infrastructure/FileSystem/GitSubmoduleManifest.cs
+++ b/Infrastructure/FileSystem/GitSubmoduleManifest.cs
@@ -23,13 +23,8 @@ internal sealed record GitSubmoduleManifest(IReadOnlySet<string> Paths, bool Rea
 					continue;
 				if (line[0] == '[')
 				{
-					var end = line.IndexOf(']');
-					if (end < 0)
+					if (!TryReadSection(line, out inSubmodule))
 						return new(paths, true);
-					var section = line[1..end].Trim();
-					inSubmodule = section.StartsWith("submodule ", StringComparison.OrdinalIgnoreCase) &&
-					              section[10..].Trim() is var name && name.Length >= 2 &&
-					              name[0] == '"' && name[^1] == '"';
 					continue;
 				}
 				if (!inSubmodule)
@@ -56,10 +51,41 @@ internal sealed record GitSubmoduleManifest(IReadOnlySet<string> Paths, bool Rea
 		}
 	}
 
+	private static bool TryReadSection(string line, out bool isSubmodule)
+	{
+		isSubmodule = false;
+		var quoted = false;
+		for (var index = 1; index < line.Length; index++)
+		{
+			if (line[index] == '\\' && quoted)
+			{
+				index++;
+				continue;
+			}
+			if (line[index] == '"')
+				quoted = !quoted;
+			if (line[index] != ']' || quoted)
+				continue;
+			var trailing = line[(index + 1)..].TrimStart();
+			if (trailing.Length > 0 && trailing[0] is not ('#' or ';'))
+				return false;
+			var section = line[1..index].Trim();
+			var separator = section.IndexOfAny([' ', '\t']);
+			if (separator < 0 || !section[..separator].Equals("submodule", StringComparison.OrdinalIgnoreCase))
+				return true;
+			var name = section[(separator + 1)..].Trim();
+			isSubmodule = name.Length >= 2 && name[0] == '"' && name[^1] == '"';
+			return isSubmodule;
+		}
+		return false;
+	}
+
 	private static bool TryReadPath(string value, out string path)
 	{
+		value = value.TrimStart();
 		var result = new System.Text.StringBuilder();
 		var quoted = false;
+		var significantLength = 0;
 		for (var index = 0; index < value.Length; index++)
 		{
 			var character = value[index];
@@ -80,8 +106,10 @@ internal sealed record GitSubmoduleManifest(IReadOnlySet<string> Paths, bool Rea
 				character = value[index];
 			}
 			result.Append(character);
+			if (quoted || !char.IsWhiteSpace(character))
+				significantLength = result.Length;
 		}
-		path = result.ToString().Trim();
+		path = result.ToString(0, significantLength);
 		return !quoted && path.Length > 0 && !Path.IsPathRooted(path) &&
 		       !path.Contains('\\') && !path.Contains(':') && !path.Any(char.IsControl) &&
 		       path.Split('/').All(static segment => segment.Length > 0 && segment is not ("." or ".."));

--- a/Infrastructure/FileSystem/GitSubmoduleManifest.cs
+++ b/Infrastructure/FileSystem/GitSubmoduleManifest.cs
@@ -1,0 +1,89 @@
+using DevProjex.Application.Services;
+
+namespace DevProjex.Infrastructure.FileSystem;
+
+internal sealed record GitSubmoduleManifest(IReadOnlySet<string> Paths, bool ReadFailed)
+{
+	private const int MaximumSubmoduleCount = 8_192;
+	public static GitSubmoduleManifest Read(string repositoryRoot, CancellationToken cancellationToken)
+	{
+		var paths = new HashSet<string>(StringComparer.Ordinal);
+		try
+		{
+			var path = Path.Combine(repositoryRoot, ".gitmodules");
+			var attributes = File.GetAttributes(path);
+			if ((attributes & (FileAttributes.ReparsePoint | FileAttributes.Directory)) != 0)
+				return new(paths, true);
+			var source = GitIgnoreFileReader.ReadWithCancellation(path, cancellationToken);
+			var inSubmodule = false;
+			foreach (var sourceLine in GitIgnoreFileReader.EnumerateLinesWithCancellation(source.Content, cancellationToken))
+			{
+				var line = sourceLine.Trim();
+				if (line.Length == 0 || line[0] is '#' or ';')
+					continue;
+				if (line[0] == '[')
+				{
+					var end = line.IndexOf(']');
+					if (end < 0)
+						return new(paths, true);
+					var section = line[1..end].Trim();
+					inSubmodule = section.StartsWith("submodule ", StringComparison.OrdinalIgnoreCase) &&
+					              section[10..].Trim() is var name && name.Length >= 2 &&
+					              name[0] == '"' && name[^1] == '"';
+					continue;
+				}
+				if (!inSubmodule)
+					continue;
+				var equals = line.IndexOf('=');
+				if (equals < 0 || !line[..equals].Trim().Equals("path", StringComparison.OrdinalIgnoreCase))
+					continue;
+				if (!TryReadPath(line[(equals + 1)..], out var relativePath))
+					return new(paths, true);
+				paths.Add(relativePath);
+				if (paths.Count > MaximumSubmoduleCount)
+					return new(paths, true);
+			}
+			return new(paths, false);
+		}
+		catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
+		{
+			return new(paths, false);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or
+		       System.Security.SecurityException or ArgumentException or NotSupportedException)
+		{
+			return new(paths, true);
+		}
+	}
+
+	private static bool TryReadPath(string value, out string path)
+	{
+		var result = new System.Text.StringBuilder();
+		var quoted = false;
+		for (var index = 0; index < value.Length; index++)
+		{
+			var character = value[index];
+			if (character == '"')
+			{
+				quoted = !quoted;
+				continue;
+			}
+			if (!quoted && character is '#' or ';')
+				break;
+			if (character == '\\')
+			{
+				if (++index >= value.Length || value[index] is not ('"' or '\\'))
+				{
+					path = string.Empty;
+					return false;
+				}
+				character = value[index];
+			}
+			result.Append(character);
+		}
+		path = result.ToString().Trim();
+		return !quoted && path.Length > 0 && !Path.IsPathRooted(path) &&
+		       !path.Contains('\\') && !path.Contains(':') && !path.Any(char.IsControl) &&
+		       path.Split('/').All(static segment => segment.Length > 0 && segment is not ("." or ".."));
+	}
+}

--- a/Infrastructure/FileSystem/ProjectTreeInventoryScanner.cs
+++ b/Infrastructure/FileSystem/ProjectTreeInventoryScanner.cs
@@ -717,7 +717,7 @@ internal readonly record struct ProjectTreeGitIgnoreContexts(
 		out bool gitIgnoreReadFailed)
 	{
 		gitIgnoreReadFailed = false;
-		if (!Enabled)
+		if (!Enabled || Secondary.IsOpaqueRepository(directoryPath))
 			return this;
 
 		var primaryContext = Primary;

--- a/Infrastructure/FileSystem/ProjectTreeInventoryScanner.cs
+++ b/Infrastructure/FileSystem/ProjectTreeInventoryScanner.cs
@@ -350,10 +350,10 @@ internal static class ProjectTreeInventoryScanner
 				gitIgnoreLoadSession,
 				cancellationToken,
 				out var gitIgnoreReadFailed);
-			if (gitIgnoreContexts.Primary.IsOpaqueRepository(parent.FullPath) && !gitIgnoreReadFailed)
+			if (gitIgnoreContexts.Enabled && gitIgnoreContexts.Primary.IsOpaqueRepository(parent.FullPath) && !gitIgnoreReadFailed)
 				continue;
 			if (!string.IsNullOrWhiteSpace(gitControlPaths.GitMetadataPath) &&
-			    !gitIgnoreContexts.Secondary.IsOpaqueRepository(parent.FullPath))
+			    (!gitIgnoreContexts.Enabled || !gitIgnoreContexts.Secondary.IsOpaqueRepository(parent.FullPath)))
 				discoveredGitRepositoryRoots.Add(parent.FullPath);
 			if (gitIgnoreReadFailed)
 			{

--- a/Infrastructure/FileSystem/ProjectTreeInventoryScanner.cs
+++ b/Infrastructure/FileSystem/ProjectTreeInventoryScanner.cs
@@ -340,8 +340,6 @@ internal static class ProjectTreeInventoryScanner
 				continue;
 
 			var gitControlPaths = FindGitControlPaths(childEntries);
-			if (!string.IsNullOrWhiteSpace(gitControlPaths.GitMetadataPath))
-				discoveredGitRepositoryRoots.Add(parent.FullPath);
 			var gitIgnoreContexts = parentGitIgnoreContexts.EnterDirectory(
 				parent.FullPath,
 				parent.RelativePath,
@@ -352,6 +350,11 @@ internal static class ProjectTreeInventoryScanner
 				gitIgnoreLoadSession,
 				cancellationToken,
 				out var gitIgnoreReadFailed);
+			if (gitIgnoreContexts.Primary.IsOpaqueRepository(parent.FullPath) && !gitIgnoreReadFailed)
+				continue;
+			if (!string.IsNullOrWhiteSpace(gitControlPaths.GitMetadataPath) &&
+			    !gitIgnoreContexts.Secondary.IsOpaqueRepository(parent.FullPath))
+				discoveredGitRepositoryRoots.Add(parent.FullPath);
 			if (gitIgnoreReadFailed)
 			{
 				MarkAccessDenied(entries, parentIndex);
@@ -719,17 +722,11 @@ internal readonly record struct ProjectTreeGitIgnoreContexts(
 
 		var primaryContext = Primary;
 		var secondaryContext = Secondary;
-		ScopedGitIgnoreMatcher? matcher = null;
-		if (!string.IsNullOrWhiteSpace(gitIgnorePath))
-		{
-			var loadResult = gitIgnoreLoadSession.LoadWithCancellation(
-				directoryPath,
-				gitIgnorePath,
-				cancellationToken);
-			matcher = loadResult.Matcher;
-			gitIgnoreReadFailed = ReportGitIgnoreReadFailures &&
-			                      loadResult.Status == GitIgnoreMatcherLoadStatus.ReadFailure;
-		}
+		var loadResult = gitIgnoreLoadSession.LoadScope(directoryPath, gitIgnorePath, gitMetadataPath,
+			gitMetadataPath is null ? null : primaryContext.GetOwningRepository(directoryPath), cancellationToken);
+		var matcher = loadResult.Matcher;
+		gitIgnoreReadFailed = (ReportGitIgnoreReadFailures || matcher?.IsOpaqueRepository == true && Primary.GitFilteringEnabled) &&
+		                     loadResult.Status == GitIgnoreMatcherLoadStatus.ReadFailure;
 
 		var requiresTrackedPathIndex =
 			primaryContext.RequiresTrackedPathIndex ||
@@ -737,7 +734,7 @@ internal readonly record struct ProjectTreeGitIgnoreContexts(
 			matcher is not null &&
 			!ReferenceEquals(matcher.Matcher, GitIgnoreMatcher.Empty);
 		var reachedRepositoryBoundary = !string.IsNullOrWhiteSpace(gitMetadataPath);
-		if (requiresTrackedPathIndex && (reachedRepositoryBoundary || matcher is not null))
+		if (matcher?.IsOpaqueRepository != true && requiresTrackedPathIndex && (reachedRepositoryBoundary || matcher is not null))
 		{
 			GitTrackedPathIndex? trackedPathIndex = null;
 			var loadedTrackedPathIndex = reachedRepositoryBoundary
@@ -786,17 +783,11 @@ internal readonly record struct ProjectTreeGitIgnoreContexts(
 			};
 		}
 
-		var primaryContainsScope = primaryContext.ContainsScope(directoryPath);
-		var secondaryContainsScope = secondaryContext.ContainsScope(directoryPath);
 		discoveredMatchers.Add(matcher);
 		return this with
 		{
-			Primary = primaryContainsScope
-				? primaryContext
-				: primaryContext.WithScope(matcher, directoryRelativePath),
-			Secondary = secondaryContainsScope
-				? secondaryContext
-				: secondaryContext.WithScope(matcher, directoryRelativePath)
+			Primary = primaryContext.WithScope(matcher, directoryRelativePath),
+			Secondary = secondaryContext.WithScope(matcher, directoryRelativePath)
 		};
 	}
 }

--- a/Infrastructure/Git/GitLocalConfigSemanticsReader.cs
+++ b/Infrastructure/Git/GitLocalConfigSemanticsReader.cs
@@ -130,7 +130,7 @@ internal static class GitLocalConfigSemanticsReader
 		}
 	}
 
-	private static bool TryResolveGitDirectory(
+	internal static bool TryResolveGitDirectory(
 		string repositoryRoot,
 		string gitMetadataPath,
 		out string gitDirectory)
@@ -173,7 +173,7 @@ internal static class GitLocalConfigSemanticsReader
 		return Directory.Exists(gitDirectory);
 	}
 
-	private static bool TryResolveCommonDirectory(
+	internal static bool TryResolveCommonDirectory(
 		string gitDirectory,
 		out string commonDirectory)
 	{

--- a/Kernel/Models/GitIgnoreMatcher.cs
+++ b/Kernel/Models/GitIgnoreMatcher.cs
@@ -17,6 +17,8 @@ public sealed class GitIgnoreMatcher
     private readonly bool _ignoreAsciiCase;
     private readonly bool _normalizeUnicode;
     private readonly bool _hasNegationRules;
+    private GitIgnoreMatcher? _lowerPrioritySource;
+    private GitIgnoreMatcher? _higherPrioritySource;
 
     // Pre-compiled search values for SIMD-optimized character lookup
     private static readonly SearchValues<char> GlobSpecialChars = SearchValues.Create("*?[");
@@ -45,6 +47,30 @@ public sealed class GitIgnoreMatcher
     }
 
     public bool HasNegationRules => _hasNegationRules;
+
+    public static GitIgnoreMatcher Combine(GitIgnoreMatcher lowerPriority, GitIgnoreMatcher higherPriority)
+    {
+        if (lowerPriority._rules.Count == 0)
+            return higherPriority;
+        if (ReferenceEquals(higherPriority, Empty))
+            return lowerPriority;
+        if (lowerPriority._normalizedRootPath != higherPriority._normalizedRootPath ||
+            lowerPriority._ignoreAsciiCase != higherPriority._ignoreAsciiCase ||
+            lowerPriority._normalizeUnicode != higherPriority._normalizeUnicode)
+            throw new ArgumentException("Rule sources must share a scope and comparison semantics.");
+        if (lowerPriority._rules.Count + higherPriority._rules.Count > MaximumEffectiveRuleCount)
+            throw new InvalidDataException("The combined ignore scope exceeds the rule limit.");
+
+        return new GitIgnoreMatcher(
+            higherPriority._normalizedRootPath,
+            [.. lowerPriority._rules, .. higherPriority._rules],
+            lowerPriority.HasNegationRules || higherPriority.HasNegationRules,
+            new GitPathComparisonSemantics(higherPriority._ignoreAsciiCase, higherPriority._normalizeUnicode))
+        {
+            _lowerPrioritySource = lowerPriority,
+            _higherPrioritySource = higherPriority
+        };
+    }
 
     public bool IsRootPath(string path)
     {
@@ -339,6 +365,11 @@ public sealed class GitIgnoreMatcher
 
     private IgnoreEvaluation EvaluateRelativeCore(ReadOnlySpan<char> relativePath, bool isDirectory, string name)
     {
+        if (_higherPrioritySource is { } higher && _lowerPrioritySource is { } lower)
+        {
+            var higherEvaluation = higher.EvaluateRelativeCore(relativePath, isDirectory, name);
+            return higherEvaluation.HasMatch ? higherEvaluation : lower.EvaluateRelativeCore(relativePath, isDirectory, name);
+        }
         var normalizedName = string.IsNullOrEmpty(name) ? Path.GetFileName(relativePath).ToString() : name;
         var evaluation = EvaluateRules(relativePath, isDirectory, normalizedName);
         var ignored = evaluation.IsIgnored;
@@ -384,6 +415,16 @@ public sealed class GitIgnoreMatcher
         bool isDirectory,
         string normalizedName)
     {
+        if (_higherPrioritySource is { } higher && _lowerPrioritySource is { } lower)
+        {
+            var higherEvaluation = higher.EvaluateRules(relativePath, isDirectory, normalizedName);
+            if (higherEvaluation.HasMatch)
+                return higherEvaluation;
+            // A root rule source can reopen descendants hidden only by info/exclude.
+            if (isDirectory && higher.ShouldTraverseIgnoredDirectoryRelativeCore(relativePath, normalizedName))
+                return default;
+            return lower.EvaluateRules(relativePath, isDirectory, normalizedName);
+        }
         normalizedName = GitPathTextNormalizer.NormalizeObservedPath(
             normalizedName,
             _normalizeUnicode,

--- a/Kernel/Models/IgnoreRules.cs
+++ b/Kernel/Models/IgnoreRules.cs
@@ -277,6 +277,8 @@ public sealed record IgnoreRules(
 			var scoped = scopedMatchersSource[0];
 			if (!IsPathInsideCompatibleScope(fullPath, scoped.ScopeRootPath))
 				return GitIgnoreEvaluation.NotIgnored;
+			if (scoped.IsOpaqueRepository)
+				return new GitIgnoreEvaluation(true, false);
 
 			return EvaluateWithSingleMatcher(scoped.Matcher, fullPath, isDirectory, name);
 		}
@@ -292,6 +294,8 @@ public sealed record IgnoreRules(
 
 		foreach (var scoped in scopedMatchers)
 		{
+			if (scoped.IsOpaqueRepository)
+				return new GitIgnoreEvaluation(true, false);
 			if (isDirectory && scoped.Matcher.HasNegationRules)
 				hasNegationAwareScope = true;
 
@@ -672,6 +676,12 @@ public sealed record IgnoreRules(
 			cacheKeyPath,
 			scopedMatchersSource,
 			static scoped => scoped.ScopeRootPath);
+		var lastBoundary = -1;
+		for (var index = 0; index < matched.Count; index++)
+			if (matched[index].IsRepositoryBoundary)
+				lastBoundary = index;
+		if (lastBoundary > 0)
+			matched = matched.Skip(lastBoundary).ToList();
 
 		ScopedGitIgnoreMatcher[] resolved = matched.Count == 0
 			? Array.Empty<ScopedGitIgnoreMatcher>()
@@ -1042,14 +1052,15 @@ public sealed record IgnoreRules(
 			get
 			{
 				if (_relativeMatcher is not null ||
-				    _additionalScopes is not null)
+				    _additionalScopes?.HasPatternRules == true)
 				{
 					return true;
 				}
 
 				return _evaluateRulesFallback &&
 				       (!ReferenceEquals(_rules.GetGitIgnoreMatcher(_useCandidates), GitIgnoreMatcher.Empty) ||
-				        _rules.GetScopedGitIgnoreMatchers(_useCandidates).Count > 0);
+				        _rules.GetScopedGitIgnoreMatchers(_useCandidates).Any(static scope =>
+					        !ReferenceEquals(scope.Matcher, GitIgnoreMatcher.Empty)));
 			}
 		}
 
@@ -1057,12 +1068,25 @@ public sealed record IgnoreRules(
 			(!_useCandidates && _rules.UseTrackedGitFilesOnly) ||
 			HasIgnoreRules;
 
+		public bool IsOpaqueRepository(string fullPath) =>
+			(_useCandidates || _rules.IsGitIgnoreTraversalEnabled) &&
+			_additionalScopes?.FindRepositoryBoundary(fullPath)?.IsOpaqueRepository == true;
+
+		public bool GitFilteringEnabled => _rules.IsGitIgnoreTraversalEnabled;
+
+		public string? GetOwningRepository(string fullPath) =>
+			_additionalScopes?.FindRepositoryBoundary(fullPath)?.ScopeRootPath;
+
+		private bool ContainsRepositoryBoundary(string fullPath) =>
+			_additionalScopes?.FindRepositoryBoundary(fullPath)?.ScopeRootPath == fullPath;
+
 		public GitIgnoreScanContext WithScope(
 			ScopedGitIgnoreMatcher scopedMatcher,
 			string scopeRelativePath)
 		{
-			if (ReferenceEquals(scopedMatcher.Matcher, GitIgnoreMatcher.Empty) ||
-			    ContainsScope(scopedMatcher.ScopeRootPath))
+			if (ReferenceEquals(scopedMatcher.Matcher, GitIgnoreMatcher.Empty) && !scopedMatcher.IsRepositoryBoundary ||
+			    ContainsScope(scopedMatcher.ScopeRootPath) &&
+			    (!scopedMatcher.IsRepositoryBoundary || ContainsRepositoryBoundary(scopedMatcher.ScopeRootPath)))
 			{
 				return this;
 			}
@@ -1084,12 +1108,12 @@ public sealed record IgnoreRules(
 			ScopedGitIgnoreMatcher scopedMatcher,
 			string scanRootPath)
 		{
-			if (ReferenceEquals(scopedMatcher.Matcher, GitIgnoreMatcher.Empty) ||
-			    ContainsScope(scopedMatcher.ScopeRootPath) ||
-			    !scopedMatcher.Matcher.TryGetRelativePath(
+			if (ReferenceEquals(scopedMatcher.Matcher, GitIgnoreMatcher.Empty) && !scopedMatcher.IsRepositoryBoundary ||
+			    ContainsScope(scopedMatcher.ScopeRootPath) &&
+			    (!scopedMatcher.IsRepositoryBoundary || ContainsRepositoryBoundary(scopedMatcher.ScopeRootPath)) ||
+			    !TryGetScopeRelativePath(scopedMatcher.ScopeRootPath,
 				    scanRootPath,
-				    out var matcherBaseRelativePath,
-				    allowRoot: true))
+				    out var matcherBaseRelativePath))
 			{
 				return this;
 			}
@@ -1148,6 +1172,8 @@ public sealed record IgnoreRules(
 				return new GitIgnoreEvaluation(IsIgnored: true, ShouldTraverseIgnoredDirectory: false);
 			if (!_useCandidates && !_rules.IsGitIgnoreTraversalEnabled)
 				return GitIgnoreEvaluation.NotIgnored;
+			if (IsOpaqueRepository(fullPath))
+				return new GitIgnoreEvaluation(true, false);
 
 			if (!_useCandidates && _rules.UseTrackedGitFilesOnly)
 				return EvaluateTrackedFilesOnly(fullPath, isDirectory);
@@ -1224,9 +1250,9 @@ public sealed record IgnoreRules(
 			if (trackedPath.Index.ContainsOrHasDescendantNormalizedRelativePath(trackedPath.RelativePath))
 				return GitIgnoreEvaluation.NotIgnored;
 
-			// Untracked directories are traversal-only containers. This lets the scanner
-			// discover an independent nested repository at any depth without exposing the
-			// container when it has no tracked descendants.
+			// Untracked containers remain traversable until the scanner can classify a
+			// repository boundary as an independent owner, declared submodule, or opaque
+			// embedded repository. Containers without tracked descendants stay hidden.
 			return new GitIgnoreEvaluation(
 				IsIgnored: true,
 				ShouldTraverseIgnoredDirectory: true);
@@ -1322,6 +1348,26 @@ public sealed record IgnoreRules(
 		{
 			private readonly AdditionalGitIgnoreScope? _parent = parent;
 			private readonly ScopedGitIgnoreMatcher _scopedMatcher = scopedMatcher;
+			public bool HasPatternRules { get; } =
+				!ReferenceEquals(scopedMatcher.Matcher, GitIgnoreMatcher.Empty) || parent?.HasPatternRules == true;
+
+			public ScopedGitIgnoreMatcher? FindRepositoryBoundary(string fullPath)
+			{
+				ScopedGitIgnoreMatcher? nearest = null;
+				for (var current = this; current is not null; current = current._parent)
+				{
+					var matcher = current._scopedMatcher;
+					if (matcher.IsRepositoryBoundary &&
+					    (nearest is null || matcher.ScopeRootPath.Length > nearest.ScopeRootPath.Length) &&
+					    IsPathInsideScope(fullPath, matcher.ScopeRootPath))
+						nearest = matcher;
+				}
+				return nearest;
+			}
+
+			private bool ResetsInheritedRules(string scanRelativePath) =>
+				_scopedMatcher.IsRepositoryBoundary &&
+				(matcherBaseRelativePath is not null || TryGetMatcherRelativePath(scanRelativePath, out _));
 
 			public bool Contains(string scopeRootPath)
 			{
@@ -1345,7 +1391,9 @@ public sealed record IgnoreRules(
 			{
 				var evaluation = inherited;
 				reIncludedIgnoredPath = false;
-				if (_parent is not null)
+				if (ResetsInheritedRules(scanRelativePath))
+					evaluation = GitIgnoreEvaluation.NotIgnored;
+				else if (_parent is not null)
 				{
 					evaluation = _parent.Evaluate(
 						scanRelativePath,
@@ -1392,7 +1440,7 @@ public sealed record IgnoreRules(
 				string name,
 				GitIgnoreMatcher.IgnoreEvaluation inherited)
 			{
-				var evaluation = _parent?.EvaluateRulesOnly(
+				var evaluation = ResetsInheritedRules(scanRelativePath) ? default : _parent?.EvaluateRulesOnly(
 					scanRelativePath,
 					isDirectory,
 					name,
@@ -1518,7 +1566,11 @@ public sealed record IgnoreRules(
 
 public sealed record ScopedGitIgnoreMatcher(
 	string ScopeRootPath,
-	GitIgnoreMatcher Matcher);
+	GitIgnoreMatcher Matcher)
+{
+	public bool IsRepositoryBoundary { get; init; }
+	public bool IsOpaqueRepository { get; init; }
+}
 
 public sealed record ScopedSmartIgnoreMatcher(
 	string ScopeRootPath,

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Smart Ignore is a local, deterministic filter — not an AI model, and not one b
 
 | Mode | What it shows |
 |---|---|
-| `.gitignore` mode | Tracked files, plus untracked files not excluded by `.gitignore` (with nested rules and negations) |
+| `.gitignore` mode | Tracked files and untracked files allowed by repository-local `.gitignore` and `info/exclude`, with opaque embedded repositories and independent declared submodules, following `git status` |
 | Tracked-files-only | Only files currently recorded in the Git index |
 | Staged | Files with staged changes |
 | Changes | Staged, unstaged, and non-ignored untracked files |

--- a/Tests/DevProjex.Tests.Integration/CrossSurfaceSelectionContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/CrossSurfaceSelectionContractIntegrationTests.cs
@@ -97,6 +97,8 @@ public sealed class CrossSurfaceSelectionContractIntegrationTests
 				"source files/services/api/dist/contracts.json",
 				"source files/src/-leading.cs",
 				"source files/src/Program.cs",
+				// The first repository now owns its scope; workspace-level rules do not leak inside.
+				"source files/src/ignored-by-git.cs",
 				"source files/src/файл.cs",
 				"source files/src/文档.md",
 				"кириллица/src/данные.cs",
@@ -123,7 +125,6 @@ public sealed class CrossSurfaceSelectionContractIntegrationTests
 			"source files/dist/manifest.json",
 			"source files/services/api/obj/project.assets.json",
 			"source files/src/empty.cs",
-			"source files/src/ignored-by-git.cs",
 			"source files/src/notes.tmp",
 			"кириллица/.venv/leak.cs",
 			"文档/target/leak.md",

--- a/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.RepositoryBoundaries.cs
+++ b/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.RepositoryBoundaries.cs
@@ -1,0 +1,182 @@
+using DevProjex.Application.Context;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed partial class DeepGitWorkspaceEvidenceIntegrationTests
+{
+	[Theory]
+	[InlineData(GitFilteringMode.RespectGitIgnore, false)]
+	[InlineData(GitFilteringMode.TrackedFilesOnly, false)]
+	[InlineData(GitFilteringMode.None, true)]
+	public async Task RepositoryBoundaries_EmbeddedCloneAndWorktreeAreOpaque(GitFilteringMode mode, bool visible)
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile("anchor.cs", "anchor");
+		InitializeIndex(temp.Path, "anchor.cs");
+		RunGit(temp.Path, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "Initial");
+		var embedded = temp.CreateDirectory("libs/SomeLib");
+		temp.CreateFile("libs/SomeLib/embedded.cs", "embedded");
+		InitializeIndex(embedded, "embedded.cs");
+		RunGit(temp.Path, "worktree", "add", "--detach", ".claude/worktrees/x");
+
+		var plan = await BuildBoundaryPlan(temp.Path, mode);
+		Assert.Equal(visible, plan.IncludedFiles.Any(path => path.EndsWith("embedded.cs", StringComparison.Ordinal)));
+		Assert.Equal(visible, plan.IncludedFiles.Any(path => path.Contains("worktrees", StringComparison.Ordinal)));
+		Assert.Contains(plan.IncludedFiles, path => path == Path.Combine(temp.Path, "anchor.cs"));
+	}
+
+	[Theory]
+	[InlineData(GitFilteringMode.RespectGitIgnore)]
+	[InlineData(GitFilteringMode.TrackedFilesOnly)]
+	public async Task RepositoryBoundaries_DeclaredSubmodulesOwnRecursiveScopes(GitFilteringMode mode)
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile("anchor.cs", "anchor");
+		temp.CreateFile(".gitignore", "*.log\n");
+		temp.CreateFile(".gitmodules", "[submodule \"x\"]\n path = third_party/x\n url = ignored\n");
+		InitializeIndex(temp.Path, "anchor.cs", ".gitignore", ".gitmodules");
+		var submodule = temp.CreateDirectory("third_party/x");
+		temp.CreateFile("third_party/x/a.log", "visible");
+		temp.CreateFile("third_party/x/drop.secret", "hidden");
+		temp.CreateFile("third_party/x/.gitignore", "*.secret\n");
+		temp.CreateFile("third_party/x/.gitmodules", "[submodule \"nested\"]\n path = nested\n");
+		InitializeIndex(submodule, "a.log", ".gitignore", ".gitmodules");
+		var nested = temp.CreateDirectory("third_party/x/nested");
+		temp.CreateFile("third_party/x/nested/nested.secret", "visible");
+		InitializeIndex(nested, "nested.secret");
+
+		var plan = await BuildBoundaryPlan(temp.Path, mode);
+		Assert.Contains(plan.IncludedFiles, path => path.EndsWith("a.log", StringComparison.Ordinal));
+		Assert.Contains(plan.IncludedFiles, path => path.EndsWith("nested.secret", StringComparison.Ordinal));
+		Assert.DoesNotContain(plan.IncludedFiles, path => path.EndsWith("drop.secret", StringComparison.Ordinal));
+	}
+
+	[Theory]
+	[InlineData(GitFilteringMode.RespectGitIgnore)]
+	[InlineData(GitFilteringMode.TrackedFilesOnly)]
+	public async Task RepositoryBoundaries_WorkspaceOwnsIndependentRepositories(GitFilteringMode mode)
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		foreach (var name in new[] { "A", "B", "A/vendor/x" })
+		{
+			var repository = temp.CreateDirectory(name);
+			temp.CreateFile(name + "/source.cs", "source");
+			InitializeIndex(repository, "source.cs");
+		}
+		var plan = await BuildBoundaryPlan(temp.Path, mode);
+		Assert.Equal(2, plan.IncludedFiles.Count);
+		Assert.DoesNotContain(plan.IncludedFiles, path => path.Contains("vendor", StringComparison.Ordinal));
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task RepositoryBoundaries_InfoExcludeAppliesAtOrdinaryAndWorktreeRoots(bool worktree)
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		var repository = temp.CreateDirectory("repository");
+		temp.CreateFile("repository/anchor.cs", "anchor");
+		InitializeIndex(repository, "anchor.cs");
+		RunGit(repository, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "Initial");
+		var root = repository;
+		if (worktree)
+		{
+			root = Path.Combine(temp.Path, "worktree");
+			RunGit(repository, "worktree", "add", "--detach", root);
+		}
+		temp.CreateFile("repository/.git/info/exclude", "notes/\n*.local\n");
+		Directory.CreateDirectory(Path.Combine(root, "notes"));
+		File.WriteAllText(Path.Combine(root, "notes", "hidden.md"), "hidden");
+		File.WriteAllText(Path.Combine(root, "notes", "keep.md"), "visible");
+		File.WriteAllText(Path.Combine(root, "visible.local"), "visible");
+		File.WriteAllText(Path.Combine(root, ".gitignore"), "!visible.local\n!notes/keep.md\n");
+		var plan = await BuildBoundaryPlan(root, GitFilteringMode.RespectGitIgnore);
+		Assert.DoesNotContain(plan.IncludedFiles, path => path.EndsWith("hidden.md", StringComparison.Ordinal));
+		Assert.Contains(plan.IncludedFiles, path => path.EndsWith("visible.local", StringComparison.Ordinal));
+		Assert.Contains(plan.IncludedFiles, path => path.EndsWith("keep.md", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task RepositoryBoundaries_DeclaredUninitializedSubmoduleIsAnOrdinaryEmptyDirectory()
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile(".gitmodules", "[submodule \"empty\"]\n path = empty\n");
+		temp.CreateDirectory("empty");
+		InitializeIndex(temp.Path, ".gitmodules");
+		var plan = await BuildBoundaryPlan(temp.Path, GitFilteringMode.RespectGitIgnore);
+		Assert.Contains(plan.EffectiveTree.Children, node => node.IsDirectory && Path.GetFileName(node.FullPath) == "empty");
+	}
+
+	[Fact]
+	public async Task RepositoryBoundaries_SubmoduleGitdirUsesItsOwnInfoExclude()
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile(".gitmodules", "[submodule \"x\"]\n path = third_party/x\n");
+		InitializeIndex(temp.Path, ".gitmodules");
+		var submodule = temp.CreateDirectory("third_party/x");
+		var metadata = Path.Combine(temp.Path, ".git", "modules", "x");
+		Directory.CreateDirectory(Path.GetDirectoryName(metadata)!);
+		RunGit(submodule, "init", "--quiet", "--separate-git-dir", metadata);
+		temp.CreateFile("third_party/x/visible.cs", "visible");
+		temp.CreateFile("third_party/x/hidden.local", "hidden");
+		File.WriteAllText(Path.Combine(metadata, "info", "exclude"), "*.local\n");
+		var plan = await BuildBoundaryPlan(temp.Path, GitFilteringMode.RespectGitIgnore);
+		Assert.Contains(plan.IncludedFiles, path => path.EndsWith("visible.cs", StringComparison.Ordinal));
+		Assert.DoesNotContain(plan.IncludedFiles, path => path.EndsWith("hidden.local", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void RepositoryBoundaries_EmbeddedDirectoryContributesOneGitIgnoreControllerImpact()
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile("anchor.cs", "anchor");
+		InitializeIndex(temp.Path, "anchor.cs");
+		var scanner = new FileSystemScanner();
+		var rules = new IgnoreRules(false, false, false, false, new HashSet<string>(), new HashSet<string>())
+		{
+			UseGitIgnore = true, EnableGitIgnoreTraversal = true, GitIgnoreCandidateMatchesActiveRules = true
+		};
+		var before = scanner.GetExtensionsWithIgnoreOptionCounts(temp.Path, rules, TestContext.Current.CancellationToken);
+		var embedded = temp.CreateDirectory("libs/SomeLib");
+		temp.CreateFile("libs/SomeLib/a.cs", "a");
+		temp.CreateFile("libs/SomeLib/deep/b.cs", "b");
+		InitializeIndex(embedded, "a.cs");
+		var after = scanner.GetExtensionsWithIgnoreOptionCounts(temp.Path, rules, TestContext.Current.CancellationToken);
+		Assert.Equal(before.Value.ControllerImpactCounts.GitIgnore + 1, after.Value.ControllerImpactCounts.GitIgnore);
+	}
+
+	[Theory]
+	[InlineData(GitFilteringMode.RespectGitIgnore)]
+	[InlineData(GitFilteringMode.TrackedFilesOnly)]
+	public async Task RepositoryBoundaries_InvalidManifestCannotAuthorizeNestedRepository(GitFilteringMode mode)
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile("anchor.cs", "anchor");
+		temp.CreateFile(".gitmodules", "[submodule \"bad\"]\n path = ../nested\n");
+		InitializeIndex(temp.Path, "anchor.cs");
+		var nested = temp.CreateDirectory("nested");
+		temp.CreateFile("nested/source.cs", "source");
+		InitializeIndex(nested, "source.cs");
+		var plan = await BuildBoundaryPlan(temp.Path, mode);
+		Assert.DoesNotContain(plan.IncludedFiles, path => path.EndsWith("source.cs", StringComparison.Ordinal));
+		Assert.Contains(plan.Diagnostics, diagnostic => diagnostic.Code == "DPX-PROJECT-PARTIAL-ACCESS");
+	}
+
+	private static Task<ProjectContextPlan> BuildBoundaryPlan(string root, GitFilteringMode mode)
+	{
+		var analysis = new ProjectAnalysisService(
+			new ScanOptionsUseCase(new FileSystemScanner()), ProjectLoadWorkflowRuntime.CreateBuildTreeUseCase(),
+			new FilterOptionSelectionService(), ProjectLoadWorkflowRuntime.CreateIgnoreOptionsService(),
+			ProjectLoadWorkflowRuntime.CreateIgnoreRulesService(), new TreeExportService(), new FileContentAnalyzer());
+		return new ProjectContextPlanner(analysis).BuildAsync(new ProjectContextRequest(root,
+			new ProjectSelectionSpec(GitMode: mode, Exclusions: [])), TestContext.Current.CancellationToken);
+	}
+}

--- a/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.RepositoryBoundaries.cs
+++ b/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.RepositoryBoundaries.cs
@@ -131,8 +131,10 @@ public sealed partial class DeepGitWorkspaceEvidenceIntegrationTests
 		Assert.DoesNotContain(plan.IncludedFiles, path => path.EndsWith("hidden.local", StringComparison.Ordinal));
 	}
 
-	[Fact]
-	public void RepositoryBoundaries_EmbeddedDirectoryContributesOneGitIgnoreControllerImpact()
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void RepositoryBoundaries_EmbeddedDirectoryContributesOneGitIgnoreControllerImpact(bool enabled)
 	{
 		EnsureGitAvailable();
 		using var temp = new TemporaryDirectory();
@@ -141,15 +143,23 @@ public sealed partial class DeepGitWorkspaceEvidenceIntegrationTests
 		var scanner = new FileSystemScanner();
 		var rules = new IgnoreRules(false, false, false, false, new HashSet<string>(), new HashSet<string>())
 		{
-			UseGitIgnore = true, EnableGitIgnoreTraversal = true, GitIgnoreCandidateMatchesActiveRules = true
+			UseGitIgnore = enabled, EnableGitIgnoreTraversal = enabled, GitIgnoreCandidateMatchesActiveRules = enabled
 		};
 		var before = scanner.GetExtensionsWithIgnoreOptionCounts(temp.Path, rules, TestContext.Current.CancellationToken);
+		var beforeBatch = scanner.GetIgnoreSectionSnapshot(temp.Path, rules, rules,
+			effectiveAllowedExtensions: null, TestContext.Current.CancellationToken);
 		var embedded = temp.CreateDirectory("libs/SomeLib");
 		temp.CreateFile("libs/SomeLib/a.cs", "a");
 		temp.CreateFile("libs/SomeLib/deep/b.cs", "b");
 		InitializeIndex(embedded, "a.cs");
 		var after = scanner.GetExtensionsWithIgnoreOptionCounts(temp.Path, rules, TestContext.Current.CancellationToken);
 		Assert.Equal(before.Value.ControllerImpactCounts.GitIgnore + 1, after.Value.ControllerImpactCounts.GitIgnore);
+		var afterBatch = scanner.GetIgnoreSectionSnapshot(temp.Path, rules, rules,
+			effectiveAllowedExtensions: null, TestContext.Current.CancellationToken);
+		Assert.Equal(beforeBatch.Value.ControllerImpactCounts.GitIgnore + 1, afterBatch.Value.ControllerImpactCounts.GitIgnore);
+		var selectedRoots = scanner.GetProjectWorkspaceSnapshotForRootSelection(temp.Path, ["libs"], rules, rules,
+			effectiveExtensionPolicy: null, cancellationToken: TestContext.Current.CancellationToken);
+		Assert.Equal(1, selectedRoots.Value.IgnoreSection.ControllerImpactCounts.GitIgnore);
 	}
 
 	[Theory]

--- a/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.RepositoryBoundaries.cs
+++ b/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.RepositoryBoundaries.cs
@@ -101,6 +101,30 @@ public sealed partial class DeepGitWorkspaceEvidenceIntegrationTests
 	}
 
 	[Fact]
+	public async Task RepositoryBoundaries_SharedWorktreeExcludesRemainRelativeToEachOwner()
+	{
+		EnsureGitAvailable();
+		using var temp = new TemporaryDirectory();
+		var repository = temp.CreateDirectory("repository");
+		temp.CreateFile("repository/anchor.cs", "anchor");
+		InitializeIndex(repository, "anchor.cs");
+		RunGit(repository, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "Initial");
+		var worktree = Path.Combine(temp.Path, "worktree");
+		RunGit(repository, "worktree", "add", "--detach", worktree);
+		temp.CreateFile("repository/.git/info/exclude", "*.local\n");
+		temp.CreateFile("repository/hidden.local", "hidden");
+		temp.CreateFile("worktree/hidden.local", "hidden");
+		temp.CreateFile("repository/.gitignore", ".gitignore\n");
+		temp.CreateFile("worktree/.gitignore", ".gitignore\n");
+		foreach (var root in new[] { repository, worktree, temp.Path, repository })
+		{
+			var plan = await BuildBoundaryPlan(root, GitFilteringMode.RespectGitIgnore);
+			Assert.Equal(root == temp.Path ? 2 : 1, plan.IncludedFiles.Count);
+			Assert.All(plan.IncludedFiles, path => Assert.EndsWith("anchor.cs", path));
+		}
+	}
+
+	[Fact]
 	public async Task RepositoryBoundaries_DeclaredUninitializedSubmoduleIsAnOrdinaryEmptyDirectory()
 	{
 		EnsureGitAvailable();

--- a/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DeepGitWorkspaceEvidenceIntegrationTests.cs
@@ -1,6 +1,6 @@
 namespace DevProjex.Tests.Integration;
 
-public sealed class DeepGitWorkspaceEvidenceIntegrationTests
+public sealed partial class DeepGitWorkspaceEvidenceIntegrationTests
 {
 	[Fact]
 	public void FullRefresh_DeepRealRepositorySwitchesGitModesWithoutChangingAvailability()

--- a/Tests/DevProjex.Tests.Integration/GitIgnoreSourceIoIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitIgnoreSourceIoIntegrationTests.cs
@@ -548,6 +548,61 @@ public sealed class GitIgnoreSourceIoIntegrationTests
 			static node => node.Name.Equals("visible.cs", StringComparison.Ordinal));
 	}
 
+	[Fact]
+	public async Task RepositoryInfoExcludeLockedSourceFailsClosedWithPartialAccessDiagnostic()
+	{
+		if (!OperatingSystem.IsWindows())
+			Assert.Skip("Exclusive sharing is a Windows filesystem contract.");
+		using var temp = new TemporaryDirectory();
+		EnsureGitAvailable(temp.Path);
+		Assert.Equal(0, RunGit(temp.Path, "init", "--quiet"));
+		temp.CreateFile("visible.cs", "visible");
+		using var lockedSource = new FileStream(Path.Combine(temp.Path, ".git", "info", "exclude"),
+			FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+		var plan = await new ProjectContextPlanner(CreateProjectAnalysisService()).BuildAsync(
+			new ProjectContextRequest(temp.Path, new ProjectSelectionSpec(
+				GitMode: GitFilteringMode.RespectGitIgnore, Exclusions: [])), TestContext.Current.CancellationToken);
+		Assert.Empty(plan.IncludedFiles);
+		Assert.Contains(plan.Diagnostics, diagnostic => diagnostic.Code == "DPX-PROJECT-PARTIAL-ACCESS");
+	}
+
+	[Fact]
+	public async Task RepositoryInfoExcludePermissionDeniedFailsClosedOnUnix()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			Assert.Skip("Unix permissions require a Unix filesystem.");
+			return;
+		}
+		using var temp = new TemporaryDirectory();
+		EnsureGitAvailable(temp.Path);
+		Assert.Equal(0, RunGit(temp.Path, "init", "--quiet"));
+		temp.CreateFile("visible.cs", "visible");
+		var source = Path.Combine(temp.Path, ".git", "info", "exclude");
+		var originalMode = File.GetUnixFileMode(source);
+		try
+		{
+			File.SetUnixFileMode(source, UnixFileMode.None);
+			try
+			{
+				using var readable = File.OpenRead(source);
+				Assert.Skip("This user can bypass Unix file permissions.");
+			}
+			catch (UnauthorizedAccessException)
+			{
+			}
+			var plan = await new ProjectContextPlanner(CreateProjectAnalysisService()).BuildAsync(
+				new ProjectContextRequest(temp.Path, new ProjectSelectionSpec(
+					GitMode: GitFilteringMode.RespectGitIgnore, Exclusions: [])), TestContext.Current.CancellationToken);
+			Assert.Empty(plan.IncludedFiles);
+			Assert.Contains(plan.Diagnostics, diagnostic => diagnostic.Code == "DPX-PROJECT-PARTIAL-ACCESS");
+		}
+		finally
+		{
+			File.SetUnixFileMode(source, originalMode);
+		}
+	}
+
 	private static ProjectAnalysisService CreateProjectAnalysisService() =>
 		new(
 			new ScanOptionsUseCase(new FileSystemScanner()),

--- a/Tests/DevProjex.Tests.Integration/GitIgnoreTrackedIndexIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitIgnoreTrackedIndexIntegrationTests.cs
@@ -295,8 +295,9 @@ public sealed class GitIgnoreTrackedIndexIntegrationTests
 			RootSet("nested"),
 			ExtensionSet(".tmp"));
 
-		Assert.Equal(2, observation.Inventory.DiscoveredGitTrackedPathIndexes.Count);
-		AssertVisible(observation.Paths, "nested/tracked.tmp");
+		// An undeclared embedded repository is opaque; its index is no longer read.
+		Assert.Single(observation.Inventory.DiscoveredGitTrackedPathIndexes);
+		AssertHidden(observation.Paths, "nested/tracked.tmp");
 		AssertHidden(observation.Paths, "nested/untracked.tmp");
 	}
 
@@ -353,9 +354,9 @@ public sealed class GitIgnoreTrackedIndexIntegrationTests
 			RootSet("submodule"),
 			ExtensionSet(".cs"));
 
-		Assert.Equal(2, observation.Inventory.DiscoveredGitTrackedPathIndexes.Count);
-		AssertVisible(observation.Paths, "submodule");
-		AssertVisible(observation.Paths, "submodule/tracked.cs");
+		// A gitlink without a .gitmodules declaration is an opaque embedded repository.
+		Assert.Single(observation.Inventory.DiscoveredGitTrackedPathIndexes);
+		AssertHidden(observation.Paths, "submodule/tracked.cs");
 	}
 
 	[Fact]
@@ -1454,13 +1455,14 @@ public sealed class GitIgnoreTrackedIndexIntegrationTests
 			ExtensionSet(".cs"),
 			rules);
 
-		AssertVisible(
+		// Depth does not make an undeclared embedded repository independent of its owner.
+		AssertHidden(
 			tree.Paths,
 			Path.Combine(repositoryRelativePath, "src", "tracked.cs").Replace('\\', '/'));
 		AssertHidden(
 			tree.Paths,
 			Path.Combine(repositoryRelativePath, "src", "untracked.cs").Replace('\\', '/'));
-		Assert.Equal(2, tree.Inventory.DiscoveredGitTrackedPathIndexes.Count);
+		Assert.Single(tree.Inventory.DiscoveredGitTrackedPathIndexes);
 	}
 
 	[Fact]
@@ -1544,10 +1546,9 @@ public sealed class GitIgnoreTrackedIndexIntegrationTests
 
 		AssertHidden(tree.Paths, "nested/previously-outer-tracked.txt");
 		AssertHidden(tree.Paths, "nested/local.txt");
-		var nestedBoundary = Assert.Single(
-			tree.Inventory.DiscoveredGitTrackedPathIndexes,
+		// The embedded boundary is retained as ignore evidence without reading its index.
+		Assert.DoesNotContain(tree.Inventory.DiscoveredGitTrackedPathIndexes,
 			index => PathComparer.Default.Equals(index.RepositoryRootPath, nestedRoot));
-		Assert.Equal(0, nestedBoundary.Count);
 	}
 
 	[Fact]
@@ -1560,6 +1561,8 @@ public sealed class GitIgnoreTrackedIndexIntegrationTests
 		InitializeIndex(outerRoot, "README.md");
 		var nestedRoot = temp.CreateDirectory("outer/nested");
 		temp.CreateFile("outer/nested/tracked.cs", "tracked in nested repository");
+		// Only a declared submodule may provide a nested index under an owning repository.
+		temp.CreateFile("outer/.gitmodules", "[submodule \"nested\"]\n path = nested\n");
 		InitializeIndex(nestedRoot, "tracked.cs");
 		File.WriteAllBytes(Path.Combine(outerRoot, ".git", "index"), [0x44, 0x50, 0x58]);
 		var rules = CreateTrackedOnlyRules(outerRoot);

--- a/Tests/DevProjex.Tests.Integration/GitIgnoreWithoutControlFileContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitIgnoreWithoutControlFileContractIntegrationTests.cs
@@ -38,9 +38,8 @@ public sealed class GitIgnoreWithoutControlFileContractIntegrationTests
 		{
 			".git-owned/keep.txt",
 			".github/workflows/build.yml",
-			"src/App.cs",
-			"src/nested/Feature.cs",
-			"worktree/Tracked.cs"
+			// Embedded repository boundaries now hide their files even without ignore patterns.
+			"src/App.cs"
 		};
 		AssertFileSet(expected, workspace.Path, analysis.Tree.Root, "analysis");
 		Assert.Equal(expected, Normalize(workspace.Path, context.IncludedFiles));

--- a/Tests/DevProjex.Tests.Integration/HierarchicalGitIgnoreAdversarialContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/HierarchicalGitIgnoreAdversarialContractIntegrationTests.cs
@@ -132,7 +132,8 @@ public sealed class HierarchicalGitIgnoreAdversarialContractIntegrationTests
 			nativeIgnored.SetEquals(applicationIgnored),
 			$"Native-only=[{string.Join(", ", nativeIgnored.Except(applicationIgnored))}]; " +
 			$"Application-only=[{string.Join(", ", applicationIgnored.Except(nativeIgnored))}]");
-		Assert.Equal(64, observation.ScopeCount);
+		// The repository boundary is retained even without a root .gitignore.
+		Assert.Equal(65, observation.ScopeCount);
 	}
 
 	[Fact]
@@ -162,7 +163,8 @@ public sealed class HierarchicalGitIgnoreAdversarialContractIntegrationTests
 			nativeIgnored.SetEquals(applicationIgnored),
 			$"Native-only=[{string.Join(", ", nativeIgnored.Except(applicationIgnored))}]; " +
 			$"Application-only=[{string.Join(", ", applicationIgnored.Except(nativeIgnored))}]");
-		Assert.Equal(15, observation.ScopeCount);
+		// The repository boundary is retained even without a root .gitignore.
+		Assert.Equal(16, observation.ScopeCount);
 	}
 
 	[Fact]
@@ -184,7 +186,8 @@ public sealed class HierarchicalGitIgnoreAdversarialContractIntegrationTests
 
 		Assert.Equal(1, observation.ScopeCount);
 		AssertHidden(observation, "repo/drop.tmp");
-		AssertVisible(observation, "repo/visible.local");
+		// Repository-local excludes now participate in the existing GitIgnore controller.
+		AssertHidden(observation, "repo/visible.local");
 		AssertVisible(observation, "repo/visible.txt");
 	}
 
@@ -219,7 +222,8 @@ public sealed class HierarchicalGitIgnoreAdversarialContractIntegrationTests
 			CreateTraversalRules());
 
 		Assert.Empty(nativeIgnored);
-		Assert.Equal(0, observation.ScopeCount);
+		// The skipped symbolic rule source does not remove the repository boundary.
+		Assert.Equal(1, observation.ScopeCount);
 		AssertVisible(observation, "repo/drop.tmp");
 	}
 

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -4788,6 +4788,8 @@ public sealed class McpServerIntegrationTests
 		var outer = workspace.CreateDirectory("outer");
 		File.WriteAllText(Path.Combine(outer, "Outer.txt"), "outer\n");
 		InitializeCommittedRepository(outer);
+		// Keep the explicit-path scope contract on a declared repository; embedded clones are now opaque.
+		File.WriteAllText(Path.Combine(outer, ".gitmodules"), "[submodule \"nested\"]\n path = nested\n");
 		var nested = workspace.CreateDirectory("outer/nested");
 		File.WriteAllText(Path.Combine(nested, "App.cs"), "v1\n");
 		InitializeCommittedRepository(nested);

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -3398,12 +3398,24 @@ public sealed class McpServerIntegrationTests
 		foreach (var testCase in cases)
 		{
 			var progress = new InlineProgress<ProgressNotificationValue>();
+			var progressToken = new ProgressToken(Guid.NewGuid().ToString("N"));
+			// SDK notification dispatch may finish after the response. Keep the handler alive
+			// through observation instead of letting CallToolAsync dispose it with the request.
+			await using var registration = server.Client.RegisterNotificationHandler(
+				NotificationMethods.ProgressNotification,
+				(notification, _) =>
+				{
+					if (notification.Params?.Deserialize<ProgressNotificationParams>() is { } value &&
+					    value.ProgressToken == progressToken)
+						progress.Report(value.Progress);
+					return ValueTask.CompletedTask;
+				});
 			var firstMessage = server.WireMessageCount;
 			var firstInputMessage = server.InputWireMessageCount;
 			var callTask = server.CallAsync(
 				testCase.ToolName,
 				testCase.Arguments,
-				progress);
+				options: new RequestOptions { ProgressToken = progressToken });
 			await progress.WaitForValueAsync(TestContext.Current.CancellationToken);
 			var result = await callTask;
 

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RepositoryBoundaries.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RepositoryBoundaries.cs
@@ -6,6 +6,69 @@ namespace DevProjex.Tests.Terminal;
 
 public sealed partial class McpServerProcessTests
 {
+	[Fact]
+	public async Task RealProcessDevProjexRepositoryFileCountsMatchGitAcrossCliAndMcp()
+	{
+		if (!await IsGitAvailableAsync())
+			Assert.Skip("Git is not available.");
+		var repository = PublishedApplicationLocator.FindRepositoryRoot();
+		using var state = new TemporaryDirectory();
+		var git = CreateBoundaryProcess(repository, state.CreateDirectory("git-state"));
+		git.FileName = "git";
+		foreach (var argument in new[] { "ls-files", "--cached", "--others", "--exclude-standard", "-z" })
+			git.ArgumentList.Add(argument);
+		var expected = (await ReadBoundaryProcessOutput(git)).Split('\0', StringSplitOptions.RemoveEmptyEntries);
+		Assert.NotEmpty(expected);
+		Assert.DoesNotContain(expected, path => path.StartsWith(".claude/worktrees/", StringComparison.Ordinal));
+
+		var cli = CreateBoundaryProcess(repository, state.CreateDirectory("cli-state"));
+		foreach (var argument in new[] { "analyze", repository, "--git-mode", "gitignore",
+		         "--exclude", "smart-ignore", "--exclude", "empty-folders", "--format", "json" })
+			cli.ArgumentList.Add(argument);
+		using var report = JsonDocument.Parse(await ReadBoundaryProcessOutput(cli));
+		Assert.Equal(expected.Length, report.RootElement.GetProperty("inventory").GetProperty("files").GetInt32());
+
+		var server = CreateBoundaryProcess(repository, state.CreateDirectory("mcp-state"));
+		foreach (var argument in new[] { "mcp", "--root", repository })
+			server.ArgumentList.Add(argument);
+		using var process = Process.Start(server) ?? throw new InvalidOperationException("MCP did not start.");
+		var errors = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+		timeout.CancelAfter(TimeSpan.FromMinutes(2));
+		await using (var client = await McpClient.CreateAsync(new StreamClientTransport(
+			process.StandardInput.BaseStream, process.StandardOutput.BaseStream),
+			clientOptions: null, loggerFactory: null, timeout.Token))
+		{
+			var response = await client.CallToolAsync("analyze", new Dictionary<string, object?>(),
+				progress: null, options: null, timeout.Token);
+			Assert.NotEqual(true, response.IsError);
+			Assert.Equal(expected.Length, response.StructuredContent!.Value.GetProperty("files").GetInt32());
+		}
+		process.StandardInput.Close();
+		await process.WaitForExitAsync(timeout.Token);
+		Assert.True(process.ExitCode == 0, await errors);
+	}
+
+	private static async Task<string> ReadBoundaryProcessOutput(ProcessStartInfo start)
+	{
+		using var process = Process.Start(start) ?? throw new InvalidOperationException("Process did not start.");
+		try
+		{
+			process.StandardInput.Close();
+			var output = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+			var errors = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+			await process.WaitForExitAsync(TestContext.Current.CancellationToken)
+				.WaitAsync(TimeSpan.FromMinutes(2), TestContext.Current.CancellationToken);
+			Assert.True(process.ExitCode == 0, await errors);
+			return await output;
+		}
+		finally
+		{
+			if (!process.HasExited)
+				process.Kill(entireProcessTree: true);
+		}
+	}
+
 	[Theory]
 	[InlineData("gitignore", false, false)]
 	[InlineData("tracked", false, false)]

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RepositoryBoundaries.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RepositoryBoundaries.cs
@@ -25,6 +25,11 @@ public sealed partial class McpServerProcessTests
 		workspace.WriteFile("project/libs/SomeLib/Embedded.cs", "embedded");
 		RunGit(embedded, "init", "--quiet");
 		RunGit(embedded, "add", "Embedded.cs");
+		workspace.WriteFile("project/libs/SomeLib/.gitmodules", "[submodule \"nested\"]\n path = nested\n");
+		var nested = workspace.CreateDirectory("project/libs/SomeLib/nested");
+		workspace.WriteFile("project/libs/SomeLib/nested/DeepEmbedded.cs", "deep embedded");
+		RunGit(nested, "init", "--quiet");
+		RunGit(nested, "add", "DeepEmbedded.cs");
 		workspace.WriteFile("project/.git/info/exclude", "local/\n");
 		workspace.WriteFile("project/local/Excluded.cs", "excluded");
 
@@ -42,6 +47,7 @@ public sealed partial class McpServerProcessTests
 			var output = await outputTask;
 			Assert.True(process.ExitCode == 0, await errorTask);
 			Assert.Equal(embeddedVisible, output.Contains("Embedded.cs", StringComparison.Ordinal));
+			Assert.Equal(embeddedVisible, output.Contains("DeepEmbedded.cs", StringComparison.Ordinal));
 			Assert.Contains("Anchor.cs", output, StringComparison.Ordinal);
 		}
 
@@ -72,6 +78,7 @@ public sealed partial class McpServerProcessTests
 			Assert.NotEqual(true, response.IsError);
 			var output = string.Join("\n", response.Content.OfType<TextContentBlock>().Select(block => block.Text));
 			Assert.Equal(embeddedVisible, output.Contains("Embedded.cs", StringComparison.Ordinal));
+			Assert.Equal(embeddedVisible, output.Contains("DeepEmbedded.cs", StringComparison.Ordinal));
 			Assert.Contains("Anchor.cs", output, StringComparison.Ordinal);
 			Assert.Contains("[Effective filters]", output, StringComparison.Ordinal);
 			Assert.Equal(mode is "none" or "unrestricted" && !changes,

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RepositoryBoundaries.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RepositoryBoundaries.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	[Theory]
+	[InlineData("gitignore", false, false)]
+	[InlineData("tracked", false, false)]
+	[InlineData("none", true, false)]
+	[InlineData("unrestricted", true, false)]
+	[InlineData("unrestricted", false, true)]
+	public async Task RealProcessRepositoryBoundariesAgreeAcrossCliAndMcp(string mode, bool embeddedVisible, bool changes)
+	{
+		if (!await IsGitAvailableAsync())
+			Assert.Skip("Git is not available.");
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/Anchor.cs", "anchor");
+		RunGit(project, "init", "--quiet");
+		RunGit(project, "add", "Anchor.cs");
+		var embedded = workspace.CreateDirectory("project/libs/SomeLib");
+		workspace.WriteFile("project/libs/SomeLib/Embedded.cs", "embedded");
+		RunGit(embedded, "init", "--quiet");
+		RunGit(embedded, "add", "Embedded.cs");
+		workspace.WriteFile("project/.git/info/exclude", "local/\n");
+		workspace.WriteFile("project/local/Excluded.cs", "excluded");
+
+		var cli = CreateBoundaryProcess(project, workspace.CreateDirectory("cli-state"));
+		foreach (var argument in new[] { "tree", project, "--git-mode", changes ? "changes" : mode == "unrestricted" ? "none" : mode,
+		         "--exclude", "none", "--format", "text" })
+			cli.ArgumentList.Add(argument);
+		using (var process = Process.Start(cli) ?? throw new InvalidOperationException("CLI did not start."))
+		{
+			process.StandardInput.Close();
+			var outputTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+			var errorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+			await process.WaitForExitAsync(TestContext.Current.CancellationToken)
+				.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+			var output = await outputTask;
+			Assert.True(process.ExitCode == 0, await errorTask);
+			Assert.Equal(embeddedVisible, output.Contains("Embedded.cs", StringComparison.Ordinal));
+			Assert.Contains("Anchor.cs", output, StringComparison.Ordinal);
+		}
+
+		var server = CreateBoundaryProcess(project, workspace.CreateDirectory("mcp-state"));
+		foreach (var argument in new[] { "mcp", "--root", project })
+			server.ArgumentList.Add(argument);
+		if (mode == "unrestricted")
+			server.ArgumentList.Add("--unrestricted");
+		else
+		{
+			server.ArgumentList.Add("--git-mode");
+			server.ArgumentList.Add(mode);
+			server.ArgumentList.Add("--exclude");
+			server.ArgumentList.Add("none");
+		}
+		using var serverProcess = Process.Start(server) ?? throw new InvalidOperationException("MCP did not start.");
+		var serverErrors = serverProcess.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+		timeout.CancelAfter(TimeSpan.FromSeconds(60));
+		await using (var client = await McpClient.CreateAsync(new StreamClientTransport(
+			serverProcess.StandardInput.BaseStream, serverProcess.StandardOutput.BaseStream),
+			clientOptions: null, loggerFactory: null, timeout.Token))
+		{
+			var arguments = new Dictionary<string, object?> { ["format"] = "text" };
+			if (changes)
+				arguments["git_scope"] = "changes";
+			var response = await client.CallToolAsync("get_tree", arguments, progress: null, options: null, timeout.Token);
+			Assert.NotEqual(true, response.IsError);
+			var output = string.Join("\n", response.Content.OfType<TextContentBlock>().Select(block => block.Text));
+			Assert.Equal(embeddedVisible, output.Contains("Embedded.cs", StringComparison.Ordinal));
+			Assert.Contains("Anchor.cs", output, StringComparison.Ordinal);
+			Assert.Contains("[Effective filters]", output, StringComparison.Ordinal);
+			Assert.Equal(mode is "none" or "unrestricted" && !changes,
+				output.Contains("Excluded.cs", StringComparison.Ordinal));
+		}
+		serverProcess.StandardInput.Close();
+		await serverProcess.WaitForExitAsync(timeout.Token);
+		Assert.True(serverProcess.ExitCode == 0, await serverErrors);
+	}
+
+	private static ProcessStartInfo CreateBoundaryProcess(string project, string stateRoot)
+	{
+		var start = new ProcessStartInfo(PublishedApplicationLocator.FindExecutable())
+		{
+			WorkingDirectory = project, UseShellExecute = false, CreateNoWindow = true,
+			RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true
+		};
+		start.Environment["DEVPROJEX_INTERNAL_DATA_ROOT"] = stateRoot;
+		return start;
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -8,7 +8,7 @@ using ModelContextProtocol.Protocol;
 
 namespace DevProjex.Tests.Terminal;
 
-public sealed class McpServerProcessTests
+public sealed partial class McpServerProcessTests
 {
 	private static readonly string[] ExpectedTools =
 	[

--- a/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Xml.Linq;
 using DevProjex.Application.Preview;
 using DevProjex.Infrastructure.Git;
+using DevProjex.Infrastructure.Processes;
 
 namespace DevProjex.Tests.Terminal;
 
@@ -1512,8 +1513,8 @@ public sealed class TerminalWorkspaceContractTests
 				new TerminalOutputOptions { Progress = TerminalProgressMode.Never })
 			.ResolveAsync(repositoryUrl, "main", TestContext.Current.CancellationToken);
 		var checkout = resolvedSource.ProjectPath;
-		var headBefore = ReadGit(checkout, "rev-parse", "HEAD");
-		var statusBefore = ReadGit(checkout, "status", "--porcelain=v1");
+		var headBefore = await ReadGit(checkout, "rev-parse", "HEAD");
+		var statusBefore = await ReadGit(checkout, "status", "--porcelain=v1");
 		var contentBefore = File.ReadAllBytes(Path.Combine(checkout, "Last.txt"));
 		var controller = new TerminalWorkspaceController(services, new TestTerminalEnvironment());
 		using var state = await controller.OpenAsync(
@@ -1536,8 +1537,8 @@ public sealed class TerminalWorkspaceContractTests
 
 		Assert.False(result.Plan.HasErrors);
 		Assert.Equal("Last.txt", Path.GetFileName(Assert.Single(result.Plan.IncludedFiles)));
-		Assert.Equal(headBefore, ReadGit(checkout, "rev-parse", "HEAD"));
-		Assert.Equal(statusBefore, ReadGit(checkout, "status", "--porcelain=v1"));
+		Assert.Equal(headBefore, await ReadGit(checkout, "rev-parse", "HEAD"));
+		Assert.Equal(statusBefore, await ReadGit(checkout, "status", "--porcelain=v1"));
 		Assert.Equal(contentBefore, File.ReadAllBytes(Path.Combine(checkout, "Last.txt")));
 		var diffResolver = new GitRemoteDiffRangeResolver();
 		var repeated = await Task.WhenAll(
@@ -1778,7 +1779,7 @@ public sealed class TerminalWorkspaceContractTests
 		}
 	}
 
-	private static string ReadGit(string workingDirectory, params string[] arguments)
+	private static async Task<string> ReadGit(string workingDirectory, params string[] arguments)
 	{
 		var startInfo = new ProcessStartInfo("git")
 		{
@@ -1791,9 +1792,14 @@ public sealed class TerminalWorkspaceContractTests
 		foreach (var argument in arguments)
 			startInfo.ArgumentList.Add(argument);
 		using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start git.");
-		var output = process.StandardOutput.ReadToEnd();
-		var error = process.StandardError.ReadToEnd();
-		Assert.True(process.WaitForExit(10_000));
+		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+		timeout.CancelAfter(TimeSpan.FromSeconds(10));
+		// Drain both pipes without blocking the process-exit continuation that invoked the test.
+		var outputTask = process.StandardOutput.ReadToEndAsync(timeout.Token);
+		var errorTask = process.StandardError.ReadToEndAsync(timeout.Token);
+		await ExternalProcessLifetime.WaitForExitOrTerminateAsync(process, timeout.Token);
+		var output = await outputTask.WaitAsync(timeout.Token);
+		var error = await errorTask.WaitAsync(timeout.Token);
 		Assert.True(process.ExitCode == 0, error);
 		return output.Trim();
 	}

--- a/Tests/DevProjex.Tests.UI/MainWindowIgnoreOptionsUiTests.cs
+++ b/Tests/DevProjex.Tests.UI/MainWindowIgnoreOptionsUiTests.cs
@@ -2607,10 +2607,43 @@ public sealed class MainWindowIgnoreOptionsUiTests
 	}
 
     [AvaloniaFact]
+    public async Task RepositoryBoundaries_GitIgnoreControllerCountsEmbeddedDirectoryAndNoneRestoresItsFiles()
+    {
+        EnsureGitAvailable();
+        using var project = UiTestProject.CreateDefault();
+        RunGit(project.RootPath, "init", "--quiet");
+        var embedded = Path.Combine(project.RootPath, "libs", "SomeLib");
+        Directory.CreateDirectory(embedded);
+        File.WriteAllText(Path.Combine(embedded, "Embedded.cs"), "class Embedded {}\n");
+        RunGit(embedded, "init", "--quiet");
+        var window = await UiTestDriver.CreateLoadedMainWindowAsync(project);
+        try
+        {
+            await UiTestDriver.WaitForIgnoreOptionStateAsync(window, IgnoreOptionId.UseGitIgnore, visible: true, isChecked: true);
+            await WaitForProjectTreePathStateAsync(window, false, "libs", "SomeLib", "Embedded.cs");
+            var coordinator = typeof(MainWindow).GetField("_selectionCoordinator",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(window)!;
+            var counts = (IgnoreControllerImpactCounts)coordinator.GetType().GetField("_ignoreControllerImpactCounts",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(coordinator)!;
+            Assert.True(counts.GitIgnore >= 1);
+            await UiTestDriver.SelectGitFilteringModeAsync(window, GitFilteringMode.None);
+            await ApplySettingsAndWaitForIgnoreRefreshAsync(window);
+            await WaitForProjectTreePathStateAsync(window, true, "libs", "SomeLib", "Embedded.cs");
+        }
+        finally
+        {
+            await UiTestDriver.CloseWindowAsync(window);
+        }
+    }
+
+    [AvaloniaFact]
     public async Task SwitchingToTrackedOnlyRescansGitIgnoredContainerForNestedRepository()
     {
         EnsureGitAvailable();
         using var project = UiTestProject.CreateWithIgnoredNestedGitRepositoryWorkspace();
+        // Only declared submodules contribute nested indexes inside an owning repository.
+        File.WriteAllText(Path.Combine(project.RootPath, ".gitmodules"),
+            "[submodule \"nested\"]\n path = ignored-container/nested\n");
         RunGit(project.RootPath, "init", "--quiet");
         RunGit(
             project.RootPath,

--- a/Tests/DevProjex.Tests.Unit/GitIgnoreMatcherLoadSessionTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitIgnoreMatcherLoadSessionTests.cs
@@ -6,6 +6,39 @@ namespace DevProjex.Tests.Unit;
 public sealed class GitIgnoreMatcherLoadSessionTests
 {
 	[Fact]
+	public void SubmoduleDeclarationsAreStableWithinOneScanAndRevalidatedByTheNext()
+	{
+		using var temp = new TemporaryDirectory();
+		var first = Path.Combine(temp.Path, "first");
+		var second = Path.Combine(temp.Path, "second");
+		Directory.CreateDirectory(Path.Combine(first, ".git"));
+		Directory.CreateDirectory(Path.Combine(second, ".git"));
+		var manifest = temp.CreateFile(".gitmodules", "[submodule \"one\"]\n path = first\n[submodule \"two\"]\n path = second\n");
+		var session = new GitIgnoreMatcherLoadSession();
+		var firstResult = session.LoadScope(first, null, Path.Combine(first, ".git"), temp.Path, TestContext.Current.CancellationToken);
+		Assert.False(firstResult.Matcher!.IsOpaqueRepository);
+		File.WriteAllText(manifest, "");
+		var cached = session.LoadScope(second, null, Path.Combine(second, ".git"), temp.Path, TestContext.Current.CancellationToken);
+		Assert.False(cached.Matcher!.IsOpaqueRepository);
+		var refreshed = new GitIgnoreMatcherLoadSession().LoadScope(second, null, Path.Combine(second, ".git"), temp.Path,
+			TestContext.Current.CancellationToken);
+		Assert.True(refreshed.Matcher!.IsOpaqueRepository);
+	}
+
+	[Theory]
+	[InlineData("../outside")]
+	[InlineData("/outside")]
+	[InlineData("a//b")]
+	[InlineData("a/./b")]
+	[InlineData("C:/outside")]
+	public void UnsafeSubmodulePathsFailClosed(string path)
+	{
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile(".gitmodules", $"[submodule \"nested\"]\n path = {path}\n");
+		Assert.True(GitSubmoduleManifest.Read(temp.Path, TestContext.Current.CancellationToken).ReadFailed);
+	}
+
+	[Fact]
 	public async Task Load_ConcurrentRequestsForOneSource_ExecutesLoaderOnce()
 	{
 		using var loaderEntered = new ManualResetEventSlim();

--- a/Tests/DevProjex.Tests.Unit/GitIgnoreMatcherLoadSessionTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitIgnoreMatcherLoadSessionTests.cs
@@ -38,6 +38,19 @@ public sealed class GitIgnoreMatcherLoadSessionTests
 		Assert.True(GitSubmoduleManifest.Read(temp.Path, TestContext.Current.CancellationToken).ReadFailed);
 	}
 
+	[Theory]
+	[InlineData("[submodule\t\"name]\"]", "\" nested \"", " nested ")]
+	[InlineData("[submodule \"name\"] # comment ]", "libs/x # comment", "libs/x")]
+	[InlineData("[submodule \"name\"]", "\"libs/#x\"", "libs/#x")]
+	public void SubmoduleDeclarationsPreserveQuotedPathsAndSectionNames(string section, string value, string expected)
+	{
+		using var temp = new TemporaryDirectory();
+		temp.CreateFile(".gitmodules", $"{section}\n path = {value}\n url = ignored\n branch = ignored\n");
+		var manifest = GitSubmoduleManifest.Read(temp.Path, TestContext.Current.CancellationToken);
+		Assert.False(manifest.ReadFailed);
+		Assert.Equal(expected, Assert.Single(manifest.Paths));
+	}
+
 	[Fact]
 	public async Task Load_ConcurrentRequestsForOneSource_ExecutesLoaderOnce()
 	{


### PR DESCRIPTION
The existing GitIgnore view recursively exposed embedded repositories and ignored repository-local `info/exclude`. Comparing the old and new real MCP processes on the same current checkout gives 14,950 versus 2,139 files. The new real CLI returns exactly the same 2,139 paths as `git ls-files --cached --others --exclude-standard`: zero missing/extra paths and zero `.claude/worktrees` files.

**Behavior**
- The nearest repository at or above the scan root owns its subtree. In a folder of projects, the first boundary reached in each subtree becomes an independent owner.
- Embedded repositories are opaque in `gitignore` and `tracked`, contribute one directory to the existing GitIgnore controller impact, and never contribute a nested index. Empty-node visibility remains controlled by `empty-folders`.
- Initialized submodules declared in their owner's `.gitmodules` have independent, recursive rule scopes. A gitlink without a declaration is embedded; an uninitialized declaration is an ordinary directory.
- Repository-local `info/exclude` precedes the root `.gitignore`. Existing gitdir/commondir resolution handles ordinary repositories, worktrees, and submodules. A root negation can override local excludes.

**Security posture**
- Rule and declaration discovery uses bounded filesystem reads, with per-scan single-flight caching. It adds no Git process implementation; existing index and momentary-state readers retain their responsibilities.
- Unreadable rules fail closed through existing partial-access diagnostics. Invalid submodule paths cannot authorize traversal. Administrative `.git` exclusion, reparse policy, and Windows control aliases remain intact.
- No application surface, public flag, exclusion token, diagnostic code, localization key, or MCP schema changes. The effective-filter footer and mandatory MCP redaction remain in place.

**Behavior change and recovery**
This intentionally narrows v5.2 `gitignore` and `tracked` visibility at embedded repositories and enables local excludes in `gitignore`. Use `--git-mode none` to inspect embedded files; MCP `--unrestricted` also disables ordinary exclusions. Global `core.excludesFile` remains outside the contract.

**Validation**
- Release host and dependencies build with `-warnaserror`: zero warnings/errors.
- Targeted unit tests: 1,083 passed, six platform skips, with opt-in matcher performance checks enabled.
- Targeted filtering integration tests: 532 passed, 30 platform/opt-in skips.
- MCP/documentation process tests: 41 passed, including the actual-checkout test comparing real published CLI/MCP counts with Git. The six repository-boundary tests exercised the self-contained single-file executable.
- Targeted headless GUI Git tests: 75 passed, including embedded controller impact/restoration and declared nested-index switching.
- CI feedback: preserved the disabled raw-inventory path, updated two fixtures tied specifically to the old cross-boundary behavior, and reran 137 targeted MCP/cross-surface/inventory checks plus four inventory-failure tests successfully. The isolated Windows remote-workspace test also passed after its CI fixture failed at the initial Git commit, before product execution.
- The MCP progress-test timeout reproduced on Linux with one logical processor. Its notification subscription now remains alive through observation instead of ending with the SDK request; all ordering, token, phase, and callback assertions remain unchanged. Ten separate single-processor Linux runs and the Windows regression checks passed. No server or protocol change was made.
- The Windows Terminal hang dump identified synchronous `ReadToEnd` in the remote-workspace test helper, before its nominal timeout. Both pipes now drain asynchronously under the same ten-second deadline, with bounded process termination; the checkout/content assertions and product code are unchanged.
- Real Git fixtures cover embedded clones/worktrees, independent workspace repositories, recursive declarations, submodule gitdir, shared commondir excludes across multiple owners, precedence, invalid manifests, and unchanged `none` visibility. Source-I/O tests cover Windows sharing denial and Unix permissions. Legacy, batch, selected-root, and GUI counts cover opaque-directory attribution, including disabled filters.
- The repository MCP measurement retains the existing oversized-SVG inspection warning; selected file counts are unaffected.
- Full local suites were not run; cross-platform CI is the final gate.

**Final checks (`b3d7fddf`)**
- [.NET CI](https://github.com/Avazbek22/DevProjex/actions/runs/33976478473): successful on Windows, Linux, and macOS, including the scanner and command matrices.
- [Release Validation](https://github.com/Avazbek22/DevProjex/actions/runs/33976482020): successful for all six publish targets and the release gate.
- One Linux Terminal attempt did not find `Outer.txt` during the existing structural-refresh test setup. It did not reproduce in an isolated Linux run, five single-processor repetitions, or all 62 tests in that class. The same-commit CI job retry passed without changing code or assertions; its underlying cause remains unconfirmed.
