### PR TITLE
feat(release): add local channel selection and fail-closed artifact gates

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -29,7 +29,7 @@ jobs:
       run_release: ${{ steps.plan.outputs.run_release }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Validate release metadata and Store alias contract
         shell: pwsh
@@ -101,10 +101,10 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-publish-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -117,7 +117,7 @@ jobs:
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb zsh fish
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}
@@ -1678,10 +1678,10 @@ jobs:
     timeout-minutes: 35
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -1668,6 +1668,44 @@ jobs:
             --filter $filter `
             --logger "console;verbosity=minimal"
 
+  release-local-channel-gate:
+    name: Local Release Channel Gate (Windows)
+    needs:
+      - plan-release
+      - validate-release-config
+    if: ${{ needs.plan-release.outputs.run_release == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 35
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build and gate representative local release channels
+        shell: pwsh
+        run: |
+          ./Scripts/release-all.ps1 `
+            -Channels github `
+            -Rids win-x64,linux-x64 `
+            -SkipWack `
+            -NonInteractive
+          . ./Scripts/release-helpers.ps1
+          $version = (Get-DefaultReleaseVersionInfo -repoRoot (Resolve-Path '.').Path).DisplayVersion
+          ./Scripts/Test-ReleaseArtifacts.ps1 `
+            -PublishRoot publish `
+            -Version $version `
+            -Channels github `
+            -Rids win-x64,linux-x64
+          ./Scripts/Test-ReleaseArtifactGateMutation.ps1 `
+            -PublishRoot publish `
+            -Version $version `
+            -Channels github `
+            -Rids win-x64,linux-x64
+
   release-gate:
     name: Release Gate
     needs:
@@ -1675,6 +1713,7 @@ jobs:
       - validate-release-config
       - prepare-publish-matrix
       - publish-smoke
+      - release-local-channel-gate
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1687,12 +1726,14 @@ jobs:
           CONFIG_RESULT: ${{ needs.validate-release-config.result }}
           MATRIX_RESULT: ${{ needs.prepare-publish-matrix.result }}
           PUBLISH_RESULT: ${{ needs.publish-smoke.result }}
+          LOCAL_CHANNEL_RESULT: ${{ needs.release-local-channel-gate.result }}
         run: |
           $results = @{
             plan = $env:PLAN_RESULT
             config = $env:CONFIG_RESULT
             matrix = $env:MATRIX_RESULT
             publish = $env:PUBLISH_RESULT
+            local_channel = $env:LOCAL_CHANNEL_RESULT
           }
           $failed = @($results.GetEnumerator() | Where-Object { $_.Value -notin @('success', 'skipped') })
           if ($failed.Count -gt 0) {

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -45,4 +45,49 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="DevProjexWriteSingleFilePayloadReceipt"
+          AfterTargets="GenerateSingleFileBundle"
+          Condition="'$(DevProjexGenerateReleasePayloadReceipt)'=='true' and
+                     '$(PublishSingleFile)'=='true' and
+                     '$(RuntimeIdentifier)'!='' and
+                     '$(DevProjexPayloadReceiptDirectory)'!=''">
+    <ItemGroup>
+      <_DevProjexPayloadReceiptFile Include="@(FilesToBundle)"
+        Condition="'%(RelativePath)'!='$(PublishedSingleFileName)'" />
+      <_DevProjexPayloadReceiptFile Remove="@(_FilesExcludedFromBundle)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_DevProjexPayloadItemsPath>$(IntermediateOutputPath)publish-payload.$(RuntimeIdentifier).items</_DevProjexPayloadItemsPath>
+      <_DevProjexPayloadReceiptPath>$(DevProjexPayloadReceiptDirectory)/publish-payload.$(RuntimeIdentifier).json</_DevProjexPayloadReceiptPath>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(_DevProjexPayloadItemsPath)"
+      Lines="@(_DevProjexPayloadReceiptFile->'%(FullPath)&#x9;%(RelativePath)')"
+      Overwrite="true" />
+    <Exec Command="pwsh -NoLogo -NoProfile -File &quot;$(MSBuildThisFileDirectory)Scripts/Write-PublishPayloadReceipt.ps1&quot; -Rid &quot;$(RuntimeIdentifier)&quot; -ItemsPath &quot;$(_DevProjexPayloadItemsPath)&quot; -OutputPath &quot;$(_DevProjexPayloadReceiptPath)&quot;" />
+  </Target>
+
+  <Target Name="DevProjexWriteStorePayloadReceipt"
+          AfterTargets="CopyFilesToPublishDirectory"
+          Condition="'$(DevProjexGenerateReleasePayloadReceipt)'=='true' and
+                     '$(PublishSingleFile)'!='true' and
+                     '$(RuntimeIdentifier)'!='' and
+                     '$(DevProjexPayloadReceiptDirectory)'!='' and
+                     '$(Configuration)'=='ReleaseStore'">
+    <ItemGroup>
+      <!-- Desktop Bridge puts PDBs in the symbol package, not in the application MSIX. -->
+      <_DevProjexPayloadReceiptFile Include="@(ResolvedFileToPublish)"
+        Condition="'%(Extension)'!='.pdb'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_DevProjexPayloadItemsPath>$(IntermediateOutputPath)publish-payload.$(RuntimeIdentifier).items</_DevProjexPayloadItemsPath>
+      <_DevProjexPayloadReceiptPath>$(DevProjexPayloadReceiptDirectory)/publish-payload.$(RuntimeIdentifier).json</_DevProjexPayloadReceiptPath>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(_DevProjexPayloadItemsPath)"
+      Lines="@(_DevProjexPayloadReceiptFile->'%(FullPath)&#x9;%(RelativePath)')"
+      Overwrite="true" />
+    <Exec Command="pwsh -NoLogo -NoProfile -File &quot;$(MSBuildThisFileDirectory)Scripts/Write-PublishPayloadReceipt.ps1&quot; -Rid &quot;$(RuntimeIdentifier)&quot; -ItemsPath &quot;$(_DevProjexPayloadItemsPath)&quot; -OutputPath &quot;$(_DevProjexPayloadReceiptPath)&quot;" />
+  </Target>
+
 </Project>

--- a/Docs/Release-Process.md
+++ b/Docs/Release-Process.md
@@ -22,10 +22,13 @@ are copied back to:
 - `publish/github/v<version>`;
 - `publish/store/v<version>`.
 
-`Packaging/Headless/payload-manifest.json` is the common payload contract for
-desktop, Store, NuGet, and npm artifacts. It defines the six RIDs and executable
-names, all native grammar resources, all embedded localization names, the Store
-execution alias, Store architectures, and Store resource languages.
+`Packaging/Headless/payload-manifest.json` keeps the cross-channel facts that are
+independent of one build: the six RIDs, executable and grammar naming, and Store
+alias, architectures, and resource languages. Every local build additionally
+emits `publish-payload.<rid>.json`. This build receipt is the authoritative list
+of publish files for that RID; each entry records its path, size, SHA-256, and,
+for a managed assembly, its complete embedded-resource name table. The receipt
+is covered by `SHA256SUMS.txt` and travels beside the release artifacts.
 
 ## Operator commands
 
@@ -44,7 +47,8 @@ PowerShell console:
 ```
 
 Build one GitHub RID for debugging. This is intentionally marked `PARTIAL`, its
