### PR TITLE
feat(release): publish headless archives and container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.idea
+.vs
+.vscode
+**/bin
+**/obj
+artifacts
+publish
+TestResults
+Tests
+Docs

--- a/.github/workflows/package-headless.yml
+++ b/.github/workflows/package-headless.yml
@@ -1,0 +1,177 @@
+name: Package Headless Release Archives
+
+on:
+  pull_request:
+    branches: [v5.2]
+    paths:
+      - '.github/workflows/package-headless.yml'
+      - 'Apps/Terminal/**'
+      - 'Apps/TerminalHost/**'
+      - 'Infrastructure/**'
+      - 'Packaging/Headless/**'
+      - 'Scripts/*Headless*'
+      - 'Scripts/*Release*'
+      - 'Scripts/release-archive-helpers.ps1'
+      - 'Directory.Build.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version without the v prefix
+        required: true
+        type: string
+      release_tag:
+        description: Existing GitHub release tag to receive the archives
+        required: false
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  package:
+    name: Build and gate six headless archives
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      release_tag: ${{ steps.metadata.outputs.release_tag }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}
+          PUBLISHED_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            version="${PUBLISHED_RELEASE_TAG#v}"
+            release_tag="${PUBLISHED_RELEASE_TAG}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            version="$(sed -n 's:.*<DevProjexVersion[^>]*>\([^<]*\)</DevProjexVersion>.*:\1:p' Directory.Build.props)"
+            release_tag=""
+          else
+            version="${DISPATCH_VERSION}"
+            release_tag="${DISPATCH_RELEASE_TAG}"
+          fi
+          if [[ "${version}" == v* || ! "${version}" =~ ^[0-9]+\.[0-9]+([.][0-9]+)?([+-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Unsupported version syntax: ${version}"
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build packages and release archives from one publish output
+        shell: pwsh
+        run: ./Scripts/build-headless-packages.ps1 -Version '${{ steps.metadata.outputs.version }}' -DryRun
+
+      - name: Prove release receipt mutations fail closed
+        shell: pwsh
+        run: >
+          ./Scripts/Test-ReleaseArtifactGateMutation.ps1
+          -PublishRoot artifacts/headless/release
+          -Version '${{ steps.metadata.outputs.version }}'
+          -Channels headless
+
+      - name: Functional smoke of the host RID archive payload
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $false
+          $binary = Resolve-Path 'artifacts/headless/publish/linux-x64/devprojex'
+          chmod +x $binary
+          $actualVersion = (& $binary --version).Trim()
+          if ($actualVersion -cne $env:VERSION) { throw "Version mismatch: expected '$env:VERSION', found '$actualVersion'." }
+
+          $sample = Join-Path $env:RUNNER_TEMP 'devprojex-headless-release-smoke'
+          New-Item -ItemType Directory -Path $sample -Force | Out-Null
+          @'
+          namespace Sample;
+          public static class Program {
+              public static int Compute(int value) {
+                  var implementationMustDisappear = value * 2;
+                  return implementationMustDisappear;
+              }
+          }
+          '@ | Set-Content -LiteralPath (Join-Path $sample 'Program.cs') -Encoding utf8NoBOM
+          $secret = 'ghp_123456789012345678901234567890123456'
+          "token=$secret" | Set-Content -LiteralPath (Join-Path $sample 'settings.txt') -Encoding utf8NoBOM
+
+          $tree = & $binary tree $sample --git-mode none --exclude none
+          if ($LASTEXITCODE -ne 0 -or -not (($tree -join "`n").Contains('Program.cs', [StringComparison]::Ordinal))) {
+            throw 'Headless archive tree smoke failed.'
+          }
+          $full = & $binary analyze $sample --format json --git-mode none --exclude none -o - | ConvertFrom-Json
+          $compressed = & $binary analyze $sample --format json --git-mode none --exclude none --compress-code -o - | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0 -or $compressed.metrics.content.chars -ge $full.metrics.content.chars) {
+            throw 'Headless archive compression smoke failed.'
+          }
+          $findings = & $binary analyze $sample --format json --git-mode none --exclude none --findings --fail-on-findings -o -
+          $findingsText = $findings -join "`n"
+          if ($LASTEXITCODE -ne 3 -or $findingsText.Contains($secret, [StringComparison]::Ordinal)) {
+            throw 'Headless archive secret gate smoke failed.'
+          }
+          node Scripts/smoke-headless-mcp.mjs $binary $sample
+          if ($LASTEXITCODE -ne 0) { throw 'Headless archive MCP initialize smoke failed.' }
+
+      - name: Report archive sizes
+        shell: pwsh
+        run: |
+          "### Headless release archives" >> $env:GITHUB_STEP_SUMMARY
+          Get-ChildItem 'artifacts/headless/release/headless/v${{ steps.metadata.outputs.version }}' -File |
+            Where-Object Name -Like 'DevProjex-headless.*' | Sort-Object Name | ForEach-Object {
+              "- ``$($_.Name)``: $($_.Length) bytes" >> $env:GITHUB_STEP_SUMMARY
+            }
+
+      - name: Stage release assets
+        if: ${{ steps.metadata.outputs.release_tag != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: headless-release-assets
+          path: artifacts/headless/release/headless/v${{ steps.metadata.outputs.version }}
+          if-no-files-found: error
+          retention-days: 1
+
+  release-upload:
+    name: Upload complete headless set to GitHub release
+    if: ${{ needs.package.outputs.release_tag != '' }}
+    needs: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: headless-release-assets
+          path: artifacts/headless-release
+
+      - name: Upload archives, receipts, and checksums
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.package.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" artifacts/headless-release/* --clobber

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -83,7 +83,7 @@ jobs:
           node-version: 24
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build both architectures without compiler emulation
         shell: bash
@@ -167,10 +167,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Build and push multi-architecture image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,196 @@
+name: Publish Headless Container
+
+on:
+  pull_request:
+    branches: [v5.2]
+    paths:
+      - '.github/workflows/publish-container.yml'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'glama.json'
+      - 'Apps/Terminal/**'
+      - 'Apps/TerminalHost/**'
+      - 'Assets/Localization/**'
+      - 'Infrastructure/**'
+      - 'Packaging/Headless/**'
+      - 'Scripts/*Headless*'
+      - 'Scripts/*Release*'
+      - 'Scripts/release-archive-helpers.ps1'
+      - 'Directory.Build.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version without the v prefix
+        required: true
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  IMAGE_NAME: ghcr.io/avazbek22/devprojex
+
+jobs:
+  prepare:
+    name: Resolve container version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          PUBLISHED_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            version="${PUBLISHED_RELEASE_TAG#v}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            version="$(sed -n 's:.*<DevProjexVersion[^>]*>\([^<]*\)</DevProjexVersion>.*:\1:p' Directory.Build.props)"
+          else
+            version="${DISPATCH_VERSION}"
+          fi
+          if [[ "${version}" == v* || ! "${version}" =~ ^[0-9]+\.[0-9]+([.][0-9]+)?([+-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Unsupported version syntax: ${version}"
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+  build-gate:
+    name: Cross-build, validate, and smoke container payloads
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build both architectures without compiler emulation
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/container-images
+          docker buildx build --platform linux/amd64 --load \
+            --build-arg "DEVPROJEX_VERSION=${VERSION}" \
+            --tag devprojex-ci:amd64 .
+          docker buildx build --platform linux/arm64 --load \
+            --build-arg "DEVPROJEX_VERSION=${VERSION}" \
+            --tag devprojex-ci:arm64 .
+          docker save devprojex-ci:amd64 | gzip -9 > artifacts/container-images/devprojex-amd64.tar.gz
+          docker save devprojex-ci:arm64 | gzip -9 > artifacts/container-images/devprojex-arm64.tar.gz
+
+      - name: Validate image payload receipts and mutation gates
+        shell: pwsh
+        run: |
+          ./Scripts/Test-HeadlessContainer.ps1 -Image devprojex-ci:amd64 -Version '${{ needs.prepare.outputs.version }}' -Rid linux-x64
+          ./Scripts/Test-HeadlessContainer.ps1 -Image devprojex-ci:arm64 -Version '${{ needs.prepare.outputs.version }}' -Rid linux-arm64
+
+      - name: Smoke amd64 with a read-only root
+        shell: pwsh
+        run: ./Scripts/Test-HeadlessContainerSmoke.ps1 -Image devprojex-ci:amd64 -Version '${{ needs.prepare.outputs.version }}'
+
+      - name: Report compressed image sizes
+        shell: pwsh
+        run: |
+          "### Headless container images" >> $env:GITHUB_STEP_SUMMARY
+          Get-ChildItem artifacts/container-images/*.tar.gz | Sort-Object Name | ForEach-Object {
+            "- ``$($_.Name)``: $($_.Length) bytes compressed" >> $env:GITHUB_STEP_SUMMARY
+          }
+
+      - name: Upload arm64 image for native smoke
+        uses: actions/upload-artifact@v7
+        with:
+          name: devprojex-container-arm64
+          path: artifacts/container-images/devprojex-arm64.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  smoke-arm64:
+    name: Smoke arm64 image on a native runner
+    needs: [prepare, build-gate]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: devprojex-container-arm64
+          path: artifacts/container-images
+
+      - name: Load and smoke arm64 with a read-only root
+        shell: pwsh
+        run: |
+          docker load -i artifacts/container-images/devprojex-arm64.tar.gz
+          if ($LASTEXITCODE -ne 0) { throw 'Could not load the arm64 image.' }
+          ./Scripts/Test-HeadlessContainerSmoke.ps1 -Image devprojex-ci:arm64 -Version '${{ needs.prepare.outputs.version }}'
+
+  publish:
+    name: Publish multi-architecture image and provenance
+    if: ${{ github.event_name == 'release' }}
+    needs: [prepare, build-gate, smoke-arm64]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-architecture image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: DEVPROJEX_VERSION=${{ needs.prepare.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest
+
+      - name: Attest image build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,10 @@
 <Project>
 
+  <PropertyGroup>
+    <DevProjexGenerateFolderPayloadReceipt
+      Condition="'$(DevProjexGenerateFolderPayloadReceipt)'=='' and '$(Configuration)'=='ReleaseStore'">true</DevProjexGenerateFolderPayloadReceipt>
+  </PropertyGroup>
+
   <!--
     TreeSitter.DotNet ships every grammar for the target architecture: 30 native libraries, ~68 MB
     on win-x64, of which DevProjex uses ten. Referencing the package without filtering adds all of
@@ -67,13 +72,13 @@
     <Exec Command="pwsh -NoLogo -NoProfile -File &quot;$(MSBuildThisFileDirectory)Scripts/Write-PublishPayloadReceipt.ps1&quot; -Rid &quot;$(RuntimeIdentifier)&quot; -ItemsPath &quot;$(_DevProjexPayloadItemsPath)&quot; -OutputPath &quot;$(_DevProjexPayloadReceiptPath)&quot;" />
   </Target>
 
-  <Target Name="DevProjexWriteStorePayloadReceipt"
+  <Target Name="DevProjexWriteFolderPayloadReceipt"
           AfterTargets="CopyFilesToPublishDirectory"
           Condition="'$(DevProjexGenerateReleasePayloadReceipt)'=='true' and
+                     '$(DevProjexGenerateFolderPayloadReceipt)'=='true' and
                      '$(PublishSingleFile)'!='true' and
                      '$(RuntimeIdentifier)'!='' and
-                     '$(DevProjexPayloadReceiptDirectory)'!='' and
-                     '$(Configuration)'=='ReleaseStore'">
+                     '$(DevProjexPayloadReceiptDirectory)'!=''">
     <ItemGroup>
       <!-- Desktop Bridge puts PDBs in the symbol package, not in the application MSIX. -->
       <_DevProjexPayloadReceiptFile Include="@(ResolvedFileToPublish)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+ARG DEVPROJEX_VERSION=5.2
+WORKDIR /src
+COPY . .
+RUN case "$TARGETARCH" in \
+      amd64) rid="linux-x64" ;; \
+      arm64) rid="linux-arm64" ;; \
+      *) echo "Unsupported container architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    dotnet publish Apps/TerminalHost/DevProjex.TerminalHost.csproj \
+      -c Release \
+      -r "$rid" \
+      --self-contained true \
+      -p:DevProjexVersion="$DEVPROJEX_VERSION" \
+      -p:PublishSingleFile=false \
+      -p:PublishTrimmed=false \
+      -p:PublishReadyToRun=false \
+      -p:DevProjexGrammarDelivery=Content \
+      -p:DevProjexGenerateReleasePayloadReceipt=true \
+      -p:DevProjexGenerateFolderPayloadReceipt=true \
+      -p:DevProjexPayloadReceiptDirectory=/out/receipt \
+      -p:DebugType=None \
+      -p:DebugSymbols=false \
+      -o /out/app
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled-extra
+WORKDIR /app
+COPY --from=build /out/app/ ./
+COPY --from=build /out/receipt/ /payload-receipt/
+ENV PATH="/app:${PATH}"
+USER app
+ENTRYPOINT ["devprojex"]

--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -116,3 +116,46 @@ or build from source. A persistent installation is also available:
 ```shell
 dotnet tool install --global devprojex
 ```
+
+## Headless binary
+
+Release automation prepares one headless archive for each supported RID. Choose
+`DevProjex-headless.v<version>.<rid>.zip` on Windows or
+`DevProjex-headless.v<version>.<rid>.tar.gz` on Linux and macOS. For example:
+
+```powershell
+Expand-Archive DevProjex-headless.v<version>.win-x64.zip
+./devprojex.exe --version
+```
+
+```bash
+tar xzf DevProjex-headless.v<version>.linux-x64.tar.gz
+./devprojex --version
+```
+
+The archive contains the same self-contained host used by the matching npm
+platform package. It provides the CLI, Terminal Workspace, and MCP server without
+Avalonia. It cannot launch the GUI with `open`; `ui ...` remains available only
+to control an already running Desktop instance.
+
+## Docker
+
+The release workflow is configured to publish a glibc-based, multi-architecture
+image for amd64 and arm64 to `ghcr.io/avazbek22/devprojex`. The image contains no
+desktop application and runs as a non-root user. Mount project input read-only by
+default:
+
+```bash
+docker run --rm -i --read-only --tmpfs /tmp \
+  -v "$PWD:/project:ro" \
+  ghcr.io/avazbek22/devprojex mcp --root /project
+
+docker run --rm --read-only --tmpfs /tmp \
+  -v "$PWD:/project:ro" \
+  ghcr.io/avazbek22/devprojex analyze /project --findings --fail-on-findings
+```
+
+Use an explicit version tag for reproducible automation, for example
+`ghcr.io/avazbek22/devprojex:5.2`. The untagged examples use Docker's `latest`
+tag only after a release workflow has published it. Alpine and other musl hosts
+are not supported.

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -628,5 +628,50 @@ For Visual Studio Code, use the same commands in `.vscode/mcp.json`:
 }
 ```
 
+### Docker launch
+
+Release automation is configured to publish the headless image at
+`ghcr.io/avazbek22/devprojex`. Docker clients should keep stdin open with `-i`,
+mount the project read-only, and run the container with a read-only root filesystem.
+
+For Claude Code:
+
+```shell
+claude mcp add devprojex-docker -- docker run --rm -i --read-only --tmpfs /tmp -v /absolute/path/to/project:/project:ro ghcr.io/avazbek22/devprojex mcp --root /project
+```
+
+For Claude Desktop or Cursor, add this entry to `mcpServers`:
+
+```json
+{
+  "devprojex-docker": {
+    "command": "docker",
+    "args": ["run", "--rm", "-i", "--read-only", "--tmpfs", "/tmp", "-v", "/absolute/path/to/project:/project:ro", "ghcr.io/avazbek22/devprojex", "mcp", "--root", "/project"]
+  }
+}
+```
+
+For Visual Studio Code, place the equivalent entry in `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "devprojex-docker": {
+      "type": "stdio",
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "--read-only", "--tmpfs", "/tmp", "-v", "${workspaceFolder}:/project:ro", "ghcr.io/avazbek22/devprojex", "mcp", "--root", "/project"]
+    }
+  }
+}
+```
+
+For OpenAI Codex, add:
+
+```toml
+[mcp_servers.devprojex_docker]
+command = "docker"
+args = ["run", "--rm", "-i", "--read-only", "--tmpfs", "/tmp", "-v", "/absolute/path/to/project:/project:ro", "ghcr.io/avazbek22/devprojex", "mcp", "--root", "/project"]
+```
+
 MCP traffic uses stdout exclusively. If startup fails, diagnostics are written
 to stderr. Closing the client's stdin terminates the server process.

--- a/Docs/Release-Process.md
+++ b/Docs/Release-Process.md
@@ -1,10 +1,11 @@
 # Release process
 
-DevProjex has two local desktop release channels and three CI-owned channels.
+DevProjex has two local desktop release channels and five CI-owned channels.
 `Scripts/release-all.ps1` owns the GitHub desktop artifacts and Microsoft Store
-upload. AppImage is assembled only by the release workflow. NuGet and npm are
-built and published only by `.github/workflows/publish-packages.yml`; the local
-desktop script never publishes any channel.
+upload. AppImage, headless archives, and the Docker image are assembled only by
+release workflows. NuGet and npm are built and published only by
+`.github/workflows/publish-packages.yml`; the local desktop script never publishes
+any CI-owned channel.
 
 ## Local channel model
 
@@ -148,3 +149,56 @@ The current publishing paths remain separate: GitHub desktop archives and Store
 uploads are prepared locally, AppImage is attached by the release workflow, and
 NuGet/npm are published through `publish-packages.yml` after their own static,
 mutation, and three-OS functional gates.
+
+## CI-owned headless archives
+
+`.github/workflows/package-headless.yml` builds all six
+`DevProjex-headless.v<version>.<rid>.zip|tar.gz` archives from the same single-file
+publish directories used to stage npm platform packages. The workflow validates
+the complete set and uploads it only for a published release, or for a manual run
+that names an existing `release_tag`. Outputs are staged below
+`artifacts/headless/release/headless/v<version>`.
+
+This channel satisfies the five connection requirements as follows:
+
+1. RID and executable names come from `payload-manifest.json`; each build emits a
+   complete `publish-payload.<rid>.json` from `_FilesToBundle`.
+2. `Test-ReleaseArtifacts.ps1 -Channels headless` checks the exact archive set,
+   USTAR executable modes, single-file entries, resources, sizes, and hashes.
+3. `Test-ReleaseArtifactGateMutation.ps1 -Channels headless` damages deterministic
+   file and resource entries plus grammar, localization, and native-library cases.
+4. The workflow runs `--version`, `tree`, both `analyze` forms, the secret exit-3
+   check, and an MCP initialize handshake against the linux-x64 archive payload.
+5. The workflow attaches archives, receipts, and `SHA256SUMS.headless.txt` to the
+   GitHub release; installation commands live in `Docs/Installation.md`.
+
+The separate checksum filename is deliberate. Desktop artifacts and
+`SHA256SUMS.txt` are produced by an operator, while headless assets are produced by
+CI. Two independent producers cannot atomically update one checksum manifest.
+
+## CI-owned Docker image
+
+`.github/workflows/publish-container.yml` builds amd64 and arm64 from the root
+`Dockerfile`, but pushes `ghcr.io/avazbek22/devprojex:<version>` and `latest` only
+for `release: published`. Pull requests and manual runs build, validate, and smoke
+without pushing. The SDK stage cross-publishes linux-arm64 on the x64 runner;
+`BUILDPLATFORM` keeps the compiler native, and the final multi-architecture image
+contains the prebuilt output without a target-architecture build step.
+
+The container channel meets the same connection contract:
+
+1. The folder publish opts into the shared build receipt and uses manifest RID and
+   binary metadata. Store retains its existing automatic folder-receipt default.
+2. `Test-ReleaseArtifacts.ps1 -Channels container` compares the extracted `/app`
+   directory with its receipt in both directions, including managed resources.
+3. `Test-ReleaseArtifactGateMutation.ps1 -Channels container` mutates a copied
+   extracted payload and proves the common diff rejects it.
+4. amd64 and native arm64 jobs run version, tree, compression, secret, and MCP
+   smoke with `--read-only`, `--tmpfs /tmp`, and a read-only project mount.
+5. The published multi-architecture manifest receives version and `latest` tags
+   plus build-provenance attestation; Docker and MCP client recipes are documented
+   in `Docs/Installation.md` and `Docs/McpServer.md`.
+
+The image is a folder publish with `DevProjexGrammarDelivery=Content`. Grammar
+libraries stay beside the executable, so neither .NET single-file extraction nor
+grammar materialization needs a writable filesystem at startup.

--- a/Docs/Release-Process.md
+++ b/Docs/Release-Process.md
@@ -200,5 +200,8 @@ The container channel meets the same connection contract:
    in `Docs/Installation.md` and `Docs/McpServer.md`.
 
 The image is a folder publish with `DevProjexGrammarDelivery=Content`. Grammar
-libraries stay beside the executable, so neither .NET single-file extraction nor
-grammar materialization needs a writable filesystem at startup.
+libraries stay beside the executable, and `CodeCompressionFactory` selects content
+delivery from the presence of that `grammars` directory on every OS. It does not
+fall back to embedded delivery when a shipped grammar is missing. Neither .NET
+single-file extraction nor grammar materialization needs a writable filesystem at
+startup.

--- a/Infrastructure/Compression/CodeCompressionFactory.cs
+++ b/Infrastructure/Compression/CodeCompressionFactory.cs
@@ -15,12 +15,26 @@ public static class CodeCompressionFactory
 	public static CodeCompressionSession CreateSession() =>
 		new(new TreeSitterCodeCompressor(CreateLocator()));
 
-	public static IGrammarLibraryLocator CreateLocator()
+	public static IGrammarLibraryLocator CreateLocator() =>
+		CreateLocator(
+			AppContext.BaseDirectory,
+			OperatingSystem.IsWindows(),
+			WindowsPackageIdentityProbe.IsPackagedApp);
+
+	internal static IGrammarLibraryLocator CreateLocator(
+		string applicationBaseDirectory,
+		bool isWindows,
+		Func<bool> isWindowsPackagedApp)
 	{
 		// Packaged builds must not load native code they wrote themselves: a runtime-materialized
 		// library is outside the package signature, which is exactly what Smart App Control and S
 		// mode verify. They ship grammars as ordinary package content instead.
-		if (OperatingSystem.IsWindows() && WindowsPackageIdentityProbe.IsPackagedApp())
+		if (isWindows && isWindowsPackagedApp())
+			return new ContentGrammarLibraryLocator();
+
+		// Folder-based packages identify content delivery through the payload they ship. Once the
+		// directory exists, the content locator remains fail-closed if an individual grammar is absent.
+		if (Directory.Exists(Path.Combine(applicationBaseDirectory, "grammars")))
 			return new ContentGrammarLibraryLocator();
 
 		return new EmbeddedGrammarLibraryLocator(

--- a/Packaging/Headless/payload-manifest.json
+++ b/Packaging/Headless/payload-manifest.json
@@ -31,6 +31,10 @@
     "tree-sitter-yaml"
   ],
   "release": {
+    "headless": {
+      "archivePrefix": "DevProjex-headless",
+      "checksumFile": "SHA256SUMS.headless.txt"
+    },
     "store": {
       "executionAlias": "devprojex.exe",
       "applicationExecutable": "DevProjex.Avalonia\\DevProjex.exe",

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The npm and NuGet packages contain the CLI, TUI, and MCP server, but not the
 desktop application. See [Docs/Installation.md](Docs/Installation.md) for the
 Node/.NET requirements and supported platforms.
 
+Release automation also prepares direct headless archives and a non-root Docker
+image; their commands and availability boundary are documented in
+[Docs/Installation.md](Docs/Installation.md).
+
 ---
 
 ## Why DevProjex? 💡

--- a/Scripts/Test-HeadlessContainer.ps1
+++ b/Scripts/Test-HeadlessContainer.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $Image,
+    [Parameter(Mandatory = $true)] [string] $Version,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('linux-x64', 'linux-arm64')]
+    [string] $Rid
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version Latest
+
+function Invoke-Docker([string[]] $Arguments) {
+    $output = & docker @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "docker $($Arguments[0]) failed with exit code $LASTEXITCODE`: $($output | Out-String)"
+    }
+    return $output
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('devprojex-container-gate-' + [guid]::NewGuid().ToString('N'))
+$publishRoot = Join-Path $temporaryRoot 'publish'
+$channelDirectory = Join-Path $publishRoot "container/v$Version"
+$payloadDirectory = Join-Path $channelDirectory $Rid
+$containerName = 'devprojex-gate-' + [guid]::NewGuid().ToString('N')
+$containerCreated = $false
+
+[System.IO.Directory]::CreateDirectory($payloadDirectory) | Out-Null
+try {
+    [void](Invoke-Docker @('create', '--name', $containerName, $Image))
+    $containerCreated = $true
+    [void](Invoke-Docker @('cp', "${containerName}:/app/.", $payloadDirectory))
+    [void](Invoke-Docker @(
+        'cp',
+        "${containerName}:/payload-receipt/publish-payload.$Rid.json",
+        (Join-Path $channelDirectory "publish-payload.$Rid.json")))
+
+    & (Join-Path $PSScriptRoot 'Test-ReleaseArtifacts.ps1') `
+        -PublishRoot $publishRoot `
+        -Version $Version `
+        -Channels container `
+        -Rids $Rid
+    if ($LASTEXITCODE -ne 0) { throw 'Container payload validation failed.' }
+
+    & (Join-Path $PSScriptRoot 'Test-ReleaseArtifactGateMutation.ps1') `
+        -PublishRoot $publishRoot `
+        -Version $Version `
+        -Channels container `
+        -Rids $Rid
+    if ($LASTEXITCODE -ne 0) { throw 'Container mutation gate failed.' }
+}
+finally {
+    if ($containerCreated) {
+        [void](& docker rm $containerName 2>&1)
+    }
+    $resolvedTemporaryRoot = [System.IO.Path]::GetFullPath($temporaryRoot)
+    $resolvedSystemTemp = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    if ($resolvedTemporaryRoot.StartsWith($resolvedSystemTemp, [System.StringComparison]::OrdinalIgnoreCase) -and
+        (Test-Path -LiteralPath $resolvedTemporaryRoot -PathType Container)) {
+        Remove-Item -LiteralPath $resolvedTemporaryRoot -Recurse -Force
+    }
+}
+
+Write-Host "Container payload and mutation gates passed for $Image ($Rid)."

--- a/Scripts/Test-HeadlessContainerSmoke.ps1
+++ b/Scripts/Test-HeadlessContainerSmoke.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $Image,
+    [Parameter(Mandatory = $true)] [string] $Version
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version Latest
+
+function Invoke-Container([string[]] $Arguments, [int] $ExpectedExitCode = 0) {
+    $output = & docker run --rm --read-only --tmpfs /tmp --volume "${script:SampleRoot}:/project:ro" $Image @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne $ExpectedExitCode) {
+        throw "Container command '$($Arguments -join ' ')' exited $exitCode instead of $ExpectedExitCode`: $($output | Out-String)"
+    }
+    return @($output)
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$script:SampleRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('devprojex-container-smoke-' + [guid]::NewGuid().ToString('N'))
+[System.IO.Directory]::CreateDirectory($script:SampleRoot) | Out-Null
+try {
+    @'
+namespace Sample;
+public static class Program {
+    public static int Compute(int value) {
+        var implementationMustDisappear = value * 2;
+        return implementationMustDisappear;
+    }
+}
+'@ | Set-Content -LiteralPath (Join-Path $script:SampleRoot 'Program.cs') -Encoding utf8NoBOM
+    $secret = 'ghp_123456789012345678901234567890123456'
+    "token=$secret" | Set-Content -LiteralPath (Join-Path $script:SampleRoot 'settings.txt') -Encoding utf8NoBOM
+
+    $actualVersion = ((Invoke-Container @('--version')) -join "`n").Trim()
+    if ($actualVersion -cne $Version) {
+        throw "Container version mismatch: expected '$Version', found '$actualVersion'."
+    }
+
+    $tree = (Invoke-Container @('tree', '/project', '--git-mode', 'none', '--exclude', 'none')) -join "`n"
+    if (-not $tree.Contains('Program.cs', [System.StringComparison]::Ordinal)) {
+        throw 'Container tree smoke did not report Program.cs.'
+    }
+
+    $full = ((Invoke-Container @(
+        'analyze', '/project', '--format', 'json', '--git-mode', 'none', '--exclude', 'none', '-o', '-')) -join "`n") |
+        ConvertFrom-Json
+    $compressed = ((Invoke-Container @(
+        'analyze', '/project', '--format', 'json', '--git-mode', 'none', '--exclude', 'none',
+        '--compress-code', '-o', '-')) -join "`n") | ConvertFrom-Json
+    if ($compressed.metrics.content.chars -ge $full.metrics.content.chars) {
+        throw 'Container compression smoke did not reduce content characters.'
+    }
+
+    $findings = (Invoke-Container @(
+        'analyze', '/project', '--format', 'json', '--git-mode', 'none', '--exclude', 'none',
+        '--findings', '--fail-on-findings', '-o', '-') 3) -join "`n"
+    if ($findings.Contains($secret, [System.StringComparison]::Ordinal)) {
+        throw 'Container secret smoke leaked the planted value.'
+    }
+    $findingsJson = $findings | ConvertFrom-Json
+    if ([int]$findingsJson.findingCount -le 0) {
+        throw 'Container secret smoke returned no findings.'
+    }
+
+    if ($null -eq (Get-Command node -ErrorAction SilentlyContinue)) {
+        Write-Host 'SKIPPED: Node is unavailable; MCP initialize smoke was not run.'
+    }
+    else {
+        & node (Join-Path $repoRoot 'Scripts/smoke-headless-mcp.mjs') docker /project `
+            run --rm -i --read-only --tmpfs /tmp --volume "${script:SampleRoot}:/project:ro" $Image
+        if ($LASTEXITCODE -ne 0) { throw 'Container MCP initialize smoke failed.' }
+    }
+}
+finally {
+    $resolvedSampleRoot = [System.IO.Path]::GetFullPath($script:SampleRoot)
+    $resolvedSystemTemp = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    if ($resolvedSampleRoot.StartsWith($resolvedSystemTemp, [System.StringComparison]::OrdinalIgnoreCase) -and
+        (Test-Path -LiteralPath $resolvedSampleRoot -PathType Container)) {
+        Remove-Item -LiteralPath $resolvedSampleRoot -Recurse -Force
+    }
+}
+
+Write-Host "Read-only container smoke passed for $Image."

--- a/Scripts/Test-HeadlessPackages.ps1
+++ b/Scripts/Test-HeadlessPackages.ps1
@@ -4,7 +4,11 @@ param(
     [string] $ArtifactsRoot,
 
     [Parameter(Mandatory = $true)]
-    [string] $Version
+    [string] $Version,
+
+    [string] $ReleasePublishRoot = "",
+
+    [string] $ReleaseVersion = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -17,6 +21,11 @@ $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
 $artifactsPath = [System.IO.Path]::GetFullPath($ArtifactsRoot)
 $nugetPath = Join-Path $artifactsPath "nuget"
 $npmPath = Join-Path $artifactsPath "npm"
+$publishPath = Join-Path $artifactsPath "publish"
+$hasReleaseArchives = -not [string]::IsNullOrWhiteSpace($ReleasePublishRoot)
+if ([string]::IsNullOrWhiteSpace($ReleaseVersion)) { $ReleaseVersion = $Version }
+
+. (Join-Path $PSScriptRoot 'release-archive-helpers.ps1')
 
 if ($manifest.schemaVersion -ne 1) {
     throw "Unsupported headless payload manifest schema: $($manifest.schemaVersion)."
@@ -80,6 +89,10 @@ function Assert-GrammarPayload(
 
 function Open-Zip([string] $Path) {
     return [System.IO.Compression.ZipFile]::OpenRead($Path)
+}
+
+function Get-BytesSha256([byte[]] $Bytes) {
+    return [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData($Bytes)).ToLowerInvariant()
 }
 
 $expectedNugetNames = @("devprojex.$Version.nupkg") + @(
@@ -234,6 +247,40 @@ try {
             Assert-Artifact (-not ($packageJson.PSObject.Properties.Name -contains "libc")) $packageName "absence of a non-Linux libc restriction"
         }
         Assert-GrammarPayload ([System.IO.File]::ReadAllBytes($binaryPath)) $rid $packageName
+
+        if ($hasReleaseArchives) {
+            $releaseDirectory = Join-Path ([System.IO.Path]::GetFullPath($ReleasePublishRoot)) "headless/v$ReleaseVersion"
+            $extension = if ($rid.os -ceq 'win32') { 'zip' } else { 'tar.gz' }
+            $releaseName = "$($manifest.release.headless.archivePrefix).v$ReleaseVersion.$($rid.rid).$extension"
+            $releasePath = Join-Path $releaseDirectory $releaseName
+            Assert-Artifact (Test-Path -LiteralPath $releasePath -PathType Leaf) $releaseName "release archive"
+
+            if ($rid.os -ceq 'win32') {
+                $releaseZip = Open-Zip $releasePath
+                try {
+                    $releaseEntries = @($releaseZip.Entries | Where-Object { -not $_.FullName.EndsWith('/') })
+                    Assert-Artifact ($releaseEntries.Count -eq 1 -and $releaseEntries[0].FullName -ceq [string]$rid.binary) `
+                        $releaseName "exact archive layout '$($rid.binary)'"
+                    $releaseBytes = Get-ZipEntryBytes $releaseEntries[0]
+                }
+                finally { $releaseZip.Dispose() }
+            }
+            else {
+                $releaseEntries = @(Read-UstarGzipArchive -archivePath $releasePath -captureEntryNames @([string]$rid.binary))
+                Assert-Artifact ($releaseEntries.Count -eq 1 -and $releaseEntries[0].Name -ceq [string]$rid.binary) `
+                    $releaseName "exact archive layout '$($rid.binary)'"
+                Assert-Artifact (($releaseEntries[0].Mode -band 73) -eq 73) $releaseName "executable mode for '$($rid.binary)'"
+                $releaseBytes = [byte[]]$releaseEntries[0].Bytes
+            }
+
+            $npmHash = Get-FileSha256Hex -path $binaryPath
+            $publishBinary = Join-Path (Join-Path $publishPath ([string]$rid.rid)) ([string]$rid.binary)
+            Assert-Artifact (Test-Path -LiteralPath $publishBinary -PathType Leaf) $releaseName "canonical publish binary"
+            $publishHash = Get-FileSha256Hex -path $publishBinary
+            $releaseHash = Get-BytesSha256 $releaseBytes
+            Assert-Artifact ($releaseHash -ceq $npmHash -and $releaseHash -ceq $publishHash) `
+                $releaseName "byte-identical release, npm, and canonical publish binaries"
+        }
     }
 
     $mainName = "devprojex-$Version.tgz"
@@ -267,4 +314,5 @@ finally {
     }
 }
 
-Write-Host "Headless package completeness gate passed for $Version (7 NuGet + 7 npm artifacts)."
+$releaseSummary = if ($hasReleaseArchives) { ' + 6 release archives' } else { '' }
+Write-Host "Headless package completeness gate passed for $Version (7 NuGet + 7 npm artifacts$releaseSummary)."

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -35,11 +35,14 @@ function Copy-ChannelFixture([string] $SourcePublishRoot, [string] $Channel) {
     return $fixturePublishRoot
 }
 
-function Write-ChannelChecksums([string] $ChannelDirectory) {
+function Write-ChannelChecksums(
+    [string] $ChannelDirectory,
+    [string] $ManifestName = 'SHA256SUMS.txt'
+) {
     $artifacts = @(Get-ChildItem -LiteralPath $ChannelDirectory -File |
-        Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'PARTIAL-BUILD.txt') } | Sort-Object Name)
+        Where-Object { $_.Name -notin @('SHA256SUMS.txt', 'SHA256SUMS.headless.txt', 'PARTIAL-BUILD.txt') } | Sort-Object Name)
     $lines = @($artifacts | ForEach-Object { "$(Get-FileSha256Hex -path $_.FullName) *$($_.Name)" })
-    Write-ReleaseChecksumManifest -path (Join-Path $ChannelDirectory 'SHA256SUMS.txt') -lines $lines
+    Write-ReleaseChecksumManifest -path (Join-Path $ChannelDirectory $ManifestName) -lines $lines
 }
 
 function Invoke-FailingValidation(
@@ -51,7 +54,7 @@ function Invoke-FailingValidation(
     $shellPath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
     $arguments = @('-NoLogo', '-NoProfile', '-File', (Join-Path $PSScriptRoot 'Test-ReleaseArtifacts.ps1'),
         '-PublishRoot', $FixturePublishRoot, '-Version', $Version, '-Channels', $Channel)
-    if ($Channel -ceq 'github') {
+    if ($Channel -in @('github', 'headless', 'container')) {
         $arguments += @('-Rids', ($script:SelectedRids -join ','))
     }
     $output = & $shellPath @arguments 2>&1 | Out-String
@@ -103,10 +106,14 @@ function Get-ReceiptMutationCases([object] $Receipt) {
 		$fixedGrammar | Add-Member -NotePropertyName Kind -NotePropertyValue 'Resource'
 	}
     $fixedNative = @($Receipt.files | Where-Object {
-        [string]$_.path -ceq 'libSkiaSharp.dll' -and $_.PSObject.Properties.Name -notcontains 'managedResources'
-    } | Select-Object -First 1)
+        $_.PSObject.Properties.Name -notcontains 'managedResources' -and
+        ([string]$_.path -ceq 'libSkiaSharp.dll' -or
+            [string]$_.path -cmatch '(^|/)(lib)?tree-sitter\.(dll|so|dylib)$')
+    } | Sort-Object {
+        if ([string]$_.path -ceq 'libSkiaSharp.dll') { 0 } else { 1 }
+    }, { [string]$_.path } | Select-Object -First 1)
     if ($fixedNative.Count -ne 1) {
-        throw "Mutation setup failed: fixed native file 'libSkiaSharp.dll' is absent from the receipt."
+        throw "Mutation setup failed: no fixed native runtime library is present in the receipt."
     }
 	$genericFile = @($Receipt.files | Where-Object {
 		[long]$_.size -gt 0 -and [string]$_.path -cne [string]$fixedNative[0].path -and
@@ -231,16 +238,71 @@ function Invoke-StoreMutation([string] $SourcePublishRoot, [object] $Case) {
     }
 }
 
+function Invoke-HeadlessMutation([string] $SourcePublishRoot, [object] $Case) {
+    $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'headless'
+    $workRoot = $null
+    try {
+        $channelDirectory = Join-Path $fixtureRoot "headless/v$Version"
+        $artifactName = "DevProjex-headless.v$Version.win-x64.zip"
+        $artifactPath = Join-Path $channelDirectory $artifactName
+        $workRoot = Join-Path $script:MutationRoot ('headless-' + [guid]::NewGuid().ToString('N'))
+        [System.IO.Directory]::CreateDirectory($workRoot) | Out-Null
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($artifactPath, $workRoot)
+        $binaryPath = Join-Path $workRoot 'devprojex.exe'
+        if ([string]$Case.Kind -ceq 'File') {
+            [DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleEntry($binaryPath, [string]$Case.File)
+        }
+        else {
+            [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateBundleResource(
+                $binaryPath, [string]$Case.File, [string]$Case.Entry)
+        }
+        Compress-Directory -SourceDirectory $workRoot -DestinationPath $artifactPath
+        Write-ChannelChecksums -ChannelDirectory $channelDirectory -ManifestName 'SHA256SUMS.headless.txt'
+        Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'headless' `
+            -ArtifactName $artifactName -ExpectedEntry ([string]$Case.Entry)
+    }
+    finally {
+        try { Remove-MutationDirectory -Path $workRoot }
+        finally { Remove-MutationDirectory -Path $fixtureRoot }
+    }
+}
+
+function Invoke-ContainerMutation([string] $SourcePublishRoot, [string] $Rid, [object] $Case) {
+    $fixtureRoot = Copy-ChannelFixture -SourcePublishRoot $SourcePublishRoot -Channel 'container'
+    try {
+        $payloadPath = Join-Path (Join-Path $fixtureRoot "container/v$Version/$Rid") `
+            (([string]$Case.File) -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        if (-not (Test-Path -LiteralPath $payloadPath -PathType Leaf)) {
+            throw "Mutation setup failed: container payload file '$($Case.File)' was not found."
+        }
+        if ([string]$Case.Kind -ceq 'File') {
+            $bytes = [System.IO.File]::ReadAllBytes($payloadPath)
+            if ($bytes.Length -eq 0) { throw "Mutation setup failed: container payload file '$($Case.File)' is empty." }
+            $offset = [int]($bytes.Length / 2)
+            $bytes[$offset] = $bytes[$offset] -bxor 1
+            [System.IO.File]::WriteAllBytes($payloadPath, $bytes)
+        }
+        else {
+            [void][DevProjex.ReleaseValidation.ReleasePayloadInspector]::MutateManagedResource(
+                $payloadPath, [string]$Case.Entry)
+        }
+        Invoke-FailingValidation -FixturePublishRoot $fixtureRoot -Channel 'container' `
+            -ArtifactName "container:$Rid" -ExpectedEntry ([string]$Case.Entry)
+    }
+    finally { Remove-MutationDirectory -Path $fixtureRoot }
+}
+
 $sourcePublishRoot = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($PublishRoot)) {
     Join-Path (Split-Path -Parent $PSScriptRoot) 'publish'
 } else { $PublishRoot }))
 $selectedChannels = @(ConvertTo-Tokens $Channels)
 $script:SelectedRids = @(ConvertTo-Tokens $Rids)
 foreach ($channel in $selectedChannels) {
-    if ($channel -notin @('github', 'store')) { throw "Unknown release channel '$channel'." }
+    if ($channel -notin @('github', 'store', 'headless', 'container')) { throw "Unknown release channel '$channel'." }
 }
-if ('github' -in $selectedChannels -and 'win-x64' -notin $script:SelectedRids) {
-    throw 'GitHub mutation gate requires win-x64 in -Rids.'
+if (@($selectedChannels | Where-Object { $_ -in @('github', 'headless') }).Count -gt 0 -and
+    'win-x64' -notin $script:SelectedRids) {
+    throw 'GitHub and headless mutation gates require win-x64 in -Rids.'
 }
 
 $script:MutationRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('devprojex-release-mutation-' + [guid]::NewGuid().ToString('N'))
@@ -256,6 +318,20 @@ try {
         $directory = Join-Path $sourcePublishRoot "store/v$Version"
         foreach ($case in @(Get-ReceiptMutationCases -Receipt (Read-PayloadReceipt $directory 'win-x64'))) {
             Invoke-StoreMutation -SourcePublishRoot $sourcePublishRoot -Case $case
+        }
+    }
+    if ('headless' -in $selectedChannels) {
+        $directory = Join-Path $sourcePublishRoot "headless/v$Version"
+        foreach ($case in @(Get-ReceiptMutationCases -Receipt (Read-PayloadReceipt $directory 'win-x64'))) {
+            Invoke-HeadlessMutation -SourcePublishRoot $sourcePublishRoot -Case $case
+        }
+    }
+    if ('container' -in $selectedChannels) {
+        $containerRid = @($script:SelectedRids | Where-Object { $_ -in @('linux-x64', 'linux-arm64') } | Select-Object -First 1)
+        if ($containerRid.Count -ne 1) { throw 'Container mutation gate requires a Linux RID in -Rids.' }
+        $directory = Join-Path $sourcePublishRoot "container/v$Version"
+        foreach ($case in @(Get-ReceiptMutationCases -Receipt (Read-PayloadReceipt $directory $containerRid[0]))) {
+            Invoke-ContainerMutation -SourcePublishRoot $sourcePublishRoot -Rid $containerRid[0] -Case $case
         }
     }
 }

--- a/Scripts/Test-ReleaseArtifactGateMutation.ps1
+++ b/Scripts/Test-ReleaseArtifactGateMutation.ps1
@@ -90,7 +90,7 @@ function Get-ReceiptMutationCases([object] $Receipt) {
 		}
 	}
 	$grammarFile = @($Receipt.files | Where-Object {
-		[string]$_.path -ceq 'grammars/tree-sitter-kotlin.dll'
+		[string]$_.path -cmatch '^grammars/(lib)?tree-sitter-kotlin\.(dll|so|dylib)$'
 	} | Select-Object -First 1)
 	if ($grammarFile.Count -eq 1) {
 		$fixedGrammar = [pscustomobject]@{

--- a/Scripts/Test-ReleaseArtifacts.ps1
+++ b/Scripts/Test-ReleaseArtifacts.ps1
@@ -91,6 +91,11 @@ function Get-GitHubArtifactName([object] $Rid) {
     throw "Unsupported release operating system '$($Rid.os)' for RID '$($Rid.rid)'."
 }
 
+function Get-HeadlessArtifactName([object] $Rid) {
+    $extension = if ($Rid.os -ceq 'win32') { 'zip' } else { 'tar.gz' }
+    return "$($script:Manifest.release.headless.archivePrefix).v$Version.$($Rid.rid).$extension"
+}
+
 function Get-PayloadReceiptName([string] $Rid) {
     return "publish-payload.$Rid.json"
 }
@@ -141,9 +146,13 @@ function Assert-ExactNames(
         -Problem "missing or unexpected $Kind; expected: $($expectedNames -join ', '); found: $($actualNames -join ', ')"
 }
 
-function Get-ChecksumEntries([string] $DirectoryPath, [string[]] $ExpectedNames) {
-    $manifestPath = Join-Path $DirectoryPath 'SHA256SUMS.txt'
-    Assert-Artifact (Test-Path -LiteralPath $manifestPath -PathType Leaf) $DirectoryPath "missing SHA256SUMS.txt"
+function Get-ChecksumEntries(
+    [string] $DirectoryPath,
+    [string[]] $ExpectedNames,
+    [string] $ManifestName = 'SHA256SUMS.txt'
+) {
+    $manifestPath = Join-Path $DirectoryPath $ManifestName
+    Assert-Artifact (Test-Path -LiteralPath $manifestPath -PathType Leaf) $DirectoryPath "missing $ManifestName"
 
     $entries = @{}
     foreach ($line in @(Get-Content -LiteralPath $manifestPath)) {
@@ -274,6 +283,47 @@ function Assert-SingleFilePayload(
         "invalid informational version; expected '$Version' in the uncompressed single-file payload"
 }
 
+function Get-ZipEntryBytes([System.IO.Compression.ZipArchiveEntry] $Entry) {
+    $entryStream = $Entry.Open()
+    try {
+        $memory = [System.IO.MemoryStream]::new()
+        try {
+            $entryStream.CopyTo($memory)
+            return $memory.ToArray()
+        }
+        finally { $memory.Dispose() }
+    }
+    finally { $entryStream.Dispose() }
+}
+
+function Assert-HeadlessArtifact([string] $ArtifactPath, [object] $Rid, [object] $Receipt) {
+    $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
+    if ($Rid.os -ceq 'win32') {
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($ArtifactPath)
+        try {
+            $entries = @($archive.Entries | Where-Object { -not $_.FullName.EndsWith('/') })
+            Assert-Artifact `
+                ($entries.Count -eq 1 -and $entries[0].FullName -ceq [string]$Rid.binary) `
+                $artifactName `
+                "invalid archive layout; expected only '$($Rid.binary)'"
+            $bytes = Get-ZipEntryBytes -Entry $entries[0]
+        }
+        finally { $archive.Dispose() }
+    }
+    else {
+        $entries = @(Read-UstarGzipArchive -archivePath $ArtifactPath -captureEntryNames @([string]$Rid.binary))
+        Assert-Artifact `
+            ($entries.Count -eq 1 -and $entries[0].Name -ceq [string]$Rid.binary) `
+            $artifactName `
+            "invalid archive layout; expected only '$($Rid.binary)'"
+        Assert-Artifact (($entries[0].Mode -band 73) -eq 73) $artifactName "invalid executable mode for '$($Rid.binary)'"
+        $bytes = [byte[]]$entries[0].Bytes
+    }
+
+    Assert-Artifact ($null -ne $bytes -and $bytes.Length -gt 0) $artifactName "empty executable '$($Rid.binary)'"
+    Assert-SingleFilePayload -Bytes $bytes -Receipt $Receipt -ArtifactName $artifactName
+}
+
 function Assert-WindowsReleaseArtifact([string] $ArtifactPath, [object] $Receipt) {
     $artifactName = [System.IO.Path]::GetFileName($ArtifactPath)
     $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($ArtifactPath)
@@ -386,6 +436,85 @@ function Test-GitHubArtifacts([object[]] $SelectedRids) {
 
     $status = if ($partial) { 'VALIDATED; PARTIAL (not release-ready)' } else { 'VALIDATED; COMPLETE' }
     return [pscustomobject]@{ Channel = 'github'; Directory = $directory; Status = $status; Artifacts = $expectedNames }
+}
+
+function Test-HeadlessArtifacts([object[]] $SelectedRids) {
+    $directory = Join-Path $script:PublishPath "headless/v$Version"
+    Assert-Artifact (Test-Path -LiteralPath $directory -PathType Container) $directory "missing headless channel directory"
+    $artifactNames = @($SelectedRids | ForEach-Object { Get-HeadlessArtifactName $_ })
+    $receiptNames = @($SelectedRids | ForEach-Object { Get-PayloadReceiptName -Rid ([string]$_.rid) })
+    $expectedNames = @($artifactNames) + @($receiptNames)
+    $actualNames = @(Get-ChildItem -LiteralPath $directory -File |
+        Where-Object { $_.Name -cne [string]$script:Manifest.release.headless.checksumFile } |
+        ForEach-Object Name)
+    Assert-ExactNames -Expected $expectedNames -Actual $actualNames -ArtifactName $directory -Kind 'headless artifact set'
+    [void](Get-ChecksumEntries `
+        -DirectoryPath $directory `
+        -ExpectedNames $expectedNames `
+        -ManifestName ([string]$script:Manifest.release.headless.checksumFile))
+
+    foreach ($rid in $SelectedRids) {
+        $artifactName = Get-HeadlessArtifactName $rid
+        $receipt = Read-PayloadReceipt `
+            -DirectoryPath $directory `
+            -Rid ([string]$rid.rid) `
+            -ArtifactName $artifactName
+        Assert-HeadlessArtifact `
+            -ArtifactPath (Join-Path $directory $artifactName) `
+            -Rid $rid `
+            -Receipt $receipt
+    }
+
+    $partial = $SelectedRids.Count -ne @($script:Manifest.rids).Count
+    $status = if ($partial) { 'VALIDATED; PARTIAL RID set' } else { 'VALIDATED; COMPLETE' }
+    return [pscustomobject]@{ Channel = 'headless'; Directory = $directory; Status = $status; Artifacts = $expectedNames }
+}
+
+function Get-FolderPayloadFiles([string] $DirectoryPath) {
+    $payloadFiles = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($file in @(Get-ChildItem -LiteralPath $DirectoryPath -Recurse -File)) {
+        $relativePath = $file.FullName.Substring($DirectoryPath.Length).TrimStart('\', '/').Replace('\', '/')
+        $resources = [DevProjex.ReleaseValidation.ReleasePayloadInspector]::TryReadManagedResources($file.FullName)
+        $payloadFiles.Add([pscustomobject]@{
+            Path = $relativePath
+            Size = $file.Length
+            Sha256 = Get-FileSha256Hex -path $file.FullName
+            IsManagedAssembly = $null -ne $resources
+            ManagedResources = if ($null -eq $resources) { @() } else { @($resources) }
+        })
+    }
+    return $payloadFiles.ToArray()
+}
+
+function Test-ContainerArtifacts([object[]] $SelectedRids) {
+    $directory = Join-Path $script:PublishPath "container/v$Version"
+    Assert-Artifact (Test-Path -LiteralPath $directory -PathType Container) $directory "missing container channel directory"
+    $expectedNames = @($SelectedRids | ForEach-Object { [string]$_.rid }) +
+        @($SelectedRids | ForEach-Object { Get-PayloadReceiptName -Rid ([string]$_.rid) })
+    $actualNames = @(Get-ChildItem -LiteralPath $directory | ForEach-Object Name)
+    Assert-ExactNames -Expected $expectedNames -Actual $actualNames -ArtifactName $directory -Kind 'container payload set'
+
+    foreach ($rid in $SelectedRids) {
+        $ridName = [string]$rid.rid
+        $payloadDirectory = Join-Path $directory $ridName
+        Assert-Artifact (Test-Path -LiteralPath $payloadDirectory -PathType Container) $ridName "missing extracted image payload"
+        $receipt = Read-PayloadReceipt -DirectoryPath $directory -Rid $ridName -ArtifactName $ridName
+        Assert-PayloadDiff `
+            -Receipt $receipt `
+            -ActualFiles @(Get-FolderPayloadFiles -DirectoryPath $payloadDirectory) `
+            -ArtifactName "container:$ridName"
+        $binaryPath = Join-Path $payloadDirectory ([string]$rid.binary)
+        Assert-Artifact (Test-Path -LiteralPath $binaryPath -PathType Leaf) "container:$ridName" "missing executable '$($rid.binary)'"
+        $binaryText = [System.Text.Encoding]::Latin1.GetString([System.IO.File]::ReadAllBytes($binaryPath))
+        Assert-Artifact `
+            ($binaryText.IndexOf($Version, [System.StringComparison]::Ordinal) -ge 0) `
+            "container:$ridName" `
+            "invalid informational version; expected '$Version'"
+    }
+
+    $partial = $SelectedRids.Count -ne 2
+    $status = if ($partial) { 'VALIDATED; PARTIAL RID set' } else { 'VALIDATED; COMPLETE' }
+    return [pscustomobject]@{ Channel = 'container'; Directory = $directory; Status = $status; Artifacts = @() }
 }
 
 function Expand-Zip([string] $ArchivePath, [string] $DestinationPath) {
@@ -603,7 +732,7 @@ Assert-Artifact ($script:Manifest.schemaVersion -eq 1) $manifestPath "unsupporte
 Assert-Artifact ($null -ne $script:Manifest.release) $manifestPath "missing release contract"
 $script:StorePackageVersion = Get-StorePackageVersion -DisplayVersion $Version
 $script:PublishPath = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($PublishRoot)) { Join-Path $repoRoot 'publish' } else { $PublishRoot }))
-$allowedChannels = @('github', 'store')
+$allowedChannels = @('github', 'store', 'headless', 'container')
 $allowedRids = @($script:Manifest.rids | ForEach-Object { [string]$_.rid })
 $selectedChannels = @(ConvertTo-Selection -Values $Channels -Allowed $allowedChannels -Kind 'channel')
 $selectedRidNames = @(ConvertTo-Selection -Values $Rids -Allowed $allowedRids -Kind 'RID')
@@ -615,6 +744,14 @@ $selectedRids = @($selectedRidNames | ForEach-Object {
 $results = New-Object 'System.Collections.Generic.List[object]'
 if ('github' -in $selectedChannels) {
     $results.Add((Test-GitHubArtifacts -SelectedRids $selectedRids))
+}
+if ('headless' -in $selectedChannels) {
+    $results.Add((Test-HeadlessArtifacts -SelectedRids $selectedRids))
+}
+if ('container' -in $selectedChannels) {
+    $containerRids = @($selectedRids | Where-Object { $_.rid -in @('linux-x64', 'linux-arm64') })
+    Assert-Artifact ($containerRids.Count -eq $selectedRids.Count) 'container' 'non-Linux RID selection'
+    $results.Add((Test-ContainerArtifacts -SelectedRids $containerRids))
 }
 if ('store' -in $selectedChannels) {
     $results.Add((Test-StoreArtifacts))

--- a/Scripts/Test-ReleaseArtifacts.ps1
+++ b/Scripts/Test-ReleaseArtifacts.ps1
@@ -505,11 +505,6 @@ function Test-ContainerArtifacts([object[]] $SelectedRids) {
             -ArtifactName "container:$ridName"
         $binaryPath = Join-Path $payloadDirectory ([string]$rid.binary)
         Assert-Artifact (Test-Path -LiteralPath $binaryPath -PathType Leaf) "container:$ridName" "missing executable '$($rid.binary)'"
-        $binaryText = [System.Text.Encoding]::Latin1.GetString([System.IO.File]::ReadAllBytes($binaryPath))
-        Assert-Artifact `
-            ($binaryText.IndexOf($Version, [System.StringComparison]::Ordinal) -ge 0) `
-            "container:$ridName" `
-            "invalid informational version; expected '$Version'"
     }
 
     $partial = $SelectedRids.Count -ne 2

--- a/Scripts/build-headless-packages.ps1
+++ b/Scripts/build-headless-packages.ps1
@@ -16,6 +16,11 @@ $nugetRoot = Join-Path $headlessRoot "nuget"
 $npmRoot = Join-Path $headlessRoot "npm"
 $publishRoot = Join-Path $headlessRoot "publish"
 $stagingRoot = Join-Path $headlessRoot "staging"
+$releasePublishRoot = Join-Path $headlessRoot "release"
+
+. (Join-Path $PSScriptRoot "release-archive-helpers.ps1")
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 function Normalize-PackageVersion([string] $Value) {
     if ($Value -match '^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)(?<suffix>[-+].+)?$') {
@@ -41,11 +46,51 @@ function Invoke-Checked([string] $FilePath, [string[]] $Arguments, [string] $Wor
     }
 }
 
+function Get-HeadlessArchiveName([object] $Rid) {
+    $extension = if ($Rid.os -ceq "win32") { "zip" } else { "tar.gz" }
+    return "$($manifest.release.headless.archivePrefix).v$Version.$($Rid.rid).$extension"
+}
+
+function New-HeadlessArchive([object] $Rid, [string] $BinaryPath) {
+    $archivePath = Join-Path $headlessReleaseRoot (Get-HeadlessArchiveName $Rid)
+    if ($Rid.os -ceq "win32") {
+        $stream = [System.IO.File]::Create($archivePath)
+        try {
+            $archive = [System.IO.Compression.ZipArchive]::new(
+                $stream,
+                [System.IO.Compression.ZipArchiveMode]::Create,
+                $false)
+            try {
+                $entry = $archive.CreateEntry([string]$Rid.binary, [System.IO.Compression.CompressionLevel]::Optimal)
+                $entryStream = $entry.Open()
+                try {
+                    $source = [System.IO.File]::OpenRead($BinaryPath)
+                    try { $source.CopyTo($entryStream) } finally { $source.Dispose() }
+                }
+                finally { $entryStream.Dispose() }
+            }
+            finally { $archive.Dispose() }
+        }
+        finally { $stream.Dispose() }
+        return
+    }
+
+    New-UstarGzipArchive -archivePath $archivePath -entries @(
+        [pscustomobject]@{
+            Name = [string]$Rid.binary
+            Mode = 493
+            IsDirectory = $false
+            SourcePath = $BinaryPath
+            Bytes = $null
+        })
+}
+
 if ([string]::IsNullOrWhiteSpace($Version)) {
     [xml] $buildProperties = Get-Content -LiteralPath (Join-Path $repoRoot "Directory.Build.props") -Raw
     $Version = [string]($buildProperties.Project.PropertyGroup.DevProjexVersion | Select-Object -First 1)
 }
 $packageVersion = Normalize-PackageVersion $Version
+$headlessReleaseRoot = Join-Path $releasePublishRoot "headless/v$Version"
 $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
 
 $resolvedHeadlessRoot = [System.IO.Path]::GetFullPath($headlessRoot)
@@ -56,7 +101,7 @@ if (-not $resolvedHeadlessRoot.StartsWith($resolvedArtifactsRoot, [System.String
 if (Test-Path -LiteralPath $resolvedHeadlessRoot) {
     Remove-Item -LiteralPath $resolvedHeadlessRoot -Recurse -Force
 }
-foreach ($directory in @($nugetRoot, $npmRoot, $publishRoot, $stagingRoot)) {
+foreach ($directory in @($nugetRoot, $npmRoot, $publishRoot, $stagingRoot, $headlessReleaseRoot)) {
     [System.IO.Directory]::CreateDirectory($directory) | Out-Null
 }
 
@@ -89,10 +134,13 @@ foreach ($rid in $manifest.rids) {
         "/p:DevProjexHeadlessBuildRoot=$ridBuildRoot",
         "/p:PublishSingleFile=true",
         "/p:IncludeNativeLibrariesForSelfExtract=true",
+        "/p:EnableCompressionInSingleFile=false",
         "/p:PublishReadyToRun=true",
         "/p:PublishTrimmed=false",
         "/p:DebugType=None",
         "/p:DebugSymbols=false",
+        "/p:DevProjexGenerateReleasePayloadReceipt=true",
+        "/p:DevProjexPayloadReceiptDirectory=$headlessReleaseRoot",
         "-o", $ridPublishRoot
     ) $repoRoot
 
@@ -129,6 +177,7 @@ foreach ($rid in $manifest.rids) {
             -PackagePath (Join-Path $npmRoot "devprojex-cli-$($rid.npmPlatform)-$packageVersion.tgz") `
             -EntryName "package/bin/$($rid.binary)"
     }
+    New-HeadlessArchive -Rid $rid -BinaryPath $publishedFiles[0].FullName
 }
 
 $mainStage = Join-Path $stagingRoot "devprojex"
@@ -142,13 +191,29 @@ Copy-Item -LiteralPath (Join-Path $repoRoot "Packaging/Npm/devprojex/bin/devproj
 Copy-Item -LiteralPath (Join-Path $repoRoot "LICENSE") -Destination (Join-Path $mainStage "LICENSE")
 Invoke-Checked "npm" @("pack", ".", "--pack-destination", $npmRoot) $mainStage
 
+$releaseFiles = @(Get-ChildItem -LiteralPath $headlessReleaseRoot -File | Sort-Object Name)
+$checksumLines = @($releaseFiles | ForEach-Object {
+    "$(Get-FileSha256Hex -path $_.FullName) *$($_.Name)"
+})
+Write-ReleaseChecksumManifest `
+    -path (Join-Path $headlessReleaseRoot ([string]$manifest.release.headless.checksumFile)) `
+    -lines $checksumLines
+
 & (Join-Path $PSScriptRoot "Test-HeadlessPackages.ps1") `
     -ArtifactsRoot $headlessRoot `
-    -Version $packageVersion
+    -Version $packageVersion `
+    -ReleasePublishRoot $releasePublishRoot `
+    -ReleaseVersion $Version
+
+& (Join-Path $PSScriptRoot "Test-ReleaseArtifacts.ps1") `
+    -PublishRoot $releasePublishRoot `
+    -Version $Version `
+    -Channels headless
 
 $packageFiles = @(
     Get-ChildItem -LiteralPath $nugetRoot -Filter "*.nupkg" -File
     Get-ChildItem -LiteralPath $npmRoot -Filter "*.tgz" -File
+    Get-ChildItem -LiteralPath $headlessReleaseRoot -File
 ) | Sort-Object Name
 $sizeReport = [System.Collections.Generic.List[string]]::new()
 $sizeReport.Add("| Package | Bytes | MiB |")

--- a/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
@@ -83,6 +83,78 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		Assert.Contains(expected, output, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public void ValidatorAcceptsAHeadlessArchiveWithItsDedicatedChecksumManifest()
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateHeadlessLinuxFixture(workspace.Path);
+
+		var result = RunValidator(workspace.Path, "headless", "linux-x64");
+
+		Assert.True(result.ExitCode == 0, result.StandardOutput + result.StandardError);
+		Assert.Contains("Channel headless: VALIDATED; PARTIAL RID set", result.StandardOutput, StringComparison.Ordinal);
+	}
+
+	[Theory]
+	[InlineData("missing-file", "receipt-only.dat")]
+	[InlineData("missing-resource", "Fixture.Missing.Resource")]
+	[InlineData("extra-file", "unexpected.dat")]
+	[InlineData("payload-hash", "libSkiaSharp.dll")]
+	[InlineData("checksum", "SHA-256")]
+	public void HeadlessValidatorUsesTheCommonFailClosedPayloadDiff(string mutation, string expected)
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateHeadlessLinuxFixture(workspace.Path, mutation);
+
+		var result = RunValidator(workspace.Path, "headless", "linux-x64");
+		var output = result.StandardOutput + result.StandardError;
+
+		Assert.NotEqual(0, result.ExitCode);
+		Assert.Contains("DevProjex-headless.v5.2.linux-x64.tar.gz", output, StringComparison.Ordinal);
+		Assert.Contains(expected, output, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void HeadlessMutationGateDamagesFilesAndResourcesWithoutChannelSpecificPayloadRules()
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateHeadlessWindowsFixture(workspace.Path);
+
+		var result = RunPowerShell(
+			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifactGateMutation.ps1"),
+			["-PublishRoot", Path.Combine(workspace.Path, "publish"), "-Version", Version,
+				"-Channels", "headless", "-Rids", "win-x64"]);
+
+		Assert.True(result.ExitCode == 0, result.StandardOutput + result.StandardError);
+		Assert.Contains("DevProjex-headless.v5.2.win-x64.zip", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("DevProjex.Assets.Localization.en.json", result.StandardOutput, StringComparison.Ordinal);
+	}
+
+	[Theory]
+	[InlineData(null, null)]
+	[InlineData("missing-file", "receipt-only.dat")]
+	[InlineData("missing-resource", "Fixture.Missing.Resource")]
+	[InlineData("extra-file", "unexpected.dat")]
+	[InlineData("payload-hash", "libSkiaSharp.dll")]
+	public void ContainerValidatorUsesTheCommonFolderPayloadDiff(string? mutation, string? expected)
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateContainerFixture(workspace.Path, mutation);
+
+		var result = RunValidator(workspace.Path, "container", "linux-x64");
+		var output = result.StandardOutput + result.StandardError;
+		if (mutation is null)
+		{
+			Assert.True(result.ExitCode == 0, output);
+			Assert.Contains("Channel container: VALIDATED; PARTIAL RID set", result.StandardOutput, StringComparison.Ordinal);
+			return;
+		}
+
+		Assert.NotEqual(0, result.ExitCode);
+		Assert.Contains("container:linux-x64", output, StringComparison.Ordinal);
+		Assert.Contains(expected!, output, StringComparison.Ordinal);
+	}
+
 	[Theory]
 	[InlineData(false, false)]
 	[InlineData(true, false)]
@@ -139,12 +211,22 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		Assert.True(singleResult.ExitCode == 0, singleResult.StandardOutput + singleResult.StandardError);
 
 		var folderResult = RunDotNet(fixture.Root,
-			["publish", fixture.AppProject, "-c", "ReleaseStore", "-r", "win-x64", "--self-contained", "false",
+			["publish", fixture.AppProject, "-c", "Release", "-r", "win-x64", "--self-contained", "false",
 				"-nodeReuse:false",
 				"/p:PublishSingleFile=false", "/p:DebugType=None", "/p:DebugSymbols=false",
 				"/p:DevProjexGenerateReleasePayloadReceipt=true",
+				"/p:DevProjexGenerateFolderPayloadReceipt=true",
 				$"/p:DevProjexPayloadReceiptDirectory={fixture.FolderReceipt}", "-o", fixture.FolderPublish]);
 		Assert.True(folderResult.ExitCode == 0, folderResult.StandardOutput + folderResult.StandardError);
+		var storeReceiptDirectory = Path.Combine(fixture.Root, "store-receipt");
+		var storeResult = RunDotNet(fixture.Root,
+			["publish", fixture.AppProject, "-c", "ReleaseStore", "-r", "win-x64", "--self-contained", "false",
+				"-nodeReuse:false", "/p:PublishSingleFile=false", "/p:DebugType=None", "/p:DebugSymbols=false",
+				"/p:DevProjexGenerateReleasePayloadReceipt=true",
+				$"/p:DevProjexPayloadReceiptDirectory={storeReceiptDirectory}", "-o", Path.Combine(fixture.Root, "store")]);
+		Assert.True(storeResult.ExitCode == 0, storeResult.StandardOutput + storeResult.StandardError);
+		Assert.True(File.Exists(Path.Combine(storeReceiptDirectory, "publish-payload.win-x64.json")),
+			"ReleaseStore must retain its implicit folder-receipt opt-in.");
 
 		var singleReceipt = ReadReceipt(Path.Combine(fixture.SingleReceipt, "publish-payload.win-x64.json"));
 		var folderReceipt = ReadReceipt(Path.Combine(fixture.FolderReceipt, "publish-payload.win-x64.json"));
@@ -244,21 +326,7 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		var payload = CreateFixturePayload(version);
 		var bundleFiles = payload.ToList();
 		var receiptFiles = payload.Select(ToReceiptFile).ToList();
-		if (mutation == "missing-file") receiptFiles.Add(new ReceiptFile("receipt-only.dat", 1, new string('0', 64), null));
-		if (mutation == "missing-resource")
-		{
-			var index = receiptFiles.FindIndex(static file => file.Path == "Assets.dll");
-			receiptFiles[index] = receiptFiles[index] with
-			{
-				ManagedResources = [.. receiptFiles[index].ManagedResources!, "Fixture.Missing.Resource"]
-			};
-		}
-		if (mutation == "extra-file") bundleFiles.Add(new PayloadFile("unexpected.dat", Encoding.ASCII.GetBytes("extra"), 0));
-		if (mutation == "payload-hash")
-		{
-			var index = receiptFiles.FindIndex(static file => file.Path == "libSkiaSharp.dll");
-			receiptFiles[index] = receiptFiles[index] with { Sha256 = new string('0', 64) };
-		}
+		ApplyPayloadMutation(mutation, bundleFiles, receiptFiles);
 
 		var artifactName = $"DevProjex.v{version}.linux-x64.tar.gz";
 		var artifactPath = Path.Combine(releaseDirectory, artifactName);
@@ -281,6 +349,103 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		if (mutation != "partial-marker")
 			File.WriteAllText(Path.Combine(releaseDirectory, "PARTIAL-BUILD.txt"),
 				"PARTIAL BUILD - NOT READY FOR RELEASE\nRIDs: linux-x64\n", new UTF8Encoding(false));
+	}
+
+	private static void CreateHeadlessLinuxFixture(string workspaceRoot, string? mutation = null)
+	{
+		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "headless", $"v{Version}");
+		Directory.CreateDirectory(releaseDirectory);
+		var payload = CreateFixturePayload();
+		var bundleFiles = payload.ToList();
+		var receiptFiles = payload.Select(ToReceiptFile).ToList();
+		ApplyPayloadMutation(mutation, bundleFiles, receiptFiles);
+
+		var artifactName = $"DevProjex-headless.v{Version}.linux-x64.tar.gz";
+		using (var file = File.Create(Path.Combine(releaseDirectory, artifactName)))
+		using (var gzip = new GZipStream(file, CompressionLevel.SmallestSize))
+		using (var writer = new TarWriter(gzip, TarEntryFormat.Ustar, leaveOpen: false))
+		{
+			writer.WriteEntry(new UstarTarEntry(TarEntryType.RegularFile, "devprojex")
+			{
+				DataStream = new MemoryStream(CreateBundle(bundleFiles), writable: false),
+				Mode = (UnixFileMode)493,
+				ModificationTime = DateTimeOffset.UnixEpoch
+			});
+		}
+		var receiptName = "publish-payload.linux-x64.json";
+		WriteReceipt(Path.Combine(releaseDirectory, receiptName), "linux-x64", receiptFiles);
+		WriteChecksums(releaseDirectory, [artifactName, receiptName],
+			mutation == "checksum" ? artifactName : null, "SHA256SUMS.headless.txt");
+	}
+
+	private static void CreateHeadlessWindowsFixture(string workspaceRoot)
+	{
+		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "headless", $"v{Version}");
+		Directory.CreateDirectory(releaseDirectory);
+		var payload = CreateFixturePayload();
+		var artifactName = $"DevProjex-headless.v{Version}.win-x64.zip";
+		File.WriteAllBytes(Path.Combine(releaseDirectory, artifactName), CreateZip(new Dictionary<string, byte[]>
+		{
+			["devprojex.exe"] = CreateBundle(payload)
+		}));
+		var receiptName = "publish-payload.win-x64.json";
+		WriteReceipt(Path.Combine(releaseDirectory, receiptName), "win-x64", payload.Select(ToReceiptFile).ToArray());
+		WriteChecksums(releaseDirectory, [artifactName, receiptName], manifestName: "SHA256SUMS.headless.txt");
+	}
+
+	private static void CreateContainerFixture(string workspaceRoot, string? mutation)
+	{
+		var releaseDirectory = Path.Combine(workspaceRoot, "publish", "container", $"v{Version}");
+		var payloadDirectory = Path.Combine(releaseDirectory, "linux-x64");
+		Directory.CreateDirectory(payloadDirectory);
+		var payload = CreateFixturePayload().ToList();
+		payload[0] = payload[0] with { Path = "devprojex" };
+		var receiptFiles = payload.Select(ToReceiptFile).ToList();
+		if (mutation == "missing-file") receiptFiles.Add(new ReceiptFile("receipt-only.dat", 1, new string('0', 64), null));
+		if (mutation == "missing-resource")
+		{
+			var index = receiptFiles.FindIndex(static file => file.Path == "Assets.dll");
+			receiptFiles[index] = receiptFiles[index] with
+			{
+				ManagedResources = [.. receiptFiles[index].ManagedResources!, "Fixture.Missing.Resource"]
+			};
+		}
+		if (mutation == "payload-hash")
+		{
+			var index = receiptFiles.FindIndex(static file => file.Path == "libSkiaSharp.dll");
+			receiptFiles[index] = receiptFiles[index] with { Sha256 = new string('0', 64) };
+		}
+
+		foreach (var file in payload)
+		{
+			var path = Path.Combine(payloadDirectory, file.Path.Replace('/', Path.DirectorySeparatorChar));
+			Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+			File.WriteAllBytes(path, file.Bytes);
+		}
+		if (mutation == "extra-file") File.WriteAllText(Path.Combine(payloadDirectory, "unexpected.dat"), "extra");
+		WriteReceipt(Path.Combine(releaseDirectory, "publish-payload.linux-x64.json"), "linux-x64", receiptFiles);
+	}
+
+	private static void ApplyPayloadMutation(
+		string? mutation,
+		List<PayloadFile> bundleFiles,
+		List<ReceiptFile> receiptFiles)
+	{
+		if (mutation == "missing-file") receiptFiles.Add(new ReceiptFile("receipt-only.dat", 1, new string('0', 64), null));
+		if (mutation == "missing-resource")
+		{
+			var index = receiptFiles.FindIndex(static file => file.Path == "Assets.dll");
+			receiptFiles[index] = receiptFiles[index] with
+			{
+				ManagedResources = [.. receiptFiles[index].ManagedResources!, "Fixture.Missing.Resource"]
+			};
+		}
+		if (mutation == "extra-file") bundleFiles.Add(new PayloadFile("unexpected.dat", Encoding.ASCII.GetBytes("extra"), 0));
+		if (mutation == "payload-hash")
+		{
+			var index = receiptFiles.FindIndex(static file => file.Path == "libSkiaSharp.dll");
+			receiptFiles[index] = receiptFiles[index] with { Sha256 = new string('0', 64) };
+		}
 	}
 
 	private static IReadOnlyList<PayloadFile> CreateFixturePayload(string version = Version) =>
@@ -436,7 +601,11 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 	private static Receipt ReadReceipt(string path) =>
 		JsonSerializer.Deserialize<Receipt>(File.ReadAllText(path), new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
 
-	private static void WriteChecksums(string directory, IEnumerable<string> names, string? invalidName = null)
+	private static void WriteChecksums(
+		string directory,
+		IEnumerable<string> names,
+		string? invalidName = null,
+		string manifestName = "SHA256SUMS.txt")
 	{
 		var lines = names.Order(StringComparer.Ordinal).Select(name =>
 		{
@@ -444,7 +613,7 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 				Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(Path.Combine(directory, name)))).ToLowerInvariant();
 			return $"{hash} *{name}";
 		});
-		File.WriteAllText(Path.Combine(directory, "SHA256SUMS.txt"), string.Join('\n', lines) + '\n', new UTF8Encoding(false));
+		File.WriteAllText(Path.Combine(directory, manifestName), string.Join('\n', lines) + '\n', new UTF8Encoding(false));
 	}
 
 	private static ReceiptBuildFixture CreateReceiptBuildFixture(string root)

--- a/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ReleaseArtifactValidationIntegrationTests.cs
@@ -155,6 +155,22 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		Assert.Contains(expected!, output, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public void ContainerMutationGateRecognizesLinuxGrammarPayloadNames()
+	{
+		using var workspace = new TemporaryDirectory();
+		CreateContainerFixture(workspace.Path, mutation: null);
+
+		var result = RunPowerShell(
+			Path.Combine(RepoRoot.Value, "Scripts", "Test-ReleaseArtifactGateMutation.ps1"),
+			["-PublishRoot", Path.Combine(workspace.Path, "publish"), "-Version", Version,
+				"-Channels", "container", "-Rids", "linux-x64"]);
+
+		Assert.True(result.ExitCode == 0, result.StandardOutput + result.StandardError);
+		Assert.Contains("grammars/libtree-sitter-kotlin.so", result.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("DevProjex.Assets.Localization.en.json", result.StandardOutput, StringComparison.Ordinal);
+	}
+
 	[Theory]
 	[InlineData(false, false)]
 	[InlineData(true, false)]
@@ -400,6 +416,8 @@ public sealed class ReleaseArtifactValidationIntegrationTests
 		Directory.CreateDirectory(payloadDirectory);
 		var payload = CreateFixturePayload().ToList();
 		payload[0] = payload[0] with { Path = "devprojex" };
+		var grammarIndex = payload.FindIndex(static file => file.Path == "grammars/tree-sitter-kotlin.dll");
+		payload[grammarIndex] = payload[grammarIndex] with { Path = "grammars/libtree-sitter-kotlin.so" };
 		var receiptFiles = payload.Select(ToReceiptFile).ToList();
 		if (mutation == "missing-file") receiptFiles.Add(new ReceiptFile("receipt-only.dat", 1, new string('0', 64), null));
 		if (mutation == "missing-resource")

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -297,6 +297,9 @@ public sealed class DocumentationAndPackagingContractTests
 
 		var release = manifest.GetProperty("release");
 		Assert.False(release.TryGetProperty("localizations", out _));
+		var headless = release.GetProperty("headless");
+		Assert.Equal("DevProjex-headless", headless.GetProperty("archivePrefix").GetString());
+		Assert.Equal("SHA256SUMS.headless.txt", headless.GetProperty("checksumFile").GetString());
 
 		var store = release.GetProperty("store");
 		var manifestLanguages = store.GetProperty("resourceLanguages")
@@ -328,6 +331,64 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("@(FilesToBundle)", buildTargets, StringComparison.Ordinal);
 		Assert.Contains("@(ResolvedFileToPublish)", buildTargets, StringComparison.Ordinal);
 		Assert.Contains("Write-PublishPayloadReceipt.ps1", buildTargets, StringComparison.Ordinal);
+		Assert.Contains("DevProjexGenerateFolderPayloadReceipt", buildTargets, StringComparison.Ordinal);
+		Assert.Contains("'$(Configuration)'=='ReleaseStore'", buildTargets, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void HeadlessReleaseAndContainerChannelsRemainDistinctAndFailClosed()
+	{
+		var rootPath = FindRepositoryRoot();
+		var buildScript = File.ReadAllText(Path.Combine(rootPath, "Scripts", "build-headless-packages.ps1"));
+		var validator = File.ReadAllText(Path.Combine(rootPath, "Scripts", "Test-ReleaseArtifacts.ps1"));
+		var archiveWorkflow = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "package-headless.yml"));
+		var containerWorkflow = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "publish-container.yml"));
+		var containerSmoke = File.ReadAllText(Path.Combine(rootPath, "Scripts", "Test-HeadlessContainerSmoke.ps1"));
+		var dockerfile = File.ReadAllText(Path.Combine(rootPath, "Dockerfile"));
+		var installation = File.ReadAllText(Path.Combine(rootPath, "Docs", "Installation.md"));
+		var releaseProcess = File.ReadAllText(Path.Combine(rootPath, "Docs", "Release-Process.md"));
+
+		Assert.Contains("$($manifest.release.headless.archivePrefix).v$Version.$($Rid.rid).$extension", buildScript, StringComparison.Ordinal);
+		Assert.DoesNotContain("DevProjex.v$Version.$($Rid.rid)", buildScript, StringComparison.Ordinal);
+		Assert.Contains("DevProjexGenerateReleasePayloadReceipt=true", buildScript, StringComparison.Ordinal);
+		Assert.Contains("'headless'", validator, StringComparison.Ordinal);
+		Assert.Contains("[string]$Rid.binary", validator, StringComparison.Ordinal);
+		Assert.Contains("release.headless.checksumFile", validator, StringComparison.Ordinal);
+
+		Assert.Contains("types: [published]", archiveWorkflow, StringComparison.Ordinal);
+		Assert.Contains("actions/checkout@v7", archiveWorkflow, StringComparison.Ordinal);
+		Assert.Contains("actions/setup-dotnet@v6", archiveWorkflow, StringComparison.Ordinal);
+		Assert.Contains("actions/upload-artifact@v7", archiveWorkflow, StringComparison.Ordinal);
+		Assert.Contains("actions/download-artifact@v8", archiveWorkflow, StringComparison.Ordinal);
+		Assert.Contains("gh release upload", archiveWorkflow, StringComparison.Ordinal);
+		Assert.Contains("if: ${{ steps.metadata.outputs.release_tag != '' }}", archiveWorkflow, StringComparison.Ordinal);
+
+		Assert.Contains("FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0", dockerfile, StringComparison.Ordinal);
+		Assert.Contains("runtime-deps:10.0-noble-chiseled-extra", dockerfile, StringComparison.Ordinal);
+		Assert.Contains("-p:PublishSingleFile=false", dockerfile, StringComparison.Ordinal);
+		Assert.Contains("-p:DevProjexGrammarDelivery=Content", dockerfile, StringComparison.Ordinal);
+		Assert.Contains("USER app", dockerfile, StringComparison.Ordinal);
+		Assert.Contains("ENTRYPOINT [\"devprojex\"]", dockerfile, StringComparison.Ordinal);
+		Assert.DoesNotContain("alpine", dockerfile, StringComparison.OrdinalIgnoreCase);
+
+		using var glama = JsonDocument.Parse(File.ReadAllText(Path.Combine(rootPath, "glama.json")));
+		Assert.Equal("https://glama.ai/mcp/schemas/server.json", glama.RootElement.GetProperty("$schema").GetString());
+		Assert.Equal(["Avazbek22"], glama.RootElement.GetProperty("maintainers").EnumerateArray()
+			.Select(static item => item.GetString()!).ToArray());
+
+		Assert.Contains("ubuntu-24.04-arm", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("linux/amd64,linux/arm64", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("actions/attest-build-provenance@v4", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("packages: write", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("id-token: write", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("attestations: write", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("--read-only", containerSmoke, StringComparison.Ordinal);
+		Assert.Contains("--tmpfs /tmp", containerSmoke, StringComparison.Ordinal);
+		Assert.DoesNotContain("setup-qemu", containerWorkflow, StringComparison.OrdinalIgnoreCase);
+
+		Assert.Contains("DevProjex-headless.v<version>.<rid>", installation, StringComparison.Ordinal);
+		Assert.Contains("ghcr.io/avazbek22/devprojex", installation, StringComparison.Ordinal);
+		Assert.Contains("Two independent producers cannot atomically update one checksum manifest", releaseProcess, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -378,6 +378,9 @@ public sealed class DocumentationAndPackagingContractTests
 
 		Assert.Contains("ubuntu-24.04-arm", containerWorkflow, StringComparison.Ordinal);
 		Assert.Contains("linux/amd64,linux/arm64", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("docker/setup-buildx-action@v4", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("docker/login-action@v4", containerWorkflow, StringComparison.Ordinal);
+		Assert.Contains("docker/build-push-action@v7", containerWorkflow, StringComparison.Ordinal);
 		Assert.Contains("actions/attest-build-provenance@v4", containerWorkflow, StringComparison.Ordinal);
 		Assert.Contains("packages: write", containerWorkflow, StringComparison.Ordinal);
 		Assert.Contains("id-token: write", containerWorkflow, StringComparison.Ordinal);

--- a/Tests/DevProjex.Tests.Unit/CodeCompressionFactoryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/CodeCompressionFactoryTests.cs
@@ -1,0 +1,47 @@
+using DevProjex.Infrastructure.Compression;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class CodeCompressionFactoryTests
+{
+	[Fact]
+	public void CreateLocator_ContentDirectoryOnNonWindows_UsesContentDelivery()
+	{
+		using var temporary = new TemporaryDirectory();
+		Directory.CreateDirectory(Path.Combine(temporary.Path, "grammars"));
+
+		var locator = CodeCompressionFactory.CreateLocator(
+			temporary.Path,
+			isWindows: false,
+			isWindowsPackagedApp: static () => false);
+
+		var content = Assert.IsType<ContentGrammarLibraryLocator>(locator);
+		Assert.Throws<FileNotFoundException>(() => content.Resolve("tree-sitter-deliberately-missing"));
+	}
+
+	[Fact]
+	public void CreateLocator_WithoutContentDirectory_UsesEmbeddedDelivery()
+	{
+		using var temporary = new TemporaryDirectory();
+
+		var locator = CodeCompressionFactory.CreateLocator(
+			temporary.Path,
+			isWindows: false,
+			isWindowsPackagedApp: static () => false);
+
+		Assert.IsType<EmbeddedGrammarLibraryLocator>(locator).Dispose();
+	}
+
+	[Fact]
+	public void CreateLocator_WindowsPackagedApp_UsesContentDeliveryWithoutDirectory()
+	{
+		using var temporary = new TemporaryDirectory();
+
+		var locator = CodeCompressionFactory.CreateLocator(
+			temporary.Path,
+			isWindows: true,
+			isWindowsPackagedApp: static () => true);
+
+		Assert.IsType<ContentGrammarLibraryLocator>(locator);
+	}
+}

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,1 @@
+{"$schema":"https://glama.ai/mcp/schemas/server.json","maintainers":["Avazbek22"]}


### PR DESCRIPTION
Implements #287 on top of v5.2.

**Headless release assets**
- Builds six distinctly named `DevProjex-headless.v<version>.<rid>.zip|tar.gz` archives from the exact single-file publish output staged into the npm platform packages.
- Emits build-derived payload receipts for every RID and a CI-owned `SHA256SUMS.headless.txt`, separate from the operator-owned desktop checksum manifest.
- Extends the common release validator and mutation gate to inspect every bundle entry, managed resource, size, hash, archive layout, and Unix executable mode before upload.
- Adds `package-headless.yml` for pull-request gates, manual release attachment, and automatic `release: published` upload.

**Container channel**
- Adds a multi-stage root Dockerfile: SDK 10 build, folder publish with content-delivered grammars, and the glibc `runtime-deps:10.0-noble-chiseled-extra` runtime as non-root `app` with no shell.
- Generalizes folder-publish receipts through an explicit opt-in while retaining the existing implicit `ReleaseStore` behavior.
- Adds exact receipt validation and generic mutation testing for extracted `/app` payloads.
- Adds amd64 and native-arm64 read-only smoke coverage for version, tree, compression, secret exit/redaction, and MCP initialization.
- Publishes `ghcr.io/avazbek22/devprojex:<version>` and `latest` only from a published release, with a multi-architecture manifest and build-provenance attestation.

**Security posture**
- Runtime smoke uses `--read-only`, `--tmpfs /tmp`, a read-only project mount, and the non-root `app` user.
- Folder publish plus `DevProjexGrammarDelivery=Content` avoids both single-file native extraction and runtime grammar materialization; `CreateLocator()` selects content delivery from the shipped `grammars` directory on every OS and remains fail-closed for missing entries.
- Pull requests and manual container runs never push an image; GHCR write and OIDC attestation permissions exist only on the release-only publish job.
- The only product-code change is the authorized `CreateLocator()` content-delivery selection; CLI/MCP contracts and desktop, Store, AppImage, npm, and NuGet layouts are unchanged.

**Validation**
- Real six-RID local packaging and receipt validation passed; archives are 58.51-62.89 MiB.
- The real mutation gate rejected deterministic file/resource changes and fixed grammar, localization, and native-library mutations while naming the archive and damaged entry.
- Targeted integration and documentation/packaging contract tests pass; TerminalHost Release build completes with zero warnings.
- Docker Desktop is not running locally, so image builds and both architecture smokes are delegated to this PR's container workflow.

**Frozen-package compatibility note**
The existing NuGet RID tool is intentionally a folder publish (apphost plus managed/runtime files), while npm and the new archive use the existing ReadyToRun single-file publish. Literal executable hash equality across all three would require changing the frozen NuGet package payload. This PR therefore proves byte identity for canonical publish -> npm -> release archive and leaves the existing NuGet fail-closed payload gate unchanged.

**Owner follow-up after the first release**
- Make the first `ghcr.io/avazbek22/devprojex` package public in GHCR.
- Re-run the Glama ownership/sync check so it builds the new root Dockerfile.
