### PR TITLE
chore(deps): refresh dependencies and GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,7 @@ jobs:
       run_documentation: ${{ steps.plan.outputs.run_documentation }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -66,15 +66,15 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os_id }}-${{ matrix.suite_id }}
           path: |
@@ -203,15 +203,15 @@ jobs:
             os_id: macos
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-terminal-command-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}
@@ -312,7 +312,7 @@ jobs:
 
       - name: Upload terminal command results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: terminal-command-results-${{ matrix.os_id }}
           path: |
@@ -344,15 +344,15 @@ jobs:
             run_large_perf_tests: "0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-ignore-scanner-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props') }}
@@ -395,7 +395,7 @@ jobs:
 
       - name: Upload ignore/scanner results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ignore-scanner-results-${{ matrix.os_id }}
           path: |
@@ -411,15 +411,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-documentation-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}

--- a/.github/workflows/grammar-delivery.yml
+++ b/.github/workflows/grammar-delivery.yml
@@ -81,15 +81,15 @@ jobs:
             binary: GrammarDeliveryProbe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-grammar-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Directory.Packages.props') }}
@@ -229,15 +229,15 @@ jobs:
             runner: windows-11-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-grammar-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Directory.Packages.props') }}

--- a/.github/workflows/package-appimage.yml
+++ b/.github/workflows/package-appimage.yml
@@ -44,7 +44,7 @@ jobs:
       upload_release: ${{ steps.metadata.outputs.upload_release }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Resolve version and release tag
         id: metadata
@@ -102,10 +102,10 @@ jobs:
             appimagetool_sha256: 1b00524ba8c6b678dc15ef88a5c25ec24def36cdfc7e3abb32ddcd068e8007fe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -135,7 +135,7 @@ jobs:
             xvfb
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: appimage-nuget-${{ matrix.rid }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}
@@ -541,7 +541,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DevProjex-${{ needs.prepare.outputs.version }}-${{ matrix.appimage_arch }}.AppImage
           path: artifacts/DevProjex-${{ needs.prepare.outputs.version }}-${{ matrix.appimage_arch }}.AppImage
@@ -558,7 +558,7 @@ jobs:
 
     steps:
       - name: Download both AppImage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: DevProjex-${{ needs.prepare.outputs.version }}-*.AppImage
           path: artifacts

--- a/.github/workflows/package-appimage.yml
+++ b/.github/workflows/package-appimage.yml
@@ -32,6 +32,12 @@ permissions:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  APPSTREAM_VERSION: 0.16.4
+  APPSTREAM_SHA256: d4f722d79c6a2f29d9dc5c6f464927469543353f386581c778c9bed7c60a54ed
+  LIBXMLB_VERSION: 0.3.14
+  LIBXMLB_SHA256: 92bea792c6a33d243e7b6f210519bd6ba71b010463fbec1b5a71ddd35736ec20
+  MESON_VERSION: 1.4.0
+  MESON_SHA256: 476a458d51fcfa322a6bdc64da5138997c542d08e6b2e49b9fa68c46fd7c4475
 
 jobs:
   prepare:
@@ -167,15 +173,16 @@ jobs:
             exit 1
           fi
 
+      - name: Cache the pinned AppStream validator
+        id: appstream_validator_cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/appstream-validator
+          key: appstream-validator-${{ runner.os }}-${{ matrix.rid }}-${{ env.APPSTREAM_VERSION }}-${{ env.APPSTREAM_SHA256 }}-${{ env.LIBXMLB_VERSION }}-${{ env.LIBXMLB_SHA256 }}-${{ env.MESON_VERSION }}-${{ env.MESON_SHA256 }}
+
       - name: Build and verify the pinned AppStream validator
+        if: steps.appstream_validator_cache.outputs.cache-hit != 'true'
         shell: bash
-        env:
-          APPSTREAM_VERSION: 0.16.4
-          APPSTREAM_SHA256: d4f722d79c6a2f29d9dc5c6f464927469543353f386581c778c9bed7c60a54ed
-          LIBXMLB_VERSION: 0.3.14
-          LIBXMLB_SHA256: 92bea792c6a33d243e7b6f210519bd6ba71b010463fbec1b5a71ddd35736ec20
-          MESON_VERSION: 1.4.0
-          MESON_SHA256: 476a458d51fcfa322a6bdc64da5138997c542d08e6b2e49b9fa68c46fd7c4475
         run: |
           set -euo pipefail
           validator_root="${RUNNER_TEMP}/appstream-validator"
@@ -228,6 +235,24 @@ jobs:
             -Dlibxmlb:cli=false \
             -Dlibxmlb:zstd=false
           python3 -m mesonbuild.mesonmain compile -C "${build_root}" appstreamcli
+
+          validator_path="${build_root}/tools/appstreamcli"
+          [[ -x "${validator_path}" ]]
+          "${validator_path}" --version | grep --fixed-strings "${APPSTREAM_VERSION}"
+
+      - name: Verify and activate the pinned AppStream validator
+        shell: bash
+        run: |
+          set -euo pipefail
+          validator_root="${RUNNER_TEMP}/appstream-validator"
+          build_root="${validator_root}/build"
+
+          echo "${APPSTREAM_SHA256}  ${validator_root}/AppStream.tar.xz" | \
+            sha256sum --check --strict
+          echo "${LIBXMLB_SHA256}  ${validator_root}/libxmlb.tar.gz" | \
+            sha256sum --check --strict
+          echo "${MESON_SHA256}  ${validator_root}/meson.whl" | \
+            sha256sum --check --strict
 
           validator_path="${build_root}/tools/appstreamcli"
           [[ -x "${validator_path}" ]]

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,15 +58,15 @@ jobs:
       display_version: ${{ steps.version.outputs.display_version }}
       package_version: ${{ steps.version.outputs.package_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Setup Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -96,7 +96,7 @@ jobs:
         run: ./Scripts/build-headless-packages.ps1 -Version '${{ steps.version.outputs.display_version }}' -DryRun
 
       - name: Upload headless packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: headless-packages
           path: |
@@ -112,9 +112,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: headless-packages
           path: artifacts/headless
@@ -148,20 +148,20 @@ jobs:
           - ubuntu-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: headless-packages
           path: artifacts/headless
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Setup Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -248,13 +248,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: headless-packages
           path: artifacts/headless
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -293,13 +293,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: headless-packages
           path: artifacts/headless
 
       - name: Setup Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/store-package-smoke.yml
+++ b/.github/workflows/store-package-smoke.yml
@@ -26,7 +26,7 @@ jobs:
       run_store: ${{ steps.plan.outputs.run_store }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -55,15 +55,15 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props') }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,17 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.1.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.1.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Avalonia" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="Hex1b" Version="0.165.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.57.1" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.57.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+    <PackageVersion Include="Spectre.Console" Version="0.57.2" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.57.2" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
     <PackageVersion Include="Terminal.Gui" Version="2.4.17" />
     <PackageVersion Include="Tomlyn" Version="2.10.1" />
     <PackageVersion Include="TreeSitter.DotNet" Version="$(TreeSitterDotNetVersion)" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.303",
+    "version": "10.0.400",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Summary
- upgrade GitHub-maintained Actions to their Node 24 majors while preserving named artifact layouts and digest enforcement
- update the requested stable package versions and pin .NET SDK 10.0.400
- cache the pinned AppStream validator by RID, component versions, and SHA-256 values while retaining source and metainfo validation
- leave release-validate.yml unchanged because #285 is not merged into v5.2

## Verification
- AvaloniaHeadlessHarnessSmokeTests via the native xUnit/MTP class filter: 2 passed
- CiTestRunnerContractTests and AppInstancePackagingContractTests: 15 passed
- DocumentationAndPackagingContractTests: 20 passed