-checksum manifest lists only the selected artifact, and it is not release-ready:
+checksum manifest lists only the selected artifact and its RID receipt, and it
+is not release-ready:
 
 ```powershell
 ./Scripts/release-all.ps1 -Channels github -Rids win-x64 -SkipWack -NonInteractive
@@ -99,15 +103,26 @@ must not be attached to a release.
 
 The static gate checks, without running foreign-RID binaries:
 
-- the exact selected GitHub artifact set and every SHA-256;
+- the exact selected GitHub artifact/receipt set and every SHA-256;
 - Windows file/product versions, Linux and macOS version evidence, archive layout,
   and executable mode bits;
-- every grammar and localization name inside each uncompressed single-file bundle;
+- the .NET single-file manifest against the RID receipt in both directions,
+  including every file path, size, SHA-256, and every managed assembly resource;
+  any compressed bundle entry fails validation;
 - macOS `Info.plist` version and application layout;
 - Store upload, bundle, x64/arm64 application packages, package/bundle versions,
-  execution alias, exact grammar set, and all Store resource languages. The
-  Store directory must contain exactly the versioned `.msixupload`, x64|arm64
-  `.msixbundle`, and x64 `.msix` emitted by the existing packaging layout.
+  execution alias, exact application payload from both RID receipts, and all
+  Store resource languages. The Store directory must contain exactly the
+  versioned `.msixupload`, x64|arm64 `.msixbundle`, x64 `.msix`, and the two
+  Windows RID receipts emitted by the existing packaging layout.
+
+Store compares every application-package file and managed resource in both
+directions. The only channel-generated additions are `AppxManifest.xml`,
+`AppxBlockMap.xml`, `[Content_Types].xml`, `AppxSignature.p7x`, `resources.pri`,
+and `Assets/**`; this allowlist is centralized in the validator. Sizes and
+SHA-256 values are checked for archive/package entries. A missing or unexpected
+help file, ignore profile, icon-pack asset, compression language resource,
+gitleaks rule, notice, managed assembly, or native RID library fails identically.
 
 The host `win-x64` artifact also runs `--version`, `tree`, compressed and full
 `analyze`, the secret findings exit-code/redaction check, and the MCP initialize
@@ -122,7 +137,8 @@ and SHA-256, the status of each selected channel, and its output directory.
 
 A new distribution channel is not connected until all five conditions are met:
 
-1. Its required payload is represented in the shared manifest.
+1. Its stable metadata is represented in the shared manifest and its build emits
+   a complete content receipt from the channel's own publish inputs.
 2. A static completeness gate fails closed on missing or invalid content.
 3. A mutation gate proves the completeness gate rejects a damaged real artifact.
 4. A functional smoke exercises the artifact through its public entry point.

--- a/Docs/Release-Process.md
+++ b/Docs/Release-Process.md
@@ -1,0 +1,134 @@
+# Release process
+
+DevProjex has two local desktop release channels and three CI-owned channels.
+`Scripts/release-all.ps1` owns the GitHub desktop artifacts and Microsoft Store
+upload. AppImage is assembled only by the release workflow. NuGet and npm are
+built and published only by `.github/workflows/publish-packages.yml`; the local
+desktop script never publishes any channel.
+
+## Local channel model
+
+The default invocation selects both local channels:
+
+- `github`: six self-contained desktop artifacts for `win-x64`, `win-arm64`,
+  `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`;
+- `store`: one unsigned `.msixupload` whose bundle contains x64 and arm64
+  application packages and all Store resource languages, plus the generated
+  `.msixbundle` and x64 `.msix` companions used by local validation and WACK.
+
+The build still runs in an isolated temporary workspace. Only validated outputs
+are copied back to:
+
+- `publish/github/v<version>`;
+- `publish/store/v<version>`.
+
+`Packaging/Headless/payload-manifest.json` is the common payload contract for
+desktop, Store, NuGet, and npm artifacts. It defines the six RIDs and executable
+names, all native grammar resources, all embedded localization names, the Store
+execution alias, Store architectures, and Store resource languages.
+
+## Operator commands
+
+Run a complete local release from an elevated PowerShell console because the
+Store WACK phase requires administrator rights:
+
+```powershell
+./Scripts/release-all.ps1 -NonInteractive
+```
+
+Rebuild and validate only the Store channel, including WACK, from an elevated
+PowerShell console:
+
+```powershell
+./Scripts/release-all.ps1 -Channels store -NonInteractive
+```
+
+Build one GitHub RID for debugging. This is intentionally marked `PARTIAL`, its
+checksum manifest lists only the selected artifact, and it is not release-ready:
+
+```powershell
+./Scripts/release-all.ps1 -Channels github -Rids win-x64 -SkipWack -NonInteractive
+```
+
+`-GitHubArtifactsOnly` remains an alias for `-Channels github`:
+
+```powershell
+./Scripts/release-all.ps1 -Version 5.1 -GitHubArtifactsOnly
+```
+
+Build Store without WACK from a non-elevated console, then validate the existing
+upload with WACK from an elevated console:
+
+```powershell
+./Scripts/release-all.ps1 -Channels store -SkipWack -NonInteractive
+./Scripts/release-all.ps1 -Channels store -WackOnly -NonInteractive
+```
+
+Re-run the fail-closed static gate without building or invoking WACK:
+
+```powershell
+./Scripts/release-all.ps1 -ValidateArtifactsOnly -Channels github,store -NonInteractive
+```
+
+Validate only an existing partial GitHub RID set:
+
+```powershell
+./Scripts/release-all.ps1 -ValidateArtifactsOnly -Channels github -Rids win-x64 -NonInteractive
+```
+
+CI uses the same non-interactive channel selection and can invoke the standalone
+gate explicitly:
+
+```powershell
+./Scripts/release-all.ps1 -Channels github -Rids win-x64,linux-x64 -SkipWack -NonInteractive
+./Scripts/Test-ReleaseArtifacts.ps1 -PublishRoot publish -Version 5.1 -Channels github -Rids win-x64,linux-x64
+./Scripts/Test-ReleaseArtifactGateMutation.ps1 -PublishRoot publish -Version 5.1 -Channels github -Rids win-x64,linux-x64
+```
+
+When `-NonInteractive` is set, `Read-Host` is never called. An invalid explicit
+version or invalid channel/RID selection exits with code 1 and one diagnostic
+line. Without `-Version`, the version still comes from `Directory.Build.props`
+through `Scripts/release-helpers.ps1`.
+
+## Release readiness
+
+A complete GitHub channel must contain exactly the six named artifacts and a
+matching `SHA256SUMS.txt`. A subset contains `PARTIAL-BUILD.txt`; validation may
+pass for exactly the requested RIDs, but the summary remains `PARTIAL` and the set
+must not be attached to a release.
+
+The static gate checks, without running foreign-RID binaries:
+
+- the exact selected GitHub artifact set and every SHA-256;
+- Windows file/product versions, Linux and macOS version evidence, archive layout,
+  and executable mode bits;
+- every grammar and localization name inside each uncompressed single-file bundle;
+- macOS `Info.plist` version and application layout;
+- Store upload, bundle, x64/arm64 application packages, package/bundle versions,
+  execution alias, exact grammar set, and all Store resource languages. The
+  Store directory must contain exactly the versioned `.msixupload`, x64|arm64
+  `.msixbundle`, and x64 `.msix` emitted by the existing packaging layout.
+
+The host `win-x64` artifact also runs `--version`, `tree`, compressed and full
+`analyze`, the secret findings exit-code/redaction check, and the MCP initialize
+handshake. The MCP check prints `SKIPPED` when Node is unavailable; no check is
+silently omitted. Store is release-ready only after the static gate and WACK both
+pass. A `-SkipWack` summary explicitly says that Store is not release-ready.
+
+Every successful invocation prints one line per selected artifact with byte size
+and SHA-256, the status of each selected channel, and its output directory.
+
+## Adding a channel
+
+A new distribution channel is not connected until all five conditions are met:
+
+1. Its required payload is represented in the shared manifest.
+2. A static completeness gate fails closed on missing or invalid content.
+3. A mutation gate proves the completeness gate rejects a damaged real artifact.
+4. A functional smoke exercises the artifact through its public entry point.
+5. Its publication path and release-readiness requirements are documented.
+
+The current publishing paths remain separate: GitHub desktop archives and Store
+uploads are prepared locally, AppImage is attached by the release workflow, and
+NuGet/npm are published through `publish-packages.yml` after their own static,
+mutation, and three-OS functional gates.

--- a/Packaging/Headless/payload-manifest.json
+++ b/Packaging/Headless/payload-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
   "rids": [
-    { "rid": "win-x64", "npmPlatform": "win32-x64", "os": "win32", "cpu": "x64", "binary": "devprojex.exe", "grammarPrefix": "", "grammarExtension": ".dll" },
-    { "rid": "win-arm64", "npmPlatform": "win32-arm64", "os": "win32", "cpu": "arm64", "binary": "devprojex.exe", "grammarPrefix": "", "grammarExtension": ".dll" },
-    { "rid": "linux-x64", "npmPlatform": "linux-x64", "os": "linux", "cpu": "x64", "binary": "devprojex", "grammarPrefix": "lib", "grammarExtension": ".so" },
-    { "rid": "linux-arm64", "npmPlatform": "linux-arm64", "os": "linux", "cpu": "arm64", "binary": "devprojex", "grammarPrefix": "lib", "grammarExtension": ".so" },
-    { "rid": "osx-x64", "npmPlatform": "darwin-x64", "os": "darwin", "cpu": "x64", "binary": "devprojex", "grammarPrefix": "lib", "grammarExtension": ".dylib" },
-    { "rid": "osx-arm64", "npmPlatform": "darwin-arm64", "os": "darwin", "cpu": "arm64", "binary": "devprojex", "grammarPrefix": "lib", "grammarExtension": ".dylib" }
+    { "rid": "win-x64", "npmPlatform": "win32-x64", "os": "win32", "cpu": "x64", "binary": "devprojex.exe", "releaseBinary": "DevProjex.exe", "grammarPrefix": "", "grammarExtension": ".dll" },
+    { "rid": "win-arm64", "npmPlatform": "win32-arm64", "os": "win32", "cpu": "arm64", "binary": "devprojex.exe", "releaseBinary": "DevProjex.exe", "grammarPrefix": "", "grammarExtension": ".dll" },
+    { "rid": "linux-x64", "npmPlatform": "linux-x64", "os": "linux", "cpu": "x64", "binary": "devprojex", "releaseBinary": "DevProjex", "grammarPrefix": "lib", "grammarExtension": ".so" },
+    { "rid": "linux-arm64", "npmPlatform": "linux-arm64", "os": "linux", "cpu": "arm64", "binary": "devprojex", "releaseBinary": "DevProjex", "grammarPrefix": "lib", "grammarExtension": ".so" },
+    { "rid": "osx-x64", "npmPlatform": "darwin-x64", "os": "darwin", "cpu": "x64", "binary": "devprojex", "releaseBinary": "DevProjex", "grammarPrefix": "lib", "grammarExtension": ".dylib" },
+    { "rid": "osx-arm64", "npmPlatform": "darwin-arm64", "os": "darwin", "cpu": "arm64", "binary": "devprojex", "releaseBinary": "DevProjex", "grammarPrefix": "lib", "grammarExtension": ".dylib" }
   ],
   "grammars": [
     "tree-sitter-bash",
@@ -29,5 +29,56 @@
     "tree-sitter-typescript",
     "tree-sitter-xml",
     "tree-sitter-yaml"
-  ]
+  ],
+  "release": {
+    "localizations": [
+      "de.json",
+      "en.json",
+      "es.json",
+      "fr.json",
+      "id.json",
+      "it.json",
+      "ja.json",
+      "kk.json",
+      "ko.json",
+      "pl.json",
+      "pt-pt.json",
+      "pt.json",
+      "ru.json",
+      "tg.json",
+      "tr.json",
+      "uk.json",
+      "uz.json",
+      "vi.json",
+      "zh-cn.json",
+      "zh-tw.json"
+    ],
+    "store": {
+      "executionAlias": "devprojex.exe",
+      "applicationExecutable": "DevProjex.Avalonia\\DevProjex.exe",
+      "platforms": ["x64", "arm64"],
+      "resourceLanguages": [
+        "de-de",
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "id-id",
+        "it-it",
+        "ja-jp",
+        "kk-kz",
+        "ko-kr",
+        "pl-pl",
+        "pt-br",
+        "pt-pt",
+        "ru-ru",
+        "tg-cyrl-tj",
+        "tr-tr",
+        "uk-ua",
+        "uz-latn-uz",
+        "vi-vn",
+        "zh-cn",
+        "zh-tw"
+      ]
+    }
+  }
 }

--- a/Packaging/Headless/payload-manifest.json
+++ b/Packaging/Headless/payload-manifest.json
@@ -31,28 +31,6 @@
     "tree-sitter-yaml"
   ],
   "release": {
-    "localizations": [
-      "de.json",
-      "en.json",
-      "es.json",
-      "fr.json",
-      "id.json",
-      "it.json",
-      "ja.json",
-      "kk.json",
-      "ko.json",
-      "pl.json",
-      "pt-pt.json",
-      "pt.json",
-      "ru.json",
-      "tg.json",
-      "tr.json",
-      "uk.json",
-      "uz.json",
-      "vi.json",
-      "zh-cn.json",
-      "zh-tw.json"
-    ],
     "store": {
       "executionAlias": "devprojex.exe",
       "applicationExecutable": "DevProjex.Avalonia\\DevProjex.exe",

--- a/Packaging/MacOS/README.md
+++ b/Packaging/MacOS/README.md
@@ -22,6 +22,9 @@ The equivalent channel form is `-Channels github`. Use `-Rids osx-x64` or
 channel commands.
 
 The resulting files are named `DevProjex.v<version>.osx-<architecture>.app.tar.gz`.
+Each selected RID also produces `publish-payload.<rid>.json`, which records every
+file and managed resource embedded by the .NET bundler and is covered by
+`SHA256SUMS.txt`.
 Each archive contains one Finder-ready `DevProjex.app` bundle:
 
 ```text

--- a/Packaging/MacOS/README.md
+++ b/Packaging/MacOS/README.md
@@ -15,6 +15,12 @@ Icon PNGs are located in `Assets/AppIcon/MacOS/AppIconSet/`:
 ./Scripts/release-all.ps1 -Version 5.1 -GitHubArtifactsOnly
 ```
 
+The equivalent channel form is `-Channels github`. Use `-Rids osx-x64` or
+`-Rids osx-arm64` for a diagnostic partial build; it includes
+`PARTIAL-BUILD.txt` and is not release-ready. See
+[`Docs/Release-Process.md`](../../Docs/Release-Process.md) for validation and
+channel commands.
+
 The resulting files are named `DevProjex.v<version>.osx-<architecture>.app.tar.gz`.
 Each archive contains one Finder-ready `DevProjex.app` bundle:
 

--- a/Packaging/README.md
+++ b/Packaging/README.md
@@ -14,10 +14,12 @@ three-OS functional gates pass.
 ./Scripts/Test-HeadlessPackageGateMutation.ps1 -ArtifactsRoot artifacts/headless -Version 5.2.0
 ```
 
-The expected RID and grammar payload is centralized in
-`Packaging/Headless/payload-manifest.json`. NuGet contains a pointer plus six RID
-packages; npm contains six platform packages plus the dependency-free launcher.
-No channel is published by the build script.
+The stable RID and grammar naming contract is centralized in
+`Packaging/Headless/payload-manifest.json`. Local desktop builds also publish a
+`publish-payload.<rid>.json` receipt generated from SDK publish items; the release
+validator compares every file and managed resource to it. NuGet contains a
+pointer plus six RID packages; npm contains six platform packages plus the
+dependency-free launcher. No channel is published by the build script.
 
 Examples for the local desktop channels:
 

--- a/Packaging/README.md
+++ b/Packaging/README.md
@@ -1,6 +1,9 @@
 # Packaging
 
 Desktop GitHub and Store artifacts remain owned by `Scripts/release-all.ps1`.
+Channel selection, partial RID builds, static validation, and the separate WACK
+workflow are documented in [`Docs/Release-Process.md`](../Docs/Release-Process.md).
+`-GitHubArtifactsOnly` remains a supported alias for `-Channels github`.
 Headless NuGet/npm artifacts are built by `Scripts/build-headless-packages.ps1`
 and published only by `.github/workflows/publish-packages.yml` after static and
 three-OS functional gates pass.
@@ -15,6 +18,15 @@ The expected RID and grammar payload is centralized in
 `Packaging/Headless/payload-manifest.json`. NuGet contains a pointer plus six RID
 packages; npm contains six platform packages plus the dependency-free launcher.
 No channel is published by the build script.
+
+Examples for the local desktop channels:
+
+```powershell
+./Scripts/release-all.ps1 -Channels github -Rids win-x64 -SkipWack -NonInteractive
+./Scripts/release-all.ps1 -Channels store -SkipWack -NonInteractive
+./Scripts/release-all.ps1 -Channels store -WackOnly -NonInteractive
+./Scripts/release-all.ps1 -ValidateArtifactsOnly -Channels github,store -NonInteractive
+```
 
 The owner-only registration and first-publish checklist is maintained in
 [`Docs/Release-Channels.md`](../Docs/Release-Channels.md).

--- a/Scripts/ReleasePayloadInspection.cs
+++ b/Scripts/ReleasePayloadInspection.cs
@@ -1,0 +1,319 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DevProjex.ReleaseValidation;
+
+public sealed class BundlePayloadEntry
+{
+    public string Path { get; init; } = string.Empty;
+    public long Offset { get; init; }
+    public long Size { get; init; }
+    public long CompressedSize { get; init; }
+    public byte FileType { get; init; }
+    public string Sha256 { get; init; } = string.Empty;
+    public string[] ManagedResources { get; init; } = Array.Empty<string>();
+    public bool IsManagedAssembly { get; init; }
+}
+
+public sealed class BundlePayloadInspection
+{
+    public uint MajorVersion { get; init; }
+    public uint MinorVersion { get; init; }
+    public BundlePayloadEntry[] Files { get; init; } = Array.Empty<BundlePayloadEntry>();
+}
+
+public static class ReleasePayloadInspector
+{
+    private static readonly byte[] BundleSignature =
+    {
+        0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
+        0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
+        0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
+        0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
+    };
+
+    public static BundlePayloadInspection InspectBundle(string path)
+    {
+        using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return InspectBundle(stream, path);
+    }
+
+    public static BundlePayloadInspection InspectBundle(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        return InspectBundle(stream, "in-memory artifact");
+    }
+
+    private static BundlePayloadInspection InspectBundle(Stream stream, string displayPath)
+    {
+        var signatureOffset = FindSignature(stream);
+        if (signatureOffset < sizeof(long))
+        {
+            throw new InvalidDataException($"'{displayPath}' is not a .NET single-file bundle.");
+        }
+
+        stream.Position = signatureOffset - sizeof(long);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+        var headerOffset = reader.ReadInt64();
+        if (headerOffset <= 0 || headerOffset >= stream.Length)
+        {
+            throw new InvalidDataException($"'{displayPath}' has an invalid .NET bundle header offset '{headerOffset}'.");
+        }
+
+        stream.Position = headerOffset;
+        var majorVersion = reader.ReadUInt32();
+        var minorVersion = reader.ReadUInt32();
+        var fileCount = reader.ReadInt32();
+        if (majorVersion is < 1 or > 6 || minorVersion != 0 || fileCount < 0 || fileCount > 100_000)
+        {
+            throw new InvalidDataException($"'{displayPath}' has an unsupported .NET bundle manifest {majorVersion}.{minorVersion} with {fileCount} files.");
+        }
+
+        _ = reader.ReadString();
+        if (majorVersion >= 2)
+        {
+            _ = reader.ReadInt64();
+            _ = reader.ReadInt64();
+            _ = reader.ReadInt64();
+            _ = reader.ReadInt64();
+            _ = reader.ReadUInt64();
+        }
+
+        var manifestEntries = new List<(long Offset, long Size, long CompressedSize, byte FileType, string Path)>(fileCount);
+        for (var index = 0; index < fileCount; index++)
+        {
+            var offset = reader.ReadInt64();
+            var size = reader.ReadInt64();
+            var compressedSize = majorVersion >= 6 ? reader.ReadInt64() : 0;
+            var fileType = reader.ReadByte();
+            var relativePath = reader.ReadString().Replace('\\', '/');
+            var storedSize = compressedSize == 0 ? size : compressedSize;
+            if (offset < 0 || size < 0 || compressedSize < 0 || offset > stream.Length - storedSize)
+            {
+                throw new InvalidDataException($"'{displayPath}' has invalid bounds for bundle entry '{relativePath}'.");
+            }
+
+            manifestEntries.Add((offset, size, compressedSize, fileType, relativePath));
+        }
+
+        var entries = new List<BundlePayloadEntry>(fileCount);
+        foreach (var entry in manifestEntries)
+        {
+            if (entry.CompressedSize != 0)
+            {
+                throw new InvalidDataException($"'{displayPath}' uses compression for bundle entry '{entry.Path}'.");
+            }
+
+            var hash = ComputeHash(stream, entry.Offset, entry.Size);
+            var resources = entry.FileType == 1
+                ? ReadManagedResources(stream, entry.Offset, entry.Size)
+                : null;
+            entries.Add(new BundlePayloadEntry
+            {
+                Path = entry.Path,
+                Offset = entry.Offset,
+                Size = entry.Size,
+                CompressedSize = entry.CompressedSize,
+                FileType = entry.FileType,
+                Sha256 = hash,
+                IsManagedAssembly = resources is not null,
+                ManagedResources = resources ?? Array.Empty<string>()
+            });
+        }
+
+        return new BundlePayloadInspection
+        {
+            MajorVersion = majorVersion,
+            MinorVersion = minorVersion,
+            Files = entries.ToArray()
+        };
+    }
+
+    public static string[]? TryReadManagedResources(string path)
+    {
+        using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return ReadManagedResources(stream, 0, stream.Length);
+    }
+
+    public static void MutateBundleEntry(string path, string relativePath)
+    {
+        var inspection = InspectBundle(path);
+        var entry = inspection.Files.SingleOrDefault(candidate =>
+            string.Equals(candidate.Path, relativePath, StringComparison.Ordinal));
+        if (entry is null || entry.Size == 0)
+        {
+            throw new InvalidDataException($"Bundle entry '{relativePath}' was not found or is empty in '{path}'.");
+        }
+
+        using var stream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        var mutationOffset = entry.Offset + (entry.Size / 2);
+        stream.Position = mutationOffset;
+        var value = stream.ReadByte();
+        stream.Position = mutationOffset;
+        stream.WriteByte((byte)(value ^ 0x01));
+    }
+
+    public static string MutateBundleResource(string path, string assemblyPath, string resourceName)
+    {
+        var inspection = InspectBundle(path);
+        var entry = inspection.Files.SingleOrDefault(candidate =>
+            string.Equals(candidate.Path, assemblyPath, StringComparison.Ordinal));
+        if (entry is null || !entry.IsManagedAssembly)
+        {
+            throw new InvalidDataException($"Managed bundle entry '{assemblyPath}' was not found in '{path}'.");
+        }
+
+        using var stream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        return MutateUtf8Name(stream, entry.Offset, entry.Size, resourceName);
+    }
+
+    public static string MutateManagedResource(string path, string resourceName)
+    {
+        using var stream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        return MutateUtf8Name(stream, 0, stream.Length, resourceName);
+    }
+
+    private static long FindSignature(Stream stream)
+    {
+        var buffer = new byte[64 * 1024 + BundleSignature.Length - 1];
+        var carry = 0;
+        long absoluteOffset = 0;
+        while (true)
+        {
+            var read = stream.Read(buffer, carry, buffer.Length - carry);
+            if (read == 0)
+            {
+                return -1;
+            }
+
+            var available = carry + read;
+            var index = IndexOf(buffer, available, BundleSignature);
+            if (index >= 0)
+            {
+                return absoluteOffset - carry + index;
+            }
+
+            carry = Math.Min(BundleSignature.Length - 1, available);
+            Buffer.BlockCopy(buffer, available - carry, buffer, 0, carry);
+            absoluteOffset += read;
+        }
+    }
+
+    private static int IndexOf(byte[] buffer, int length, byte[] needle)
+    {
+        for (var index = 0; index <= length - needle.Length; index++)
+        {
+            var found = true;
+            for (var needleIndex = 0; needleIndex < needle.Length; needleIndex++)
+            {
+                if (buffer[index + needleIndex] == needle[needleIndex])
+                {
+                    continue;
+                }
+
+                found = false;
+                break;
+            }
+
+            if (found)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static string ComputeHash(Stream stream, long offset, long size)
+    {
+        stream.Position = offset;
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[128 * 1024];
+        var remaining = size;
+        while (remaining > 0)
+        {
+            var read = stream.Read(buffer, 0, (int)Math.Min(buffer.Length, remaining));
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            hash.AppendData(buffer, 0, read);
+            remaining -= read;
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    private static string[]? ReadManagedResources(Stream stream, long offset, long size)
+    {
+        if (size <= 0 || size > int.MaxValue)
+        {
+            return null;
+        }
+
+        stream.Position = offset;
+        var bytes = new byte[(int)size];
+        stream.ReadExactly(bytes);
+        try
+        {
+            using var memory = new MemoryStream(bytes, writable: false);
+            using var peReader = new PEReader(memory, PEStreamOptions.LeaveOpen);
+            if (!peReader.HasMetadata)
+            {
+                return null;
+            }
+
+            var metadata = peReader.GetMetadataReader();
+            return metadata.ManifestResources
+                .Select(handle => metadata.GetManifestResource(handle))
+                .Where(resource => resource.Implementation.IsNil)
+                .Select(resource => metadata.GetString(resource.Name))
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string MutateUtf8Name(Stream stream, long offset, long size, string name)
+    {
+        var needle = Encoding.UTF8.GetBytes(name);
+        if (needle.Length == 0 || size > int.MaxValue)
+        {
+            throw new InvalidDataException($"Resource name '{name}' cannot be mutated.");
+        }
+
+        stream.Position = offset;
+        var bytes = new byte[(int)size];
+        stream.ReadExactly(bytes);
+        var index = IndexOf(bytes, bytes.Length, needle);
+        if (index < 0)
+        {
+            throw new InvalidDataException($"Resource name '{name}' was not found.");
+        }
+
+        var changedName = name.ToCharArray();
+        var changedIndex = changedName.Length - 1;
+        changedName[changedIndex] = changedName[changedIndex] == 'X' ? 'Y' : 'X';
+        var replacement = Encoding.UTF8.GetBytes(changedName);
+        if (replacement.Length != needle.Length)
+        {
+            throw new InvalidDataException($"Resource name '{name}' cannot be mutated without changing its byte length.");
+        }
+
+        stream.Position = offset + index;
+        stream.Write(replacement, 0, replacement.Length);
+        return new string(changedName);
+    }
+}

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -132,21 +132,39 @@ function Get-ReceiptMutationCases([object] $Receipt) {
     )
 }
 
+function Remove-MutationDirectory([AllowNull()][string] $Path) {
+    if ([string]::IsNullOrWhiteSpace($Path)) { return }
+    $mutationRoot = [System.IO.Path]::GetFullPath($script:MutationRoot)
+    $mutationRoot = $mutationRoot.TrimEnd([char[]]@('\', '/')) + [System.IO.Path]::DirectorySeparatorChar
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not $resolvedPath.StartsWith($mutationRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Mutation cleanup refused path outside its temporary root: $resolvedPath"
+    }
+    if (Test-Path -LiteralPath $resolvedPath -PathType Container) {
+        Remove-Item -LiteralPath $resolvedPath -Recurse -Force
+    }
+}
+
 function Invoke-GitHubMutation([string] $SourcePublishRoot, [object] $Case) {
     $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'github'
-    $artifactName = "DevProjex.v$Version.win-x64.exe"
-    $channelDirectory = Join-Path $fixtureRoot "github/v$Version"
-    $artifactPath = Join-Path $channelDirectory $artifactName
-    if ([string]$Case.Kind -ceq 'File') {
-        [DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleEntry($artifactPath, [string]$Case.File)
+    try {
+        $artifactName = "DevProjex.v$Version.win-x64.exe"
+        $channelDirectory = Join-Path $fixtureRoot "github/v$Version"
+        $artifactPath = Join-Path $channelDirectory $artifactName
+        if ([string]$Case.Kind -ceq 'File') {
+            [DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleEntry($artifactPath, [string]$Case.File)
+        }
+        else {
+            [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleResource(
+                $artifactPath, [string]$Case.File, [string]$Case.Entry)
+        }
+        Write-ChannelChecksums -ChannelDirectory $channelDirectory
+        Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'github' `
+            -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
     }
-    else {
-        [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleResource(
-            $artifactPath, [string]$Case.File, [string]$Case.Entry)
+    finally {
+        Remove-MutationDirectory -Path $fixtureRoot
     }
-    Write-ChannelChecksums -ChannelDirectory $channelDirectory
-    Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'github' `
-        -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
 }
 
 function Compress-Directory([string] $SourceDirectory, [string] $DestinationPath) {
@@ -157,49 +175,60 @@ function Compress-Directory([string] $SourceDirectory, [string] $DestinationPath
 
 function Invoke-StoreMutation([string] $SourcePublishRoot, [object] $Case) {
     $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'store'
-    $channelDirectory = Join-Path $fixtureRoot "store/v$Version"
-    $uploads = @(Get-ChildItem -LiteralPath $channelDirectory -File -Filter '*.msixupload')
-    if ($uploads.Count -ne 1) { throw "Mutation setup failed: expected one .msixupload, found $($uploads.Count)." }
-    $artifactName = $uploads[0].Name
-    $workRoot = Join-Path $script:MutationRoot ('store-' + [guid]::NewGuid().ToString('N'))
-    $uploadRoot = Join-Path $workRoot 'upload'
-    $bundleRoot = Join-Path $workRoot 'bundle'
-    $packageRoot = Join-Path $workRoot 'package'
-    New-Item -ItemType Directory -Path $uploadRoot, $bundleRoot, $packageRoot -Force | Out-Null
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($uploads[0].FullName, $uploadRoot)
-    $bundles = @(Get-ChildItem -LiteralPath $uploadRoot -Recurse -File -Filter '*.msixbundle')
-    if ($bundles.Count -ne 1) { throw "Mutation setup failed: '$artifactName' must contain exactly one .msixbundle." }
-    $bundleRelativePath = $bundles[0].FullName.Substring($uploadRoot.Length).TrimStart([char[]]@('\', '/'))
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($bundles[0].FullName, $bundleRoot)
-    [xml]$bundleManifest = Get-Content -LiteralPath (Join-Path $bundleRoot 'AppxMetadata\AppxBundleManifest.xml') -Raw
-    $packageNode = $bundleManifest.SelectSingleNode("//*[local-name()='Package' and translate(@Architecture,'X','x')='x64']")
-    if ($null -eq $packageNode) { throw "Mutation setup failed: '$artifactName' has no x64 package." }
-    $packagePath = Join-Path $bundleRoot (([string]$packageNode.GetAttribute('FileName')) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($packagePath, $packageRoot)
-    $payloadPath = Join-Path (Join-Path $packageRoot 'DevProjex.Avalonia') (([string]$Case.File) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    if (-not (Test-Path -LiteralPath $payloadPath -PathType Leaf)) {
-        throw "Mutation setup failed: Store payload file '$($Case.File)' was not found."
+    $workRoot = $null
+    try {
+        $channelDirectory = Join-Path $fixtureRoot "store/v$Version"
+        $uploads = @(Get-ChildItem -LiteralPath $channelDirectory -File -Filter '*.msixupload')
+        if ($uploads.Count -ne 1) { throw "Mutation setup failed: expected one .msixupload, found $($uploads.Count)." }
+        $artifactName = $uploads[0].Name
+        $workRoot = Join-Path $script:MutationRoot ('store-' + [guid]::NewGuid().ToString('N'))
+        $uploadRoot = Join-Path $workRoot 'upload'
+        $bundleRoot = Join-Path $workRoot 'bundle'
+        $packageRoot = Join-Path $workRoot 'package'
+        New-Item -ItemType Directory -Path $uploadRoot, $bundleRoot, $packageRoot -Force | Out-Null
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($uploads[0].FullName, $uploadRoot)
+        $bundles = @(Get-ChildItem -LiteralPath $uploadRoot -Recurse -File -Filter '*.msixbundle')
+        if ($bundles.Count -ne 1) { throw "Mutation setup failed: '$artifactName' must contain exactly one .msixbundle." }
+        $bundleRelativePath = $bundles[0].FullName.Substring($uploadRoot.Length).TrimStart([char[]]@('\', '/'))
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($bundles[0].FullName, $bundleRoot)
+        [xml]$bundleManifest = Get-Content -LiteralPath (Join-Path $bundleRoot 'AppxMetadata\AppxBundleManifest.xml') -Raw
+        $packageNode = $bundleManifest.SelectSingleNode("//*[local-name()='Package' and translate(@Architecture,'X','x')='x64']")
+        if ($null -eq $packageNode) { throw "Mutation setup failed: '$artifactName' has no x64 package." }
+        $packagePath = Join-Path $bundleRoot (([string]$packageNode.GetAttribute('FileName')) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($packagePath, $packageRoot)
+        $payloadPath = Join-Path (Join-Path $packageRoot 'DevProjex.Avalonia') (([string]$Case.File) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        if (-not (Test-Path -LiteralPath $payloadPath -PathType Leaf)) {
+            throw "Mutation setup failed: Store payload file '$($Case.File)' was not found."
+        }
+        if ([string]$Case.Kind -ceq 'File') {
+            $bytes = [System.IO.File]::ReadAllBytes($payloadPath)
+            if ($bytes.Length -eq 0) { throw "Mutation setup failed: Store payload file '$($Case.File)' is empty." }
+            $offset = [int]($bytes.Length / 2)
+            $bytes[$offset] = $bytes[$offset] -bxor 1
+            [System.IO.File]::WriteAllBytes($payloadPath, $bytes)
+        }
+        else {
+            [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateManagedResource($payloadPath, [string]$Case.Entry)
+        }
+        Compress-Directory -SourceDirectory $packageRoot -DestinationPath $packagePath
+        Compress-Directory -SourceDirectory $bundleRoot -DestinationPath $bundles[0].FullName
+        $rebuiltBundlePath = Join-Path $uploadRoot ($bundleRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        if ($rebuiltBundlePath -cne $bundles[0].FullName) {
+            Copy-Item -LiteralPath $bundles[0].FullName -Destination $rebuiltBundlePath -Force
+        }
+        Compress-Directory -SourceDirectory $uploadRoot -DestinationPath $uploads[0].FullName
+        Write-ChannelChecksums -ChannelDirectory $channelDirectory
+        Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'store' `
+            -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
     }
-    if ([string]$Case.Kind -ceq 'File') {
-        $bytes = [System.IO.File]::ReadAllBytes($payloadPath)
-        if ($bytes.Length -eq 0) { throw "Mutation setup failed: Store payload file '$($Case.File)' is empty." }
-        $offset = [int]($bytes.Length / 2)
-        $bytes[$offset] = $bytes[$offset] -bxor 1
-        [System.IO.File]::WriteAllBytes($payloadPath, $bytes)
+    finally {
+        try {
+            Remove-MutationDirectory -Path $workRoot
+        }
+        finally {
+            Remove-MutationDirectory -Path $fixtureRoot
+        }
     }
-    else {
-        [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateManagedResource($payloadPath, [string]$Case.Entry)
-    }
-    Compress-Directory -SourceDirectory $packageRoot -DestinationPath $packagePath
-    Compress-Directory -SourceDirectory $bundleRoot -DestinationPath $bundles[0].FullName
-    $rebuiltBundlePath = Join-Path $uploadRoot ($bundleRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    if ($rebuiltBundlePath -cne $bundles[0].FullName) {
-        Copy-Item -LiteralPath $bundles[0].FullName -Destination $rebuiltBundlePath -Force
-    }
-    Compress-Directory -SourceDirectory $uploadRoot -DestinationPath $uploads[0].FullName
-    Write-ChannelChecksums -ChannelDirectory $channelDirectory
-    Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'store' `
-        -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
 }
 
 $sourcePublishRoot = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($PublishRoot)) {

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -84,16 +84,14 @@ function Get-ReceiptMutationCases([object] $Receipt) {
             if ([string]$resource -ceq 'DevProjex.Assets.Localization.en.json') { $fixedLocalization = $candidate }
 		}
 	}
-	if ($null -eq $fixedGrammar) {
-		$grammarFile = @($Receipt.files | Where-Object {
-			[string]$_.path -ceq 'grammars/tree-sitter-kotlin.dll'
-		} | Select-Object -First 1)
-		if ($grammarFile.Count -eq 1) {
-			$fixedGrammar = [pscustomobject]@{
-				Kind = 'File'
-				File = [string]$grammarFile[0].path
-				Entry = [string]$grammarFile[0].path
-			}
+	$grammarFile = @($Receipt.files | Where-Object {
+		[string]$_.path -ceq 'grammars/tree-sitter-kotlin.dll'
+	} | Select-Object -First 1)
+	if ($grammarFile.Count -eq 1) {
+		$fixedGrammar = [pscustomobject]@{
+			Kind = 'File'
+			File = [string]$grammarFile[0].path
+			Entry = [string]$grammarFile[0].path
 		}
 	}
 	if ($null -eq $fixedGrammar -or $null -eq $fixedLocalization) {

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -1,0 +1,241 @@
+[CmdletBinding()]
+param(
+    [string] $PublishRoot = "",
+
+    [Parameter(Mandatory = $true)]
+    [string] $Version,
+
+    [string[]] $Channels = @("github", "store"),
+
+    [string[]] $Rids = @(
+        "win-x64",
+        "win-arm64",
+        "linux-x64",
+        "linux-arm64",
+        "osx-x64",
+        "osx-arm64"
+    )
+)
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'release-archive-helpers.ps1')
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function ConvertTo-Tokens([string[]] $Values) {
+    return @(
+        $Values |
+            ForEach-Object { ([string]$_).Split(',') } |
+            ForEach-Object { $_.Trim().ToLowerInvariant() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+    )
+}
+
+function Copy-ChannelFixture([string] $SourcePublishRoot, [string] $Channel) {
+    $fixturePublishRoot = Join-Path $script:MutationRoot ([guid]::NewGuid().ToString('N'))
+    $sourceDirectory = Join-Path $SourcePublishRoot "$Channel/v$Version"
+    $destinationDirectory = Join-Path $fixturePublishRoot "$Channel/v$Version"
+    if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
+        throw "Mutation setup failed: channel directory was not found: $sourceDirectory"
+    }
+    New-Item -ItemType Directory -Path (Split-Path -Parent $destinationDirectory) -Force | Out-Null
+    Copy-Item -LiteralPath $sourceDirectory -Destination $destinationDirectory -Recurse -Force
+    return $fixturePublishRoot
+}
+
+function Replace-BytesInFile(
+    [string] $Path,
+    [string] $NeedleText,
+    [string] $ReplacementText
+) {
+    $needle = [System.Text.Encoding]::ASCII.GetBytes($NeedleText)
+    $replacement = [System.Text.Encoding]::ASCII.GetBytes($ReplacementText)
+    if ($needle.Length -ne $replacement.Length) {
+        throw "Mutation replacement must preserve byte length: '$NeedleText' -> '$ReplacementText'."
+    }
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $replacements = 0
+    for ($offset = 0; $offset -le $bytes.Length - $needle.Length; $offset++) {
+        $match = $true
+        for ($index = 0; $index -lt $needle.Length; $index++) {
+            if ($bytes[$offset + $index] -ne $needle[$index]) {
+                $match = $false
+                break
+            }
+        }
+        if (-not $match) {
+            continue
+        }
+        [System.Array]::Copy($replacement, 0, $bytes, $offset, $replacement.Length)
+        $replacements++
+        $offset += $needle.Length - 1
+    }
+    if ($replacements -eq 0) {
+        throw "Mutation setup failed: '$NeedleText' was not found in '$Path'."
+    }
+    [System.IO.File]::WriteAllBytes($Path, $bytes)
+}
+
+function Write-ChannelChecksums([string] $ChannelDirectory) {
+    $artifacts = @(
+        Get-ChildItem -LiteralPath $ChannelDirectory -File |
+            Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt') } |
+            Sort-Object Name
+    )
+    $lines = @($artifacts | ForEach-Object { "$(Get-FileSha256Hex -path $_.FullName) *$($_.Name)" })
+    Write-ReleaseChecksumManifest -path (Join-Path $ChannelDirectory 'SHA256SUMS.txt') -lines $lines
+}
+
+function Invoke-FailingValidation(
+    [string] $FixturePublishRoot,
+    [string] $Channel,
+    [string] $ArtifactName,
+    [string] $ExpectedMissing
+) {
+    $shellPath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+    $arguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-File', (Join-Path $PSScriptRoot 'Test-ReleaseArtifacts.ps1'),
+        '-PublishRoot', $FixturePublishRoot,
+        '-Version', $Version,
+        '-Channels', $Channel
+    )
+    if ($Channel -ceq 'github') {
+        $arguments += @('-Rids', ($script:SelectedRids -join ','))
+    }
+    $output = & $shellPath @arguments 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -eq 0) {
+        throw "Mutation gate failed open for '$ArtifactName' after removing '$ExpectedMissing'."
+    }
+    if ($output.IndexOf($ArtifactName, [System.StringComparison]::Ordinal) -lt 0 -or
+        $output.IndexOf($ExpectedMissing, [System.StringComparison]::Ordinal) -lt 0) {
+        throw "Mutation gate failed without naming artifact '$ArtifactName' and '$ExpectedMissing': $output"
+    }
+    Write-Host "Mutation gate passed: $ArtifactName -> $ExpectedMissing"
+}
+
+function Invoke-GitHubMutation([string] $SourcePublishRoot, [string] $Needle, [string] $Replacement) {
+    if ('win-x64' -notin $script:SelectedRids) {
+        throw "GitHub mutation gate requires win-x64 in -Rids."
+    }
+    $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'github'
+    $artifactName = "DevProjex.v$Version.win-x64.exe"
+    $channelDirectory = Join-Path $fixtureRoot "github/v$Version"
+    Replace-BytesInFile -Path (Join-Path $channelDirectory $artifactName) -NeedleText $Needle -ReplacementText $Replacement
+    Write-ChannelChecksums -ChannelDirectory $channelDirectory
+    Invoke-FailingValidation `
+        -FixturePublishRoot $fixtureRoot `
+        -Channel 'github' `
+        -ArtifactName $artifactName `
+        -ExpectedMissing $Needle
+}
+
+function Compress-Directory([string] $SourceDirectory, [string] $DestinationPath) {
+    if (Test-Path -LiteralPath $DestinationPath) {
+        Remove-Item -LiteralPath $DestinationPath -Force
+    }
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $SourceDirectory,
+        $DestinationPath,
+        [System.IO.Compression.CompressionLevel]::Optimal,
+        $false)
+}
+
+function Invoke-StoreGrammarMutation([string] $SourcePublishRoot) {
+    $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'store'
+    $channelDirectory = Join-Path $fixtureRoot "store/v$Version"
+    $uploads = @(Get-ChildItem -LiteralPath $channelDirectory -File -Filter '*.msixupload')
+    if ($uploads.Count -ne 1) {
+        throw "Mutation setup failed: expected one .msixupload, found $($uploads.Count)."
+    }
+    $artifactName = $uploads[0].Name
+    $workRoot = Join-Path $script:MutationRoot ('store-' + [guid]::NewGuid().ToString('N'))
+    $uploadRoot = Join-Path $workRoot 'upload'
+    $bundleRoot = Join-Path $workRoot 'bundle'
+    New-Item -ItemType Directory -Path $uploadRoot, $bundleRoot -Force | Out-Null
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($uploads[0].FullName, $uploadRoot)
+    $bundles = @(Get-ChildItem -LiteralPath $uploadRoot -Recurse -File -Filter '*.msixbundle')
+    if ($bundles.Count -ne 1) {
+        throw "Mutation setup failed: '$artifactName' must contain exactly one .msixbundle."
+    }
+    $bundleRelativePath = $bundles[0].FullName.Substring($uploadRoot.Length).TrimStart([char[]]@('\', '/'))
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($bundles[0].FullName, $bundleRoot)
+
+    $mutatedPackage = $null
+    foreach ($package in @(Get-ChildItem -LiteralPath $bundleRoot -Recurse -File -Filter '*.msix')) {
+        $packageRoot = Join-Path $workRoot ('package-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $packageRoot -Force | Out-Null
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($package.FullName, $packageRoot)
+        $grammar = Get-ChildItem -LiteralPath $packageRoot -Recurse -File -Filter 'tree-sitter-kotlin.dll' | Select-Object -First 1
+        if ($null -eq $grammar) {
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+            continue
+        }
+        Rename-Item -LiteralPath $grammar.FullName -NewName 'tree-sitter-Xotlin.dll'
+        Compress-Directory -SourceDirectory $packageRoot -DestinationPath $package.FullName
+        $mutatedPackage = $package
+        break
+    }
+    if ($null -eq $mutatedPackage) {
+        throw "Mutation setup failed: Store grammar 'tree-sitter-kotlin.dll' was not found."
+    }
+
+    Compress-Directory -SourceDirectory $bundleRoot -DestinationPath $bundles[0].FullName
+    $rebuiltBundlePath = Join-Path $uploadRoot ($bundleRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if ($rebuiltBundlePath -cne $bundles[0].FullName) {
+        Copy-Item -LiteralPath $bundles[0].FullName -Destination $rebuiltBundlePath -Force
+    }
+    Compress-Directory -SourceDirectory $uploadRoot -DestinationPath $uploads[0].FullName
+    Write-ChannelChecksums -ChannelDirectory $channelDirectory
+    Invoke-FailingValidation `
+        -FixturePublishRoot $fixtureRoot `
+        -Channel 'store' `
+        -ArtifactName $artifactName `
+        -ExpectedMissing 'tree-sitter-kotlin.dll'
+}
+
+$sourcePublishRoot = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($PublishRoot)) {
+    Join-Path (Split-Path -Parent $PSScriptRoot) 'publish'
+} else {
+    $PublishRoot
+}))
+$selectedChannels = @(ConvertTo-Tokens $Channels)
+$script:SelectedRids = @(ConvertTo-Tokens $Rids)
+foreach ($channel in $selectedChannels) {
+    if ($channel -notin @('github', 'store')) {
+        throw "Unknown release channel '$channel'."
+    }
+}
+
+$script:MutationRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('devprojex-release-mutation-' + [guid]::NewGuid().ToString('N'))
+[System.IO.Directory]::CreateDirectory($script:MutationRoot) | Out-Null
+try {
+    if ('github' -in $selectedChannels) {
+        Invoke-GitHubMutation `
+            -SourcePublishRoot $sourcePublishRoot `
+            -Needle 'tree-sitter-kotlin.dll' `
+            -Replacement 'tree-sitter-Xotlin.dll'
+        Invoke-GitHubMutation `
+            -SourcePublishRoot $sourcePublishRoot `
+            -Needle 'en.json' `
+            -Replacement 'eX.json'
+    }
+    if ('store' -in $selectedChannels) {
+        Invoke-StoreGrammarMutation -SourcePublishRoot $sourcePublishRoot
+    }
+}
+finally {
+    $resolvedMutationRoot = [System.IO.Path]::GetFullPath($script:MutationRoot)
+    $resolvedSystemTemp = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    if ($resolvedMutationRoot.StartsWith($resolvedSystemTemp, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $resolvedMutationRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$global:LASTEXITCODE = 0

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -1,20 +1,9 @@
 [CmdletBinding()]
 param(
     [string] $PublishRoot = "",
-
-    [Parameter(Mandatory = $true)]
-    [string] $Version,
-
+    [Parameter(Mandatory = $true)] [string] $Version,
     [string[]] $Channels = @("github", "store"),
-
-    [string[]] $Rids = @(
-        "win-x64",
-        "win-arm64",
-        "linux-x64",
-        "linux-arm64",
-        "osx-x64",
-        "osx-arm64"
-    )
+    [string[]] $Rids = @("win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64")
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,15 +13,12 @@ Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot 'release-archive-helpers.ps1')
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
+Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
 
 function ConvertTo-Tokens([string[]] $Values) {
-    return @(
-        $Values |
-            ForEach-Object { ([string]$_).Split(',') } |
-            ForEach-Object { $_.Trim().ToLowerInvariant() } |
-            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-            Select-Object -Unique
-    )
+    return @($Values | ForEach-Object { ([string]$_).Split(',') } |
+        ForEach-Object { $_.Trim().ToLowerInvariant() } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 }
 
 function Copy-ChannelFixture([string] $SourcePublishRoot, [string] $Channel) {
@@ -47,45 +33,9 @@ function Copy-ChannelFixture([string] $SourcePublishRoot, [string] $Channel) {
     return $fixturePublishRoot
 }
 
-function Replace-BytesInFile(
-    [string] $Path,
-    [string] $NeedleText,
-    [string] $ReplacementText
-) {
-    $needle = [System.Text.Encoding]::ASCII.GetBytes($NeedleText)
-    $replacement = [System.Text.Encoding]::ASCII.GetBytes($ReplacementText)
-    if ($needle.Length -ne $replacement.Length) {
-        throw "Mutation replacement must preserve byte length: '$NeedleText' -> '$ReplacementText'."
-    }
-    $bytes = [System.IO.File]::ReadAllBytes($Path)
-    $replacements = 0
-    for ($offset = 0; $offset -le $bytes.Length - $needle.Length; $offset++) {
-        $match = $true
-        for ($index = 0; $index -lt $needle.Length; $index++) {
-            if ($bytes[$offset + $index] -ne $needle[$index]) {
-                $match = $false
-                break
-            }
-        }
-        if (-not $match) {
-            continue
-        }
-        [System.Array]::Copy($replacement, 0, $bytes, $offset, $replacement.Length)
-        $replacements++
-        $offset += $needle.Length - 1
-    }
-    if ($replacements -eq 0) {
-        throw "Mutation setup failed: '$NeedleText' was not found in '$Path'."
-    }
-    [System.IO.File]::WriteAllBytes($Path, $bytes)
-}
-
 function Write-ChannelChecksums([string] $ChannelDirectory) {
-    $artifacts = @(
-        Get-ChildItem -LiteralPath $ChannelDirectory -File |
-            Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt') } |
-            Sort-Object Name
-    )
+    $artifacts = @(Get-ChildItem -LiteralPath $ChannelDirectory -File |
+        Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt') } | Sort-Object Name)
     $lines = @($artifacts | ForEach-Object { "$(Get-FileSha256Hex -path $_.FullName) *$($_.Name)" })
     Write-ReleaseChecksumManifest -path (Join-Path $ChannelDirectory 'SHA256SUMS.txt') -lines $lines
 }
@@ -94,98 +44,153 @@ function Invoke-FailingValidation(
     [string] $FixturePublishRoot,
     [string] $Channel,
     [string] $ArtifactName,
-    [string] $ExpectedMissing
+    [string] $ExpectedEntry
 ) {
     $shellPath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
-    $arguments = @(
-        '-NoLogo',
-        '-NoProfile',
-        '-File', (Join-Path $PSScriptRoot 'Test-ReleaseArtifacts.ps1'),
-        '-PublishRoot', $FixturePublishRoot,
-        '-Version', $Version,
-        '-Channels', $Channel
-    )
+    $arguments = @('-NoLogo', '-NoProfile', '-File', (Join-Path $PSScriptRoot 'Test-ReleaseArtifacts.ps1'),
+        '-PublishRoot', $FixturePublishRoot, '-Version', $Version, '-Channels', $Channel)
     if ($Channel -ceq 'github') {
         $arguments += @('-Rids', ($script:SelectedRids -join ','))
     }
     $output = & $shellPath @arguments 2>&1 | Out-String
-    $exitCode = $LASTEXITCODE
-    if ($exitCode -eq 0) {
-        throw "Mutation gate failed open for '$ArtifactName' after removing '$ExpectedMissing'."
+    if ($LASTEXITCODE -eq 0) {
+        throw "Mutation gate failed open for '$ArtifactName' after changing '$ExpectedEntry'."
     }
     if ($output.IndexOf($ArtifactName, [System.StringComparison]::Ordinal) -lt 0 -or
-        $output.IndexOf($ExpectedMissing, [System.StringComparison]::Ordinal) -lt 0) {
-        throw "Mutation gate failed without naming artifact '$ArtifactName' and '$ExpectedMissing': $output"
+        $output.IndexOf($ExpectedEntry, [System.StringComparison]::Ordinal) -lt 0) {
+        throw "Mutation gate failed without naming artifact '$ArtifactName' and '$ExpectedEntry': $output"
     }
-    Write-Host "Mutation gate passed: $ArtifactName -> $ExpectedMissing"
+    Write-Host "Mutation gate passed: $ArtifactName -> $ExpectedEntry"
 }
 
-function Invoke-GitHubMutation([string] $SourcePublishRoot, [string] $Needle, [string] $Replacement) {
-    if ('win-x64' -notin $script:SelectedRids) {
-        throw "GitHub mutation gate requires win-x64 in -Rids."
+function Read-PayloadReceipt([string] $ChannelDirectory, [string] $Rid) {
+    $path = Join-Path $ChannelDirectory "publish-payload.$Rid.json"
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Mutation setup failed: payload receipt was not found: $path"
     }
+    return Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+}
+
+function Get-ReceiptMutationCases([object] $Receipt) {
+    $fixedGrammar = $null
+    $fixedLocalization = $null
+    $resourceCandidates = New-Object 'System.Collections.Generic.List[object]'
+	foreach ($file in @($Receipt.files)) {
+        if ($file.PSObject.Properties.Name -notcontains 'managedResources') { continue }
+        foreach ($resource in @($file.managedResources)) {
+            $candidate = [pscustomobject]@{ File = [string]$file.path; Entry = [string]$resource }
+            $resourceCandidates.Add($candidate)
+            if ([string]$resource -ceq 'DevProjex.Grammars/tree-sitter-kotlin.dll') { $fixedGrammar = $candidate }
+            if ([string]$resource -ceq 'DevProjex.Assets.Localization.en.json') { $fixedLocalization = $candidate }
+		}
+	}
+	if ($null -eq $fixedGrammar) {
+		$grammarFile = @($Receipt.files | Where-Object {
+			[string]$_.path -ceq 'grammars/tree-sitter-kotlin.dll'
+		} | Select-Object -First 1)
+		if ($grammarFile.Count -eq 1) {
+			$fixedGrammar = [pscustomobject]@{
+				Kind = 'File'
+				File = [string]$grammarFile[0].path
+				Entry = [string]$grammarFile[0].path
+			}
+		}
+	}
+	if ($null -eq $fixedGrammar -or $null -eq $fixedLocalization) {
+		throw 'Mutation setup failed: fixed grammar or localization resource is absent from the receipt.'
+	}
+	if ($fixedGrammar.PSObject.Properties.Name -notcontains 'Kind') {
+		$fixedGrammar | Add-Member -NotePropertyName Kind -NotePropertyValue 'Resource'
+	}
+    $fixedNative = @($Receipt.files | Where-Object {
+        [string]$_.path -ceq 'libSkiaSharp.dll' -and $_.PSObject.Properties.Name -notcontains 'managedResources'
+    } | Select-Object -First 1)
+    if ($fixedNative.Count -ne 1) {
+        throw "Mutation setup failed: fixed native file 'libSkiaSharp.dll' is absent from the receipt."
+    }
+	$genericFile = @($Receipt.files | Where-Object {
+		[long]$_.size -gt 0 -and [string]$_.path -cne [string]$fixedNative[0].path -and
+		[string]$_.path -cne [string]$fixedGrammar.File -and
+		$_.PSObject.Properties.Name -notcontains 'managedResources'
+    } | Sort-Object { [string]$_.sha256 }, { [string]$_.path } | Select-Object -First 1)
+    $genericResource = @($resourceCandidates | Where-Object {
+        [string]$_.Entry -cne [string]$fixedGrammar.Entry -and
+        [string]$_.Entry -cne [string]$fixedLocalization.Entry
+    } | Sort-Object {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes("$($_.File)`0$($_.Entry)")
+        [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData($bytes))
+    } | Select-Object -First 1)
+    if ($genericFile.Count -ne 1 -or $genericResource.Count -ne 1) {
+        throw 'Mutation setup failed: the receipt has no generic file or embedded-resource candidate.'
+    }
+    return @(
+        [pscustomobject]@{ Label = 'deterministic file'; Kind = 'File'; File = [string]$genericFile[0].path; Entry = [string]$genericFile[0].path },
+        [pscustomobject]@{ Label = 'deterministic resource'; Kind = 'Resource'; File = [string]$genericResource[0].File; Entry = [string]$genericResource[0].Entry },
+		[pscustomobject]@{ Label = 'grammar'; Kind = [string]$fixedGrammar.Kind; File = [string]$fixedGrammar.File; Entry = [string]$fixedGrammar.Entry },
+        [pscustomobject]@{ Label = 'localization resource'; Kind = 'Resource'; File = [string]$fixedLocalization.File; Entry = [string]$fixedLocalization.Entry },
+        [pscustomobject]@{ Label = 'native library'; Kind = 'File'; File = [string]$fixedNative[0].path; Entry = [string]$fixedNative[0].path }
+    )
+}
+
+function Invoke-GitHubMutation([string] $SourcePublishRoot, [object] $Case) {
     $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'github'
     $artifactName = "DevProjex.v$Version.win-x64.exe"
     $channelDirectory = Join-Path $fixtureRoot "github/v$Version"
-    Replace-BytesInFile -Path (Join-Path $channelDirectory $artifactName) -NeedleText $Needle -ReplacementText $Replacement
+    $artifactPath = Join-Path $channelDirectory $artifactName
+    if ([string]$Case.Kind -ceq 'File') {
+        [DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleEntry($artifactPath, [string]$Case.File)
+    }
+    else {
+        [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleResource(
+            $artifactPath, [string]$Case.File, [string]$Case.Entry)
+    }
     Write-ChannelChecksums -ChannelDirectory $channelDirectory
-    Invoke-FailingValidation `
-        -FixturePublishRoot $fixtureRoot `
-        -Channel 'github' `
-        -ArtifactName $artifactName `
-        -ExpectedMissing $Needle
+    Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'github' `
+        -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
 }
 
 function Compress-Directory([string] $SourceDirectory, [string] $DestinationPath) {
-    if (Test-Path -LiteralPath $DestinationPath) {
-        Remove-Item -LiteralPath $DestinationPath -Force
-    }
+    if (Test-Path -LiteralPath $DestinationPath) { Remove-Item -LiteralPath $DestinationPath -Force }
     [System.IO.Compression.ZipFile]::CreateFromDirectory(
-        $SourceDirectory,
-        $DestinationPath,
-        [System.IO.Compression.CompressionLevel]::Optimal,
-        $false)
+        $SourceDirectory, $DestinationPath, [System.IO.Compression.CompressionLevel]::Optimal, $false)
 }
 
-function Invoke-StoreGrammarMutation([string] $SourcePublishRoot) {
+function Invoke-StoreMutation([string] $SourcePublishRoot, [object] $Case) {
     $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'store'
     $channelDirectory = Join-Path $fixtureRoot "store/v$Version"
     $uploads = @(Get-ChildItem -LiteralPath $channelDirectory -File -Filter '*.msixupload')
-    if ($uploads.Count -ne 1) {
-        throw "Mutation setup failed: expected one .msixupload, found $($uploads.Count)."
-    }
+    if ($uploads.Count -ne 1) { throw "Mutation setup failed: expected one .msixupload, found $($uploads.Count)." }
     $artifactName = $uploads[0].Name
     $workRoot = Join-Path $script:MutationRoot ('store-' + [guid]::NewGuid().ToString('N'))
     $uploadRoot = Join-Path $workRoot 'upload'
     $bundleRoot = Join-Path $workRoot 'bundle'
-    New-Item -ItemType Directory -Path $uploadRoot, $bundleRoot -Force | Out-Null
+    $packageRoot = Join-Path $workRoot 'package'
+    New-Item -ItemType Directory -Path $uploadRoot, $bundleRoot, $packageRoot -Force | Out-Null
     [System.IO.Compression.ZipFile]::ExtractToDirectory($uploads[0].FullName, $uploadRoot)
     $bundles = @(Get-ChildItem -LiteralPath $uploadRoot -Recurse -File -Filter '*.msixbundle')
-    if ($bundles.Count -ne 1) {
-        throw "Mutation setup failed: '$artifactName' must contain exactly one .msixbundle."
-    }
+    if ($bundles.Count -ne 1) { throw "Mutation setup failed: '$artifactName' must contain exactly one .msixbundle." }
     $bundleRelativePath = $bundles[0].FullName.Substring($uploadRoot.Length).TrimStart([char[]]@('\', '/'))
     [System.IO.Compression.ZipFile]::ExtractToDirectory($bundles[0].FullName, $bundleRoot)
-
-    $mutatedPackage = $null
-    foreach ($package in @(Get-ChildItem -LiteralPath $bundleRoot -Recurse -File -Filter '*.msix')) {
-        $packageRoot = Join-Path $workRoot ('package-' + [guid]::NewGuid().ToString('N'))
-        New-Item -ItemType Directory -Path $packageRoot -Force | Out-Null
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($package.FullName, $packageRoot)
-        $grammar = Get-ChildItem -LiteralPath $packageRoot -Recurse -File -Filter 'tree-sitter-kotlin.dll' | Select-Object -First 1
-        if ($null -eq $grammar) {
-            Remove-Item -LiteralPath $packageRoot -Recurse -Force
-            continue
-        }
-        Rename-Item -LiteralPath $grammar.FullName -NewName 'tree-sitter-Xotlin.dll'
-        Compress-Directory -SourceDirectory $packageRoot -DestinationPath $package.FullName
-        $mutatedPackage = $package
-        break
+    [xml]$bundleManifest = Get-Content -LiteralPath (Join-Path $bundleRoot 'AppxMetadata\AppxBundleManifest.xml') -Raw
+    $packageNode = $bundleManifest.SelectSingleNode("//*[local-name()='Package' and translate(@Architecture,'X','x')='x64']")
+    if ($null -eq $packageNode) { throw "Mutation setup failed: '$artifactName' has no x64 package." }
+    $packagePath = Join-Path $bundleRoot (([string]$packageNode.GetAttribute('FileName')) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($packagePath, $packageRoot)
+    $payloadPath = Join-Path (Join-Path $packageRoot 'DevProjex.Avalonia') (([string]$Case.File) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path -LiteralPath $payloadPath -PathType Leaf)) {
+        throw "Mutation setup failed: Store payload file '$($Case.File)' was not found."
     }
-    if ($null -eq $mutatedPackage) {
-        throw "Mutation setup failed: Store grammar 'tree-sitter-kotlin.dll' was not found."
+    if ([string]$Case.Kind -ceq 'File') {
+        $bytes = [System.IO.File]::ReadAllBytes($payloadPath)
+        if ($bytes.Length -eq 0) { throw "Mutation setup failed: Store payload file '$($Case.File)' is empty." }
+        $offset = [int]($bytes.Length / 2)
+        $bytes[$offset] = $bytes[$offset] -bxor 1
+        [System.IO.File]::WriteAllBytes($payloadPath, $bytes)
     }
-
+    else {
+        [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateManagedResource($payloadPath, [string]$Case.Entry)
+    }
+    Compress-Directory -SourceDirectory $packageRoot -DestinationPath $packagePath
     Compress-Directory -SourceDirectory $bundleRoot -DestinationPath $bundles[0].FullName
     $rebuiltBundlePath = Join-Path $uploadRoot ($bundleRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
     if ($rebuiltBundlePath -cne $bundles[0].FullName) {
@@ -193,41 +198,36 @@ function Invoke-StoreGrammarMutation([string] $SourcePublishRoot) {
     }
     Compress-Directory -SourceDirectory $uploadRoot -DestinationPath $uploads[0].FullName
     Write-ChannelChecksums -ChannelDirectory $channelDirectory
-    Invoke-FailingValidation `
-        -FixturePublishRoot $fixtureRoot `
-        -Channel 'store' `
-        -ArtifactName $artifactName `
-        -ExpectedMissing 'tree-sitter-kotlin.dll'
+    Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'store' `
+        -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
 }
 
 $sourcePublishRoot = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($PublishRoot)) {
     Join-Path (Split-Path -Parent $PSScriptRoot) 'publish'
-} else {
-    $PublishRoot
-}))
+} else { $PublishRoot }))
 $selectedChannels = @(ConvertTo-Tokens $Channels)
 $script:SelectedRids = @(ConvertTo-Tokens $Rids)
 foreach ($channel in $selectedChannels) {
-    if ($channel -notin @('github', 'store')) {
-        throw "Unknown release channel '$channel'."
-    }
+    if ($channel -notin @('github', 'store')) { throw "Unknown release channel '$channel'." }
+}
+if ('github' -in $selectedChannels -and 'win-x64' -notin $script:SelectedRids) {
+    throw 'GitHub mutation gate requires win-x64 in -Rids.'
 }
 
 $script:MutationRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('devprojex-release-mutation-' + [guid]::NewGuid().ToString('N'))
 [System.IO.Directory]::CreateDirectory($script:MutationRoot) | Out-Null
 try {
     if ('github' -in $selectedChannels) {
-        Invoke-GitHubMutation `
-            -SourcePublishRoot $sourcePublishRoot `
-            -Needle 'tree-sitter-kotlin.dll' `
-            -Replacement 'tree-sitter-Xotlin.dll'
-        Invoke-GitHubMutation `
-            -SourcePublishRoot $sourcePublishRoot `
-            -Needle 'en.json' `
-            -Replacement 'eX.json'
+        $directory = Join-Path $sourcePublishRoot "github/v$Version"
+        foreach ($case in @(Get-ReceiptMutationCases -Receipt (Read-PayloadReceipt $directory 'win-x64'))) {
+            Invoke-GitHubMutation -SourcePublishRoot $sourcePublishRoot -Case $case
+        }
     }
     if ('store' -in $selectedChannels) {
-        Invoke-StoreGrammarMutation -SourcePublishRoot $sourcePublishRoot
+        $directory = Join-Path $sourcePublishRoot "store/v$Version"
+        foreach ($case in @(Get-ReceiptMutationCases -Receipt (Read-PayloadReceipt $directory 'win-x64'))) {
+            Invoke-StoreMutation -SourcePublishRoot $sourcePublishRoot -Case $case
+        }
     }
 }
 finally {

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -13,7 +13,9 @@ Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot 'release-archive-helpers.ps1')
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
-Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
+if ($null -eq ('DevProjex.ReleaseValidation.ReleasePayloadInspector' -as [type])) {
+    Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
+}
 
 function ConvertTo-Tokens([string[]] $Values) {
     return @($Values | ForEach-Object { ([string]$_).Split(',') } |

--- a/Scripts/Test-ReleaseArtifacts.ps1
+++ b/Scripts/Test-ReleaseArtifacts.ps1
@@ -1,0 +1,455 @@
+[CmdletBinding()]
+param(
+    [string] $PublishRoot = "",
+
+    [Parameter(Mandatory = $true)]
+    [string] $Version,
+
+    [string[]] $Channels = @("github", "store"),
+
+    [string[]] $Rids = @(
+        "win-x64",
+        "win-arm64",
+        "linux-x64",
+        "linux-arm64",
+        "osx-x64",
+        "osx-arm64"
+    )
+)
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot "release-archive-helpers.ps1")
+
+function ConvertTo-Selection(
+    [string[]] $Values,
+    [string[]] $Allowed,
+    [string] $Kind
+) {
+    $selection = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($value in @($Values)) {
+        foreach ($token in @(([string]$value).Split(','))) {
+            $normalized = $token.Trim().ToLowerInvariant()
+            if ([string]::IsNullOrWhiteSpace($normalized)) {
+                continue
+            }
+            if ($normalized -notin $Allowed) {
+                throw "Unknown release $Kind '$token'. Allowed values: $($Allowed -join ', ')."
+            }
+            if ($normalized -notin $selection) {
+                $selection.Add($normalized)
+            }
+        }
+    }
+    if ($selection.Count -eq 0) {
+        throw "At least one release $Kind must be selected."
+    }
+    return $selection.ToArray()
+}
+
+function Fail-Artifact([string] $ArtifactName, [string] $Problem) {
+    throw "Artifact '$ArtifactName' is incomplete: $Problem."
+}
+
+function Assert-Artifact(
+    [bool] $Condition,
+    [string] $ArtifactName,
+    [string] $Problem
+) {
+    if (-not $Condition) {
+        Fail-Artifact -ArtifactName $ArtifactName -Problem $Problem
+    }
+}
+
+function Get-StorePackageVersion([string] $DisplayVersion) {
+    if ($DisplayVersion -notmatch '^\d+(\.\d+){0,3}$') {
+        throw "Invalid release version '$DisplayVersion'. Expected 1-4 numeric segments."
+    }
+    $parts = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($part in $DisplayVersion.Split('.')) {
+        $parts.Add($part)
+    }
+    while ($parts.Count -lt 4) {
+        $parts.Add('0')
+    }
+    return $parts -join '.'
+}
+
+function Get-GitHubArtifactName([object] $Rid) {
+    if ($Rid.os -ceq 'win32') {
+        return "DevProjex.v$Version.$($Rid.rid).exe"
+    }
+    if ($Rid.os -ceq 'linux') {
+        return "DevProjex.v$Version.$($Rid.rid).tar.gz"
+    }
+    if ($Rid.os -ceq 'darwin') {
+        return "DevProjex.v$Version.$($Rid.rid).app.tar.gz"
+    }
+    throw "Unsupported release operating system '$($Rid.os)' for RID '$($Rid.rid)'."
+}
+
+function Assert-ExactNames(
+    [string[]] $Expected,
+    [string[]] $Actual,
+    [string] $ArtifactName,
+    [string] $Kind
+) {
+    $expectedNames = @($Expected | Sort-Object)
+    $actualNames = @($Actual | Sort-Object)
+    $differences = @(Compare-Object -ReferenceObject $expectedNames -DifferenceObject $actualNames -CaseSensitive)
+    Assert-Artifact `
+        -Condition ($differences.Count -eq 0) `
+        -ArtifactName $ArtifactName `
+        -Problem "missing or unexpected $Kind; expected: $($expectedNames -join ', '); found: $($actualNames -join ', ')"
+}
+
+function Get-ChecksumEntries([string] $DirectoryPath, [string[]] $ExpectedNames) {
+    $manifestPath = Join-Path $DirectoryPath 'SHA256SUMS.txt'
+    Assert-Artifact (Test-Path -LiteralPath $manifestPath -PathType Leaf) $DirectoryPath "missing SHA256SUMS.txt"
+
+    $entries = @{}
+    foreach ($line in @(Get-Content -LiteralPath $manifestPath)) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+        if ($line -notmatch '^(?<hash>[0-9a-f]{64}) \*(?<name>[^\r\n]+)$') {
+            Fail-Artifact $manifestPath "invalid checksum line '$line'"
+        }
+        $name = [string]$Matches.name
+        if ($entries.ContainsKey($name)) {
+            Fail-Artifact $manifestPath "duplicate checksum for '$name'"
+        }
+        $entries[$name] = [string]$Matches.hash
+    }
+
+    Assert-ExactNames -Expected $ExpectedNames -Actual @($entries.Keys) -ArtifactName $manifestPath -Kind 'checksum entries'
+    foreach ($name in $ExpectedNames) {
+        $artifactPath = Join-Path $DirectoryPath $name
+        Assert-Artifact (Test-Path -LiteralPath $artifactPath -PathType Leaf) $name "missing file"
+        $actualHash = Get-FileSha256Hex -path $artifactPath
+        Assert-Artifact ($actualHash -ceq [string]$entries[$name]) $name "invalid SHA-256; expected '$($entries[$name])', found '$actualHash'"
+    }
+    return $entries
+}
+
+function Assert-BinaryPayload(
+    [byte[]] $Bytes,
+    [object] $Rid,
+    [string] $ArtifactName
+) {
+    $payload = [System.Text.Encoding]::Latin1.GetString($Bytes)
+    $expectedPayloadNames = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($grammar in @($script:Manifest.grammars)) {
+        $grammarName = "$($Rid.grammarPrefix)$grammar$($Rid.grammarExtension)"
+        $expectedPayloadNames.Add([pscustomobject]@{ Name = $grammarName; Kind = 'grammar' })
+    }
+    foreach ($localization in @($script:Manifest.release.localizations)) {
+        $expectedPayloadNames.Add([pscustomobject]@{ Name = [string]$localization; Kind = 'localization' })
+    }
+    $pattern = @($expectedPayloadNames |
+        ForEach-Object { [System.Text.RegularExpressions.Regex]::Escape([string]$_.Name) } |
+        Sort-Object { $_.Length } -Descending) -join '|'
+    $foundNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+    foreach ($match in [System.Text.RegularExpressions.Regex]::Matches(
+        $payload,
+        $pattern,
+        [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)) {
+        [void]$foundNames.Add($match.Value)
+    }
+    foreach ($expected in $expectedPayloadNames) {
+        Assert-Artifact `
+            ($foundNames.Contains([string]$expected.Name)) `
+            $ArtifactName `
+            "missing $($expected.Kind) '$($expected.Name)'"
+    }
+    Assert-Artifact `
+        ($payload.IndexOf($Version, [System.StringComparison]::Ordinal) -ge 0) `
+        $ArtifactName `
+        "invalid informational version; expected '$Version' in the uncompressed single-file payload"
+}
+
+function Assert-WindowsReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
+    $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
+    $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($ArtifactPath)
+    Assert-Artifact `
+        (-not [string]::IsNullOrWhiteSpace($versionInfo.FileVersion) -and
+            $versionInfo.FileVersion.StartsWith($script:StorePackageVersion, [System.StringComparison]::OrdinalIgnoreCase)) `
+        $artifactName `
+        "invalid FileVersion; expected '$script:StorePackageVersion', found '$($versionInfo.FileVersion)'"
+    Assert-Artifact `
+        (-not [string]::IsNullOrWhiteSpace($versionInfo.ProductVersion) -and
+            $versionInfo.ProductVersion.StartsWith($Version, [System.StringComparison]::OrdinalIgnoreCase)) `
+        $artifactName `
+        "invalid ProductVersion; expected '$Version', found '$($versionInfo.ProductVersion)'"
+    Assert-BinaryPayload -Bytes ([System.IO.File]::ReadAllBytes($ArtifactPath)) -Rid $Rid -ArtifactName $artifactName
+}
+
+function Assert-LinuxReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
+    $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
+    $entries = @(Read-UstarGzipArchive -archivePath $ArtifactPath -captureEntryNames @([string]$Rid.releaseBinary))
+    Assert-Artifact ($entries.Count -eq 1) $artifactName "invalid archive layout; expected only '$($Rid.releaseBinary)'"
+    $binary = $entries[0]
+    Assert-Artifact ($binary.Name -ceq [string]$Rid.releaseBinary) $artifactName "missing executable '$($Rid.releaseBinary)'"
+    Assert-Artifact (($binary.Mode -band 73) -eq 73) $artifactName "invalid executable mode for '$($Rid.releaseBinary)'"
+    Assert-Artifact ($null -ne $binary.Bytes -and $binary.Bytes.Length -gt 0) $artifactName "empty executable '$($Rid.releaseBinary)'"
+    Assert-BinaryPayload -Bytes $binary.Bytes -Rid $Rid -ArtifactName $artifactName
+}
+
+function Get-PlistValue([xml] $Document, [string] $Key) {
+    $keyNode = $Document.SelectSingleNode("/plist/dict/key[text()='$Key']")
+    if ($null -eq $keyNode) {
+        return $null
+    }
+    $valueNode = $keyNode.NextSibling
+    while ($null -ne $valueNode -and $valueNode.NodeType -ne [System.Xml.XmlNodeType]::Element) {
+        $valueNode = $valueNode.NextSibling
+    }
+    if ($null -eq $valueNode -or $valueNode.LocalName -ne 'string') {
+        return $null
+    }
+    return [string]$valueNode.InnerText
+}
+
+function Assert-MacReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
+    $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
+    $binaryEntryName = 'DevProjex.app/Contents/MacOS/DevProjex'
+    $plistEntryName = 'DevProjex.app/Contents/Info.plist'
+    $expectedEntries = @(
+        'DevProjex.app/',
+        'DevProjex.app/Contents/',
+        $plistEntryName,
+        'DevProjex.app/Contents/MacOS/',
+        $binaryEntryName,
+        'DevProjex.app/Contents/Resources/',
+        'DevProjex.app/Contents/Resources/app.icns'
+    )
+    $entries = @(Read-UstarGzipArchive -archivePath $ArtifactPath -captureEntryNames @($plistEntryName, $binaryEntryName))
+    Assert-ExactNames -Expected $expectedEntries -Actual @($entries | ForEach-Object Name) -ArtifactName $artifactName -Kind 'macOS bundle entries'
+    $binary = $entries | Where-Object { $_.Name -ceq $binaryEntryName } | Select-Object -First 1
+    Assert-Artifact ($null -ne $binary -and ($binary.Mode -band 73) -eq 73) $artifactName "invalid executable mode for '$binaryEntryName'"
+    Assert-BinaryPayload -Bytes $binary.Bytes -Rid $Rid -ArtifactName $artifactName
+    $plist = $entries | Where-Object { $_.Name -ceq $plistEntryName } | Select-Object -First 1
+    Assert-Artifact ($null -ne $plist -and $null -ne $plist.Bytes) $artifactName "missing Info.plist"
+    [xml]$plistDocument = [System.Text.Encoding]::UTF8.GetString($plist.Bytes)
+    foreach ($versionKey in @('CFBundleVersion', 'CFBundleShortVersionString')) {
+        $actualVersion = Get-PlistValue -Document $plistDocument -Key $versionKey
+        Assert-Artifact ($actualVersion -ceq $Version) $artifactName "invalid $versionKey; expected '$Version', found '$actualVersion'"
+    }
+}
+
+function Test-GitHubArtifacts([object[]] $SelectedRids) {
+    $directory = Join-Path $script:PublishPath "github/v$Version"
+    Assert-Artifact (Test-Path -LiteralPath $directory -PathType Container) $directory "missing GitHub channel directory"
+    $expectedNames = @($SelectedRids | ForEach-Object { Get-GitHubArtifactName $_ })
+    $actualNames = @(
+        Get-ChildItem -LiteralPath $directory -File |
+            Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt') } |
+            ForEach-Object Name
+    )
+    Assert-ExactNames -Expected $expectedNames -Actual $actualNames -ArtifactName $directory -Kind 'GitHub artifact set'
+    [void](Get-ChecksumEntries -DirectoryPath $directory -ExpectedNames $expectedNames)
+
+    $partial = $SelectedRids.Count -ne @($script:Manifest.rids).Count
+    $partialMarker = Join-Path $directory 'PARTIAL-BUILD.txt'
+    if ($partial) {
+        Assert-Artifact (Test-Path -LiteralPath $partialMarker -PathType Leaf) $directory "missing PARTIAL-BUILD.txt for a partial RID set"
+        $marker = Get-Content -LiteralPath $partialMarker -Raw
+        foreach ($rid in $SelectedRids) {
+            Assert-Artifact ($marker.IndexOf([string]$rid.rid, [System.StringComparison]::Ordinal) -ge 0) $partialMarker "missing selected RID '$($rid.rid)'"
+        }
+    }
+    else {
+        Assert-Artifact (-not (Test-Path -LiteralPath $partialMarker)) $directory "unexpected PARTIAL-BUILD.txt for a complete RID set"
+    }
+
+    foreach ($rid in $SelectedRids) {
+        $artifactPath = Join-Path $directory (Get-GitHubArtifactName $rid)
+        if ($rid.os -ceq 'win32') {
+            Assert-WindowsReleaseArtifact -ArtifactPath $artifactPath -Rid $rid
+        }
+        elseif ($rid.os -ceq 'linux') {
+            Assert-LinuxReleaseArtifact -ArtifactPath $artifactPath -Rid $rid
+        }
+        else {
+            Assert-MacReleaseArtifact -ArtifactPath $artifactPath -Rid $rid
+        }
+    }
+
+    $status = if ($partial) { 'VALIDATED; PARTIAL (not release-ready)' } else { 'VALIDATED; COMPLETE' }
+    return [pscustomobject]@{ Channel = 'github'; Directory = $directory; Status = $status; Artifacts = $expectedNames }
+}
+
+function Expand-Zip([string] $ArchivePath, [string] $DestinationPath) {
+    [System.IO.Directory]::CreateDirectory($DestinationPath) | Out-Null
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($ArchivePath, $DestinationPath)
+}
+
+function Assert-StoreExecutionAlias([xml] $PackageManifest, [string] $PackageRoot, [string] $ArtifactName) {
+    $applications = @($PackageManifest.SelectNodes("//*[local-name()='Application']"))
+    Assert-Artifact ($applications.Count -eq 1) $ArtifactName "invalid Store Application count '$($applications.Count)'"
+    $aliases = @($PackageManifest.SelectNodes("//*[local-name()='ExecutionAlias']"))
+    Assert-Artifact ($aliases.Count -eq 1) $ArtifactName "invalid Store execution-alias count '$($aliases.Count)'"
+    $alias = [string]$aliases[0].GetAttribute('Alias')
+    Assert-Artifact ($alias -ceq [string]$script:Manifest.release.store.executionAlias) $ArtifactName "invalid execution alias '$alias'"
+    $aliasExtensions = @($PackageManifest.SelectNodes("//*[local-name()='Extension' and @Category='windows.appExecutionAlias']"))
+    Assert-Artifact ($aliasExtensions.Count -eq 1) $ArtifactName "missing windows.appExecutionAlias extension"
+    $executable = [string]$aliasExtensions[0].GetAttribute('Executable')
+    $expectedExecutable = [string]$script:Manifest.release.store.applicationExecutable
+    Assert-Artifact ($executable -ceq $expectedExecutable) $ArtifactName "invalid execution-alias executable '$executable'; expected '$expectedExecutable'"
+    $packagedExecutable = Join-Path $PackageRoot ($expectedExecutable -replace '[\\/]', [System.IO.Path]::DirectorySeparatorChar)
+    Assert-Artifact (Test-Path -LiteralPath $packagedExecutable -PathType Leaf) $ArtifactName "missing execution-alias executable '$expectedExecutable'"
+}
+
+function Assert-StoreApplicationPackage(
+    [string] $PackagePath,
+    [string] $Architecture,
+    [string] $ArtifactName,
+    [string] $TemporaryRoot
+) {
+    $packageRoot = Join-Path $TemporaryRoot ("package-" + $Architecture + '-' + [guid]::NewGuid().ToString('N'))
+    Expand-Zip -ArchivePath $PackagePath -DestinationPath $packageRoot
+    $manifestPath = Join-Path $packageRoot 'AppxManifest.xml'
+    Assert-Artifact (Test-Path -LiteralPath $manifestPath -PathType Leaf) $ArtifactName "missing AppxManifest.xml for '$Architecture'"
+    [xml]$packageManifest = Get-Content -LiteralPath $manifestPath -Raw
+    $identity = $packageManifest.SelectSingleNode("/*[local-name()='Package']/*[local-name()='Identity']")
+    Assert-Artifact ($null -ne $identity) $ArtifactName "missing package identity for '$Architecture'"
+    $actualArchitecture = [string]$identity.GetAttribute('ProcessorArchitecture')
+    $actualVersion = [string]$identity.GetAttribute('Version')
+    Assert-Artifact ($actualArchitecture.ToLowerInvariant() -ceq $Architecture) $ArtifactName "invalid package architecture '$actualArchitecture'; expected '$Architecture'"
+    Assert-Artifact ($actualVersion -ceq $script:StorePackageVersion) $ArtifactName "invalid package version '$actualVersion'; expected '$script:StorePackageVersion'"
+    Assert-StoreExecutionAlias -PackageManifest $packageManifest -PackageRoot $packageRoot -ArtifactName $ArtifactName
+
+    $applicationDirectory = Split-Path -Path ([string]$script:Manifest.release.store.applicationExecutable) -Parent
+    $grammarDirectory = Join-Path (Join-Path $packageRoot $applicationDirectory) 'grammars'
+    Assert-Artifact (Test-Path -LiteralPath $grammarDirectory -PathType Container) $ArtifactName "missing grammar directory '$applicationDirectory\grammars'"
+    $expectedGrammars = @($script:Manifest.grammars | ForEach-Object { "$_`.dll" })
+    $actualGrammars = @(Get-ChildItem -LiteralPath $grammarDirectory -File -Filter 'tree-sitter-*.dll' | ForEach-Object Name)
+    Assert-ExactNames -Expected $expectedGrammars -Actual $actualGrammars -ArtifactName $ArtifactName -Kind "grammar set for '$Architecture'"
+}
+
+function Assert-StoreBundle(
+    [string] $BundlePath,
+    [string] $ArtifactName,
+    [string] $TemporaryRoot
+) {
+    $bundleRoot = Join-Path $TemporaryRoot ('bundle-' + [guid]::NewGuid().ToString('N'))
+    Expand-Zip -ArchivePath $BundlePath -DestinationPath $bundleRoot
+    $bundleManifestPath = Join-Path $bundleRoot 'AppxMetadata/AppxBundleManifest.xml'
+    Assert-Artifact (Test-Path -LiteralPath $bundleManifestPath -PathType Leaf) $ArtifactName "missing AppxBundleManifest.xml"
+    [xml]$bundleManifest = Get-Content -LiteralPath $bundleManifestPath -Raw
+    $bundleIdentity = $bundleManifest.SelectSingleNode("/*[local-name()='Bundle']/*[local-name()='Identity']")
+    Assert-Artifact ($null -ne $bundleIdentity) $ArtifactName "missing bundle identity"
+    $bundleVersion = [string]$bundleIdentity.GetAttribute('Version')
+    Assert-Artifact ($bundleVersion -ceq $script:StorePackageVersion) $ArtifactName "invalid bundle version '$bundleVersion'; expected '$script:StorePackageVersion'"
+
+    $packageNodes = @($bundleManifest.SelectNodes("//*[local-name()='Package' and @Architecture]"))
+    $expectedPlatforms = @($script:Manifest.release.store.platforms | ForEach-Object { ([string]$_).ToLowerInvariant() })
+    $actualPlatforms = @($packageNodes | ForEach-Object { ([string]$_.GetAttribute('Architecture')).ToLowerInvariant() } | Sort-Object -Unique)
+    Assert-ExactNames -Expected $expectedPlatforms -Actual $actualPlatforms -ArtifactName $ArtifactName -Kind 'Store bundle platforms'
+
+    $languageNodes = @($bundleManifest.SelectNodes("//*[local-name()='Resource' and @Language]"))
+    $actualLanguages = @($languageNodes | ForEach-Object { ([string]$_.GetAttribute('Language')).ToLowerInvariant() } | Sort-Object -Unique)
+    $expectedLanguages = @($script:Manifest.release.store.resourceLanguages | ForEach-Object { ([string]$_).ToLowerInvariant() })
+    Assert-ExactNames -Expected $expectedLanguages -Actual $actualLanguages -ArtifactName $ArtifactName -Kind 'Store resource languages'
+
+    foreach ($platform in $expectedPlatforms) {
+        $matches = @($packageNodes | Where-Object { ([string]$_.GetAttribute('Architecture')).ToLowerInvariant() -ceq $platform })
+        Assert-Artifact ($matches.Count -eq 1) $ArtifactName "missing one application package for '$platform'"
+        $fileName = [string]$matches[0].GetAttribute('FileName')
+        $packagePath = Join-Path $bundleRoot ($fileName -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        Assert-Artifact (Test-Path -LiteralPath $packagePath -PathType Leaf) $ArtifactName "missing inner package '$fileName'"
+        Assert-StoreApplicationPackage -PackagePath $packagePath -Architecture $platform -ArtifactName $ArtifactName -TemporaryRoot $TemporaryRoot
+    }
+}
+
+function Assert-StoreUpload([string] $UploadPath, [string] $TemporaryRoot) {
+    $artifactName = [System.IO.Path]::GetFileName($UploadPath)
+    $uploadRoot = Join-Path $TemporaryRoot 'upload'
+    Expand-Zip -ArchivePath $UploadPath -DestinationPath $uploadRoot
+    $bundles = @(Get-ChildItem -LiteralPath $uploadRoot -Recurse -File -Filter '*.msixbundle')
+    Assert-Artifact ($bundles.Count -eq 1) $artifactName "missing one x64|arm64 .msixbundle"
+    Assert-StoreBundle `
+        -BundlePath $bundles[0].FullName `
+        -ArtifactName $artifactName `
+        -TemporaryRoot $TemporaryRoot
+}
+
+function Test-StoreArtifacts() {
+    $directory = Join-Path $script:PublishPath "store/v$Version"
+    Assert-Artifact (Test-Path -LiteralPath $directory -PathType Container) $directory "missing Store channel directory"
+    $expectedNames = @(
+        "DevProjex.Store_$($script:StorePackageVersion)_x64_arm64_bundle_ReleaseStore.msixupload",
+        "DevProjex.Store_$($script:StorePackageVersion)_x64_arm64_ReleaseStore.msixbundle",
+        "DevProjex.Store_$($script:StorePackageVersion)_x64_ReleaseStore.msix"
+    )
+    $packages = @(Get-ChildItem -LiteralPath $directory -File |
+        Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'msix-build.log') })
+    $packageNames = @($packages | ForEach-Object Name)
+    Assert-ExactNames -Expected $expectedNames -Actual $packageNames -ArtifactName $directory -Kind 'Store artifact set'
+    $uploads = @($packages | Where-Object { $_.Extension -ceq '.msixupload' })
+    Assert-Artifact ($uploads.Count -eq 1) $directory "missing exactly one .msixupload; found '$($uploads.Count)'"
+    [void](Get-ChecksumEntries -DirectoryPath $directory -ExpectedNames $expectedNames)
+
+    $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("devprojex-release-artifacts-" + [guid]::NewGuid().ToString('N'))
+    [System.IO.Directory]::CreateDirectory($temporaryRoot) | Out-Null
+    try {
+        Assert-StoreUpload -UploadPath $uploads[0].FullName -TemporaryRoot $temporaryRoot
+        Assert-StoreBundle `
+            -BundlePath (Join-Path $directory $expectedNames[1]) `
+            -ArtifactName $expectedNames[1] `
+            -TemporaryRoot $temporaryRoot
+        Assert-StoreApplicationPackage `
+            -PackagePath (Join-Path $directory $expectedNames[2]) `
+            -Architecture 'x64' `
+            -ArtifactName $expectedNames[2] `
+            -TemporaryRoot $temporaryRoot
+    }
+    finally {
+        $resolvedTemporaryRoot = [System.IO.Path]::GetFullPath($temporaryRoot)
+        $resolvedSystemTemp = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+        if ($resolvedTemporaryRoot.StartsWith($resolvedSystemTemp, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Remove-Item -LiteralPath $resolvedTemporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    return [pscustomobject]@{ Channel = 'store'; Directory = $directory; Status = 'VALIDATED; WACK status separate'; Artifacts = $expectedNames }
+}
+
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$manifestPath = Join-Path $repoRoot 'Packaging/Headless/payload-manifest.json'
+$script:Manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+Assert-Artifact ($script:Manifest.schemaVersion -eq 1) $manifestPath "unsupported schema version '$($script:Manifest.schemaVersion)'"
+Assert-Artifact ($null -ne $script:Manifest.release) $manifestPath "missing release contract"
+$script:StorePackageVersion = Get-StorePackageVersion -DisplayVersion $Version
+$script:PublishPath = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($PublishRoot)) { Join-Path $repoRoot 'publish' } else { $PublishRoot }))
+$allowedChannels = @('github', 'store')
+$allowedRids = @($script:Manifest.rids | ForEach-Object { [string]$_.rid })
+$selectedChannels = @(ConvertTo-Selection -Values $Channels -Allowed $allowedChannels -Kind 'channel')
+$selectedRidNames = @(ConvertTo-Selection -Values $Rids -Allowed $allowedRids -Kind 'RID')
+$selectedRids = @($selectedRidNames | ForEach-Object {
+    $ridName = $_
+    $script:Manifest.rids | Where-Object { $_.rid -ceq $ridName } | Select-Object -First 1
+})
+
+$results = New-Object 'System.Collections.Generic.List[object]'
+if ('github' -in $selectedChannels) {
+    $results.Add((Test-GitHubArtifacts -SelectedRids $selectedRids))
+}
+if ('store' -in $selectedChannels) {
+    $results.Add((Test-StoreArtifacts))
+}
+
+Write-Host 'Release artifact validation summary:'
+foreach ($result in $results) {
+    Write-Host "  Channel $($result.Channel): $($result.Status)"
+    foreach ($artifactName in @($result.Artifacts | Sort-Object)) {
+        $artifactPath = Join-Path $result.Directory $artifactName
+        $item = Get-Item -LiteralPath $artifactPath
+        Write-Host "    $artifactName | $($item.Length) bytes | SHA-256 $(Get-FileSha256Hex -path $artifactPath)"
+    }
+    Write-Host "    Output: $($result.Directory)"
+}

--- a/Scripts/Test-ReleaseArtifacts.ps1
+++ b/Scripts/Test-ReleaseArtifacts.ps1
@@ -91,6 +91,41 @@ function Get-GitHubArtifactName([object] $Rid) {
     throw "Unsupported release operating system '$($Rid.os)' for RID '$($Rid.rid)'."
 }
 
+function Get-PayloadReceiptName([string] $Rid) {
+    return "publish-payload.$Rid.json"
+}
+
+function Read-PayloadReceipt(
+    [string] $DirectoryPath,
+    [string] $Rid,
+    [string] $ArtifactName
+) {
+    $receiptName = Get-PayloadReceiptName -Rid $Rid
+    $receiptPath = Join-Path $DirectoryPath $receiptName
+    Assert-Artifact (Test-Path -LiteralPath $receiptPath -PathType Leaf) $ArtifactName "missing payload receipt '$receiptName'"
+    try {
+        $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json
+    }
+    catch {
+        Fail-Artifact $ArtifactName "invalid payload receipt '$receiptName': $($_.Exception.Message)"
+    }
+    Assert-Artifact `
+        ($receipt.PSObject.Properties.Name -contains 'schemaVersion') `
+        $ArtifactName `
+        "payload receipt '$receiptName' has no schemaVersion"
+    Assert-Artifact ($receipt.schemaVersion -eq 1) $ArtifactName "unsupported payload receipt schema '$($receipt.schemaVersion)'"
+    Assert-Artifact `
+        ($receipt.PSObject.Properties.Name -contains 'rid') `
+        $ArtifactName `
+        "payload receipt '$receiptName' has no RID"
+    Assert-Artifact ([string]$receipt.rid -ceq $Rid) $ArtifactName "payload receipt '$receiptName' names RID '$($receipt.rid)'"
+    Assert-Artifact `
+        ($receipt.PSObject.Properties.Name -contains 'files' -and $null -ne $receipt.files) `
+        $ArtifactName `
+        "payload receipt '$receiptName' has no files"
+    return $receipt
+}
+
 function Assert-ExactNames(
     [string[]] $Expected,
     [string[]] $Actual,
@@ -135,43 +170,111 @@ function Get-ChecksumEntries([string] $DirectoryPath, [string[]] $ExpectedNames)
     return $entries
 }
 
-function Assert-BinaryPayload(
-    [byte[]] $Bytes,
-    [object] $Rid,
+function Assert-PayloadDiff(
+    [object] $Receipt,
+    [object[]] $ActualFiles,
     [string] $ArtifactName
 ) {
-    $payload = [System.Text.Encoding]::Latin1.GetString($Bytes)
-    $expectedPayloadNames = New-Object 'System.Collections.Generic.List[object]'
-    foreach ($grammar in @($script:Manifest.grammars)) {
-        $grammarName = "$($Rid.grammarPrefix)$grammar$($Rid.grammarExtension)"
-        $expectedPayloadNames.Add([pscustomobject]@{ Name = $grammarName; Kind = 'grammar' })
-    }
-    foreach ($localization in @($script:Manifest.release.localizations)) {
-        $expectedPayloadNames.Add([pscustomobject]@{ Name = [string]$localization; Kind = 'localization' })
-    }
-    $pattern = @($expectedPayloadNames |
-        ForEach-Object { [System.Text.RegularExpressions.Regex]::Escape([string]$_.Name) } |
-        Sort-Object { $_.Length } -Descending) -join '|'
-    $foundNames = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
-    foreach ($match in [System.Text.RegularExpressions.Regex]::Matches(
-        $payload,
-        $pattern,
-        [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)) {
-        [void]$foundNames.Add($match.Value)
-    }
-    foreach ($expected in $expectedPayloadNames) {
+    $expectedByPath = @{}
+    foreach ($expected in @($Receipt.files)) {
         Assert-Artifact `
-            ($foundNames.Contains([string]$expected.Name)) `
+            ($null -ne $expected -and $expected.PSObject.Properties.Name -contains 'path') `
             $ArtifactName `
-            "missing $($expected.Kind) '$($expected.Name)'"
+            'payload receipt contains a file without a path'
+        $path = ([string]$expected.path).Replace('\', '/')
+        Assert-Artifact (-not [string]::IsNullOrWhiteSpace($path)) $ArtifactName 'payload receipt contains an empty file path'
+        Assert-Artifact (-not $expectedByPath.ContainsKey($path)) $ArtifactName "payload receipt contains duplicate file '$path'"
+        Assert-Artifact `
+            ($expected.PSObject.Properties.Name -contains 'size') `
+            $ArtifactName `
+            "payload receipt has no size for '$path'"
+        Assert-Artifact `
+            ($expected.PSObject.Properties.Name -contains 'sha256') `
+            $ArtifactName `
+            "payload receipt has no SHA-256 for '$path'"
+        Assert-Artifact ([long]$expected.size -ge 0) $ArtifactName "payload receipt has an invalid size for '$path'"
+        Assert-Artifact ([string]$expected.sha256 -cmatch '^[0-9a-f]{64}$') $ArtifactName "payload receipt has an invalid SHA-256 for '$path'"
+        if ($expected.PSObject.Properties.Name -contains 'managedResources') {
+            $resourceNames = @($expected.managedResources | ForEach-Object { [string]$_ })
+            Assert-Artifact `
+                (@($resourceNames | Sort-Object -Unique).Count -eq $resourceNames.Count) `
+                $ArtifactName `
+                "payload receipt has duplicate managed-resource names for '$path'"
+        }
+        $expectedByPath[$path] = $expected
     }
+
+    $actualByPath = @{}
+    foreach ($actual in @($ActualFiles)) {
+        $path = ([string]$actual.Path).Replace('\', '/')
+        Assert-Artifact (-not $actualByPath.ContainsKey($path)) $ArtifactName "artifact contains duplicate file '$path'"
+        $actualByPath[$path] = $actual
+    }
+
+    foreach ($path in @($expectedByPath.Keys | Sort-Object)) {
+        if (-not $actualByPath.ContainsKey($path)) {
+            Fail-Artifact $ArtifactName "missing file '$path'"
+        }
+    }
+    foreach ($path in @($actualByPath.Keys | Sort-Object)) {
+        if (-not $expectedByPath.ContainsKey($path)) {
+            Fail-Artifact $ArtifactName "unexpected file '$path'"
+        }
+    }
+
+    foreach ($path in @($expectedByPath.Keys | Sort-Object)) {
+        $expected = $expectedByPath[$path]
+        $actual = $actualByPath[$path]
+        $expectsResources = $expected.PSObject.Properties.Name -contains 'managedResources'
+        if ($expectsResources) {
+            Assert-Artifact ([bool]$actual.IsManagedAssembly) $ArtifactName "file '$path' is no longer a managed assembly"
+            $expectedResources = @($expected.managedResources | ForEach-Object { [string]$_ })
+            $actualResources = @($actual.ManagedResources | ForEach-Object { [string]$_ })
+            foreach ($resource in @($expectedResources | Sort-Object)) {
+                if ($resource -cnotin $actualResources) {
+                    Fail-Artifact $ArtifactName "missing resource '$resource' from '$path'"
+                }
+            }
+            foreach ($resource in @($actualResources | Sort-Object)) {
+                if ($resource -cnotin $expectedResources) {
+                    Fail-Artifact $ArtifactName "unexpected resource '$resource' in '$path'"
+                }
+            }
+        }
+        elseif ([bool]$actual.IsManagedAssembly) {
+            Fail-Artifact $ArtifactName "unexpected managed assembly '$path'"
+        }
+
+        $expectedSize = [long]$expected.size
+        $actualSize = [long]$actual.Size
+        Assert-Artifact ($actualSize -eq $expectedSize) $ArtifactName "invalid size for '$path'; expected '$expectedSize', found '$actualSize'"
+        $expectedHash = ([string]$expected.sha256).ToLowerInvariant()
+        $actualHash = ([string]$actual.Sha256).ToLowerInvariant()
+        Assert-Artifact ($actualHash -ceq $expectedHash) $ArtifactName "invalid SHA-256 for '$path'; expected '$expectedHash', found '$actualHash'"
+    }
+}
+
+function Assert-SingleFilePayload(
+    [byte[]] $Bytes,
+    [object] $Receipt,
+    [string] $ArtifactName
+) {
+    try {
+        $inspection = [DevProjex.ReleaseValidation.ReleasePayloadInspector]::InspectBundle($Bytes)
+    }
+    catch {
+        $problem = if ($null -ne $_.Exception.InnerException) { $_.Exception.InnerException.Message } else { $_.Exception.Message }
+        Fail-Artifact $ArtifactName $problem
+    }
+    Assert-PayloadDiff -Receipt $Receipt -ActualFiles @($inspection.Files) -ArtifactName $ArtifactName
+    $payload = [System.Text.Encoding]::Latin1.GetString($Bytes)
     Assert-Artifact `
         ($payload.IndexOf($Version, [System.StringComparison]::Ordinal) -ge 0) `
         $ArtifactName `
         "invalid informational version; expected '$Version' in the uncompressed single-file payload"
 }
 
-function Assert-WindowsReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
+function Assert-WindowsReleaseArtifact([string] $ArtifactPath, [object] $Receipt) {
     $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
     $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($ArtifactPath)
     Assert-Artifact `
@@ -184,10 +287,10 @@ function Assert-WindowsReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
             $versionInfo.ProductVersion.StartsWith($Version, [System.StringComparison]::OrdinalIgnoreCase)) `
         $artifactName `
         "invalid ProductVersion; expected '$Version', found '$($versionInfo.ProductVersion)'"
-    Assert-BinaryPayload -Bytes ([System.IO.File]::ReadAllBytes($ArtifactPath)) -Rid $Rid -ArtifactName $artifactName
+    Assert-SingleFilePayload -Bytes ([System.IO.File]::ReadAllBytes($ArtifactPath)) -Receipt $Receipt -ArtifactName $artifactName
 }
 
-function Assert-LinuxReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
+function Assert-LinuxReleaseArtifact([string] $ArtifactPath, [object] $Rid, [object] $Receipt) {
     $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
     $entries = @(Read-UstarGzipArchive -archivePath $ArtifactPath -captureEntryNames @([string]$Rid.releaseBinary))
     Assert-Artifact ($entries.Count -eq 1) $artifactName "invalid archive layout; expected only '$($Rid.releaseBinary)'"
@@ -195,7 +298,7 @@ function Assert-LinuxReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
     Assert-Artifact ($binary.Name -ceq [string]$Rid.releaseBinary) $artifactName "missing executable '$($Rid.releaseBinary)'"
     Assert-Artifact (($binary.Mode -band 73) -eq 73) $artifactName "invalid executable mode for '$($Rid.releaseBinary)'"
     Assert-Artifact ($null -ne $binary.Bytes -and $binary.Bytes.Length -gt 0) $artifactName "empty executable '$($Rid.releaseBinary)'"
-    Assert-BinaryPayload -Bytes $binary.Bytes -Rid $Rid -ArtifactName $artifactName
+    Assert-SingleFilePayload -Bytes $binary.Bytes -Receipt $Receipt -ArtifactName $artifactName
 }
 
 function Get-PlistValue([xml] $Document, [string] $Key) {
@@ -213,7 +316,7 @@ function Get-PlistValue([xml] $Document, [string] $Key) {
     return [string]$valueNode.InnerText
 }
 
-function Assert-MacReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
+function Assert-MacReleaseArtifact([string] $ArtifactPath, [object] $Rid, [object] $Receipt) {
     $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
     $binaryEntryName = 'DevProjex.app/Contents/MacOS/DevProjex'
     $plistEntryName = 'DevProjex.app/Contents/Info.plist'
@@ -230,7 +333,7 @@ function Assert-MacReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
     Assert-ExactNames -Expected $expectedEntries -Actual @($entries | ForEach-Object Name) -ArtifactName $artifactName -Kind 'macOS bundle entries'
     $binary = $entries | Where-Object { $_.Name -ceq $binaryEntryName } | Select-Object -First 1
     Assert-Artifact ($null -ne $binary -and ($binary.Mode -band 73) -eq 73) $artifactName "invalid executable mode for '$binaryEntryName'"
-    Assert-BinaryPayload -Bytes $binary.Bytes -Rid $Rid -ArtifactName $artifactName
+    Assert-SingleFilePayload -Bytes $binary.Bytes -Receipt $Receipt -ArtifactName $artifactName
     $plist = $entries | Where-Object { $_.Name -ceq $plistEntryName } | Select-Object -First 1
     Assert-Artifact ($null -ne $plist -and $null -ne $plist.Bytes) $artifactName "missing Info.plist"
     [xml]$plistDocument = [System.Text.Encoding]::UTF8.GetString($plist.Bytes)
@@ -243,7 +346,9 @@ function Assert-MacReleaseArtifact([string] $ArtifactPath, [object] $Rid) {
 function Test-GitHubArtifacts([object[]] $SelectedRids) {
     $directory = Join-Path $script:PublishPath "github/v$Version"
     Assert-Artifact (Test-Path -LiteralPath $directory -PathType Container) $directory "missing GitHub channel directory"
-    $expectedNames = @($SelectedRids | ForEach-Object { Get-GitHubArtifactName $_ })
+    $artifactNames = @($SelectedRids | ForEach-Object { Get-GitHubArtifactName $_ })
+    $receiptNames = @($SelectedRids | ForEach-Object { Get-PayloadReceiptName -Rid ([string]$_.rid) })
+    $expectedNames = @($artifactNames) + @($receiptNames)
     $actualNames = @(
         Get-ChildItem -LiteralPath $directory -File |
             Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt') } |
@@ -267,14 +372,15 @@ function Test-GitHubArtifacts([object[]] $SelectedRids) {
 
     foreach ($rid in $SelectedRids) {
         $artifactPath = Join-Path $directory (Get-GitHubArtifactName $rid)
+        $receipt = Read-PayloadReceipt -DirectoryPath $directory -Rid ([string]$rid.rid) -ArtifactName ([System.IO.Path]::GetFileName($artifactPath))
         if ($rid.os -ceq 'win32') {
-            Assert-WindowsReleaseArtifact -ArtifactPath $artifactPath -Rid $rid
+            Assert-WindowsReleaseArtifact -ArtifactPath $artifactPath -Receipt $receipt
         }
         elseif ($rid.os -ceq 'linux') {
-            Assert-LinuxReleaseArtifact -ArtifactPath $artifactPath -Rid $rid
+            Assert-LinuxReleaseArtifact -ArtifactPath $artifactPath -Rid $rid -Receipt $receipt
         }
         else {
-            Assert-MacReleaseArtifact -ArtifactPath $artifactPath -Rid $rid
+            Assert-MacReleaseArtifact -ArtifactPath $artifactPath -Rid $rid -Receipt $receipt
         }
     }
 
@@ -285,6 +391,52 @@ function Test-GitHubArtifacts([object[]] $SelectedRids) {
 function Expand-Zip([string] $ArchivePath, [string] $DestinationPath) {
     [System.IO.Directory]::CreateDirectory($DestinationPath) | Out-Null
     [System.IO.Compression.ZipFile]::ExtractToDirectory($ArchivePath, $DestinationPath)
+}
+
+function Test-StoreChannelAddition([string] $Path) {
+    $normalized = $Path.Replace('\', '/')
+    # Package identity and application declarations are generated by Desktop Bridge.
+    if ($normalized -ceq 'AppxManifest.xml') { return $true }
+    # The block map is generated from the final package layout.
+    if ($normalized -ceq 'AppxBlockMap.xml') { return $true }
+    # OPC content types describe the MSIX container itself.
+    if ($normalized -ceq '[Content_Types].xml') { return $true }
+    # Package signing adds this file after payload collection.
+    if ($normalized -ceq 'AppxSignature.p7x') { return $true }
+    # PRI data is generated from Store resource declarations.
+    if ($normalized -ceq 'resources.pri') { return $true }
+    # Store logos and tiles belong to the packaging project, not the application publish.
+    if ($normalized.StartsWith('Assets/', [System.StringComparison]::Ordinal)) { return $true }
+    return $false
+}
+
+function Get-StorePayloadFiles(
+    [string] $PackageRoot,
+    [string] $ApplicationDirectory,
+    [string] $ArtifactName
+) {
+    $applicationPrefix = $ApplicationDirectory.Replace('\', '/').TrimEnd('/') + '/'
+    $payloadFiles = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($file in @(Get-ChildItem -LiteralPath $PackageRoot -Recurse -File)) {
+        $relativePath = $file.FullName.Substring($PackageRoot.Length).TrimStart('\', '/').Replace('\', '/')
+        if (-not $relativePath.StartsWith($applicationPrefix, [System.StringComparison]::Ordinal)) {
+            if (-not (Test-StoreChannelAddition -Path $relativePath)) {
+                Fail-Artifact $ArtifactName "unexpected file '$relativePath'"
+            }
+            continue
+        }
+
+        $payloadPath = $relativePath.Substring($applicationPrefix.Length)
+        $resources = [DevProjex.ReleaseValidation.ReleasePayloadInspector]::TryReadManagedResources($file.FullName)
+        $payloadFiles.Add([pscustomobject]@{
+            Path = $payloadPath
+            Size = $file.Length
+            Sha256 = Get-FileSha256Hex -path $file.FullName
+            IsManagedAssembly = $null -ne $resources
+            ManagedResources = if ($null -eq $resources) { @() } else { @($resources) }
+        })
+    }
+    return $payloadFiles.ToArray()
 }
 
 function Assert-StoreExecutionAlias([xml] $PackageManifest, [string] $PackageRoot, [string] $ArtifactName) {
@@ -307,7 +459,8 @@ function Assert-StoreApplicationPackage(
     [string] $PackagePath,
     [string] $Architecture,
     [string] $ArtifactName,
-    [string] $TemporaryRoot
+    [string] $TemporaryRoot,
+    [object] $Receipt
 ) {
     $packageRoot = Join-Path $TemporaryRoot ("package-" + $Architecture + '-' + [guid]::NewGuid().ToString('N'))
     Expand-Zip -ArchivePath $PackagePath -DestinationPath $packageRoot
@@ -323,17 +476,18 @@ function Assert-StoreApplicationPackage(
     Assert-StoreExecutionAlias -PackageManifest $packageManifest -PackageRoot $packageRoot -ArtifactName $ArtifactName
 
     $applicationDirectory = Split-Path -Path ([string]$script:Manifest.release.store.applicationExecutable) -Parent
-    $grammarDirectory = Join-Path (Join-Path $packageRoot $applicationDirectory) 'grammars'
-    Assert-Artifact (Test-Path -LiteralPath $grammarDirectory -PathType Container) $ArtifactName "missing grammar directory '$applicationDirectory\grammars'"
-    $expectedGrammars = @($script:Manifest.grammars | ForEach-Object { "$_`.dll" })
-    $actualGrammars = @(Get-ChildItem -LiteralPath $grammarDirectory -File -Filter 'tree-sitter-*.dll' | ForEach-Object Name)
-    Assert-ExactNames -Expected $expectedGrammars -Actual $actualGrammars -ArtifactName $ArtifactName -Kind "grammar set for '$Architecture'"
+    $payloadFiles = @(Get-StorePayloadFiles `
+        -PackageRoot $packageRoot `
+        -ApplicationDirectory $applicationDirectory `
+        -ArtifactName $ArtifactName)
+    Assert-PayloadDiff -Receipt $Receipt -ActualFiles $payloadFiles -ArtifactName $ArtifactName
 }
 
 function Assert-StoreBundle(
     [string] $BundlePath,
     [string] $ArtifactName,
-    [string] $TemporaryRoot
+    [string] $TemporaryRoot,
+    [hashtable] $Receipts
 ) {
     $bundleRoot = Join-Path $TemporaryRoot ('bundle-' + [guid]::NewGuid().ToString('N'))
     Expand-Zip -ArchivePath $BundlePath -DestinationPath $bundleRoot
@@ -361,11 +515,16 @@ function Assert-StoreBundle(
         $fileName = [string]$matches[0].GetAttribute('FileName')
         $packagePath = Join-Path $bundleRoot ($fileName -replace '/', [System.IO.Path]::DirectorySeparatorChar)
         Assert-Artifact (Test-Path -LiteralPath $packagePath -PathType Leaf) $ArtifactName "missing inner package '$fileName'"
-        Assert-StoreApplicationPackage -PackagePath $packagePath -Architecture $platform -ArtifactName $ArtifactName -TemporaryRoot $TemporaryRoot
+        Assert-StoreApplicationPackage `
+            -PackagePath $packagePath `
+            -Architecture $platform `
+            -ArtifactName $ArtifactName `
+            -TemporaryRoot $TemporaryRoot `
+            -Receipt $Receipts[$platform]
     }
 }
 
-function Assert-StoreUpload([string] $UploadPath, [string] $TemporaryRoot) {
+function Assert-StoreUpload([string] $UploadPath, [string] $TemporaryRoot, [hashtable] $Receipts) {
     $artifactName = [System.IO.Path]::GetFileName($UploadPath)
     $uploadRoot = Join-Path $TemporaryRoot 'upload'
     Expand-Zip -ArchivePath $UploadPath -DestinationPath $uploadRoot
@@ -374,38 +533,53 @@ function Assert-StoreUpload([string] $UploadPath, [string] $TemporaryRoot) {
     Assert-StoreBundle `
         -BundlePath $bundles[0].FullName `
         -ArtifactName $artifactName `
-        -TemporaryRoot $TemporaryRoot
+        -TemporaryRoot $TemporaryRoot `
+        -Receipts $Receipts
 }
 
 function Test-StoreArtifacts() {
     $directory = Join-Path $script:PublishPath "store/v$Version"
     Assert-Artifact (Test-Path -LiteralPath $directory -PathType Container) $directory "missing Store channel directory"
-    $expectedNames = @(
+    $packageNames = @(
         "DevProjex.Store_$($script:StorePackageVersion)_x64_arm64_bundle_ReleaseStore.msixupload",
         "DevProjex.Store_$($script:StorePackageVersion)_x64_arm64_ReleaseStore.msixbundle",
         "DevProjex.Store_$($script:StorePackageVersion)_x64_ReleaseStore.msix"
     )
+    $storeRidNames = @($script:Manifest.release.store.platforms | ForEach-Object { "win-$(([string]$_).ToLowerInvariant())" })
+    $receiptNames = @($storeRidNames | ForEach-Object { Get-PayloadReceiptName -Rid $_ })
+    $expectedNames = @($packageNames) + @($receiptNames)
     $packages = @(Get-ChildItem -LiteralPath $directory -File |
-        Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'msix-build.log') })
-    $packageNames = @($packages | ForEach-Object Name)
-    Assert-ExactNames -Expected $expectedNames -Actual $packageNames -ArtifactName $directory -Kind 'Store artifact set'
+        Where-Object { $_.Extension -in @('.msixupload', '.msixbundle', '.msix') })
+    $actualNames = @(Get-ChildItem -LiteralPath $directory -File |
+        Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'msix-build.log') } |
+        ForEach-Object Name)
+    Assert-ExactNames -Expected $expectedNames -Actual $actualNames -ArtifactName $directory -Kind 'Store artifact set'
     $uploads = @($packages | Where-Object { $_.Extension -ceq '.msixupload' })
     Assert-Artifact ($uploads.Count -eq 1) $directory "missing exactly one .msixupload; found '$($uploads.Count)'"
     [void](Get-ChecksumEntries -DirectoryPath $directory -ExpectedNames $expectedNames)
 
+    $receipts = @{}
+    foreach ($platform in @($script:Manifest.release.store.platforms)) {
+        $platformName = ([string]$platform).ToLowerInvariant()
+        $rid = "win-$platformName"
+        $receipts[$platformName] = Read-PayloadReceipt -DirectoryPath $directory -Rid $rid -ArtifactName $directory
+    }
+
     $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("devprojex-release-artifacts-" + [guid]::NewGuid().ToString('N'))
     [System.IO.Directory]::CreateDirectory($temporaryRoot) | Out-Null
     try {
-        Assert-StoreUpload -UploadPath $uploads[0].FullName -TemporaryRoot $temporaryRoot
+        Assert-StoreUpload -UploadPath $uploads[0].FullName -TemporaryRoot $temporaryRoot -Receipts $receipts
         Assert-StoreBundle `
-            -BundlePath (Join-Path $directory $expectedNames[1]) `
-            -ArtifactName $expectedNames[1] `
-            -TemporaryRoot $temporaryRoot
+            -BundlePath (Join-Path $directory $packageNames[1]) `
+            -ArtifactName $packageNames[1] `
+            -TemporaryRoot $temporaryRoot `
+            -Receipts $receipts
         Assert-StoreApplicationPackage `
-            -PackagePath (Join-Path $directory $expectedNames[2]) `
+            -PackagePath (Join-Path $directory $packageNames[2]) `
             -Architecture 'x64' `
-            -ArtifactName $expectedNames[2] `
-            -TemporaryRoot $temporaryRoot
+            -ArtifactName $packageNames[2] `
+            -TemporaryRoot $temporaryRoot `
+            -Receipt $receipts['x64']
     }
     finally {
         $resolvedTemporaryRoot = [System.IO.Path]::GetFullPath($temporaryRoot)
@@ -419,6 +593,7 @@ function Test-StoreArtifacts() {
 
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
+Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
 
 $manifestPath = Join-Path $repoRoot 'Packaging/Headless/payload-manifest.json'
 $script:Manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json

--- a/Scripts/Test-ReleaseArtifacts.ps1
+++ b/Scripts/Test-ReleaseArtifacts.ps1
@@ -593,7 +593,9 @@ function Test-StoreArtifacts() {
 
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
-Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
+if ($null -eq ('DevProjex.ReleaseValidation.ReleasePayloadInspector' -as [type])) {
+    Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
+}
 
 $manifestPath = Join-Path $repoRoot 'Packaging/Headless/payload-manifest.json'
 $script:Manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json

--- a/Scripts/Write-PublishPayloadReceipt.ps1
+++ b/Scripts/Write-PublishPayloadReceipt.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Rid,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ItemsPath,
+
+    [Parameter(Mandatory = $true)]
+    [string] $OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Add-Type -Path (Join-Path $PSScriptRoot 'ReleasePayloadInspection.cs')
+
+$files = New-Object 'System.Collections.Generic.List[object]'
+$seenPaths = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+foreach ($line in @(Get-Content -LiteralPath $ItemsPath)) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+        continue
+    }
+
+    $parts = $line.Split("`t", 2)
+    if ($parts.Count -ne 2) {
+        throw "Invalid publish payload item '$line'."
+    }
+
+    $sourcePath = [System.IO.Path]::GetFullPath($parts[0])
+    $relativePath = $parts[1].Replace('\', '/').TrimStart('/')
+    if ([string]::IsNullOrWhiteSpace($relativePath) -or -not $seenPaths.Add($relativePath)) {
+        throw "Duplicate or empty publish payload path '$relativePath'."
+    }
+    if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+        throw "Publish payload source '$sourcePath' for '$relativePath' does not exist."
+    }
+
+    $item = Get-Item -LiteralPath $sourcePath
+    $resources = [DevProjex.ReleaseValidation.ReleasePayloadInspector]::TryReadManagedResources($sourcePath)
+    $entry = [ordered]@{
+        path = $relativePath
+        size = $item.Length
+        sha256 = (Get-FileHash -LiteralPath $sourcePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+    if ($null -ne $resources) {
+        $entry.managedResources = @($resources)
+    }
+    $files.Add($entry)
+}
+
+$receiptDirectory = Split-Path -Parent $OutputPath
+if (-not [string]::IsNullOrWhiteSpace($receiptDirectory)) {
+    [System.IO.Directory]::CreateDirectory($receiptDirectory) | Out-Null
+}
+
+$receipt = [ordered]@{
+    schemaVersion = 1
+    rid = $Rid
+    files = @($files | Sort-Object { [string]$_.path })
+}
+$json = $receipt | ConvertTo-Json -Depth 8
+[System.IO.File]::WriteAllText(
+    [System.IO.Path]::GetFullPath($OutputPath),
+    $json + [Environment]::NewLine,
+    [System.Text.UTF8Encoding]::new($false))
+
+Write-Host "Release payload receipt: $OutputPath ($($files.Count) files)"

--- a/Scripts/release-all.ps1
+++ b/Scripts/release-all.ps1
@@ -1,14 +1,12 @@
 <#
 .SYNOPSIS
-  Interactive release builder that runs in an isolated temporary workspace.
+  Builds or validates selected local release channels in an isolated workspace.
 
 .DESCRIPTION
-  This script keeps your local Rider workspace stable:
-    1) asks for a version in 2-4 segment format (4.6 / 4.7.1 / 4.7.1.0)
-    2) copies repo to a temporary isolated workspace
-    3) builds GitHub artifacts in Release mode
-    4) optionally builds the Microsoft Store package in ReleaseStore mode
-    5) copies final artifacts back to local publish folders only
+  The default run builds all GitHub and Microsoft Store artifacts. Channels and
+  GitHub runtime identifiers can be narrowed for diagnostics. Existing artifacts
+  can be validated without rebuilding, and WACK can be run separately from an
+  elevated console after a Store build that used -SkipWack.
 
   The script never writes build artifacts into your working source tree
   except:
@@ -24,9 +22,23 @@ param(
     [string]$Version = "",
     [switch]$ValidateConfigOnly,
     [switch]$SmokeStoreBuildOnly,
-    [switch]$GitHubArtifactsOnly
+    [switch]$GitHubArtifactsOnly,
+    [string[]]$Channels = @("github", "store"),
+    [string[]]$Rids = @(
+        "win-x64",
+        "win-arm64",
+        "linux-x64",
+        "linux-arm64",
+        "osx-x64",
+        "osx-arm64"
+    ),
+    [switch]$SkipWack,
+    [switch]$WackOnly,
+    [switch]$ValidateArtifactsOnly,
+    [switch]$NonInteractive
 )
 
+$script:ChannelsExplicit = $PSBoundParameters.ContainsKey('Channels')
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "release-helpers.ps1")
@@ -41,10 +53,304 @@ $script:StoreApplicationId = "App"
 $script:StoreExecutionAliasName = "devprojex.exe"
 $script:StoreUiPackageExecutable = "DevProjex.Avalonia\DevProjex.exe"
 $script:StoreFullTrustEntryPoint = "Windows.FullTrustApplication"
+$script:AllReleaseChannels = @("github", "store")
+$script:AllReleaseRids = @(
+    "win-x64",
+    "win-arm64",
+    "linux-x64",
+    "linux-arm64",
+    "osx-x64",
+    "osx-arm64"
+)
 
 function Write-Step([string]$message) {
     Write-Host ""
     Write-Host "=== $message ===" -ForegroundColor Cyan
+}
+
+function ConvertTo-ReleaseSelection(
+    [string[]]$values,
+    [string[]]$allowed,
+    [string]$kind
+) {
+    $selection = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($value in @($values)) {
+        foreach ($token in @(([string]$value).Split(','))) {
+            $normalized = $token.Trim().ToLowerInvariant()
+            if ([string]::IsNullOrWhiteSpace($normalized)) {
+                continue
+            }
+            if ($normalized -notin $allowed) {
+                throw "Unknown release $kind '$token'. Allowed values: $($allowed -join ', ')."
+            }
+            if ($normalized -notin $selection) {
+                $selection.Add($normalized)
+            }
+        }
+    }
+    if ($selection.Count -eq 0) {
+        throw "At least one release $kind must be selected."
+    }
+    return $selection.ToArray()
+}
+
+function Resolve-ReleaseInvocation([bool]$channelsExplicit) {
+    $selectedChannels = @(ConvertTo-ReleaseSelection -values $Channels -allowed $script:AllReleaseChannels -kind 'channel')
+    $selectedRids = @(ConvertTo-ReleaseSelection -values $Rids -allowed $script:AllReleaseRids -kind 'RID')
+
+    if ($GitHubArtifactsOnly) {
+        if ($channelsExplicit -and
+            ($selectedChannels.Count -ne 1 -or $selectedChannels[0] -cne 'github')) {
+            throw "-GitHubArtifactsOnly is an alias for -Channels github and cannot be combined with another channel selection."
+        }
+        $selectedChannels = @('github')
+    }
+
+    $legacyModes = @(@($ValidateConfigOnly, $SmokeStoreBuildOnly) | Where-Object { $_ })
+    if ($legacyModes.Count -gt 1 -or
+        (($ValidateConfigOnly -or $SmokeStoreBuildOnly) -and
+            ($GitHubArtifactsOnly -or $WackOnly -or $ValidateArtifactsOnly))) {
+        throw "Use only one of -ValidateConfigOnly, -SmokeStoreBuildOnly, -WackOnly, or -ValidateArtifactsOnly."
+    }
+    if ($WackOnly -and 'github' -in $selectedChannels) {
+        throw "-WackOnly supports only the store channel; pass -Channels store."
+    }
+    if ($SkipWack -and $WackOnly) {
+        throw "-SkipWack cannot be combined with -WackOnly."
+    }
+    if ($ValidateArtifactsOnly -and $WackOnly) {
+        throw "-ValidateArtifactsOnly cannot be combined with -WackOnly."
+    }
+
+    return [pscustomobject]@{
+        Channels = $selectedChannels
+        Rids = $selectedRids
+        IsPartialGitHub = ($selectedRids.Count -ne $script:AllReleaseRids.Count)
+    }
+}
+
+function Resolve-ReleaseVersionInfo([string]$repoRoot) {
+    $defaultReleaseVersionInfo = Get-DefaultReleaseVersionInfo -repoRoot $repoRoot
+    $initialVersion = if ([string]::IsNullOrWhiteSpace($Version)) {
+        [string]$defaultReleaseVersionInfo.DisplayVersion
+    }
+    else {
+        $Version
+    }
+
+    if ($NonInteractive) {
+        $parsedVersion = Try-ParseVersionInput -rawVersion $initialVersion
+        if ($null -eq $parsedVersion) {
+            throw "Invalid release version '$initialVersion'. Expected 1-4 numeric segments."
+        }
+        return $parsedVersion
+    }
+
+    return Get-VersionInteractive -currentValue $initialVersion
+}
+
+function Invoke-ReleaseArtifactValidator(
+    [string]$publishRoot,
+    [string]$version,
+    [string[]]$channels,
+    [string[]]$rids,
+    [string]$validatorRepoRoot = ""
+) {
+    $arguments = @{
+        PublishRoot = $publishRoot
+        Version = $version
+        Channels = $channels
+        Rids = $rids
+    }
+    $validationRoot = if ([string]::IsNullOrWhiteSpace($validatorRepoRoot)) {
+        $script:IsolatedRepoRoot
+    }
+    else {
+        $validatorRepoRoot
+    }
+    & (Join-Path $validationRoot 'Scripts\Test-ReleaseArtifacts.ps1') @arguments
+}
+
+function Write-GitHubPartialMarker(
+    [string]$releaseDirectory,
+    [string]$version,
+    [string[]]$rids
+) {
+    $markerPath = Join-Path $releaseDirectory 'PARTIAL-BUILD.txt'
+    $content = @(
+        'PARTIAL BUILD - NOT READY FOR RELEASE',
+        "Version: $version",
+        "RIDs: $($rids -join ', ')"
+    )
+    Set-Content -LiteralPath $markerPath -Value $content -Encoding UTF8
+}
+
+function Write-ChannelChecksums([string]$directory) {
+    $artifactFiles = @(
+        Get-ChildItem -LiteralPath $directory -File |
+            Where-Object {
+                $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt', 'msix-build.log')
+            } |
+            Sort-Object Name
+    )
+    $hashLines = @($artifactFiles | ForEach-Object {
+        "$(Get-FileSha256Hex -path $_.FullName) *$($_.Name)"
+    })
+    Write-ReleaseChecksumManifest -path (Join-Path $directory 'SHA256SUMS.txt') -lines $hashLines
+}
+
+function Write-ReleaseSummary(
+    [string]$sourceRoot,
+    [string]$version,
+    [string[]]$channels,
+    [bool]$partialGitHub,
+    [string]$githubStatus,
+    [string]$storeStatus
+) {
+    Write-Step 'Release summary'
+    foreach ($channel in $channels) {
+        $directory = Join-Path $sourceRoot "publish\$channel\v$version"
+        $status = if ($channel -ceq 'github') { $githubStatus } else { $storeStatus }
+        if ($channel -ceq 'github' -and $partialGitHub) {
+            $status += '; PARTIAL'
+        }
+        Write-Host "Channel ${channel}: $status"
+        foreach ($artifact in @(Get-ChildItem -LiteralPath $directory -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt', 'msix-build.log') } |
+            Sort-Object Name)) {
+            Write-Host "  $($artifact.Name) | $($artifact.Length) bytes | SHA-256 $(Get-FileSha256Hex -path $artifact.FullName)"
+        }
+        Write-Host "  Output: $directory"
+    }
+}
+
+function Test-WackSummaryPassed([string]$summaryPath) {
+    if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+        return $false
+    }
+    return $null -ne (Get-Content -LiteralPath $summaryPath |
+        Where-Object { $_ -match '^(MSIXUPLOAD|MSIXBUNDLE|MSIX): PASS \(' } |
+        Select-Object -First 1)
+}
+
+function Invoke-CapturedArtifactCommand(
+    [string]$executablePath,
+    [string[]]$arguments,
+    [string]$workingDirectory
+) {
+    $quotedArguments = @($arguments | ForEach-Object {
+        $argument = [string]$_
+        if ($argument.Length -eq 0 -or $argument -match '[\s"]') {
+            '"' + $argument.Replace('"', '\"') + '"'
+        }
+        else {
+            $argument
+        }
+    })
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = $executablePath
+    $startInfo.Arguments = $quotedArguments -join ' '
+    $startInfo.WorkingDirectory = $workingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw "Could not start release artifact '$executablePath'."
+    }
+    try {
+        $standardOutputTask = $process.StandardOutput.ReadToEndAsync()
+        $standardErrorTask = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit(120000)) {
+            $process.Kill()
+            throw "Release artifact command timed out: $($arguments -join ' ')"
+        }
+        return [pscustomobject]@{
+            ExitCode = $process.ExitCode
+            StandardOutput = $standardOutputTask.GetAwaiter().GetResult()
+            StandardError = $standardErrorTask.GetAwaiter().GetResult()
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+function Invoke-HostGitHubArtifactSmoke(
+    [string]$releaseDirectory,
+    [string]$version,
+    [string[]]$selectedRids
+) {
+    if (-not [Environment]::Is64BitOperatingSystem -or
+        [Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT -or
+        'win-x64' -notin $selectedRids) {
+        Write-Host 'Host artifact smoke: SKIPPED (win-x64 Windows host artifact was not selected).'
+        return
+    }
+
+    $artifactPath = Join-Path $releaseDirectory "DevProjex.v$version.win-x64.exe"
+    $sampleRoot = Join-Path $releaseDirectory '_functional-smoke'
+    New-Item -ItemType Directory -Path $sampleRoot -Force | Out-Null
+    $secretValue = 'ghp_123456789012345678901234567890123456'
+    try {
+        @'
+namespace Sample;
+public static class Program {
+    public static int Compute(int value) {
+        var implementationMustDisappear = value * 2;
+        return implementationMustDisappear;
+    }
+}
+'@ | Set-Content -LiteralPath (Join-Path $sampleRoot 'Program.cs') -Encoding UTF8
+        "token=$secretValue" | Set-Content -LiteralPath (Join-Path $sampleRoot 'settings.txt') -Encoding UTF8
+
+        $versionResult = Invoke-CapturedArtifactCommand $artifactPath @('--version') $sampleRoot
+        if ($versionResult.ExitCode -ne 0 -or $versionResult.StandardOutput.Trim() -cne $version) {
+            throw "Host artifact --version smoke failed. Expected '$version', got '$($versionResult.StandardOutput.Trim())'."
+        }
+        $treeResult = Invoke-CapturedArtifactCommand $artifactPath @('tree', $sampleRoot, '--git-mode', 'none', '--exclude', 'none') $sampleRoot
+        if ($treeResult.ExitCode -ne 0 -or
+            $treeResult.StandardOutput.IndexOf('Program.cs', [System.StringComparison]::Ordinal) -lt 0) {
+            throw 'Host artifact tree smoke failed.'
+        }
+        $fullResult = Invoke-CapturedArtifactCommand $artifactPath @('analyze', $sampleRoot, '--format', 'json', '--git-mode', 'none', '--exclude', 'none', '-o', '-') $sampleRoot
+        $compressedResult = Invoke-CapturedArtifactCommand $artifactPath @('analyze', $sampleRoot, '--format', 'json', '--git-mode', 'none', '--exclude', 'none', '--compress-code', '-o', '-') $sampleRoot
+        if ($fullResult.ExitCode -ne 0 -or $compressedResult.ExitCode -ne 0) {
+            throw 'Host artifact analyze smoke failed.'
+        }
+        $full = $fullResult.StandardOutput | ConvertFrom-Json
+        $compressed = $compressedResult.StandardOutput | ConvertFrom-Json
+        if ([long]$compressed.metrics.content.chars -ge [long]$full.metrics.content.chars) {
+            throw 'Host artifact compression smoke did not reduce content characters.'
+        }
+        $findingsResult = Invoke-CapturedArtifactCommand $artifactPath @('analyze', $sampleRoot, '--format', 'json', '--git-mode', 'none', '--exclude', 'none', '--findings', '--fail-on-findings', '-o', '-') $sampleRoot
+        $combinedFindingsOutput = $findingsResult.StandardOutput + $findingsResult.StandardError
+        if ($findingsResult.ExitCode -ne 3 -or
+            $combinedFindingsOutput.IndexOf('findingCount', [System.StringComparison]::Ordinal) -lt 0 -or
+            $combinedFindingsOutput.IndexOf($secretValue, [System.StringComparison]::Ordinal) -ge 0) {
+            throw 'Host artifact secret-finding smoke failed or exposed the secret value.'
+        }
+
+        $node = Get-Command node -ErrorAction SilentlyContinue
+        if ($null -eq $node) {
+            Write-Host 'MCP initialize smoke: SKIPPED (node was not found in PATH).'
+        }
+        else {
+            Invoke-ExternalCommand `
+                -filePath $node.Source `
+                -arguments @((Join-Path $script:IsolatedRepoRoot 'Scripts\smoke-headless-mcp.mjs'), $artifactPath, $sampleRoot) `
+                -failureMessage 'Host artifact MCP initialize smoke failed' `
+                -workingDirectory $script:IsolatedRepoRoot
+        }
+        Write-Host 'Host artifact functional smoke passed.'
+    }
+    finally {
+        if (Test-Path -LiteralPath $sampleRoot) {
+            Remove-Item -LiteralPath $sampleRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Invoke-ExternalCommand(
@@ -653,12 +959,50 @@ function Invoke-StoreSmokeBuild([string]$repoRoot, [string]$versionOverride) {
 
         Invoke-ExternalCommand -filePath $msbuildPath -arguments $msbuildArgs -failureMessage "MS Store smoke build failed" -workingDirectory $repoRoot
 
-        $artifacts = Get-ChildItem -Path $outputRoot -Recurse -File -Include *.msixupload,*.msixbundle,*.msix -ErrorAction SilentlyContinue
+        $artifacts = @(
+            Get-ChildItem -Path $outputRoot -Recurse -File -Include *.msixupload,*.msixbundle,*.msix -ErrorAction SilentlyContinue
+            Get-ChildItem `
+                -Path (Join-Path $repoRoot 'Packaging\Windows\DevProjex.Store\bin\x64\ReleaseStore') `
+                -Recurse `
+                -File `
+                -Filter "DevProjex.Store_${storePackageVersion}_x64_ReleaseStore.msix" `
+                -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+        )
         if ($null -eq $artifacts -or $artifacts.Count -eq 0) {
             throw "Store smoke build did not produce any MSIX artifacts."
         }
 
         Assert-StoreArtifactsContainExecutionAlias -artifacts @($artifacts) -tempDirectory (Join-Path $outputRoot "_execution_alias_validation")
+
+        $validationPublishRoot = Join-Path $outputRoot 'publish'
+        [void](New-StoreValidationDirectory `
+            -artifacts @($artifacts) `
+            -buildLogPath '' `
+            -publishRoot $validationPublishRoot `
+            -version $resolvedDisplayVersion)
+        Invoke-ReleaseArtifactValidator `
+            -publishRoot $validationPublishRoot `
+            -version $resolvedDisplayVersion `
+            -channels @('store') `
+            -rids $script:AllReleaseRids `
+            -validatorRepoRoot $repoRoot
+        & (Join-Path $repoRoot 'Scripts\Test-ReleaseArtifactGateMutation.ps1') `
+            -PublishRoot $validationPublishRoot `
+            -Version $resolvedDisplayVersion `
+            -Channels @('store') `
+            -Rids $script:AllReleaseRids
+        if ($LASTEXITCODE -ne 0) {
+            throw "Store artifact mutation gate failed with exit code $LASTEXITCODE."
+        }
+        Write-ReleaseSummary `
+            -sourceRoot $outputRoot `
+            -version $resolvedDisplayVersion `
+            -channels @('store') `
+            -partialGitHub $false `
+            -githubStatus 'not selected' `
+            -storeStatus 'built and validated; WACK not run (smoke mode)'
 
         Write-Host "Store smoke build succeeded."
         $artifacts | Sort-Object Name | ForEach-Object { Write-Host "  $($_.FullName)" }
@@ -971,7 +1315,8 @@ function New-MacReleaseArchive(
 function Build-GitHubArtifactsInWorkspace(
     [string]$version,
     [string]$configuration,
-    [string]$storePackageVersion
+    [string]$storePackageVersion,
+    [string[]]$rids
 ) {
     $projectPath = Join-Path $script:IsolatedRepoRoot "Apps\Avalonia\DevProjex.Avalonia.csproj"
     if (-not (Test-Path $projectPath)) {
@@ -990,7 +1335,7 @@ function Build-GitHubArtifactsInWorkspace(
         @{ Rid = "linux-arm64"; Binary = "DevProjex"; Kind = "Linux"; Name = "DevProjex.v$version.linux-arm64.tar.gz" },
         @{ Rid = "osx-x64"; Binary = "DevProjex"; Kind = "MacOS"; Name = "DevProjex.v$version.osx-x64.app.tar.gz" },
         @{ Rid = "osx-arm64"; Binary = "DevProjex"; Kind = "MacOS"; Name = "DevProjex.v$version.osx-arm64.app.tar.gz" }
-    )
+    ) | Where-Object { $_.Rid -in $rids }
 
     if (Test-Path $releaseDir) {
         Remove-Item -Path $releaseDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -1019,6 +1364,7 @@ function Build-GitHubArtifactsInWorkspace(
             "--self-contained", "true",
             "/p:PublishSingleFile=true",
             "/p:IncludeNativeLibrariesForSelfExtract=true",
+            "/p:EnableCompressionInSingleFile=false",
             # ReadyToRun reduces JIT work for packaged RID-specific desktop binaries.
             "/p:PublishReadyToRun=true",
             "/p:PublishTrimmed=false",
@@ -1070,21 +1416,16 @@ function Build-GitHubArtifactsInWorkspace(
         }
     }
 
-    $shaFile = Join-Path $releaseDir "SHA256SUMS.txt"
-    $hashLines = @()
-    Get-ChildItem -Path $releaseDir -File |
-        Where-Object { $_.Name -ne "SHA256SUMS.txt" } |
-        Sort-Object Name |
-        ForEach-Object {
-            $hash = Get-FileSha256Hex -path $_.FullName
-            $hashLines += "$hash *$($_.Name)"
-        }
-
-    Write-ReleaseChecksumManifest -path $shaFile -lines $hashLines
+    if ($rids.Count -ne $script:AllReleaseRids.Count) {
+        Write-GitHubPartialMarker -releaseDirectory $releaseDir -version $version -rids $rids
+    }
+    Write-ChannelChecksums -directory $releaseDir
 
     if (Test-Path $workDir) {
         Remove-Item -Path $workDir -Recurse -Force -ErrorAction SilentlyContinue
     }
+
+    Invoke-HostGitHubArtifactSmoke -releaseDirectory $releaseDir -version $version -selectedRids $rids
 
     Write-Host ""
     Write-Host "GitHub release artifacts are ready:"
@@ -1333,11 +1674,48 @@ function Build-StoreArtifactsInWorkspace(
     Write-Host "  Architectures: $bundlePlatforms"
 }
 
-function Get-StoreArtifactPaths() {
-    $candidateRoots = @(
-        (Join-Path $script:IsolatedRepoRoot "publish\store"),
-        (Join-Path $script:IsolatedRepoRoot "Packaging\Windows\DevProjex.Store\publish\store")
-    )
+function New-StoreValidationDirectory(
+    [object[]]$artifacts,
+    [string]$buildLogPath,
+    [string]$publishRoot,
+    [string]$version
+) {
+    $destination = Join-Path $publishRoot "store\v$version"
+    if (Test-Path -LiteralPath $destination) {
+        Remove-Item -LiteralPath $destination -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $destination -Force | Out-Null
+
+    foreach ($artifact in @($artifacts | Sort-Object Name -Unique)) {
+        Copy-Item -LiteralPath $artifact.FullName -Destination (Join-Path $destination $artifact.Name) -Force
+    }
+    if (-not [string]::IsNullOrWhiteSpace($buildLogPath) -and
+        (Test-Path -LiteralPath $buildLogPath -PathType Leaf)) {
+        Copy-Item -LiteralPath $buildLogPath -Destination (Join-Path $destination 'msix-build.log') -Force
+    }
+    Write-ChannelChecksums -directory $destination
+    return $destination
+}
+
+function Stage-StoreArtifactsForValidation([string]$version) {
+    $artifacts = @(Get-StoreArtifactPaths)
+    if ($artifacts.Count -eq 0) {
+        throw "MS Store artifacts (.msixupload/.msixbundle/.msix) not found in isolated workspace."
+    }
+    return New-StoreValidationDirectory `
+        -artifacts $artifacts `
+        -buildLogPath (Join-Path $script:IsolatedRepoRoot 'publish\store\msix-build.log') `
+        -publishRoot (Join-Path $script:IsolatedRepoRoot 'publish') `
+        -version $version
+}
+
+function Get-StoreArtifactPaths([string[]]$candidateRoots = @()) {
+    if ($candidateRoots.Count -eq 0) {
+        $candidateRoots = @(
+            (Join-Path $script:IsolatedRepoRoot "publish\store"),
+            (Join-Path $script:IsolatedRepoRoot "Packaging\Windows\DevProjex.Store\publish\store")
+        )
+    }
 
     $artifacts = @()
     foreach ($candidateRoot in $candidateRoots) {
@@ -1452,10 +1830,18 @@ function Get-InnerPackageFromMsixUpload([string]$msixUploadPath, [string]$tempDi
     return $null
 }
 
-function Invoke-WackValidationInWorkspace() {
+function Invoke-WackValidationInWorkspace(
+    [string]$artifactRoot = "",
+    [string]$reportDirectory = ""
+) {
     Write-Step "Running WACK validation"
 
-    $storeArtifacts = Get-StoreArtifactPaths
+    $storeArtifacts = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
+        @(Get-StoreArtifactPaths)
+    }
+    else {
+        @(Get-StoreArtifactPaths -candidateRoots @($artifactRoot))
+    }
     if ($null -eq $storeArtifacts -or $storeArtifacts.Count -eq 0) {
         throw "WACK validation failed: Store artifacts were not found in isolated workspace."
     }
@@ -1465,7 +1851,12 @@ function Invoke-WackValidationInWorkspace() {
         throw "WACK validation cannot start: appcert.exe not found. Install Windows SDK (App Certification Kit)."
     }
 
-    $reportDir = Join-Path $script:IsolatedRepoRoot "publish\store\wack"
+    $reportDir = if ([string]::IsNullOrWhiteSpace($reportDirectory)) {
+        Join-Path $script:IsolatedRepoRoot "publish\store\wack"
+    }
+    else {
+        $reportDirectory
+    }
     New-Item -ItemType Directory -Force -Path $reportDir | Out-Null
     $tempExtractionDir = Join-Path $reportDir "_temp_msixupload"
     $summaryLines = New-Object System.Collections.Generic.List[string]
@@ -1571,58 +1962,25 @@ function Invoke-WackValidationInWorkspace() {
 function Publish-ArtifactsToSource(
     [string]$sourceRoot,
     [string]$version,
-    [switch]$GitHubOnly
+    [string[]]$channels
 ) {
     Write-Step "Publishing artifacts to source publish folder"
 
-    $isolatedGitHubDir = Join-Path $script:IsolatedRepoRoot "publish\github\v$version"
-    if (-not (Test-Path $isolatedGitHubDir)) {
-        throw "Isolated GitHub artifacts folder not found: $isolatedGitHubDir"
-    }
-
-    $sourceGitHubDir = Join-Path $sourceRoot "publish\github\v$version"
-    if (Test-Path $sourceGitHubDir) {
-        Remove-Item -Path $sourceGitHubDir -Recurse -Force -ErrorAction SilentlyContinue
-    }
-    New-Item -ItemType Directory -Path $sourceGitHubDir -Force | Out-Null
-    Copy-Item -Path (Join-Path $isolatedGitHubDir "*") -Destination $sourceGitHubDir -Recurse -Force
-
-    if ($GitHubOnly) {
-        return @{
-            GitHub = $sourceGitHubDir
-            Store = $null
+    $published = @{}
+    foreach ($channel in $channels) {
+        $isolatedDirectory = Join-Path $script:IsolatedRepoRoot "publish\$channel\v$version"
+        if (-not (Test-Path -LiteralPath $isolatedDirectory -PathType Container)) {
+            throw "Isolated $channel artifacts folder not found: $isolatedDirectory"
         }
+        $sourceDirectory = Join-Path $sourceRoot "publish\$channel\v$version"
+        if (Test-Path -LiteralPath $sourceDirectory) {
+            Remove-Item -LiteralPath $sourceDirectory -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $sourceDirectory -Force | Out-Null
+        Copy-Item -Path (Join-Path $isolatedDirectory '*') -Destination $sourceDirectory -Recurse -Force
+        $published[$channel] = $sourceDirectory
     }
-
-    $storeArtifacts = Get-StoreArtifactPaths
-    if ($null -eq $storeArtifacts -or $storeArtifacts.Count -eq 0) {
-        throw "MS Store artifacts (.msixupload/.msixbundle/.msix) not found in isolated workspace."
-    }
-
-    $sourceStoreDir = Join-Path $sourceRoot "publish\store\v$version"
-    if (Test-Path $sourceStoreDir) {
-        Remove-Item -Path $sourceStoreDir -Recurse -Force -ErrorAction SilentlyContinue
-    }
-    New-Item -ItemType Directory -Path $sourceStoreDir -Force | Out-Null
-
-    foreach ($storeArtifact in $storeArtifacts) {
-        Copy-Item -Path $storeArtifact.FullName -Destination (Join-Path $sourceStoreDir $storeArtifact.Name) -Force
-    }
-
-    $isolatedBuildLogPath = Join-Path $script:IsolatedRepoRoot "publish\store\msix-build.log"
-    if (Test-Path $isolatedBuildLogPath) {
-        Copy-Item -Path $isolatedBuildLogPath -Destination (Join-Path $sourceStoreDir "msix-build.log") -Force
-    }
-
-    $isolatedWackDir = Join-Path $script:IsolatedRepoRoot "publish\store\wack"
-    if (Test-Path $isolatedWackDir) {
-        Copy-Item -Path $isolatedWackDir -Destination (Join-Path $sourceStoreDir "wack") -Recurse -Force
-    }
-
-    return @{
-        GitHub = $sourceGitHubDir
-        Store = $sourceStoreDir
-    }
+    return $published
 }
 
 function Start-DeferredCleanup([string]$targetPath) {
@@ -1763,76 +2121,173 @@ function Cleanup-IsolatedWorkspace() {
     }
 }
 
-Ensure-DotnetAvailable
-$repoRoot = Get-DevProjexRepoRoot -startPath $PSScriptRoot
+function Invoke-ReleaseMain() {
+    $repoRoot = Get-DevProjexRepoRoot -startPath $PSScriptRoot
+    $invocation = Resolve-ReleaseInvocation -channelsExplicit $script:ChannelsExplicit
 
-if (($ValidateConfigOnly -and $SmokeStoreBuildOnly) -or
-    ($GitHubArtifactsOnly -and ($ValidateConfigOnly -or $SmokeStoreBuildOnly))) {
-    throw "Use only one of -ValidateConfigOnly, -SmokeStoreBuildOnly, or -GitHubArtifactsOnly."
-}
-
-if ($ValidateConfigOnly) {
-    Invoke-ReleaseConfigValidation -repoRoot $repoRoot
-    return
-}
-
-if ($SmokeStoreBuildOnly) {
-    Invoke-StoreSmokeBuild -repoRoot $repoRoot -versionOverride $Version
-    return
-}
-
-$defaultReleaseVersionInfo = Get-DefaultReleaseVersionInfo -repoRoot $repoRoot
-$initialVersion = if ([string]::IsNullOrWhiteSpace($Version)) { [string]$defaultReleaseVersionInfo.DisplayVersion } else { $Version }
-$versionInfo = Get-VersionInteractive -currentValue $initialVersion
-$resolvedVersion = [string]$versionInfo.DisplayVersion
-$storePackageVersion = [string]$versionInfo.StorePackageVersion
-$sourceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$finalPaths = $null
-
-Write-Step "Release plan"
-Write-Host "Version: $resolvedVersion"
-Write-Host "Store package version: $storePackageVersion"
-Write-Host "Build mode  : isolated workspace (local source tree untouched)"
-Write-Host "GitHub build: Release (single-file, self-contained)"
-Write-Step "Headless package channels"
-Write-Host "NuGet and npm headless channels are published by the publish-packages workflow."
-if ($GitHubArtifactsOnly) {
-    Write-Host "Store build : skipped (-GitHubArtifactsOnly)"
-}
-else {
-    Write-Host "Store build : ReleaseStore (.msixupload, x64|arm64)"
-    Write-Host "Store check : WACK (must pass before artifacts are published)"
-}
-Write-Host "Store listing CSV: not modified"
-Write-Step "Validating release config"
-Invoke-ReleaseConfigValidation -repoRoot $repoRoot
-
-try {
-    Create-IsolatedWorkspace -sourceRoot $sourceRoot
-    Configure-IsolatedNuGetCache
-
-    Write-Step "Building GitHub artifacts in isolated workspace"
-    Build-GitHubArtifactsInWorkspace -version $resolvedVersion -configuration "Release" -storePackageVersion $storePackageVersion
-
-    if (-not $GitHubArtifactsOnly) {
-        Write-Step "Building Microsoft Store package in isolated workspace"
-        Build-StoreArtifactsInWorkspace -displayVersion $resolvedVersion -configuration "ReleaseStore" -platform "x64" -bundlePlatforms "x64|arm64" -packageVersion $storePackageVersion
-
-        Invoke-WackValidationInWorkspace
+    if ($ValidateConfigOnly) {
+        Invoke-ReleaseConfigValidation -repoRoot $repoRoot
+        Write-Step 'Release summary'
+        Write-Host 'Configuration: VALIDATED'
+        return
     }
 
-    $finalPaths = Publish-ArtifactsToSource `
+    if ($SmokeStoreBuildOnly) {
+        Ensure-DotnetAvailable
+        Invoke-StoreSmokeBuild -repoRoot $repoRoot -versionOverride $Version
+        return
+    }
+
+    $versionInfo = Resolve-ReleaseVersionInfo -repoRoot $repoRoot
+    $resolvedVersion = [string]$versionInfo.DisplayVersion
+    $storePackageVersion = [string]$versionInfo.StorePackageVersion
+    $sourceRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $sourcePublishRoot = Join-Path $sourceRoot 'publish'
+
+    if ($ValidateArtifactsOnly) {
+        Invoke-ReleaseArtifactValidator `
+            -publishRoot $sourcePublishRoot `
+            -version $resolvedVersion `
+            -channels $invocation.Channels `
+            -rids $invocation.Rids `
+            -validatorRepoRoot $repoRoot
+        $wackSummary = Join-Path $sourceRoot "publish\store\v$resolvedVersion\wack\summary.txt"
+        $storeStatus = if (Test-WackSummaryPassed -summaryPath $wackSummary) {
+            'validated; WACK passed'
+        }
+        else {
+            'validated; WACK not passed'
+        }
+        Write-ReleaseSummary `
+            -sourceRoot $sourceRoot `
+            -version $resolvedVersion `
+            -channels $invocation.Channels `
+            -partialGitHub $invocation.IsPartialGitHub `
+            -githubStatus 'validated' `
+            -storeStatus $storeStatus
+        return
+    }
+
+    if ($WackOnly) {
+        $storeDirectory = Join-Path $sourceRoot "publish\store\v$resolvedVersion"
+        Invoke-ReleaseArtifactValidator `
+            -publishRoot $sourcePublishRoot `
+            -version $resolvedVersion `
+            -channels @('store') `
+            -rids $invocation.Rids `
+            -validatorRepoRoot $repoRoot
+        Invoke-WackValidationInWorkspace `
+            -artifactRoot $storeDirectory `
+            -reportDirectory (Join-Path $storeDirectory 'wack')
+        Write-ReleaseSummary `
+            -sourceRoot $sourceRoot `
+            -version $resolvedVersion `
+            -channels @('store') `
+            -partialGitHub $false `
+            -githubStatus 'not selected' `
+            -storeStatus 'validated; WACK passed'
+        return
+    }
+
+    Ensure-DotnetAvailable
+    Write-Step "Release plan"
+    Write-Host "Version: $resolvedVersion"
+    Write-Host "Store package version: $storePackageVersion"
+    Write-Host "Channels: $($invocation.Channels -join ', ')"
+    if ('github' -in $invocation.Channels) {
+        Write-Host "GitHub RIDs: $($invocation.Rids -join ', ')"
+        if ($invocation.IsPartialGitHub) {
+            Write-Host 'GitHub set: PARTIAL (not release-ready)'
+        }
+    }
+    Write-Host "Build mode: isolated workspace (local source tree untouched)"
+    if ('github' -in $invocation.Channels) {
+        Write-Host "GitHub build: Release (single-file, self-contained, uncompressed bundle)"
+    }
+    if ('store' -in $invocation.Channels) {
+        Write-Host "Store build: ReleaseStore (.msixupload, x64|arm64)"
+        Write-Host $(if ($SkipWack) { 'Store check: WACK not run (-SkipWack); not release-ready' } else { 'Store check: WACK must pass' })
+    }
+    Write-Step "Headless package channels"
+    Write-Host "NuGet and npm headless channels are published by the publish-packages workflow."
+    Write-Host "Store listing CSV: not modified"
+    Write-Step "Validating release config"
+    Invoke-ReleaseConfigValidation -repoRoot $repoRoot
+
+    try {
+        Create-IsolatedWorkspace -sourceRoot $sourceRoot
+        Configure-IsolatedNuGetCache
+
+        if ('github' -in $invocation.Channels) {
+            Write-Step "Building GitHub artifacts in isolated workspace"
+            Build-GitHubArtifactsInWorkspace `
+                -version $resolvedVersion `
+                -configuration "Release" `
+                -storePackageVersion $storePackageVersion `
+                -rids $invocation.Rids
+            Invoke-ReleaseArtifactValidator `
+                -publishRoot (Join-Path $script:IsolatedRepoRoot 'publish') `
+                -version $resolvedVersion `
+                -channels @('github') `
+                -rids $invocation.Rids
+        }
+
+        if ('store' -in $invocation.Channels) {
+            Write-Step "Building Microsoft Store package in isolated workspace"
+            Build-StoreArtifactsInWorkspace `
+                -displayVersion $resolvedVersion `
+                -configuration "ReleaseStore" `
+                -platform "x64" `
+                -bundlePlatforms "x64|arm64" `
+                -packageVersion $storePackageVersion
+            $storeValidationDirectory = Stage-StoreArtifactsForValidation -version $resolvedVersion
+            Invoke-ReleaseArtifactValidator `
+                -publishRoot (Join-Path $script:IsolatedRepoRoot 'publish') `
+                -version $resolvedVersion `
+                -channels @('store') `
+                -rids $invocation.Rids
+            if (-not $SkipWack) {
+                Invoke-WackValidationInWorkspace `
+                    -artifactRoot $storeValidationDirectory `
+                    -reportDirectory (Join-Path $storeValidationDirectory 'wack')
+            }
+        }
+
+        [void](Publish-ArtifactsToSource `
+            -sourceRoot $sourceRoot `
+            -version $resolvedVersion `
+            -channels $invocation.Channels)
+    }
+    finally {
+        Restore-NuGetEnvironment
+        Cleanup-IsolatedWorkspace
+    }
+
+    $storeStatus = if ('store' -notin $invocation.Channels) {
+        'not selected'
+    }
+    elseif ($SkipWack) {
+        'built and validated; WACK not passed; not release-ready'
+    }
+    else {
+        'built and validated; WACK passed'
+    }
+    Write-ReleaseSummary `
         -sourceRoot $sourceRoot `
         -version $resolvedVersion `
-        -GitHubOnly:$GitHubArtifactsOnly
-
-    Write-Step "Done"
-    Write-Host "GitHub artifacts: $($finalPaths.GitHub)"
-    if (-not $GitHubArtifactsOnly) {
-        Write-Host "MS Store artifacts: $($finalPaths.Store)"
-    }
+        -channels $invocation.Channels `
+        -partialGitHub $invocation.IsPartialGitHub `
+        -githubStatus 'built and validated' `
+        -storeStatus $storeStatus
 }
-finally {
-    Restore-NuGetEnvironment
-    Cleanup-IsolatedWorkspace
+
+try {
+    Invoke-ReleaseMain
+}
+catch {
+    if ($NonInteractive) {
+        [Console]::Error.WriteLine($_.Exception.Message.Replace("`r", ' ').Replace("`n", ' '))
+        exit 1
+    }
+    throw
 }

--- a/Scripts/release-all.ps1
+++ b/Scripts/release-all.ps1
@@ -928,6 +928,7 @@ function Invoke-StoreSmokeBuild([string]$repoRoot, [string]$versionOverride) {
     $msbuildPath = Get-MsBuildPath
     $targetPlatformResolution = Resolve-StoreTargetPlatformVersion -projectPath $projectPath
     $outputRoot = Join-Path $env:TEMP ("devprojex-store-smoke-" + [Guid]::NewGuid().ToString("N"))
+    $payloadReceiptDirectory = Join-Path $outputRoot 'payload-receipts'
     $originalProjectContent = $null
     $projectPatched = $false
 
@@ -944,6 +945,16 @@ function Invoke-StoreSmokeBuild([string]$repoRoot, [string]$versionOverride) {
         $originalProjectContent = Get-Content -Path $projectPath -Raw
         $projectPatched = Set-StoreProjectTargetPlatformVersion -projectPath $projectPath -targetPlatformVersion $targetPlatformResolution.ResolvedVersion
 
+        foreach ($staleStorePath in @(
+            (Join-Path $repoRoot 'Packaging\Windows\DevProjex.Store\bin'),
+            (Join-Path $repoRoot 'Packaging\Windows\DevProjex.Store\obj'),
+            (Join-Path $repoRoot 'Packaging\Windows\DevProjex.Store\BundleArtifacts')
+        )) {
+            if (Test-Path -LiteralPath $staleStorePath) {
+                Remove-Item -LiteralPath $staleStorePath -Recurse -Force
+            }
+        }
+
         Invoke-ExternalCommand -filePath "dotnet" -arguments (@("restore", $appProjectPath, "/p:Configuration=ReleaseStore") + $versionProperties) -failureMessage "dotnet restore failed for store smoke build" -workingDirectory $repoRoot
 
         $msbuildArgs = @(
@@ -954,7 +965,9 @@ function Invoke-StoreSmokeBuild([string]$repoRoot, [string]$versionOverride) {
             "/p:AppxBundlePlatforms=x64|arm64",
             "/p:UapAppxPackageBuildMode=StoreUpload",
             "/p:GenerateAppInstallerFile=false",
-            "/p:AppxPackageDir=$outputRoot\"
+            "/p:AppxPackageDir=$outputRoot\",
+            "/p:DevProjexGenerateReleasePayloadReceipt=true",
+            "/p:DevProjexPayloadReceiptDirectory=$payloadReceiptDirectory"
         ) + $versionProperties
 
         Invoke-ExternalCommand -filePath $msbuildPath -arguments $msbuildArgs -failureMessage "MS Store smoke build failed" -workingDirectory $repoRoot
@@ -979,6 +992,7 @@ function Invoke-StoreSmokeBuild([string]$repoRoot, [string]$versionOverride) {
         $validationPublishRoot = Join-Path $outputRoot 'publish'
         [void](New-StoreValidationDirectory `
             -artifacts @($artifacts) `
+            -payloadReceipts @(Get-ChildItem -LiteralPath $payloadReceiptDirectory -File -Filter 'publish-payload.win-*.json') `
             -buildLogPath '' `
             -publishRoot $validationPublishRoot `
             -version $resolvedDisplayVersion)
@@ -1327,6 +1341,7 @@ function Build-GitHubArtifactsInWorkspace(
 
     $releaseDir = Join-Path $script:IsolatedRepoRoot "publish\github\v$version"
     $workDir = Join-Path $releaseDir "_work"
+    $receiptDir = Join-Path $workDir "receipts"
 
     $targets = @(
         @{ Rid = "win-x64"; Binary = "DevProjex.exe"; Kind = "Windows"; Name = "DevProjex.v$version.win-x64.exe" },
@@ -1343,6 +1358,7 @@ function Build-GitHubArtifactsInWorkspace(
 
     New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
     New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $receiptDir -Force | Out-Null
 
     Write-Host "Preparing GitHub release artifacts..."
     Write-Host "  Version: $version"
@@ -1371,6 +1387,8 @@ function Build-GitHubArtifactsInWorkspace(
             "/p:EnableProjectLoadTiming=false",
             "/p:DebugType=None",
             "/p:DebugSymbols=false",
+            "/p:DevProjexGenerateReleasePayloadReceipt=true",
+            "/p:DevProjexPayloadReceiptDirectory=$receiptDir",
             "-o", $ridOutDir
         ) + $versionProperties
 
@@ -1414,6 +1432,13 @@ function Build-GitHubArtifactsInWorkspace(
                 throw "Unsupported GitHub artifact kind '$($target.Kind)' for $rid."
             }
         }
+
+        $receiptName = "publish-payload.$rid.json"
+        $receiptPath = Join-Path $receiptDir $receiptName
+        if (-not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
+            throw "Payload receipt was not generated for RID '$rid': $receiptPath"
+        }
+        Copy-Item -LiteralPath $receiptPath -Destination (Join-Path $releaseDir $receiptName) -Force
     }
 
     if ($rids.Count -ne $script:AllReleaseRids.Count) {
@@ -1572,6 +1597,8 @@ function Build-StoreArtifactsInWorkspace(
 
     $publishStoreDir = Join-Path $script:IsolatedRepoRoot "publish\store"
     New-Item -ItemType Directory -Force -Path $publishStoreDir | Out-Null
+    $payloadReceiptDirectory = Join-Path $publishStoreDir 'payload-receipts'
+    New-Item -ItemType Directory -Force -Path $payloadReceiptDirectory | Out-Null
     $buildLogRelative = "publish\store\msix-build.log"
 
     $bundleMode = if ($bundlePlatforms -like "*|*") { "Always" } else { "Never" }
@@ -1583,6 +1610,8 @@ function Build-StoreArtifactsInWorkspace(
         "/p:AppxBundlePlatforms=$bundlePlatforms",
         "/p:UapAppxPackageBuildMode=StoreUpload",
         "/p:AppxPackageDir=publish\store\",
+        "/p:DevProjexGenerateReleasePayloadReceipt=true",
+        "/p:DevProjexPayloadReceiptDirectory=$payloadReceiptDirectory",
         "/p:EnableProjectLoadTiming=false",
         "/flp:logfile=$buildLogRelative;verbosity=normal"
     ) + $versionProperties
@@ -1676,6 +1705,7 @@ function Build-StoreArtifactsInWorkspace(
 
 function New-StoreValidationDirectory(
     [object[]]$artifacts,
+    [object[]]$payloadReceipts,
     [string]$buildLogPath,
     [string]$publishRoot,
     [string]$version
@@ -1688,6 +1718,9 @@ function New-StoreValidationDirectory(
 
     foreach ($artifact in @($artifacts | Sort-Object Name -Unique)) {
         Copy-Item -LiteralPath $artifact.FullName -Destination (Join-Path $destination $artifact.Name) -Force
+    }
+    foreach ($receipt in @($payloadReceipts | Sort-Object Name -Unique)) {
+        Copy-Item -LiteralPath $receipt.FullName -Destination (Join-Path $destination $receipt.Name) -Force
     }
     if (-not [string]::IsNullOrWhiteSpace($buildLogPath) -and
         (Test-Path -LiteralPath $buildLogPath -PathType Leaf)) {
@@ -1704,9 +1737,18 @@ function Stage-StoreArtifactsForValidation([string]$version) {
     }
     return New-StoreValidationDirectory `
         -artifacts $artifacts `
+        -payloadReceipts @(Get-StorePayloadReceiptPaths) `
         -buildLogPath (Join-Path $script:IsolatedRepoRoot 'publish\store\msix-build.log') `
         -publishRoot (Join-Path $script:IsolatedRepoRoot 'publish') `
         -version $version
+}
+
+function Get-StorePayloadReceiptPaths() {
+    $receiptDirectory = Join-Path $script:IsolatedRepoRoot 'publish\store\payload-receipts'
+    if (-not (Test-Path -LiteralPath $receiptDirectory -PathType Container)) {
+        return @()
+    }
+    return @(Get-ChildItem -LiteralPath $receiptDirectory -File -Filter 'publish-payload.win-*.json')
 }
 
 function Get-StoreArtifactPaths([string[]]$candidateRoots = @()) {

--- a/Tests/DevProjex.Tests.Integration/DevProjex.Tests.Integration.csproj
+++ b/Tests/DevProjex.Tests.Integration/DevProjex.Tests.Integration.csproj
@@ -29,5 +29,6 @@
   <ItemGroup>
     <Compile Include="..\Shared\StoreListing\**\*.cs" LinkBase="StoreListing" />
     <Compile Include="..\Shared\ProjectLoadWorkflow\**\*.cs" LinkBase="ProjectLoadWorkflow" />
+    <Compile Include="..\..\Scripts\ReleasePayloadInspection.cs" Link="ReleasePayloadInspection.cs" />
   </ItemGroup>
 </Project>

--- a/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using DevProjex.ReleaseValidation;
 using DevProjex.Tests.Integration.Helpers;
 using DevProjex.Tests.Shared.StoreListing;
 
@@ -25,62 +26,52 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 
 		Assert.Equal(0, result.ExitCode);
 		Assert.Contains("Channel github: VALIDATED; PARTIAL (not release-ready)", result.StandardOutput, StringComparison.Ordinal);
-		Assert.Contains("DevProjex.v5.2.linux-x64.tar.gz", result.StandardOutput, StringComparison.Ordinal);
-		Assert.Contains("SHA-256", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("publish-payload.linux-x64.json", result.StandardOutput, StringComparison.Ordinal);
 	}
 
 	[Theory]
-	[InlineData("grammar")]
-	[InlineData("localization")]
+	[InlineData("missing-file")]
+	[InlineData("missing-resource")]
+	[InlineData("extra-file")]
+	[InlineData("payload-hash")]
 	[InlineData("checksum")]
 	[InlineData("partial-marker")]
 	public void ValidatorFailsClosedForIncompleteGitHubArtifacts(string mutation)
 	{
 		using var workspace = new TemporaryDirectory();
-		CreateLinuxFixture(
-			workspace.Path,
-			omitGrammar: mutation == "grammar",
-			omitLocalization: mutation == "localization",
-			invalidChecksum: mutation == "checksum",
-			omitPartialMarker: mutation == "partial-marker");
+		CreateLinuxFixture(workspace.Path, mutation);
 
 		var result = RunValidator(workspace.Path, "github", "linux-x64");
 		var output = result.StandardOutput + result.StandardError;
 
 		Assert.NotEqual(0, result.ExitCode);
 		Assert.Contains("incomplete", output, StringComparison.OrdinalIgnoreCase);
-		switch (mutation)
+		var expected = mutation switch
 		{
-			case "grammar":
-				Assert.Contains("DevProjex.v5.2.linux-x64.tar.gz", output, StringComparison.Ordinal);
-				Assert.Contains("libtree-sitter-kotlin.so", output, StringComparison.Ordinal);
-				break;
-			case "localization":
-				Assert.Contains("DevProjex.v5.2.linux-x64.tar.gz", output, StringComparison.Ordinal);
-				Assert.Contains("en.json", output, StringComparison.Ordinal);
-				break;
-			case "checksum":
-				Assert.Contains("invalid SHA-256", output, StringComparison.Ordinal);
-				break;
-			case "partial-marker":
-				Assert.Contains("PARTIAL-BUILD.txt", output, StringComparison.Ordinal);
-				break;
-		}
+			"missing-file" => "receipt-only.dat",
+			"missing-resource" => "Fixture.Missing.Resource",
+			"extra-file" => "unexpected.dat",
+			"payload-hash" => "libSkiaSharp.dll",
+			"checksum" => "SHA-256",
+			"partial-marker" => "PARTIAL-BUILD.txt",
+			_ => throw new ArgumentOutOfRangeException(nameof(mutation))
+		};
+		Assert.Contains(expected, output, StringComparison.Ordinal);
 	}
 
 	[Theory]
 	[InlineData(false, false)]
 	[InlineData(true, false)]
 	[InlineData(false, true)]
-	public void ValidatorReadsStoreUploadBundlePackagesAndManifest(bool omitGrammar, bool omitLanguage)
+	public void ValidatorReadsStoreUploadBundlePackagesAndReceipts(bool omitPayloadFile, bool omitLanguage)
 	{
 		using var workspace = new TemporaryDirectory();
-		var artifactName = CreateStoreFixture(workspace.Path, omitGrammar, omitLanguage);
+		var artifactName = CreateStoreFixture(workspace.Path, omitPayloadFile, omitLanguage);
 
 		var result = RunValidator(workspace.Path, "store", "win-x64");
 		var output = result.StandardOutput + result.StandardError;
 
-		if (!omitGrammar && !omitLanguage)
+		if (!omitPayloadFile && !omitLanguage)
 		{
 			Assert.Equal(0, result.ExitCode);
 			Assert.Contains("Channel store: VALIDATED", result.StandardOutput, StringComparison.Ordinal);
@@ -89,29 +80,79 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 
 		Assert.NotEqual(0, result.ExitCode);
 		Assert.Contains(artifactName, output, StringComparison.Ordinal);
-		Assert.Contains(
-			omitGrammar ? "tree-sitter-kotlin.dll" : "Store resource languages",
-			output,
-			StringComparison.Ordinal);
+		Assert.Contains(omitPayloadFile ? "libSkiaSharp.dll" : "Store resource languages", output, StringComparison.Ordinal);
 	}
 
 	[Fact]
-	public void StoreMutationGateProvesTheValidatorRejectsAMissingGrammar()
+	public void StoreMutationGateUsesTheSameDiffForFilesAndEmbeddedResources()
 	{
 		using var workspace = new TemporaryDirectory();
-		CreateStoreFixture(workspace.Path, omitGrammar: false, omitLanguage: false);
+		CreateStoreFixture(workspace.Path, omitPayloadFile: false, omitLanguage: false);
 
 		var result = RunPowerShell(
 			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifactGateMutation.ps1"),
-			[
-				"-PublishRoot", Path.Combine(workspace.Path, "publish"),
-				"-Version", Version,
-				"-Channels", "store"
-			]);
+			["-PublishRoot", Path.Combine(workspace.Path, "publish"), "-Version", Version, "-Channels", "store"]);
 
 		Assert.Equal(0, result.ExitCode);
-		Assert.Contains("Mutation gate passed", result.StandardOutput, StringComparison.Ordinal);
-		Assert.Contains("tree-sitter-kotlin.dll", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("DevProjex.Grammars/tree-sitter-kotlin.dll", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("DevProjex.Assets.Localization.en.json", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("libSkiaSharp.dll", result.StandardOutput, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void SdkReceiptMatchesBundleFolderPublishAndManagedResourceTables()
+	{
+		using var workspace = new TemporaryDirectory();
+		var fixture = CreateReceiptBuildFixture(workspace.Path);
+
+		var singleResult = RunDotNet(fixture.Root,
+			["publish", fixture.AppProject, "-c", "Release", "-r", "win-x64", "--self-contained", "false",
+				"-nodeReuse:false",
+				"/p:PublishSingleFile=true", "/p:IncludeNativeLibrariesForSelfExtract=true",
+				"/p:EnableCompressionInSingleFile=false", "/p:DebugType=None", "/p:DebugSymbols=false",
+				"/p:DevProjexGenerateReleasePayloadReceipt=true",
+				$"/p:DevProjexPayloadReceiptDirectory={fixture.SingleReceipt}", "-o", fixture.SinglePublish]);
+		Assert.True(singleResult.ExitCode == 0, singleResult.StandardOutput + singleResult.StandardError);
+
+		var folderResult = RunDotNet(fixture.Root,
+			["publish", fixture.AppProject, "-c", "ReleaseStore", "-r", "win-x64", "--self-contained", "false",
+				"-nodeReuse:false",
+				"/p:PublishSingleFile=false", "/p:DebugType=None", "/p:DebugSymbols=false",
+				"/p:DevProjexGenerateReleasePayloadReceipt=true",
+				$"/p:DevProjexPayloadReceiptDirectory={fixture.FolderReceipt}", "-o", fixture.FolderPublish]);
+		Assert.True(folderResult.ExitCode == 0, folderResult.StandardOutput + folderResult.StandardError);
+
+		var singleReceipt = ReadReceipt(Path.Combine(fixture.SingleReceipt, "publish-payload.win-x64.json"));
+		var folderReceipt = ReadReceipt(Path.Combine(fixture.FolderReceipt, "publish-payload.win-x64.json"));
+		var bundle = ReleasePayloadInspector.InspectBundle(Path.Combine(fixture.SinglePublish, "FixtureApp.exe"));
+		Assert.Equal(
+			singleReceipt.Files.Select(static file => file.Path).Order(StringComparer.Ordinal),
+			bundle.Files.Select(static file => file.Path).Order(StringComparer.Ordinal));
+
+		var folderFiles = Directory.EnumerateFiles(fixture.FolderPublish, "*", SearchOption.AllDirectories)
+			.Select(path => Path.GetRelativePath(fixture.FolderPublish, path).Replace('\\', '/'))
+			.Where(static path => !path.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
+			.Order(StringComparer.Ordinal);
+		Assert.Equal(folderFiles, folderReceipt.Files.Select(static file => file.Path).Order(StringComparer.Ordinal));
+		var unbundledPayloadFiles = folderReceipt.Files
+			.Where(static file => file.Path != "FixtureApp.exe")
+			.Select(static file => file.Path)
+			.Order(StringComparer.Ordinal);
+		var bundledPayloadFiles = singleReceipt.Files.Select(static file => file.Path).Order(StringComparer.Ordinal);
+		Assert.True(unbundledPayloadFiles.SequenceEqual(bundledPayloadFiles, StringComparer.Ordinal),
+			$"Folder only: {string.Join(", ", unbundledPayloadFiles.Except(bundledPayloadFiles, StringComparer.Ordinal))}; " +
+			$"bundle only: {string.Join(", ", bundledPayloadFiles.Except(unbundledPayloadFiles, StringComparer.Ordinal))}");
+
+		foreach (var assemblyName in new[] { "Assets.dll", "Infrastructure.dll" })
+		{
+			var beforeBundle = ReleasePayloadInspector.TryReadManagedResources(Path.Combine(fixture.FolderPublish, assemblyName));
+			var fromBundle = bundle.Files.Single(file => file.Path == assemblyName).ManagedResources;
+			var fromReceipt = singleReceipt.Files.Single(file => file.Path == assemblyName).ManagedResources;
+			Assert.Equal(beforeBundle, fromBundle);
+			Assert.Equal(beforeBundle, fromReceipt);
+		}
+		Assert.Contains("Fixture.Assets.NewContent.txt",
+			singleReceipt.Files.Single(file => file.Path == "Assets.dll").ManagedResources!);
 	}
 
 	public static TheoryData<string[], string> InvalidReleaseInvocations => new()
@@ -126,9 +167,7 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 
 	[Theory]
 	[MemberData(nameof(InvalidReleaseInvocations))]
-	public void NonInteractiveReleaseValidationRejectsInvalidInputOnOneLine(
-		string[] arguments,
-		string expectedMessage)
+	public void NonInteractiveReleaseValidationRejectsInvalidInputOnOneLine(string[] arguments, string expectedMessage)
 	{
 		var result = RunPowerShell(Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"), arguments);
 		var lines = (result.StandardOutput + result.StandardError)
@@ -142,14 +181,11 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 	[Fact]
 	public void NonInteractiveConfigValidationUsesTheRepositoryVersionWithoutPrompting()
 	{
-		var result = RunPowerShell(
-			Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"),
+		var result = RunPowerShell(Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"),
 			["-ValidateConfigOnly", "-NonInteractive"]);
-		var output = result.StandardOutput + result.StandardError;
-
 		Assert.Equal(0, result.ExitCode);
-		Assert.Contains("Configuration: VALIDATED", output, StringComparison.Ordinal);
-		Assert.DoesNotContain("Enter release version", output, StringComparison.Ordinal);
+		Assert.Contains("Configuration: VALIDATED", result.StandardOutput + result.StandardError, StringComparison.Ordinal);
+		Assert.DoesNotContain("Enter release version", result.StandardOutput + result.StandardError, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -160,96 +196,139 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		try
 		{
 			CreateLinuxFixture(RepoRoot.Value, version: version);
-
-			var result = RunPowerShell(
-				Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"),
-				[
-					"-ValidateArtifactsOnly",
-					"-Channels", "github",
-					"-Rids", "linux-x64",
-					"-Version", version,
-					"-NonInteractive"
-				]);
-
+			var result = RunPowerShell(Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"),
+				["-ValidateArtifactsOnly", "-Channels", "github", "-Rids", "linux-x64",
+					"-Version", version, "-NonInteractive"]);
 			Assert.Equal(0, result.ExitCode);
 			Assert.Contains("Channel github: validated; PARTIAL", result.StandardOutput, StringComparison.Ordinal);
 		}
 		finally
 		{
-			if (Directory.Exists(releaseDirectory))
-			{
-				Directory.Delete(releaseDirectory, recursive: true);
-			}
+			if (Directory.Exists(releaseDirectory)) Directory.Delete(releaseDirectory, recursive: true);
 		}
 	}
 
 	private static ProcessResult RunValidator(string workspaceRoot, string channel, string rids) =>
-		RunPowerShell(
-			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifacts.ps1"),
-			[
-				"-PublishRoot", Path.Combine(workspaceRoot, "publish"),
-				"-Version", Version,
-				"-Channels", channel,
-				"-Rids", rids
-			]);
+		RunPowerShell(Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifacts.ps1"),
+			["-PublishRoot", Path.Combine(workspaceRoot, "publish"), "-Version", Version,
+				"-Channels", channel, "-Rids", rids]);
 
-	private static void CreateLinuxFixture(
-		string workspaceRoot,
-		bool omitGrammar = false,
-		bool omitLocalization = false,
-		bool invalidChecksum = false,
-		bool omitPartialMarker = false,
-		string version = Version)
+	private static void CreateLinuxFixture(string workspaceRoot, string? mutation = null, string version = Version)
 	{
-		var manifest = LoadManifest();
 		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "github", $"v{version}");
 		Directory.CreateDirectory(releaseDirectory);
+		var payload = CreateFixturePayload(version);
+		var bundleFiles = payload.ToList();
+		var receiptFiles = payload.Select(ToReceiptFile).ToList();
+		if (mutation == "missing-file") receiptFiles.Add(new ReceiptFile("receipt-only.dat", 1, new string('0', 64), null));
+		if (mutation == "missing-resource")
+		{
+			var index = receiptFiles.FindIndex(static file => file.Path == "Assets.dll");
+			receiptFiles[index] = receiptFiles[index] with
+			{
+				ManagedResources = [.. receiptFiles[index].ManagedResources!, "Fixture.Missing.Resource"]
+			};
+		}
+		if (mutation == "extra-file") bundleFiles.Add(new PayloadFile("unexpected.dat", Encoding.ASCII.GetBytes("extra"), 0));
+		if (mutation == "payload-hash")
+		{
+			var index = receiptFiles.FindIndex(static file => file.Path == "libSkiaSharp.dll");
+			receiptFiles[index] = receiptFiles[index] with { Sha256 = new string('0', 64) };
+		}
+
 		var artifactName = $"DevProjex.v{version}.linux-x64.tar.gz";
 		var artifactPath = Path.Combine(releaseDirectory, artifactName);
-		var payloadParts = new List<string> { version };
-		payloadParts.AddRange(manifest.Grammars
-			.Where(grammar => !omitGrammar || grammar != "tree-sitter-kotlin")
-			.Select(grammar => $"lib{grammar}.so"));
-		payloadParts.AddRange(manifest.Localizations
-			.Where(localization => !omitLocalization || localization != "en.json"));
-		var payload = Encoding.UTF8.GetBytes(string.Join('\0', payloadParts));
-
+		var bundle = CreateBundle(bundleFiles);
 		using (var file = File.Create(artifactPath))
 		using (var gzip = new GZipStream(file, CompressionLevel.SmallestSize))
 		using (var writer = new TarWriter(gzip, TarEntryFormat.Ustar, leaveOpen: false))
 		{
-			var entry = new UstarTarEntry(TarEntryType.RegularFile, "DevProjex")
+			writer.WriteEntry(new UstarTarEntry(TarEntryType.RegularFile, "DevProjex")
 			{
-				DataStream = new MemoryStream(payload, writable: false),
+				DataStream = new MemoryStream(bundle, writable: false),
 				Mode = (UnixFileMode)493,
 				ModificationTime = DateTimeOffset.UnixEpoch
-			};
-			writer.WriteEntry(entry);
+			});
 		}
 
-		var hash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(artifactPath))).ToLowerInvariant();
-		if (invalidChecksum)
-		{
-			hash = new string('0', 64);
-		}
-		File.WriteAllText(Path.Combine(releaseDirectory, "SHA256SUMS.txt"), $"{hash} *{artifactName}\n", new UTF8Encoding(false));
-		if (!omitPartialMarker)
-		{
-			File.WriteAllText(
-				Path.Combine(releaseDirectory, "PARTIAL-BUILD.txt"),
-				"PARTIAL BUILD - NOT READY FOR RELEASE\nRIDs: linux-x64\n",
-				new UTF8Encoding(false));
-		}
+		var receiptName = "publish-payload.linux-x64.json";
+		WriteReceipt(Path.Combine(releaseDirectory, receiptName), "linux-x64", receiptFiles);
+		WriteChecksums(releaseDirectory, [artifactName, receiptName], mutation == "checksum" ? artifactName : null);
+		if (mutation != "partial-marker")
+			File.WriteAllText(Path.Combine(releaseDirectory, "PARTIAL-BUILD.txt"),
+				"PARTIAL BUILD - NOT READY FOR RELEASE\nRIDs: linux-x64\n", new UTF8Encoding(false));
 	}
 
-	private static string CreateStoreFixture(string workspaceRoot, bool omitGrammar, bool omitLanguage)
+	private static IReadOnlyList<PayloadFile> CreateFixturePayload(string version = Version) =>
+	[
+		new("DevProjex.exe", Encoding.ASCII.GetBytes($"fixture-{version}"), 2),
+		new("Assets.dll", File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "Assets.dll")), 1),
+		new("Infrastructure.dll", File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "Infrastructure.dll")), 1),
+		new("libSkiaSharp.dll", Encoding.ASCII.GetBytes($"native-{version}"), 2),
+		new("DevProjex.runtimeconfig.json", Encoding.UTF8.GetBytes($"{{\"version\":\"{version}\"}}"), 4)
+	];
+
+	private static byte[] CreateBundle(IReadOnlyList<PayloadFile> files)
 	{
-		var manifest = LoadManifest();
+		var signature = Convert.FromHexString("8B1202B96A612038727B930214D7A03213F5B9E6EFAE3318EE3B2DCE24B36AAE");
+		using var stream = new MemoryStream();
+		using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+		writer.Write(0L);
+		writer.Write(signature);
+		var entries = new List<(PayloadFile File, long Offset)>();
+		foreach (var file in files)
+		{
+			entries.Add((file, stream.Position));
+			writer.Write(file.Bytes);
+		}
+		var headerOffset = stream.Position;
+		writer.Write(6u);
+		writer.Write(0u);
+		writer.Write(entries.Count);
+		writer.Write("FixtureId001");
+		for (var index = 0; index < 5; index++) writer.Write(0L);
+		foreach (var entry in entries)
+		{
+			writer.Write(entry.Offset);
+			writer.Write((long)entry.File.Bytes.Length);
+			writer.Write(0L);
+			writer.Write(entry.File.FileType);
+			writer.Write(entry.File.Path);
+		}
+		stream.Position = 0;
+		writer.Write(headerOffset);
+		return stream.ToArray();
+	}
+
+	private static ReceiptFile ToReceiptFile(PayloadFile file)
+	{
+		string[]? resources = null;
+		if (file.FileType == 1)
+		{
+			var path = Path.Combine(Path.GetTempPath(), $"dpx-receipt-{Guid.NewGuid():N}.dll");
+			try
+			{
+				File.WriteAllBytes(path, file.Bytes);
+				resources = ReleasePayloadInspector.TryReadManagedResources(path);
+			}
+			finally
+			{
+				File.Delete(path);
+			}
+		}
+		return new ReceiptFile(file.Path, file.Bytes.LongLength,
+			Convert.ToHexString(SHA256.HashData(file.Bytes)).ToLowerInvariant(), resources);
+	}
+
+	private static string CreateStoreFixture(string workspaceRoot, bool omitPayloadFile, bool omitLanguage)
+	{
+		var payload = CreateFixturePayload();
+		var receiptFiles = payload.Select(ToReceiptFile).ToArray();
 		var x64PackageName = "DevProjex_5.2.0.0_x64.msix";
 		var arm64PackageName = "DevProjex_5.2.0.0_arm64.msix";
-		var x64Package = CreateStorePackage(manifest.Grammars, "x64", omitGrammar);
-		var arm64Package = CreateStorePackage(manifest.Grammars, "arm64", omitGrammar: false);
-		var languages = manifest.StoreLanguages.Where(language => !omitLanguage || language != "en-us");
+		var x64Package = CreateStorePackage(payload, "x64", omitPayloadFile);
+		var arm64Package = CreateStorePackage(payload, "arm64", omitPayloadFile: false);
+		var languages = LoadStoreLanguages().Where(language => !omitLanguage || language != "en-us");
 		var bundleManifest = $$"""
 			<?xml version="1.0" encoding="utf-8"?>
 			<Bundle xmlns="http://schemas.microsoft.com/appx/2013/bundle">
@@ -258,9 +337,7 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 			    <Package Type="application" Architecture="x64" FileName="{{x64PackageName}}" />
 			    <Package Type="application" Architecture="arm64" FileName="{{arm64PackageName}}" />
 			  </Packages>
-			  <Resources>
-			    {{string.Join(Environment.NewLine + "    ", languages.Select(language => $"<Resource Language=\"{language}\" />"))}}
-			  </Resources>
+			  <Resources>{{string.Concat(languages.Select(language => $"<Resource Language=\"{language}\" />"))}}</Resources>
 			</Bundle>
 			""";
 		var bundle = CreateZip(new Dictionary<string, byte[]>(StringComparer.Ordinal)
@@ -270,61 +347,35 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 			[arm64PackageName] = arm64Package
 		});
 		var artifactName = "DevProjex.Store_5.2.0.0_x64_arm64_bundle_ReleaseStore.msixupload";
-		var upload = CreateZip(new Dictionary<string, byte[]>(StringComparer.Ordinal)
-		{
-			["DevProjex_5.2.0.0_x64_arm64.msixbundle"] = bundle
-		});
-		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "store", $"v{Version}");
-		Directory.CreateDirectory(releaseDirectory);
 		var artifacts = new Dictionary<string, byte[]>(StringComparer.Ordinal)
 		{
-			[artifactName] = upload,
+			[artifactName] = CreateZip(new Dictionary<string, byte[]> { ["DevProjex_5.2.0.0_x64_arm64.msixbundle"] = bundle }),
 			["DevProjex.Store_5.2.0.0_x64_arm64_ReleaseStore.msixbundle"] = bundle,
 			["DevProjex.Store_5.2.0.0_x64_ReleaseStore.msix"] = x64Package
 		};
-		foreach (var (name, bytes) in artifacts)
-		{
-			File.WriteAllBytes(Path.Combine(releaseDirectory, name), bytes);
-		}
-		var checksumLines = artifacts
-			.OrderBy(static artifact => artifact.Key, StringComparer.Ordinal)
-			.Select(static artifact =>
-				$"{Convert.ToHexString(SHA256.HashData(artifact.Value)).ToLowerInvariant()} *{artifact.Key}");
-		File.WriteAllText(
-			Path.Combine(releaseDirectory, "SHA256SUMS.txt"),
-			string.Join('\n', checksumLines) + '\n',
-			new UTF8Encoding(false));
+		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "store", $"v{Version}");
+		Directory.CreateDirectory(releaseDirectory);
+		foreach (var (name, bytes) in artifacts) File.WriteAllBytes(Path.Combine(releaseDirectory, name), bytes);
+		foreach (var rid in new[] { "win-x64", "win-arm64" })
+			WriteReceipt(Path.Combine(releaseDirectory, $"publish-payload.{rid}.json"), rid, receiptFiles);
+		WriteChecksums(releaseDirectory, [.. artifacts.Keys, "publish-payload.win-x64.json", "publish-payload.win-arm64.json"]);
 		return artifactName;
 	}
 
-	private static byte[] CreateStorePackage(IEnumerable<string> grammars, string architecture, bool omitGrammar)
+	private static byte[] CreateStorePackage(IReadOnlyList<PayloadFile> payload, string architecture, bool omitPayloadFile)
 	{
-		var packageManifest = $$"""
+		var manifest = $$"""
 			<?xml version="1.0" encoding="utf-8"?>
-			<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-			         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-			         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10">
+			<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10">
 			  <Identity Name="DevProjex" Publisher="CN=Test" Version="{{StoreVersion}}" ProcessorArchitecture="{{architecture}}" />
-			  <Applications>
-			    <Application Id="App" Executable="DevProjex.Avalonia.exe" EntryPoint="Windows.FullTrustApplication">
-			      <Extensions>
-			        <uap3:Extension Category="windows.appExecutionAlias" Executable="DevProjex.Avalonia\DevProjex.exe" EntryPoint="Windows.FullTrustApplication">
-			          <uap3:AppExecutionAlias><desktop:ExecutionAlias Alias="devprojex.exe" /></uap3:AppExecutionAlias>
-			        </uap3:Extension>
-			      </Extensions>
-			    </Application>
-			  </Applications>
+			  <Applications><Application Id="App" Executable="DevProjex.Avalonia.exe" EntryPoint="Windows.FullTrustApplication"><Extensions>
+			    <uap3:Extension Category="windows.appExecutionAlias" Executable="DevProjex.Avalonia\DevProjex.exe" EntryPoint="Windows.FullTrustApplication"><uap3:AppExecutionAlias><desktop:ExecutionAlias Alias="devprojex.exe" /></uap3:AppExecutionAlias></uap3:Extension>
+			  </Extensions></Application></Applications>
 			</Package>
 			""";
-		var entries = new Dictionary<string, byte[]>(StringComparer.Ordinal)
-		{
-			["AppxManifest.xml"] = Encoding.UTF8.GetBytes(packageManifest),
-			["DevProjex.Avalonia/DevProjex.exe"] = Encoding.ASCII.GetBytes("fixture")
-		};
-		foreach (var grammar in grammars.Where(grammar => !omitGrammar || grammar != "tree-sitter-kotlin"))
-		{
-			entries[$"DevProjex.Avalonia/grammars/{grammar}.dll"] = Encoding.ASCII.GetBytes(grammar);
-		}
+		var entries = new Dictionary<string, byte[]>(StringComparer.Ordinal) { ["AppxManifest.xml"] = Encoding.UTF8.GetBytes(manifest) };
+		foreach (var file in payload.Where(file => !omitPayloadFile || file.Path != "libSkiaSharp.dll"))
+			entries[$"DevProjex.Avalonia/{file.Path}"] = file.Bytes;
 		return CreateZip(entries);
 	}
 
@@ -332,62 +383,100 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 	{
 		using var stream = new MemoryStream();
 		using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+		foreach (var (name, content) in entries)
 		{
-			foreach (var (name, content) in entries)
-			{
-				var entry = archive.CreateEntry(name, CompressionLevel.SmallestSize);
-				using var entryStream = entry.Open();
-				entryStream.Write(content);
-			}
+			var entry = archive.CreateEntry(name, CompressionLevel.SmallestSize);
+			using var entryStream = entry.Open();
+			entryStream.Write(content);
 		}
 		return stream.ToArray();
 	}
 
-	private static ReleaseManifest LoadManifest()
+	private static string[] LoadStoreLanguages()
 	{
-		using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(
-			RepoRoot.Value,
-			"Packaging",
-			"Headless",
-			"payload-manifest.json")));
-		var root = document.RootElement;
-		return new ReleaseManifest(
-			root.GetProperty("grammars").EnumerateArray().Select(static item => item.GetString()!).ToArray(),
-			root.GetProperty("release").GetProperty("localizations").EnumerateArray().Select(static item => item.GetString()!).ToArray(),
-			root.GetProperty("release").GetProperty("store").GetProperty("resourceLanguages").EnumerateArray().Select(static item => item.GetString()!).ToArray());
+		using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(RepoRoot.Value,
+			"Packaging", "Headless", "payload-manifest.json")));
+		return document.RootElement.GetProperty("release").GetProperty("store").GetProperty("resourceLanguages")
+			.EnumerateArray().Select(static item => item.GetString()!).ToArray();
 	}
 
-	private static ProcessResult RunPowerShell(string scriptPath, IReadOnlyList<string> arguments)
+	private static void WriteReceipt(string path, string rid, IReadOnlyList<ReceiptFile> files)
 	{
-		var startInfo = new ProcessStartInfo
-		{
-			FileName = "pwsh",
-			WorkingDirectory = RepoRoot.Value,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			UseShellExecute = false
-		};
-		startInfo.ArgumentList.Add("-NoLogo");
-		startInfo.ArgumentList.Add("-NoProfile");
-		startInfo.ArgumentList.Add("-File");
-		startInfo.ArgumentList.Add(scriptPath);
-		foreach (var argument in arguments)
-		{
-			startInfo.ArgumentList.Add(argument);
-		}
+		var payload = new { schemaVersion = 1, rid, files = files.Select(file => file.ManagedResources is null
+			? (object)new { path = file.Path, size = file.Size, sha256 = file.Sha256 }
+			: new { path = file.Path, size = file.Size, sha256 = file.Sha256, managedResources = file.ManagedResources }) };
+		File.WriteAllText(path, JsonSerializer.Serialize(payload), new UTF8Encoding(false));
+	}
 
-		using var process = Process.Start(startInfo)
-			?? throw new InvalidOperationException("Could not start pwsh.");
-		var standardOutput = process.StandardOutput.ReadToEnd();
-		var standardError = process.StandardError.ReadToEnd();
+	private static Receipt ReadReceipt(string path) =>
+		JsonSerializer.Deserialize<Receipt>(File.ReadAllText(path), new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+	private static void WriteChecksums(string directory, IEnumerable<string> names, string? invalidName = null)
+	{
+		var lines = names.Order(StringComparer.Ordinal).Select(name =>
+		{
+			var hash = name == invalidName ? new string('0', 64) :
+				Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(Path.Combine(directory, name)))).ToLowerInvariant();
+			return $"{hash} *{name}";
+		});
+		File.WriteAllText(Path.Combine(directory, "SHA256SUMS.txt"), string.Join('\n', lines) + '\n', new UTF8Encoding(false));
+	}
+
+	private static ReceiptBuildFixture CreateReceiptBuildFixture(string root)
+	{
+		var scripts = Directory.CreateDirectory(Path.Combine(root, "Scripts")).FullName;
+		File.Copy(Path.Combine(RepoRoot.Value, "Directory.Build.targets"), Path.Combine(root, "Directory.Build.targets"));
+		File.Copy(Path.Combine(RepoRoot.Value, "Scripts", "Write-PublishPayloadReceipt.ps1"), Path.Combine(scripts, "Write-PublishPayloadReceipt.ps1"));
+		File.Copy(Path.Combine(RepoRoot.Value, "Scripts", "ReleasePayloadInspection.cs"), Path.Combine(scripts, "ReleasePayloadInspection.cs"));
+		CreateFixtureProject(root, "Assets", "Fixture.Assets.NewContent.txt");
+		CreateFixtureProject(root, "Infrastructure", "Fixture.Infrastructure.Rule.json");
+		var app = Path.Combine(root, "FixtureApp");
+		Directory.CreateDirectory(app);
+		File.WriteAllText(Path.Combine(app, "FixtureApp.csproj"), """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType><AssemblyName>FixtureApp</AssemblyName></PropertyGroup>
+			  <ItemGroup><ProjectReference Include="..\Assets\Assets.csproj" /><ProjectReference Include="..\Infrastructure\Infrastructure.csproj" /></ItemGroup>
+			</Project>
+			""");
+		File.WriteAllText(Path.Combine(app, "Program.cs"), "System.Console.WriteLine(typeof(Assets.Marker).FullName + typeof(Infrastructure.Marker).FullName);");
+		return new ReceiptBuildFixture(root, Path.Combine(app, "FixtureApp.csproj"),
+			Path.Combine(root, "single"), Path.Combine(root, "single-receipt"),
+			Path.Combine(root, "folder"), Path.Combine(root, "folder-receipt"));
+	}
+
+	private static void CreateFixtureProject(string root, string name, string logicalName)
+	{
+		var directory = Directory.CreateDirectory(Path.Combine(root, name)).FullName;
+		File.WriteAllText(Path.Combine(directory, $"{name}.csproj"), $$"""
+			<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net10.0</TargetFramework><EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems></PropertyGroup>
+			<ItemGroup><EmbeddedResource Include="content.txt" LogicalName="{{logicalName}}" /></ItemGroup></Project>
+			""");
+		File.WriteAllText(Path.Combine(directory, "Marker.cs"), $"namespace {name}; public sealed class Marker {{ }}");
+		File.WriteAllText(Path.Combine(directory, "content.txt"), name);
+	}
+
+	private static ProcessResult RunPowerShell(string scriptPath, IReadOnlyList<string> arguments) =>
+		RunProcess("pwsh", RepoRoot.Value, ["-NoLogo", "-NoProfile", "-File", scriptPath, .. arguments]);
+
+	private static ProcessResult RunDotNet(string workingDirectory, IReadOnlyList<string> arguments) =>
+		RunProcess("dotnet", workingDirectory, arguments);
+
+	private static ProcessResult RunProcess(string fileName, string workingDirectory, IReadOnlyList<string> arguments)
+	{
+		var startInfo = new ProcessStartInfo { FileName = fileName, WorkingDirectory = workingDirectory,
+			RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false };
+		foreach (var argument in arguments) startInfo.ArgumentList.Add(argument);
+		using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Could not start {fileName}.");
+		var output = process.StandardOutput.ReadToEnd();
+		var error = process.StandardError.ReadToEnd();
 		process.WaitForExit();
-		return new ProcessResult(process.ExitCode, standardOutput, standardError);
+		return new ProcessResult(process.ExitCode, output, error);
 	}
 
-	private sealed record ReleaseManifest(
-		IReadOnlyList<string> Grammars,
-		IReadOnlyList<string> Localizations,
-		IReadOnlyList<string> StoreLanguages);
-
+	private sealed record PayloadFile(string Path, byte[] Bytes, byte FileType);
+	private sealed record ReceiptFile(string Path, long Size, string Sha256, string[]? ManagedResources);
+	private sealed record Receipt(string Rid, ReceiptFile[] Files);
+	private sealed record ReceiptBuildFixture(string Root, string AppProject, string SinglePublish,
+		string SingleReceipt, string FolderPublish, string FolderReceipt);
 	private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
 }

--- a/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
@@ -1,0 +1,393 @@
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using DevProjex.Tests.Integration.Helpers;
+using DevProjex.Tests.Shared.StoreListing;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class ReleaseArtifactValidationIntegrationTests
+{
+	private const string Version = "5.2";
+	private const string StoreVersion = "5.2.0.0";
+	private static readonly Lazy<string> RepoRoot = new(StoreListingPaths.FindRepositoryRoot);
+
+	[Fact]
+	public void ValidatorAcceptsACompletePartialRidSetAndReportsThatItIsNotReleaseReady()
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateLinuxFixture(workspace.Path);
+
+		var result = RunValidator(workspace.Path, "github", "linux-x64");
+
+		Assert.Equal(0, result.ExitCode);
+		Assert.Contains("Channel github: VALIDATED; PARTIAL (not release-ready)", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("DevProjex.v5.2.linux-x64.tar.gz", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("SHA-256", result.StandardOutput, StringComparison.Ordinal);
+	}
+
+	[Theory]
+	[InlineData("grammar")]
+	[InlineData("localization")]
+	[InlineData("checksum")]
+	[InlineData("partial-marker")]
+	public void ValidatorFailsClosedForIncompleteGitHubArtifacts(string mutation)
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateLinuxFixture(
+			workspace.Path,
+			omitGrammar: mutation == "grammar",
+			omitLocalization: mutation == "localization",
+			invalidChecksum: mutation == "checksum",
+			omitPartialMarker: mutation == "partial-marker");
+
+		var result = RunValidator(workspace.Path, "github", "linux-x64");
+		var output = result.StandardOutput + result.StandardError;
+
+		Assert.NotEqual(0, result.ExitCode);
+		Assert.Contains("incomplete", output, StringComparison.OrdinalIgnoreCase);
+		switch (mutation)
+		{
+			case "grammar":
+				Assert.Contains("DevProjex.v5.2.linux-x64.tar.gz", output, StringComparison.Ordinal);
+				Assert.Contains("libtree-sitter-kotlin.so", output, StringComparison.Ordinal);
+				break;
+			case "localization":
+				Assert.Contains("DevProjex.v5.2.linux-x64.tar.gz", output, StringComparison.Ordinal);
+				Assert.Contains("en.json", output, StringComparison.Ordinal);
+				break;
+			case "checksum":
+				Assert.Contains("invalid SHA-256", output, StringComparison.Ordinal);
+				break;
+			case "partial-marker":
+				Assert.Contains("PARTIAL-BUILD.txt", output, StringComparison.Ordinal);
+				break;
+		}
+	}
+
+	[Theory]
+	[InlineData(false, false)]
+	[InlineData(true, false)]
+	[InlineData(false, true)]
+	public void ValidatorReadsStoreUploadBundlePackagesAndManifest(bool omitGrammar, bool omitLanguage)
+	{
+		using var workspace = new TemporaryDirectory();
+		var artifactName = CreateStoreFixture(workspace.Path, omitGrammar, omitLanguage);
+
+		var result = RunValidator(workspace.Path, "store", "win-x64");
+		var output = result.StandardOutput + result.StandardError;
+
+		if (!omitGrammar && !omitLanguage)
+		{
+			Assert.Equal(0, result.ExitCode);
+			Assert.Contains("Channel store: VALIDATED", result.StandardOutput, StringComparison.Ordinal);
+			return;
+		}
+
+		Assert.NotEqual(0, result.ExitCode);
+		Assert.Contains(artifactName, output, StringComparison.Ordinal);
+		Assert.Contains(
+			omitGrammar ? "tree-sitter-kotlin.dll" : "Store resource languages",
+			output,
+			StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void StoreMutationGateProvesTheValidatorRejectsAMissingGrammar()
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateStoreFixture(workspace.Path, omitGrammar: false, omitLanguage: false);
+
+		var result = RunPowerShell(
+			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifactGateMutation.ps1"),
+			[
+				"-PublishRoot", Path.Combine(workspace.Path, "publish"),
+				"-Version", Version,
+				"-Channels", "store"
+			]);
+
+		Assert.Equal(0, result.ExitCode);
+		Assert.Contains("Mutation gate passed", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("tree-sitter-kotlin.dll", result.StandardOutput, StringComparison.Ordinal);
+	}
+
+	public static TheoryData<string[], string> InvalidReleaseInvocations => new()
+	{
+		{ ["-ValidateArtifactsOnly", "-Channels", "unknown", "-NonInteractive"], "Unknown release channel 'unknown'" },
+		{ ["-ValidateArtifactsOnly", "-Channels", "github", "-Rids", "unknown", "-NonInteractive"], "Unknown release RID 'unknown'" },
+		{ ["-WackOnly", "-Channels", "github", "-NonInteractive"], "-WackOnly supports only the store channel" },
+		{ ["-WackOnly", "-Channels", "store", "-SkipWack", "-NonInteractive"], "-SkipWack cannot be combined with -WackOnly" },
+		{ ["-WackOnly", "-ValidateArtifactsOnly", "-Channels", "store", "-NonInteractive"], "-ValidateArtifactsOnly cannot be combined with -WackOnly" },
+		{ ["-ValidateArtifactsOnly", "-Channels", "github", "-Version", "invalid", "-NonInteractive"], "Invalid release version 'invalid'" }
+	};
+
+	[Theory]
+	[MemberData(nameof(InvalidReleaseInvocations))]
+	public void NonInteractiveReleaseValidationRejectsInvalidInputOnOneLine(
+		string[] arguments,
+		string expectedMessage)
+	{
+		var result = RunPowerShell(Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"), arguments);
+		var lines = (result.StandardOutput + result.StandardError)
+			.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+		Assert.Equal(1, result.ExitCode);
+		Assert.Single(lines);
+		Assert.Contains(expectedMessage, lines[0], StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void NonInteractiveConfigValidationUsesTheRepositoryVersionWithoutPrompting()
+	{
+		var result = RunPowerShell(
+			Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"),
+			["-ValidateConfigOnly", "-NonInteractive"]);
+		var output = result.StandardOutput + result.StandardError;
+
+		Assert.Equal(0, result.ExitCode);
+		Assert.Contains("Configuration: VALIDATED", output, StringComparison.Ordinal);
+		Assert.DoesNotContain("Enter release version", output, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ValidateArtifactsOnlyValidatesAnExistingPartialRidSetWithoutBuilding()
+	{
+		var version = $"278.{Environment.ProcessId}.{Random.Shared.Next(1, 1_000_000)}";
+		var releaseDirectory = Path.Combine(RepoRoot.Value, "publish", "github", $"v{version}");
+		try
+		{
+			CreateLinuxFixture(RepoRoot.Value, version: version);
+
+			var result = RunPowerShell(
+				Path.Combine(RepoRoot.Value, "Scripts", "release-all.ps1"),
+				[
+					"-ValidateArtifactsOnly",
+					"-Channels", "github",
+					"-Rids", "linux-x64",
+					"-Version", version,
+					"-NonInteractive"
+				]);
+
+			Assert.Equal(0, result.ExitCode);
+			Assert.Contains("Channel github: validated; PARTIAL", result.StandardOutput, StringComparison.Ordinal);
+		}
+		finally
+		{
+			if (Directory.Exists(releaseDirectory))
+			{
+				Directory.Delete(releaseDirectory, recursive: true);
+			}
+		}
+	}
+
+	private static ProcessResult RunValidator(string workspaceRoot, string channel, string rids) =>
+		RunPowerShell(
+			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifacts.ps1"),
+			[
+				"-PublishRoot", Path.Combine(workspaceRoot, "publish"),
+				"-Version", Version,
+				"-Channels", channel,
+				"-Rids", rids
+			]);
+
+	private static void CreateLinuxFixture(
+		string workspaceRoot,
+		bool omitGrammar = false,
+		bool omitLocalization = false,
+		bool invalidChecksum = false,
+		bool omitPartialMarker = false,
+		string version = Version)
+	{
+		var manifest = LoadManifest();
+		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "github", $"v{version}");
+		Directory.CreateDirectory(releaseDirectory);
+		var artifactName = $"DevProjex.v{version}.linux-x64.tar.gz";
+		var artifactPath = Path.Combine(releaseDirectory, artifactName);
+		var payloadParts = new List<string> { version };
+		payloadParts.AddRange(manifest.Grammars
+			.Where(grammar => !omitGrammar || grammar != "tree-sitter-kotlin")
+			.Select(grammar => $"lib{grammar}.so"));
+		payloadParts.AddRange(manifest.Localizations
+			.Where(localization => !omitLocalization || localization != "en.json"));
+		var payload = Encoding.UTF8.GetBytes(string.Join('\0', payloadParts));
+
+		using (var file = File.Create(artifactPath))
+		using (var gzip = new GZipStream(file, CompressionLevel.SmallestSize))
+		using (var writer = new TarWriter(gzip, TarEntryFormat.Ustar, leaveOpen: false))
+		{
+			var entry = new UstarTarEntry(TarEntryType.RegularFile, "DevProjex")
+			{
+				DataStream = new MemoryStream(payload, writable: false),
+				Mode = (UnixFileMode)493,
+				ModificationTime = DateTimeOffset.UnixEpoch
+			};
+			writer.WriteEntry(entry);
+		}
+
+		var hash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(artifactPath))).ToLowerInvariant();
+		if (invalidChecksum)
+		{
+			hash = new string('0', 64);
+		}
+		File.WriteAllText(Path.Combine(releaseDirectory, "SHA256SUMS.txt"), $"{hash} *{artifactName}\n", new UTF8Encoding(false));
+		if (!omitPartialMarker)
+		{
+			File.WriteAllText(
+				Path.Combine(releaseDirectory, "PARTIAL-BUILD.txt"),
+				"PARTIAL BUILD - NOT READY FOR RELEASE\nRIDs: linux-x64\n",
+				new UTF8Encoding(false));
+		}
+	}
+
+	private static string CreateStoreFixture(string workspaceRoot, bool omitGrammar, bool omitLanguage)
+	{
+		var manifest = LoadManifest();
+		var x64PackageName = "DevProjex_5.2.0.0_x64.msix";
+		var arm64PackageName = "DevProjex_5.2.0.0_arm64.msix";
+		var x64Package = CreateStorePackage(manifest.Grammars, "x64", omitGrammar);
+		var arm64Package = CreateStorePackage(manifest.Grammars, "arm64", omitGrammar: false);
+		var languages = manifest.StoreLanguages.Where(language => !omitLanguage || language != "en-us");
+		var bundleManifest = $$"""
+			<?xml version="1.0" encoding="utf-8"?>
+			<Bundle xmlns="http://schemas.microsoft.com/appx/2013/bundle">
+			  <Identity Name="DevProjex" Publisher="CN=Test" Version="{{StoreVersion}}" />
+			  <Packages>
+			    <Package Type="application" Architecture="x64" FileName="{{x64PackageName}}" />
+			    <Package Type="application" Architecture="arm64" FileName="{{arm64PackageName}}" />
+			  </Packages>
+			  <Resources>
+			    {{string.Join(Environment.NewLine + "    ", languages.Select(language => $"<Resource Language=\"{language}\" />"))}}
+			  </Resources>
+			</Bundle>
+			""";
+		var bundle = CreateZip(new Dictionary<string, byte[]>(StringComparer.Ordinal)
+		{
+			["AppxMetadata/AppxBundleManifest.xml"] = Encoding.UTF8.GetBytes(bundleManifest),
+			[x64PackageName] = x64Package,
+			[arm64PackageName] = arm64Package
+		});
+		var artifactName = "DevProjex.Store_5.2.0.0_x64_arm64_bundle_ReleaseStore.msixupload";
+		var upload = CreateZip(new Dictionary<string, byte[]>(StringComparer.Ordinal)
+		{
+			["DevProjex_5.2.0.0_x64_arm64.msixbundle"] = bundle
+		});
+		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "store", $"v{Version}");
+		Directory.CreateDirectory(releaseDirectory);
+		var artifacts = new Dictionary<string, byte[]>(StringComparer.Ordinal)
+		{
+			[artifactName] = upload,
+			["DevProjex.Store_5.2.0.0_x64_arm64_ReleaseStore.msixbundle"] = bundle,
+			["DevProjex.Store_5.2.0.0_x64_ReleaseStore.msix"] = x64Package
+		};
+		foreach (var (name, bytes) in artifacts)
+		{
+			File.WriteAllBytes(Path.Combine(releaseDirectory, name), bytes);
+		}
+		var checksumLines = artifacts
+			.OrderBy(static artifact => artifact.Key, StringComparer.Ordinal)
+			.Select(static artifact =>
+				$"{Convert.ToHexString(SHA256.HashData(artifact.Value)).ToLowerInvariant()} *{artifact.Key}");
+		File.WriteAllText(
+			Path.Combine(releaseDirectory, "SHA256SUMS.txt"),
+			string.Join('\n', checksumLines) + '\n',
+			new UTF8Encoding(false));
+		return artifactName;
+	}
+
+	private static byte[] CreateStorePackage(IEnumerable<string> grammars, string architecture, bool omitGrammar)
+	{
+		var packageManifest = $$"""
+			<?xml version="1.0" encoding="utf-8"?>
+			<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+			         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+			         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10">
+			  <Identity Name="DevProjex" Publisher="CN=Test" Version="{{StoreVersion}}" ProcessorArchitecture="{{architecture}}" />
+			  <Applications>
+			    <Application Id="App" Executable="DevProjex.Avalonia.exe" EntryPoint="Windows.FullTrustApplication">
+			      <Extensions>
+			        <uap3:Extension Category="windows.appExecutionAlias" Executable="DevProjex.Avalonia\DevProjex.exe" EntryPoint="Windows.FullTrustApplication">
+			          <uap3:AppExecutionAlias><desktop:ExecutionAlias Alias="devprojex.exe" /></uap3:AppExecutionAlias>
+			        </uap3:Extension>
+			      </Extensions>
+			    </Application>
+			  </Applications>
+			</Package>
+			""";
+		var entries = new Dictionary<string, byte[]>(StringComparer.Ordinal)
+		{
+			["AppxManifest.xml"] = Encoding.UTF8.GetBytes(packageManifest),
+			["DevProjex.Avalonia/DevProjex.exe"] = Encoding.ASCII.GetBytes("fixture")
+		};
+		foreach (var grammar in grammars.Where(grammar => !omitGrammar || grammar != "tree-sitter-kotlin"))
+		{
+			entries[$"DevProjex.Avalonia/grammars/{grammar}.dll"] = Encoding.ASCII.GetBytes(grammar);
+		}
+		return CreateZip(entries);
+	}
+
+	private static byte[] CreateZip(IReadOnlyDictionary<string, byte[]> entries)
+	{
+		using var stream = new MemoryStream();
+		using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+		{
+			foreach (var (name, content) in entries)
+			{
+				var entry = archive.CreateEntry(name, CompressionLevel.SmallestSize);
+				using var entryStream = entry.Open();
+				entryStream.Write(content);
+			}
+		}
+		return stream.ToArray();
+	}
+
+	private static ReleaseManifest LoadManifest()
+	{
+		using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(
+			RepoRoot.Value,
+			"Packaging",
+			"Headless",
+			"payload-manifest.json")));
+		var root = document.RootElement;
+		return new ReleaseManifest(
+			root.GetProperty("grammars").EnumerateArray().Select(static item => item.GetString()!).ToArray(),
+			root.GetProperty("release").GetProperty("localizations").EnumerateArray().Select(static item => item.GetString()!).ToArray(),
+			root.GetProperty("release").GetProperty("store").GetProperty("resourceLanguages").EnumerateArray().Select(static item => item.GetString()!).ToArray());
+	}
+
+	private static ProcessResult RunPowerShell(string scriptPath, IReadOnlyList<string> arguments)
+	{
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = "pwsh",
+			WorkingDirectory = RepoRoot.Value,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false
+		};
+		startInfo.ArgumentList.Add("-NoLogo");
+		startInfo.ArgumentList.Add("-NoProfile");
+		startInfo.ArgumentList.Add("-File");
+		startInfo.ArgumentList.Add(scriptPath);
+		foreach (var argument in arguments)
+		{
+			startInfo.ArgumentList.Add(argument);
+		}
+
+		using var process = Process.Start(startInfo)
+			?? throw new InvalidOperationException("Could not start pwsh.");
+		var standardOutput = process.StandardOutput.ReadToEnd();
+		var standardError = process.StandardError.ReadToEnd();
+		process.WaitForExit();
+		return new ProcessResult(process.ExitCode, standardOutput, standardError);
+	}
+
+	private sealed record ReleaseManifest(
+		IReadOnlyList<string> Grammars,
+		IReadOnlyList<string> Localizations,
+		IReadOnlyList<string> StoreLanguages);
+
+	private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+}

--- a/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
@@ -29,6 +29,30 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		Assert.Contains("publish-payload.linux-x64.json", result.StandardOutput, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public void ValidatorReusesPayloadInspectorLoadedFromAnotherPath()
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateLinuxFixture(workspace.Path);
+		var alternateDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "alternate")).FullName;
+		var alternateInspector = Path.Combine(alternateDirectory, "ReleasePayloadInspection.cs");
+		File.Copy(Path.Combine(RepoRoot.Value, "Scripts", "ReleasePayloadInspection.cs"), alternateInspector);
+		var wrapperPath = Path.Combine(workspace.Path, "invoke-validator.ps1");
+		File.WriteAllText(wrapperPath, """
+			param($InspectorPath, $ValidatorPath, $PublishRoot)
+			Add-Type -Path $InspectorPath
+			& $ValidatorPath -PublishRoot $PublishRoot -Version 5.2 -Channels github -Rids linux-x64
+			exit $LASTEXITCODE
+			""", new UTF8Encoding(false));
+
+		var result = RunPowerShell(wrapperPath,
+			["-InspectorPath", alternateInspector,
+				"-ValidatorPath", Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifacts.ps1"),
+				"-PublishRoot", Path.Combine(workspace.Path, "publish")]);
+
+		Assert.True(result.ExitCode == 0, result.StandardOutput + result.StandardError);
+	}
+
 	[Theory]
 	[InlineData("missing-file")]
 	[InlineData("missing-resource")]

--- a/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
@@ -24,7 +24,7 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 
 		var result = RunValidator(workspace.Path, "github", "linux-x64");
 
-		Assert.Equal(0, result.ExitCode);
+		Assert.True(result.ExitCode == 0, result.StandardOutput + result.StandardError);
 		Assert.Contains("Channel github: VALIDATED; PARTIAL (not release-ready)", result.StandardOutput, StringComparison.Ordinal);
 		Assert.Contains("publish-payload.linux-x64.json", result.StandardOutput, StringComparison.Ordinal);
 	}
@@ -93,8 +93,8 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifactGateMutation.ps1"),
 			["-PublishRoot", Path.Combine(workspace.Path, "publish"), "-Version", Version, "-Channels", "store"]);
 
-		Assert.Equal(0, result.ExitCode);
-		Assert.Contains("DevProjex.Grammars/tree-sitter-kotlin.dll", result.StandardOutput, StringComparison.Ordinal);
+		Assert.True(result.ExitCode == 0, result.StandardOutput + result.StandardError);
+		Assert.Contains("grammars/tree-sitter-kotlin.dll", result.StandardOutput, StringComparison.Ordinal);
 		Assert.Contains("DevProjex.Assets.Localization.en.json", result.StandardOutput, StringComparison.Ordinal);
 		Assert.Contains("libSkiaSharp.dll", result.StandardOutput, StringComparison.Ordinal);
 	}
@@ -264,6 +264,7 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		new("DevProjex.exe", Encoding.ASCII.GetBytes($"fixture-{version}"), 2),
 		new("Assets.dll", File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "Assets.dll")), 1),
 		new("Infrastructure.dll", File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "Infrastructure.dll")), 1),
+		new("grammars/tree-sitter-kotlin.dll", Encoding.ASCII.GetBytes($"grammar-{version}"), 2),
 		new("libSkiaSharp.dll", Encoding.ASCII.GetBytes($"native-{version}"), 2),
 		new("DevProjex.runtimeconfig.json", Encoding.UTF8.GetBytes($"{{\"version\":\"{version}\"}}"), 4)
 	];

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -20,7 +20,8 @@ public sealed class DocumentationAndPackagingContractTests
 		"Desktop-Control.md",
 		"SmartIgnore.md",
 		"HideSecrets.md",
-		"Release-Channels.md"
+		"Release-Channels.md",
+		"Release-Process.md"
 	];
 
 	[Fact]
@@ -269,6 +270,69 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("NuGet/login@v1", workflow, StringComparison.Ordinal);
 		Assert.Contains("inputs.dry_run == false", workflow, StringComparison.Ordinal);
 		Assert.DoesNotContain("--skip-duplicate", workflow, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ReleasePayloadManifestTracksEveryGrammarLocalizationAndStoreResource()
+	{
+		var rootPath = FindRepositoryRoot();
+		using var manifestDocument = JsonDocument.Parse(File.ReadAllText(Path.Combine(
+			rootPath,
+			"Packaging",
+			"Headless",
+			"payload-manifest.json")));
+		var manifest = manifestDocument.RootElement;
+		var manifestGrammars = manifest.GetProperty("grammars")
+			.EnumerateArray()
+			.Select(static element => element.GetString())
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+		var infrastructure = XDocument.Load(Path.Combine(rootPath, "Infrastructure", "Infrastructure.csproj"));
+		var projectGrammars = infrastructure.Descendants()
+			.Where(static element => element.Name.LocalName is "DevProjexGrammar" or "DevProjexVendoredGrammar")
+			.Select(static element => element.Attribute("Include")?.Value)
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+		Assert.Equal(projectGrammars, manifestGrammars);
+
+		var release = manifest.GetProperty("release");
+		var manifestLocalizations = release.GetProperty("localizations")
+			.EnumerateArray()
+			.Select(static element => element.GetString())
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+		var localizationFiles = Directory.EnumerateFiles(Path.Combine(rootPath, "Assets", "Localization"), "*.json")
+			.Select(Path.GetFileName)
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+		Assert.Equal(localizationFiles, manifestLocalizations);
+
+		var store = release.GetProperty("store");
+		var manifestLanguages = store.GetProperty("resourceLanguages")
+			.EnumerateArray()
+			.Select(static element => element.GetString()!.ToLowerInvariant())
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+		var storeManifest = XDocument.Load(Path.Combine(
+			rootPath,
+			"Packaging",
+			"Windows",
+			"DevProjex.Store",
+			"Package.appxmanifest"));
+		var storeLanguages = storeManifest.Descendants()
+			.Where(static element => element.Name.LocalName == "Resource")
+			.Select(static element => element.Attribute("Language")!.Value.ToLowerInvariant())
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+		Assert.Equal(storeLanguages, manifestLanguages);
+		Assert.Equal(["arm64", "x64"], store.GetProperty("platforms")
+			.EnumerateArray()
+			.Select(static element => element.GetString())
+			.Order(StringComparer.Ordinal));
+
+		var releaseScript = File.ReadAllText(Path.Combine(rootPath, "Scripts", "release-all.ps1"));
+		Assert.Contains("/p:EnableCompressionInSingleFile=false", releaseScript, StringComparison.Ordinal);
+		Assert.Contains("Test-ReleaseArtifacts.ps1", releaseScript, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -273,7 +273,7 @@ public sealed class DocumentationAndPackagingContractTests
 	}
 
 	[Fact]
-	public void ReleasePayloadManifestTracksEveryGrammarLocalizationAndStoreResource()
+	public void ReleasePayloadContractsTrackGrammarsStoreResourcesAndSdkPublishItems()
 	{
 		var rootPath = FindRepositoryRoot();
 		using var manifestDocument = JsonDocument.Parse(File.ReadAllText(Path.Combine(
@@ -296,16 +296,7 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Equal(projectGrammars, manifestGrammars);
 
 		var release = manifest.GetProperty("release");
-		var manifestLocalizations = release.GetProperty("localizations")
-			.EnumerateArray()
-			.Select(static element => element.GetString())
-			.Order(StringComparer.Ordinal)
-			.ToArray();
-		var localizationFiles = Directory.EnumerateFiles(Path.Combine(rootPath, "Assets", "Localization"), "*.json")
-			.Select(Path.GetFileName)
-			.Order(StringComparer.Ordinal)
-			.ToArray();
-		Assert.Equal(localizationFiles, manifestLocalizations);
+		Assert.False(release.TryGetProperty("localizations", out _));
 
 		var store = release.GetProperty("store");
 		var manifestLanguages = store.GetProperty("resourceLanguages")
@@ -333,6 +324,10 @@ public sealed class DocumentationAndPackagingContractTests
 		var releaseScript = File.ReadAllText(Path.Combine(rootPath, "Scripts", "release-all.ps1"));
 		Assert.Contains("/p:EnableCompressionInSingleFile=false", releaseScript, StringComparison.Ordinal);
 		Assert.Contains("Test-ReleaseArtifacts.ps1", releaseScript, StringComparison.Ordinal);
+		var buildTargets = File.ReadAllText(Path.Combine(rootPath, "Directory.Build.targets"));
+		Assert.Contains("@(FilesToBundle)", buildTargets, StringComparison.Ordinal);
+		Assert.Contains("@(ResolvedFileToPublish)", buildTargets, StringComparison.Ordinal);
+		Assert.Contains("Write-PublishPayloadReceipt.ps1", buildTargets, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/AppInstances/AppInstancePackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Unit/AppInstances/AppInstancePackagingContractTests.cs
@@ -270,7 +270,11 @@ public sealed class AppInstancePackagingContractTests
         Assert.Contains("DevProjex.v$version.osx-arm64.app.tar.gz", releaseScript, StringComparison.Ordinal);
         Assert.Contains("New-UstarGzipArchive", releaseScript, StringComparison.Ordinal);
         Assert.Contains("Read-UstarGzipArchive", releaseScript, StringComparison.Ordinal);
-        Assert.Contains("-GitHubOnly:$GitHubArtifactsOnly", releaseScript, StringComparison.Ordinal);
+        // Channel selection intentionally replaces the former boolean-only copy boundary;
+        // -GitHubArtifactsOnly remains an input alias and is normalized before this call.
+        Assert.Contains("-channels $invocation.Channels", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("/p:EnableCompressionInSingleFile=false", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("Test-ReleaseArtifacts.ps1", releaseScript, StringComparison.Ordinal);
         Assert.Contains("(Join-Path $sourceRoot \"artifacts\")", releaseScript, StringComparison.Ordinal);
         Assert.Contains("(Join-Path $sourceRoot \".artifacts\")", releaseScript, StringComparison.Ordinal);
         Assert.Contains("\"bin\"", releaseScript, StringComparison.Ordinal);
@@ -298,10 +302,10 @@ public sealed class AppInstancePackagingContractTests
             "Get-RelativePublishedPath -basePath $ridOutDir -publishedPath $_.FullName",
             releaseScript,
             StringComparison.Ordinal);
-        Assert.Contains(
-            "Build-GitHubArtifactsInWorkspace -version $resolvedVersion -configuration \"Release\" -storePackageVersion $storePackageVersion",
-            releaseScript,
-            StringComparison.Ordinal);
+        Assert.Contains("Build-GitHubArtifactsInWorkspace `", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("-configuration \"Release\" `", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("-storePackageVersion $storePackageVersion `", releaseScript, StringComparison.Ordinal);
+        Assert.Contains("-rids $invocation.Rids", releaseScript, StringComparison.Ordinal);
         Assert.DoesNotContain("\"/p:PublishTrimmed=true\"", releaseScript, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Implements #278 on top of the v5.2 branch.

**Release workflow**
- `release-all.ps1` selects local `github` and `store` channels with `-Channels`; `-GitHubArtifactsOnly` remains a supported alias.
- `-Rids` supports the existing six desktop RIDs. A subset produces `PARTIAL-BUILD.txt`, a subset checksum manifest, and a non-release-ready summary.
- Store build and WACK are separable with `-SkipWack` and `-WackOnly`; `-ValidateArtifactsOnly` rechecks existing outputs without building or invoking WACK.
- `-NonInteractive` never prompts and reports invalid input as one line with exit code 1.
- Every successful artifact operation reports channel readiness plus size and SHA-256 for each artifact and payload receipt.

**Build-derived, fail-closed content contract**
- Each RID build emits `publish-payload.<rid>.json` from the same SDK publish items used by the single-file bundler or Store folder publish. Every file has a relative path, size, SHA-256, and complete embedded-resource table when it is managed.
- The stable manifest retains RID/grammar naming and Store metadata; its former hand-maintained localization list is removed.
- GitHub validation parses the official .NET bundle header, rejects compression, and compares files and managed resources to the receipt exactly in both directions.
- Store validation opens upload, bundle, and architecture packages and applies the same exact receipt diff while retaining version, platform, language, alias, and package-layout checks. Channel-generated MSIX files have one documented centralized allowlist.
- Receipt files are checksum-covered and copied beside artifacts. Partial RID sets remain clearly marked and are valid only for their requested RIDs.
- Mutation gates select a deterministic file and embedded resource from the receipt, then also prove grammar, localization, and native-library damage is rejected with the artifact and entry named. Each mutation workspace is released immediately so disk use stays bounded.

This covers managed assemblies, RID-native libraries, grammar files/resources, HelpContent, IgnoreProfiles, IconPacks, Compression/Languages resources, gitleaks rules, localizations, notices, runtime configuration, and future publish items without validator edits.

**Security posture**
- Validation is static for foreign RIDs and never runs their binaries or loads managed assemblies; resource tables are read through `System.Reflection.Metadata`.
- Only the selected host `win-x64` artifact receives the existing functional smoke: version, tree, compression, secret finding/redaction, and MCP initialization.
- Store WACK remains the explicit certification step and still requires an elevated Windows console.
- Build and validation retain the isolated workspace model and do not publish any channel.

**Behavior and operator recipes**
- The default invocation still builds both local channels and runs WACK. The previous GitHub-only path remains `./Scripts/release-all.ps1 -GitHubArtifactsOnly`.
- Build Store without elevation using `./Scripts/release-all.ps1 -Channels store -SkipWack -NonInteractive`, then run `./Scripts/release-all.ps1 -Channels store -WackOnly -NonInteractive` from an elevated console.
- Recheck existing outputs with `./Scripts/release-all.ps1 -ValidateArtifactsOnly -Channels github,store -NonInteractive`.
- CI builds representative `win-x64` and `linux-x64` GitHub artifacts and runs static and mutation gates when the release planner selects packaging-sensitive changes.

**Verification**
- 21 receipt/validator integration scenarios, including bundle-header and pre-bundle resource-table oracles plus automatic discovery of a new `EmbeddedResource`.
- Release archive, Store listing, packaging, documentation, and CI planner contracts.
- Real partial GitHub build, static revalidation, host functional smoke, and five receipt-driven mutations.
- Real x64/arm64 Store smoke with 315-file receipts, exact upload/bundle/package validation, and five receipt-driven mutations.

