### PR TITLE
fix(ranking): correct importance scoring and reports

### DIFF
--- a/Application/Context/ProjectContextDocumentService.cs
+++ b/Application/Context/ProjectContextDocumentService.cs
@@ -1946,7 +1946,8 @@ public sealed class ProjectContextDocumentService(
 	private static void EnsureRankingSourceVersion(string path, RankingSourceVersion? expectedVersion)
 	{
 		if (expectedVersion is { } version && !version.IsCurrent(path))
-			throw new IOException("A selected source file changed after importance facts were indexed.");
+			throw new IOException(
+				"Selected source content changed during importance ranking; repeat the export.");
 	}
 
 	private static void WriteRanking(

--- a/Application/Context/ProjectContextDocumentService.cs
+++ b/Application/Context/ProjectContextDocumentService.cs
@@ -1165,18 +1165,32 @@ public sealed class ProjectContextDocumentService(
 				EstimateCompleteSnapshotRetainedBytes(path),
 				cancellationToken)
 			.ConfigureAwait(false);
+		IFileContentSnapshot? snapshot = null;
 		try
 		{
 			EnsureRankingSourceVersion(path, expectedVersion);
-			var snapshot = await OpenSourceSnapshotAsync(projectRoot, path, cancellationToken)
+			snapshot = await OpenSourceSnapshotAsync(projectRoot, path, cancellationToken)
 				.ConfigureAwait(false);
 			EnsureRankingSourceVersion(path, expectedVersion);
 			if (expectedVersion is { } version)
 				snapshot = new RankingValidatedSourceSnapshot(snapshot, path, version);
-			return new BudgetedCompleteSourceSnapshot(snapshot, lease);
+			var budgeted = new BudgetedCompleteSourceSnapshot(snapshot, lease);
+			snapshot = null;
+			return budgeted;
 		}
 		catch
 		{
+			if (snapshot is not null)
+			{
+				try
+				{
+					await snapshot.DisposeAsync().ConfigureAwait(false);
+				}
+				catch
+				{
+					// Preserve the source-version failure while still attempting to release the handle.
+				}
+			}
 			lease.Dispose();
 			throw;
 		}

--- a/Application/Ranking/ImportanceRankingModels.cs
+++ b/Application/Ranking/ImportanceRankingModels.cs
@@ -15,6 +15,18 @@ public enum ImportanceFileRole
 	EntryPoint
 }
 
+public enum ImportanceRankingStage
+{
+	IndexingFacts,
+	ReadingHistory,
+	ComputingPriorities
+}
+
+public readonly record struct ImportanceRankingProgress(
+	ImportanceRankingStage Stage,
+	int Completed,
+	int Total);
+
 public sealed record ImportanceRankingEntry(
 	string FullPath,
 	string Path,
@@ -97,4 +109,11 @@ public interface IImportanceRankingService
 		string sourceRoot,
 		IReadOnlyList<string> candidateFiles,
 		CancellationToken cancellationToken = default);
+
+	Task<ImportanceRankingReport> RankAsync(
+		string sourceRoot,
+		IReadOnlyList<string> candidateFiles,
+		IProgress<ImportanceRankingProgress>? progress,
+		CancellationToken cancellationToken = default) =>
+		RankAsync(sourceRoot, candidateFiles, cancellationToken);
 }

--- a/Application/Ranking/ImportanceRankingModels.cs
+++ b/Application/Ranking/ImportanceRankingModels.cs
@@ -51,6 +51,10 @@ public sealed record ImportanceRankingReport(
 
 	public int FilesWithResolvedEdges { get; init; }
 
+	public bool GitHistoryIsShallow { get; init; }
+
+	public bool GitHistoryIsComplete { get; init; } = true;
+
 	internal IReadOnlyDictionary<string, RankingSourceVersion> SourceVersions { get; init; } =
 		new Dictionary<string, RankingSourceVersion>(StringComparer.Ordinal);
 }

--- a/Application/Ranking/ImportanceRankingModels.cs
+++ b/Application/Ranking/ImportanceRankingModels.cs
@@ -15,6 +15,21 @@ public enum ImportanceFileRole
 	EntryPoint
 }
 
+public enum ImportanceMissingSignalPolicy
+{
+	Redistribute,
+	NeutralFill,
+	ConfidenceLimited
+}
+
+public enum ImportanceRankingSignal
+{
+	None,
+	Graph,
+	Git,
+	Role
+}
+
 public enum ImportanceRankingStage
 {
 	IndexingFacts,
@@ -39,7 +54,16 @@ public sealed record ImportanceRankingEntry(
 	ImportanceFileRole Role,
 	bool HasGraphFacts,
 	bool HasGitHistory,
-	ProjectGitHistoryUnavailableReason? GitUnavailableReason = null);
+	ProjectGitHistoryUnavailableReason? GitUnavailableReason = null)
+{
+	public double Confidence { get; init; } = 1;
+
+	public ImportanceRankingSignal MainContribution { get; init; }
+
+	public bool ConfidenceLimited { get; init; }
+
+	public bool IsCoordinator { get; init; }
+}
 
 public sealed record ImportanceRankingReport(
 	string Algorithm,
@@ -66,6 +90,11 @@ public sealed record ImportanceRankingReport(
 	public bool GitHistoryIsShallow { get; init; }
 
 	public bool GitHistoryIsComplete { get; init; } = true;
+
+	public bool HasMissingSignals { get; init; }
+
+	public ImportanceMissingSignalPolicy MissingSignalPolicy { get; init; } =
+		ImportanceMissingSignalPolicy.ConfidenceLimited;
 
 	internal IReadOnlyDictionary<string, RankingSourceVersion> SourceVersions { get; init; } =
 		new Dictionary<string, RankingSourceVersion>(StringComparer.Ordinal);

--- a/Application/Ranking/ImportanceRankingModels.cs
+++ b/Application/Ranking/ImportanceRankingModels.cs
@@ -41,6 +41,14 @@ public sealed record ImportanceRankingReport(
 	bool RedistributedMissingSignals,
 	string GraphVariant)
 {
+	public int ResolvedInternalReferences { get; init; }
+
+	public int InternalReferenceCandidates { get; init; }
+
+	public double ResolvedInternalReferenceCoverage { get; init; }
+
+	public int FilesWithResolvedEdges { get; init; }
+
 	internal IReadOnlyDictionary<string, RankingSourceVersion> SourceVersions { get; init; } =
 		new Dictionary<string, RankingSourceVersion>(StringComparer.Ordinal);
 }

--- a/Application/Ranking/ImportanceRankingModels.cs
+++ b/Application/Ranking/ImportanceRankingModels.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace DevProjex.Application.Ranking;
 
 public enum ProjectContextRank
@@ -53,16 +55,27 @@ public sealed record ImportanceRankingReport(
 		new Dictionary<string, RankingSourceVersion>(StringComparer.Ordinal);
 }
 
-internal readonly record struct RankingSourceVersion(bool Exists, long Length, long LastWriteTimeUtcTicks)
+internal readonly record struct RankingSourceVersion(
+	bool Exists,
+	long Length,
+	long LastWriteTimeUtcTicks,
+	string? ContentHash)
 {
 	internal static RankingSourceVersion Capture(string path)
 	{
 		try
 		{
 			var file = new FileInfo(path);
-			return file.Exists
-				? new RankingSourceVersion(true, file.Length, file.LastWriteTimeUtc.Ticks)
-				: default;
+			if (!file.Exists)
+				return default;
+			using var stream = new FileStream(
+				path,
+				FileMode.Open,
+				FileAccess.Read,
+				FileShare.ReadWrite | FileShare.Delete);
+			var hash = Convert.ToHexString(SHA256.HashData(stream));
+			file.Refresh();
+			return new RankingSourceVersion(true, file.Length, file.LastWriteTimeUtc.Ticks, hash);
 		}
 		catch (Exception exception) when (
 			exception is IOException or UnauthorizedAccessException or System.Security.SecurityException)

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -176,11 +176,11 @@ public sealed class ImportanceRankingService(
 	{
 		for (var attempt = 0; attempt < 2; attempt++)
 		{
-			var before = CaptureVersions(candidatePaths);
+			var before = CaptureVersions(candidatePaths, cancellationToken);
 			var snapshot = await dependencyFactsEngine
 				.IndexAsync(root, candidatePaths, progress: null, cancellationToken)
 				.ConfigureAwait(false);
-			var after = CaptureVersions(candidatePaths);
+			var after = CaptureVersions(candidatePaths, cancellationToken);
 			if (VersionsEqual(before, after))
 				return (snapshot, after);
 		}
@@ -189,11 +189,17 @@ public sealed class ImportanceRankingService(
 	}
 
 	private static IReadOnlyDictionary<string, RankingSourceVersion> CaptureVersions(
-		IReadOnlyList<string> paths) =>
-		paths.ToDictionary(
-			Path.GetFullPath,
-			RankingSourceVersion.Capture,
-			PathComparer.Default);
+		IReadOnlyList<string> paths,
+		CancellationToken cancellationToken)
+	{
+		var versions = new Dictionary<string, RankingSourceVersion>(paths.Count, PathComparer.Default);
+		foreach (var path in paths)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			versions[Path.GetFullPath(path)] = RankingSourceVersion.Capture(path);
+		}
+		return versions;
+	}
 
 	private static bool VersionsEqual(
 		IReadOnlyDictionary<string, RankingSourceVersion> left,

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -11,6 +11,9 @@ public sealed class ImportanceRankingService(
 	public const double GraphWeight = 0.85;
 	public const double GitWeight = 0.10;
 	public const double RoleWeight = 0.05;
+	public const double PageRankAbsoluteQuantum = 1e-12;
+	public const ImportanceMissingSignalPolicy MissingSignalPolicy =
+		ImportanceMissingSignalPolicy.ConfidenceLimited;
 	private const int MaximumTopEntries = 10;
 	private const int PageRankIterations = 30;
 	private static readonly HashSet<string> TestFrameworks = new(StringComparer.OrdinalIgnoreCase)
@@ -76,6 +79,7 @@ public sealed class ImportanceRankingService(
 		var dependents = new Dictionary<string, int>(candidates.Length, StringComparer.Ordinal);
 		var dependencies = new Dictionary<string, int>(candidates.Length, StringComparer.Ordinal);
 		var roles = new Dictionary<string, ImportanceFileRole>(candidates.Length, StringComparer.Ordinal);
+		var coordinators = new Dictionary<string, bool>(candidates.Length, StringComparer.Ordinal);
 		foreach (var candidate in candidates)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -84,7 +88,7 @@ public sealed class ImportanceRankingService(
 			{
 				dependents[candidate.RelativePath] = graph.Dependents[node];
 				dependencies[candidate.RelativePath] = graph.Outgoing[node].Length;
-				graphRaw[candidate.RelativePath] = pageRank[node];
+				graphRaw[candidate.RelativePath] = QuantizePageRank(pageRank[node]);
 			}
 			else
 			{
@@ -95,6 +99,10 @@ public sealed class ImportanceRankingService(
 			roles[candidate.RelativePath] = ClassifyRole(
 				candidate.RelativePath,
 				facts,
+				dependents[candidate.RelativePath],
+				dependencies[candidate.RelativePath]);
+			coordinators[candidate.RelativePath] = IsCoordinatorCandidate(
+				roles[candidate.RelativePath],
 				dependents[candidate.RelativePath],
 				dependencies[candidate.RelativePath]);
 		}
@@ -108,7 +116,9 @@ public sealed class ImportanceRankingService(
 			gitRaw[candidate.RelativePath] = history.Files.TryGetValue(candidate.FullPath, out var activity)
 				? activity.CommitCount + Recency(activity, history.WindowSize)
 				: null;
-			roleRaw[candidate.RelativePath] = RoleValue(roles[candidate.RelativePath]);
+			roleRaw[candidate.RelativePath] = RoleValue(
+				roles[candidate.RelativePath],
+				coordinators[candidate.RelativePath]);
 		}
 		var gitNormalized = RankNormalize(gitRaw, cancellationToken);
 		var roleNormalized = RankNormalize(roleRaw, cancellationToken);
@@ -119,7 +129,10 @@ public sealed class ImportanceRankingService(
 		var resolvedInternalReferenceCoverage = internalReferenceCandidates == 0
 			? 0
 			: Math.Clamp((double)resolvedInternalReferences / internalReferenceCandidates, 0, 1);
-		var redistributed = coverage < 1 || gitRaw.Values.Any(static value => value is null);
+		var hasMissingSignals = coverage < 1 || gitRaw.Values.Any(static value => value is null);
+		var gitConfidence = history.IsShallow && !history.IsComplete
+			? Math.Clamp((double)history.CommitCount / history.WindowSize, 0, 1)
+			: 1;
 
 		var scored = new List<ScoredCandidate>(candidates.Length);
 		var scoreProgressStep = Math.Max(1, candidates.Length / 25);
@@ -127,11 +140,13 @@ public sealed class ImportanceRankingService(
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			var candidate = candidates[index];
-			var score = CalculateScore(
+			var score = CalculateScoreBreakdown(
 				graphNormalized[candidate.RelativePath],
 				gitNormalized[candidate.RelativePath],
 				roleNormalized[candidate.RelativePath] ?? 0.5,
-				coverage);
+				coverage,
+				MissingSignalPolicy,
+				gitConfidence);
 			scored.Add(new ScoredCandidate(candidate, score));
 			if ((index + 1) % scoreProgressStep == 0 || index + 1 == candidates.Length)
 			{
@@ -144,7 +159,7 @@ public sealed class ImportanceRankingService(
 		}
 
 		var ordered = scored
-			.OrderByDescending(static candidate => candidate.Score)
+			.OrderByDescending(static candidate => candidate.Score.Score)
 			.ThenBy(static candidate => candidate.Candidate.RelativePath, StringComparer.Ordinal)
 			.Select((candidate, index) =>
 			{
@@ -160,7 +175,7 @@ public sealed class ImportanceRankingService(
 					candidate.Candidate.FullPath,
 					path,
 					index + 1,
-					candidate.Score,
+					candidate.Score.Score,
 					dependents[path],
 					dependencies[path],
 					hasHistory ? activity!.CommitCount : null,
@@ -168,7 +183,14 @@ public sealed class ImportanceRankingService(
 					roles[path],
 					graphRaw[path] is not null,
 					hasHistory,
-					historyReason);
+					historyReason)
+				{
+					Confidence = candidate.Score.Confidence,
+					MainContribution = candidate.Score.MainContribution,
+					ConfidenceLimited = MissingSignalPolicy == ImportanceMissingSignalPolicy.ConfidenceLimited &&
+						candidate.Score.Confidence < 1,
+					IsCoordinator = coordinators[path]
+				};
 			})
 			.ToArray();
 		Report(progress, ImportanceRankingStage.ComputingPriorities, computationUnits, computationUnits);
@@ -184,7 +206,7 @@ public sealed class ImportanceRankingService(
 			history.WindowSize,
 			history.CommitCount,
 			history.UnavailableReason,
-			redistributed,
+			MissingSignalPolicy == ImportanceMissingSignalPolicy.Redistribute && hasMissingSignals,
 			GraphVariant)
 		{
 			ResolvedInternalReferences = resolvedInternalReferences,
@@ -193,6 +215,8 @@ public sealed class ImportanceRankingService(
 			FilesWithResolvedEdges = graph.FilesWithEdges,
 			GitHistoryIsShallow = history.IsShallow,
 			GitHistoryIsComplete = history.IsComplete,
+			HasMissingSignals = hasMissingSignals,
+			MissingSignalPolicy = MissingSignalPolicy,
 			SourceVersions = sourceVersions
 		};
 	}
@@ -276,23 +300,53 @@ public sealed class ImportanceRankingService(
 	}
 
 	internal static double CalculateScore(double? graph, double? git, double role, double graphCoverage)
+		=> CalculateScoreBreakdown(
+			graph,
+			git,
+			role,
+			graphCoverage,
+			MissingSignalPolicy,
+			gitConfidence: 1).Score;
+
+	internal static ImportanceScoreBreakdown CalculateScoreBreakdown(
+		double? graph,
+		double? git,
+		double role,
+		double graphCoverage,
+		ImportanceMissingSignalPolicy policy,
+		double gitConfidence = 1)
 	{
 		var coverage = Math.Clamp(graphCoverage, 0, 1);
 		var effectiveGraphWeight = GraphWeight * coverage;
-		var graphDeficit = GraphWeight - effectiveGraphWeight;
-		var nonGraphWeight = GitWeight + RoleWeight;
-		var effectiveGitWeight = GitWeight + graphDeficit * GitWeight / nonGraphWeight;
-		var effectiveRoleWeight = RoleWeight + graphDeficit * RoleWeight / nonGraphWeight;
-		var signals = new List<(double Value, double Weight)>(3);
-		if (graph is { } graphValue)
-			signals.Add((graphValue, effectiveGraphWeight));
-		if (git is { } gitValue)
-			signals.Add((gitValue, effectiveGitWeight));
-		signals.Add((role, effectiveRoleWeight));
-		var availableWeight = signals.Sum(static signal => signal.Weight);
-		return availableWeight <= 0
-			? 0
-			: signals.Sum(static signal => signal.Value * signal.Weight) / availableWeight;
+		var effectiveGitWeight = GitWeight * Math.Clamp(gitConfidence, 0, 1);
+		var graphContribution = graph.GetValueOrDefault() * (graph is null ? 0 : effectiveGraphWeight);
+		var gitContribution = git.GetValueOrDefault() * (git is null ? 0 : effectiveGitWeight);
+		var roleContribution = role * RoleWeight;
+		var availableWeight = (graph is null ? 0 : effectiveGraphWeight) +
+		                      (git is null ? 0 : effectiveGitWeight) + RoleWeight;
+		var knownContribution = graphContribution + gitContribution + roleContribution;
+		var score = policy switch
+		{
+			ImportanceMissingSignalPolicy.Redistribute => availableWeight <= 0
+				? 0
+				: knownContribution / availableWeight,
+			ImportanceMissingSignalPolicy.NeutralFill =>
+				knownContribution + (1 - availableWeight) * 0.5,
+			ImportanceMissingSignalPolicy.ConfidenceLimited => knownContribution,
+			_ => throw new ArgumentOutOfRangeException(nameof(policy), policy, null)
+		};
+		var mainContribution = graphContribution >= gitContribution && graphContribution >= roleContribution
+			? ImportanceRankingSignal.Graph
+			: gitContribution >= roleContribution
+				? ImportanceRankingSignal.Git
+				: ImportanceRankingSignal.Role;
+		return new ImportanceScoreBreakdown(
+			score,
+			Math.Clamp(availableWeight, 0, 1),
+			graphContribution,
+			gitContribution,
+			roleContribution,
+			mainContribution);
 	}
 
 	internal static ImportanceFileRole ClassifyRole(
@@ -305,10 +359,16 @@ public sealed class ImportanceRankingService(
 			return ImportanceFileRole.Manifest;
 		if (HasTestFrameworkEvidence(facts) || HasTestPathEvidence(path) && facts?.Status == DependencyFileStatus.Supported)
 			return ImportanceFileRole.TestSource;
-		if (dependents == 0 && dependencies >= 3)
+		if (HasExplicitEntryPointEvidence(facts))
 			return ImportanceFileRole.EntryPoint;
 		return ImportanceFileRole.Source;
 	}
+
+	internal static bool IsCoordinatorCandidate(
+		ImportanceFileRole role,
+		int dependents,
+		int dependencies) =>
+		role == ImportanceFileRole.Source && dependents == 0 && dependencies >= 3;
 
 	internal static IReadOnlyDictionary<string, double> CalculatePageRank(
 		IReadOnlyList<(string FullPath, string RelativePath)> candidates,
@@ -324,7 +384,7 @@ public sealed class ImportanceRankingService(
 		var ranks = CalculatePageRank(graph, cancellationToken, iterationCompleted);
 		var result = new Dictionary<string, double>(graph.Paths.Length, StringComparer.Ordinal);
 		for (var node = 0; node < graph.Paths.Length; node++)
-			result[graph.Paths[node]] = ranks[node];
+			result[graph.Paths[node]] = QuantizePageRank(ranks[node]);
 		return result;
 	}
 
@@ -441,6 +501,19 @@ public sealed class ImportanceRankingService(
 		       facts.ContextNamespaces.Any(context => TestFrameworks.Contains(NormalizeFramework(context)));
 	}
 
+	private static bool HasExplicitEntryPointEvidence(FileFacts? facts) =>
+		facts?.Declarations.Any(static declaration =>
+			declaration.Identity.SymbolKind is SymbolKind.Function or SymbolKind.Module &&
+			IsEntryPointName(declaration.Identity.QualifiedName)) == true;
+
+	private static bool IsEntryPointName(string qualifiedName)
+	{
+		var separator = qualifiedName.LastIndexOfAny(['.', ':', '/', '\\']);
+		var name = separator >= 0 ? qualifiedName[(separator + 1)..] : qualifiedName;
+		return name.Equals("Main", StringComparison.Ordinal) ||
+		       name.Equals("__main__", StringComparison.Ordinal);
+	}
+
 	private static string NormalizeFramework(string value)
 	{
 		var normalized = value.Trim().TrimStart('@').Replace("::", ".", StringComparison.Ordinal).ToLowerInvariant();
@@ -473,14 +546,18 @@ public sealed class ImportanceRankingService(
 		       name.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
 	}
 
-	private static double RoleValue(ImportanceFileRole role) => role switch
+	private static double RoleValue(ImportanceFileRole role, bool isCoordinator) => role switch
 	{
 		ImportanceFileRole.Manifest => 1,
-		ImportanceFileRole.EntryPoint => 0.75,
+		ImportanceFileRole.EntryPoint => 0.9,
+		ImportanceFileRole.Source when isCoordinator => 0.65,
 		ImportanceFileRole.Source => 0.5,
 		ImportanceFileRole.TestSource => 0,
 		_ => throw new ArgumentOutOfRangeException(nameof(role), role, null)
 	};
+
+	internal static double QuantizePageRank(double value) =>
+		Math.Round(value / PageRankAbsoluteQuantum, MidpointRounding.ToEven) * PageRankAbsoluteQuantum;
 
 	private static double Recency(ProjectGitFileActivity activity, int window) =>
 		activity.MostRecentCommitPosition <= 0 || window <= 1
@@ -503,7 +580,7 @@ public sealed class ImportanceRankingService(
 
 	private const int ProjectGitHistoryReaderWindow = 200;
 	private sealed record Candidate(string FullPath, string RelativePath);
-	private sealed record ScoredCandidate(Candidate Candidate, double Score);
+	private sealed record ScoredCandidate(Candidate Candidate, ImportanceScoreBreakdown Score);
 	private sealed record RankingGraph(
 		string[] Paths,
 		IReadOnlyDictionary<string, int> NodeByPath,
@@ -511,6 +588,14 @@ public sealed class ImportanceRankingService(
 		int[] Dependents,
 		int EdgeCount,
 		int FilesWithEdges);
+
+	internal readonly record struct ImportanceScoreBreakdown(
+		double Score,
+		double Confidence,
+		double GraphContribution,
+		double GitContribution,
+		double RoleContribution,
+		ImportanceRankingSignal MainContribution);
 
 	private sealed class BoundedFactsProgress(
 		IProgress<ImportanceRankingProgress>? progress,

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -81,13 +81,23 @@ public sealed class ImportanceRankingService(
 			static candidate => candidate.RelativePath,
 			candidate => (double?)RoleValue(roles[candidate.RelativePath]),
 			StringComparer.Ordinal));
-		var coverage = candidates.Length == 0
+		var coverage = CalculateExtractedFactsCoverage(dependency.Coverage, candidates.Length);
+		var internalReferenceCandidates = dependency.Edges.Count(static edge =>
+			edge.Status != ResolutionStatus.External);
+		var resolvedInternalReferences = dependency.Edges.Count(edge =>
+			edge.Status == ResolutionStatus.Resolved &&
+			edge.Target is { } target &&
+			!StringComparer.Ordinal.Equals(edge.Source, target));
+		var resolvedInternalReferenceCoverage = internalReferenceCandidates == 0
 			? 0
-			: Math.Clamp(
-				(double)Math.Max(0, dependency.Coverage.Supported - dependency.Coverage.ExtractionFailed) /
-				candidates.Length,
-				0,
-				1);
+			: (double)resolvedInternalReferences / internalReferenceCandidates;
+		var filesWithResolvedEdges = dependency.Edges
+			.Where(static edge => edge.Status == ResolutionStatus.Resolved &&
+				edge.Target is not null &&
+				!StringComparer.Ordinal.Equals(edge.Source, edge.Target))
+			.SelectMany(static edge => new[] { edge.Source, edge.Target! })
+			.Distinct(StringComparer.Ordinal)
+			.Count();
 		var redistributed = coverage < 1 || gitRaw.Values.Any(static value => value is null);
 
 		var scored = new List<ScoredCandidate>(candidates.Length);
@@ -143,9 +153,20 @@ public sealed class ImportanceRankingService(
 			redistributed,
 			GraphVariant)
 		{
+			ResolvedInternalReferences = resolvedInternalReferences,
+			InternalReferenceCandidates = internalReferenceCandidates,
+			ResolvedInternalReferenceCoverage = resolvedInternalReferenceCoverage,
+			FilesWithResolvedEdges = filesWithResolvedEdges,
 			SourceVersions = sourceVersions
 		};
 	}
+
+	internal static double CalculateExtractedFactsCoverage(
+		DependencyFactsCoverage coverage,
+		int candidateCount) =>
+		candidateCount <= 0
+			? 0
+			: Math.Clamp((double)coverage.Supported / candidateCount, 0, 1);
 
 	private async Task<(DependencyIndexSnapshot Snapshot, IReadOnlyDictionary<string, RankingSourceVersion> Versions)>
 		ReadStableDependencySnapshotAsync(

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -12,15 +12,23 @@ public sealed class ImportanceRankingService(
 	public const double GitWeight = 0.10;
 	public const double RoleWeight = 0.05;
 	private const int MaximumTopEntries = 10;
+	private const int PageRankIterations = 30;
 	private static readonly HashSet<string> TestFrameworks = new(StringComparer.OrdinalIgnoreCase)
 	{
 		"xunit", "nunit", "microsoft.visualstudio.testtools.unittesting",
 		"vitest", "jest", "mocha", "pytest", "unittest"
 	};
 
+	public Task<ImportanceRankingReport> RankAsync(
+		string sourceRoot,
+		IReadOnlyList<string> candidateFiles,
+		CancellationToken cancellationToken = default) =>
+		RankAsync(sourceRoot, candidateFiles, progress: null, cancellationToken);
+
 	public async Task<ImportanceRankingReport> RankAsync(
 		string sourceRoot,
 		IReadOnlyList<string> candidateFiles,
+		IProgress<ImportanceRankingProgress>? progress,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(sourceRoot);
@@ -36,79 +44,103 @@ public sealed class ImportanceRankingService(
 			return EmptyReport();
 
 		var candidatePaths = candidates.Select(static candidate => candidate.FullPath).ToArray();
-		var dependencyTask = ReadStableDependencySnapshotAsync(root, candidatePaths, cancellationToken);
-		var historyTask = gitHistoryReader.ReadAsync(
+		Report(progress, ImportanceRankingStage.IndexingFacts, 0, candidates.Length);
+		var factsProgress = new BoundedFactsProgress(progress, candidates.Length);
+		var (dependency, sourceVersions) = await ReadStableDependencySnapshotAsync(
 			root,
 			candidatePaths,
-			cancellationToken);
-		await Task.WhenAll(dependencyTask, historyTask).ConfigureAwait(false);
-		var (dependency, sourceVersions) = await dependencyTask.ConfigureAwait(false);
-		var history = await historyTask.ConfigureAwait(false);
+			factsProgress,
+			cancellationToken).ConfigureAwait(false);
+		Report(progress, ImportanceRankingStage.IndexingFacts, candidates.Length, candidates.Length);
 
+		Report(progress, ImportanceRankingStage.ReadingHistory, 0, 1);
+		var history = await gitHistoryReader.ReadAsync(root, candidatePaths, cancellationToken)
+			.ConfigureAwait(false);
+		Report(progress, ImportanceRankingStage.ReadingHistory, 1, 1);
+
+		const int computationUnits = 100;
+		Report(progress, ImportanceRankingStage.ComputingPriorities, 0, computationUnits);
 		var factsByPath = dependency.Files.ToDictionary(static file => file.Path, StringComparer.Ordinal);
-		var graphRaw = new Dictionary<string, double?>(StringComparer.Ordinal);
-		var dependents = new Dictionary<string, int>(StringComparer.Ordinal);
-		var dependencies = new Dictionary<string, int>(StringComparer.Ordinal);
-		var roles = new Dictionary<string, ImportanceFileRole>(StringComparer.Ordinal);
-		var pageRank = CalculatePageRank(candidates, dependency);
+		var graph = BuildGraph(candidates, dependency, cancellationToken);
+		Report(progress, ImportanceRankingStage.ComputingPriorities, 10, computationUnits);
+		var pageRank = CalculatePageRank(
+			graph,
+			cancellationToken,
+			iteration => Report(
+				progress,
+				ImportanceRankingStage.ComputingPriorities,
+				10 + (iteration + 1) * 50 / PageRankIterations,
+				computationUnits));
+
+		var graphRaw = new Dictionary<string, double?>(candidates.Length, StringComparer.Ordinal);
+		var dependents = new Dictionary<string, int>(candidates.Length, StringComparer.Ordinal);
+		var dependencies = new Dictionary<string, int>(candidates.Length, StringComparer.Ordinal);
+		var roles = new Dictionary<string, ImportanceFileRole>(candidates.Length, StringComparer.Ordinal);
 		foreach (var candidate in candidates)
 		{
+			cancellationToken.ThrowIfCancellationRequested();
 			factsByPath.TryGetValue(candidate.RelativePath, out var facts);
-			var supported = facts?.Status == DependencyFileStatus.Supported;
-			var incoming = supported
-				? UniqueResolvedSources(dependency.EdgesByTarget.GetValueOrDefault(candidate.RelativePath))
-				: 0;
-			var outgoing = supported
-				? UniqueResolvedTargets(dependency.EdgesBySource.GetValueOrDefault(candidate.RelativePath))
-				: 0;
-			dependents[candidate.RelativePath] = incoming;
-			dependencies[candidate.RelativePath] = outgoing;
-			graphRaw[candidate.RelativePath] = supported
-				? pageRank.GetValueOrDefault(candidate.RelativePath)
-				: null;
-			roles[candidate.RelativePath] = ClassifyRole(candidate.RelativePath, facts, incoming, outgoing);
+			if (graph.NodeByPath.TryGetValue(candidate.RelativePath, out var node))
+			{
+				dependents[candidate.RelativePath] = graph.Dependents[node];
+				dependencies[candidate.RelativePath] = graph.Outgoing[node].Length;
+				graphRaw[candidate.RelativePath] = pageRank[node];
+			}
+			else
+			{
+				dependents[candidate.RelativePath] = 0;
+				dependencies[candidate.RelativePath] = 0;
+				graphRaw[candidate.RelativePath] = null;
+			}
+			roles[candidate.RelativePath] = ClassifyRole(
+				candidate.RelativePath,
+				facts,
+				dependents[candidate.RelativePath],
+				dependencies[candidate.RelativePath]);
 		}
 
-		var graphNormalized = RankNormalize(graphRaw);
-		var gitRaw = candidates.ToDictionary(
-			static candidate => candidate.RelativePath,
-			candidate => history.Files.TryGetValue(candidate.FullPath, out var activity)
-				? (double?)(activity.CommitCount + Recency(activity, history.WindowSize))
-				: null,
-			StringComparer.Ordinal);
-		var gitNormalized = RankNormalize(gitRaw);
-		var roleNormalized = RankNormalize(candidates.ToDictionary(
-			static candidate => candidate.RelativePath,
-			candidate => (double?)RoleValue(roles[candidate.RelativePath]),
-			StringComparer.Ordinal));
+		var graphNormalized = RankNormalize(graphRaw, cancellationToken);
+		var gitRaw = new Dictionary<string, double?>(candidates.Length, StringComparer.Ordinal);
+		var roleRaw = new Dictionary<string, double?>(candidates.Length, StringComparer.Ordinal);
+		foreach (var candidate in candidates)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			gitRaw[candidate.RelativePath] = history.Files.TryGetValue(candidate.FullPath, out var activity)
+				? activity.CommitCount + Recency(activity, history.WindowSize)
+				: null;
+			roleRaw[candidate.RelativePath] = RoleValue(roles[candidate.RelativePath]);
+		}
+		var gitNormalized = RankNormalize(gitRaw, cancellationToken);
+		var roleNormalized = RankNormalize(roleRaw, cancellationToken);
 		var coverage = CalculateExtractedFactsCoverage(dependency.Coverage, candidates.Length);
 		var internalReferenceCandidates = dependency.Edges.Count(static edge =>
 			edge.Status != ResolutionStatus.External);
-		var resolvedInternalReferences = dependency.Edges.Count(edge =>
-			edge.Status == ResolutionStatus.Resolved &&
-			edge.Target is { } target &&
-			!StringComparer.Ordinal.Equals(edge.Source, target));
+		var resolvedInternalReferences = graph.EdgeCount;
 		var resolvedInternalReferenceCoverage = internalReferenceCandidates == 0
 			? 0
-			: (double)resolvedInternalReferences / internalReferenceCandidates;
-		var filesWithResolvedEdges = dependency.Edges
-			.Where(static edge => edge.Status == ResolutionStatus.Resolved &&
-				edge.Target is not null &&
-				!StringComparer.Ordinal.Equals(edge.Source, edge.Target))
-			.SelectMany(static edge => new[] { edge.Source, edge.Target! })
-			.Distinct(StringComparer.Ordinal)
-			.Count();
+			: Math.Clamp((double)resolvedInternalReferences / internalReferenceCandidates, 0, 1);
 		var redistributed = coverage < 1 || gitRaw.Values.Any(static value => value is null);
 
 		var scored = new List<ScoredCandidate>(candidates.Length);
-		foreach (var candidate in candidates)
+		var scoreProgressStep = Math.Max(1, candidates.Length / 25);
+		for (var index = 0; index < candidates.Length; index++)
 		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var candidate = candidates[index];
 			var score = CalculateScore(
 				graphNormalized[candidate.RelativePath],
 				gitNormalized[candidate.RelativePath],
 				roleNormalized[candidate.RelativePath] ?? 0.5,
 				coverage);
 			scored.Add(new ScoredCandidate(candidate, score));
+			if ((index + 1) % scoreProgressStep == 0 || index + 1 == candidates.Length)
+			{
+				Report(
+					progress,
+					ImportanceRankingStage.ComputingPriorities,
+					70 + (index + 1) * 29 / candidates.Length,
+					computationUnits);
+			}
 		}
 
 		var ordered = scored
@@ -116,6 +148,7 @@ public sealed class ImportanceRankingService(
 			.ThenBy(static candidate => candidate.Candidate.RelativePath, StringComparer.Ordinal)
 			.Select((candidate, index) =>
 			{
+				cancellationToken.ThrowIfCancellationRequested();
 				var path = candidate.Candidate.RelativePath;
 				var hasHistory = history.Files.TryGetValue(candidate.Candidate.FullPath, out var activity);
 				var historyReason = hasHistory
@@ -138,6 +171,7 @@ public sealed class ImportanceRankingService(
 					historyReason);
 			})
 			.ToArray();
+		Report(progress, ImportanceRankingStage.ComputingPriorities, computationUnits, computationUnits);
 
 		return new ImportanceRankingReport(
 			AlgorithmId,
@@ -156,7 +190,7 @@ public sealed class ImportanceRankingService(
 			ResolvedInternalReferences = resolvedInternalReferences,
 			InternalReferenceCandidates = internalReferenceCandidates,
 			ResolvedInternalReferenceCoverage = resolvedInternalReferenceCoverage,
-			FilesWithResolvedEdges = filesWithResolvedEdges,
+			FilesWithResolvedEdges = graph.FilesWithEdges,
 			GitHistoryIsShallow = history.IsShallow,
 			GitHistoryIsComplete = history.IsComplete,
 			SourceVersions = sourceVersions
@@ -174,13 +208,14 @@ public sealed class ImportanceRankingService(
 		ReadStableDependencySnapshotAsync(
 			string root,
 			IReadOnlyList<string> candidatePaths,
+			IProgress<DependencyIndexProgress>? progress,
 			CancellationToken cancellationToken)
 	{
 		for (var attempt = 0; attempt < 2; attempt++)
 		{
 			var before = CaptureVersions(candidatePaths, cancellationToken);
 			var snapshot = await dependencyFactsEngine
-				.IndexAsync(root, candidatePaths, progress: null, cancellationToken)
+				.IndexAsync(root, candidatePaths, progress, cancellationToken)
 				.ConfigureAwait(false);
 			var after = CaptureVersions(candidatePaths, cancellationToken);
 			if (VersionsEqual(before, after))
@@ -210,7 +245,8 @@ public sealed class ImportanceRankingService(
 			right.TryGetValue(pair.Key, out var version) && version == pair.Value);
 
 	internal static IReadOnlyDictionary<string, double?> RankNormalize(
-		IReadOnlyDictionary<string, double?> values)
+		IReadOnlyDictionary<string, double?> values,
+		CancellationToken cancellationToken = default)
 	{
 		var present = values
 			.Where(static pair => pair.Value is not null)
@@ -223,11 +259,15 @@ public sealed class ImportanceRankingService(
 		if (present.Length == 1)
 		{
 			foreach (var pair in present[0])
+			{
+				cancellationToken.ThrowIfCancellationRequested();
 				result[pair.Key] = 0.5;
+			}
 			return result;
 		}
 		for (var index = 0; index < present.Length; index++)
 		{
+			cancellationToken.ThrowIfCancellationRequested();
 			var normalized = (double)index / (present.Length - 1);
 			foreach (var pair in present[index])
 				result[pair.Key] = normalized;
@@ -272,15 +312,27 @@ public sealed class ImportanceRankingService(
 
 	internal static IReadOnlyDictionary<string, double> CalculatePageRank(
 		IReadOnlyList<(string FullPath, string RelativePath)> candidates,
-		DependencyIndexSnapshot snapshot) =>
-		CalculatePageRank(candidates.Select(static candidate => new Candidate(candidate.FullPath, candidate.RelativePath)).ToArray(), snapshot);
-
-	private static IReadOnlyDictionary<string, double> CalculatePageRank(
-		IReadOnlyList<Candidate> candidates,
-		DependencyIndexSnapshot snapshot)
+		DependencyIndexSnapshot snapshot,
+		CancellationToken cancellationToken = default,
+		Action<int>? iterationCompleted = null)
 	{
-		const double damping = 0.85;
-		const int iterations = 30;
+		var candidateRecords = candidates
+			.Select(static candidate => new Candidate(candidate.FullPath, candidate.RelativePath))
+			.OrderBy(static candidate => candidate.RelativePath, StringComparer.Ordinal)
+			.ToArray();
+		var graph = BuildGraph(candidateRecords, snapshot, cancellationToken);
+		var ranks = CalculatePageRank(graph, cancellationToken, iterationCompleted);
+		var result = new Dictionary<string, double>(graph.Paths.Length, StringComparer.Ordinal);
+		for (var node = 0; node < graph.Paths.Length; node++)
+			result[graph.Paths[node]] = ranks[node];
+		return result;
+	}
+
+	private static RankingGraph BuildGraph(
+		IReadOnlyList<Candidate> candidates,
+		DependencyIndexSnapshot snapshot,
+		CancellationToken cancellationToken)
+	{
 		var supportedPaths = snapshot.Files
 			.Where(static file => file.Status == DependencyFileStatus.Supported)
 			.Select(static file => file.Path)
@@ -291,54 +343,95 @@ public sealed class ImportanceRankingService(
 			.Distinct(StringComparer.Ordinal)
 			.Order(StringComparer.Ordinal)
 			.ToArray();
-		var pathSet = paths.ToHashSet(StringComparer.Ordinal);
-		var outgoingSets = paths.ToDictionary(static path => path, static _ => new HashSet<string>(StringComparer.Ordinal), StringComparer.Ordinal);
+		var nodeByPath = new Dictionary<string, int>(paths.Length, StringComparer.Ordinal);
+		for (var node = 0; node < paths.Length; node++)
+			nodeByPath.Add(paths[node], node);
+		var outgoingSets = new HashSet<int>[paths.Length];
+		for (var node = 0; node < outgoingSets.Length; node++)
+			outgoingSets[node] = [];
 		foreach (var edge in snapshot.Edges)
 		{
-			if (edge.Status == ResolutionStatus.Resolved &&
-			    edge.Target is { } target &&
-			    edge.Source != target &&
-			    pathSet.Contains(edge.Source) &&
-			    pathSet.Contains(target))
+			cancellationToken.ThrowIfCancellationRequested();
+			if (edge.Status != ResolutionStatus.Resolved ||
+				edge.Target is not { } target ||
+				!nodeByPath.TryGetValue(edge.Source, out var sourceNode) ||
+				!nodeByPath.TryGetValue(target, out var targetNode) ||
+				sourceNode == targetNode)
 			{
-				outgoingSets[edge.Source].Add(target);
+				continue;
+			}
+			outgoingSets[sourceNode].Add(targetNode);
+		}
+
+		var outgoing = new int[paths.Length][];
+		var dependents = new int[paths.Length];
+		var filesWithEdges = new bool[paths.Length];
+		var edgeCount = 0;
+		for (var source = 0; source < paths.Length; source++)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			outgoing[source] = outgoingSets[source].Order().ToArray();
+			edgeCount += outgoing[source].Length;
+			if (outgoing[source].Length > 0)
+				filesWithEdges[source] = true;
+			foreach (var target in outgoing[source])
+			{
+				dependents[target]++;
+				filesWithEdges[target] = true;
 			}
 		}
-		var outgoing = outgoingSets.ToDictionary(
-			static pair => pair.Key,
-			static pair => pair.Value.Order(StringComparer.Ordinal).ToArray(),
-			StringComparer.Ordinal);
-		var count = paths.Length;
+		return new RankingGraph(
+			paths,
+			nodeByPath,
+			outgoing,
+			dependents,
+			edgeCount,
+			filesWithEdges.Count(static value => value));
+	}
+
+	private static double[] CalculatePageRank(
+		RankingGraph graph,
+		CancellationToken cancellationToken,
+		Action<int>? iterationCompleted = null)
+	{
+		const double damping = 0.85;
+		var count = graph.Paths.Length;
 		if (count == 0)
-			return new Dictionary<string, double>(StringComparer.Ordinal);
-		var rank = paths.ToDictionary(static path => path, _ => 1d / count, StringComparer.Ordinal);
-		for (var iteration = 0; iteration < iterations; iteration++)
+			return [];
+		var rank = new double[count];
+		var next = new double[count];
+		Array.Fill(rank, 1d / count);
+		for (var iteration = 0; iteration < PageRankIterations; iteration++)
 		{
-			var next = paths.ToDictionary(static path => path, _ => (1 - damping) / count, StringComparer.Ordinal);
-			var dangling = paths.Where(path => outgoing[path].Length == 0).Sum(path => rank[path]);
-			foreach (var path in paths)
-				next[path] += damping * dangling / count;
-			foreach (var source in paths)
+			cancellationToken.ThrowIfCancellationRequested();
+			Array.Fill(next, (1 - damping) / count);
+			var dangling = 0d;
+			for (var source = 0; source < count; source++)
 			{
-				var targets = outgoing[source];
+				if ((source & 255) == 0)
+					cancellationToken.ThrowIfCancellationRequested();
+				if (graph.Outgoing[source].Length == 0)
+					dangling += rank[source];
+			}
+			var danglingShare = damping * dangling / count;
+			for (var node = 0; node < count; node++)
+				next[node] += danglingShare;
+			for (var source = 0; source < count; source++)
+			{
+				if ((source & 255) == 0)
+					cancellationToken.ThrowIfCancellationRequested();
+				var targets = graph.Outgoing[source];
 				if (targets.Length == 0)
 					continue;
 				var share = damping * rank[source] / targets.Length;
 				foreach (var target in targets)
 					next[target] += share;
 			}
-			rank = next;
+			(rank, next) = (next, rank);
+			iterationCompleted?.Invoke(iteration);
 		}
 		return rank;
 	}
-
-	private static int UniqueResolvedSources(IReadOnlyList<DependencyEdge>? edges) =>
-		edges?.Where(static edge => edge.Status == ResolutionStatus.Resolved && edge.Target is not null && edge.Source != edge.Target)
-			.Select(static edge => edge.Source).Distinct(StringComparer.Ordinal).Count() ?? 0;
-
-	private static int UniqueResolvedTargets(IReadOnlyList<DependencyEdge>? edges) =>
-		edges?.Where(static edge => edge.Status == ResolutionStatus.Resolved && edge.Target is not null && edge.Source != edge.Target)
-			.Select(static edge => edge.Target!).Distinct(StringComparer.Ordinal).Count() ?? 0;
 
 	private static bool HasTestFrameworkEvidence(FileFacts? facts)
 	{
@@ -401,7 +494,42 @@ public sealed class ImportanceRankingService(
 		new(AlgorithmId, [], [], 0, 0, 0, 0, ProjectGitHistoryReaderWindow, 0,
 			ProjectGitHistoryUnavailableReason.NotRepository, false, GraphVariant);
 
+	private static void Report(
+		IProgress<ImportanceRankingProgress>? progress,
+		ImportanceRankingStage stage,
+		int completed,
+		int total) =>
+		progress?.Report(new ImportanceRankingProgress(stage, Math.Clamp(completed, 0, total), total));
+
 	private const int ProjectGitHistoryReaderWindow = 200;
 	private sealed record Candidate(string FullPath, string RelativePath);
 	private sealed record ScoredCandidate(Candidate Candidate, double Score);
+	private sealed record RankingGraph(
+		string[] Paths,
+		IReadOnlyDictionary<string, int> NodeByPath,
+		int[][] Outgoing,
+		int[] Dependents,
+		int EdgeCount,
+		int FilesWithEdges);
+
+	private sealed class BoundedFactsProgress(
+		IProgress<ImportanceRankingProgress>? progress,
+		int candidateCount) : IProgress<DependencyIndexProgress>
+	{
+		private readonly int _step = Math.Max(1, candidateCount / 100);
+		private int _lastReported;
+
+		public void Report(DependencyIndexProgress value)
+		{
+			var completed = Math.Clamp(value.CompletedFiles, 0, value.TotalFiles);
+			if (completed != value.TotalFiles && completed - _lastReported < _step)
+				return;
+			_lastReported = completed;
+			ImportanceRankingService.Report(
+				progress,
+				ImportanceRankingStage.IndexingFacts,
+				completed,
+				Math.Max(1, value.TotalFiles));
+		}
+	}
 }

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -157,6 +157,8 @@ public sealed class ImportanceRankingService(
 			InternalReferenceCandidates = internalReferenceCandidates,
 			ResolvedInternalReferenceCoverage = resolvedInternalReferenceCoverage,
 			FilesWithResolvedEdges = filesWithResolvedEdges,
+			GitHistoryIsShallow = history.IsShallow,
+			GitHistoryIsComplete = history.IsComplete,
 			SourceVersions = sourceVersions
 		};
 	}

--- a/Application/Ranking/ProjectGitHistory.cs
+++ b/Application/Ranking/ProjectGitHistory.cs
@@ -23,6 +23,10 @@ public sealed record ProjectGitHistorySnapshot(
 	string? Detail = null)
 {
 	public bool IsAvailable => UnavailableReason == ProjectGitHistoryUnavailableReason.None;
+
+	public bool IsShallow { get; init; }
+
+	public bool IsComplete { get; init; } = true;
 }
 
 public interface IProjectGitHistoryReader

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -341,28 +341,46 @@ internal sealed class DevProjexMcpTools(
 				: await new ImportanceRankingService(
 						Projects.DependencyFactsEngine,
 						new ProjectGitHistoryReader())
-					.RankAsync(plan.SourceRoot, plan.IncludedFiles, cancellationToken)
+					.RankAsync(
+						plan.SourceRoot,
+						plan.IncludedFiles,
+						new Progress<ImportanceRankingProgress>(value =>
+						{
+							var total = Math.Max(1, value.Total);
+							var fraction = Math.Clamp((double)value.Completed / total, 0, 1);
+							var (start, end, label) = value.Stage switch
+							{
+								ImportanceRankingStage.IndexingFacts => (11d, 20d, "indexing ranking facts"),
+								ImportanceRankingStage.ReadingHistory => (21d, 23d, "reading ranking history"),
+								ImportanceRankingStage.ComputingPriorities => (24d, 29d, "computing priorities"),
+								_ => throw new ArgumentOutOfRangeException()
+							};
+							operationProgress.Milestone(
+								start + fraction * (end - start),
+								$"{label} {value.Completed}/{value.Total}");
+						}),
+						cancellationToken)
 					.ConfigureAwait(false);
 			var transformedFileCount = view == ProjectContextView.Tree ? 0 : plan.IncludedFiles.Count;
-			operationProgress.Milestone(11, $"transforming content 0/{transformedFileCount}");
+			operationProgress.Milestone(30, $"transforming content 0/{transformedFileCount}");
 			await using var prepared = view == ProjectContextView.Tree
 				? null
 				: await Projects.PrepareAsync(
 						plan,
 						McpDetailLevel.Full,
-						operationProgress.Measure("transforming content", 12, 59),
+						operationProgress.Measure("transforming content", 31, 64),
 						cancellationToken)
 					.ConfigureAwait(false);
 			operationProgress.Milestone(
-				60,
+				65,
 				$"transforming content {transformedFileCount}/{transformedFileCount}");
 			var writtenFileCount = view == ProjectContextView.Tree ? 0 : plan.IncludedFiles.Count;
-			operationProgress.Milestone(61, $"writing pack 0/{writtenFileCount}");
+			operationProgress.Milestone(66, $"writing pack 0/{writtenFileCount}");
 			ProjectContextWriteResult? writeResult = null;
 			var pack = await packs.CreateAsync(
 				async (stream, token) =>
 				{
-					var writeProgress = operationProgress.Measure("writing pack", 62, 99);
+					var writeProgress = operationProgress.Measure("writing pack", 67, 99);
 					if (prepared is null)
 					{
 						writeResult = await Projects.DocumentService.WriteCompleteWithReportAsync(
@@ -1218,31 +1236,54 @@ internal sealed class DevProjexMcpTools(
 	{
 		if (report is null)
 			return null;
-		var output = new StringBuilder(1_024);
-		output.Append("[Ranking] ")
+		var status = new StringBuilder(512);
+		status.Append("[Ranking] ")
 			.Append(report.Algorithm)
 			.Append(" · graph ")
 			.Append(report.GraphVariant)
-			.Append(' ')
+			.Append(" · facts ")
 			.Append(Math.Round(report.GraphCoverage * 100, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture))
 			.Append("% of ")
 			.Append(report.CandidateCount.ToString(CultureInfo.InvariantCulture))
 			.Append(" sources · git window ")
 			.Append(report.GitWindow.ToString(CultureInfo.InvariantCulture))
 			.Append(" commits · tests deprioritized");
-		if (report.GitUnavailableReason != ProjectGitHistoryUnavailableReason.None)
+		status.Append("\n[Ranking coverage] facts ")
+			.Append(Math.Round(report.GraphCoverage * 100, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture))
+			.Append("% · resolved internal references ")
+			.Append(report.ResolvedInternalReferences.ToString(CultureInfo.InvariantCulture))
+			.Append('/')
+			.Append(report.InternalReferenceCandidates.ToString(CultureInfo.InvariantCulture))
+			.Append(" (")
+			.Append(Math.Round(report.ResolvedInternalReferenceCoverage * 100, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture))
+			.Append("%) · files with resolved edges ")
+			.Append(report.FilesWithResolvedEdges.ToString(CultureInfo.InvariantCulture));
+		if (report.HasMissingSignals)
 		{
-			output.Append(" · git unavailable: ")
-				.Append(report.GitUnavailableReason)
-				.Append("; weights redistributed");
+			status.Append(" · missing signals: ")
+				.Append(report.MissingSignalPolicy switch
+				{
+					ImportanceMissingSignalPolicy.Redistribute => "redistributed",
+					ImportanceMissingSignalPolicy.NeutralFill => "neutral fill",
+					ImportanceMissingSignalPolicy.ConfidenceLimited => "confidence limited",
+					_ => throw new ArgumentOutOfRangeException()
+				});
 		}
-		else if (report.RedistributedMissingSignals)
+		if (report.GitHistoryIsShallow && !report.GitHistoryIsComplete)
 		{
-			output.Append(" · missing signals redistributed");
+			status.Append("\n[Ranking git] read ")
+				.Append(report.GitCommitCount.ToString(CultureInfo.InvariantCulture))
+				.Append('/')
+				.Append(report.GitWindow.ToString(CultureInfo.InvariantCulture))
+				.Append(" commits; shallow history");
 		}
+
+		var projectData = new StringBuilder(1_024);
 		foreach (var entry in report.TopEntries.Take(10))
 		{
-			output.Append("\n[Ranking top] ")
+			if (projectData.Length > 0)
+				projectData.Append('\n');
+			projectData.Append("[Ranking top] ")
 				.Append(McpTextEscaping.EscapeSingleLine(entry.Path))
 				.Append(" — dependents ")
 				.Append(entry.Dependents.ToString(CultureInfo.InvariantCulture))
@@ -1254,17 +1295,31 @@ internal sealed class DevProjexMcpTools(
 				.Append('/')
 				.Append(report.GitWindow.ToString(CultureInfo.InvariantCulture));
 			if (entry.Role == ImportanceFileRole.TestSource)
-				output.Append(" · test source");
+				projectData.Append(" · test source");
 			else if (entry.Role == ImportanceFileRole.Manifest)
-				output.Append(" · manifest");
+				projectData.Append(" · manifest");
 			else if (entry.Role == ImportanceFileRole.EntryPoint)
-				output.Append(" · entry point");
+				projectData.Append(" · entry point");
+			else if (entry.IsCoordinator)
+				projectData.Append(" · coordinator");
+			projectData.Append(" · priority ")
+				.Append(entry.Priority.ToString(CultureInfo.InvariantCulture))
+				.Append("; graph ")
+				.Append(entry.HasGraphFacts ? "available" : "unavailable")
+				.Append("; git ")
+				.Append(entry.HasGitHistory ? "available" : "unavailable")
+				.Append("; main contribution: ")
+				.Append(entry.MainContribution.ToString().ToLowerInvariant());
+			if (entry.ConfidenceLimited)
+				projectData.Append("; confidence limited");
 		}
 		if (tokenBudget is not null)
 		{
 			foreach (var file in tokenBudget.RankedSkippedFiles ?? [])
 			{
-				output.Append("\n[Skipped] ")
+				if (projectData.Length > 0)
+					projectData.Append('\n');
+				projectData.Append("[Skipped] ")
 					.Append(McpTextEscaping.EscapeSingleLine(file.Path))
 					.Append(" — priority ")
 					.Append(file.Priority!.Value.ToString(CultureInfo.InvariantCulture))
@@ -1275,7 +1330,9 @@ internal sealed class DevProjexMcpTools(
 					.Append(" remaining: does not fit the remaining budget");
 			}
 		}
-		return output.ToString();
+		return projectData.Length == 0
+			? status.ToString()
+			: status.Append("\n\n").Append(McpSpotlight.Wrap(projectData.ToString())).ToString();
 	}
 
 	private sealed record McpSelectionResult(

--- a/Apps/Terminal/Execution/ExportContextCommandHandler.cs
+++ b/Apps/Terminal/Execution/ExportContextCommandHandler.cs
@@ -30,6 +30,19 @@ public sealed class ExportContextCommandHandler(
 				request.MaxFileBytes,
 				cancellationToken)
 			.ConfigureAwait(false);
+		if (plan.HasErrors)
+		{
+			new ContextDiagnosticRenderer(environment, request.Output, services.Localization)
+				.Write(plan.Diagnostics);
+			return CommandLineExitCodes.PolicyFailure;
+		}
+		var ranking = request.Rank is null
+			? null
+			: await (rankingService ?? new ImportanceRankingService(
+					services.DependencyFactsEngine,
+					new ProjectGitHistoryReader()))
+				.RankAsync(plan.SourceRoot, plan.IncludedFiles, cancellationToken)
+				.ConfigureAwait(false);
 		var transformationContext = CreateTransformationContext(plan, request.View);
 		await using var prepared = transformationContext is null
 			? null
@@ -40,15 +53,6 @@ public sealed class ExportContextCommandHandler(
 			plan = CodeCompressionDiagnostic.Append(plan, compressionSnapshot.Availability);
 		new ContextDiagnosticRenderer(environment, request.Output, services.Localization)
 			.Write(plan.Diagnostics);
-		if (plan.HasErrors)
-			return CommandLineExitCodes.PolicyFailure;
-		var ranking = request.Rank is null
-			? null
-			: await (rankingService ?? new ImportanceRankingService(
-					services.DependencyFactsEngine,
-					new ProjectGitHistoryReader()))
-				.RankAsync(plan.SourceRoot, plan.IncludedFiles, cancellationToken)
-				.ConfigureAwait(false);
 
 		var outputPath = request.OutputPath is not null and not "-"
 			? ExactOutputDestinationValidator.ValidateContext(

--- a/Apps/Terminal/Execution/RankingOutput.cs
+++ b/Apps/Terminal/Execution/RankingOutput.cs
@@ -15,13 +15,9 @@ internal static class RankingOutput
 		if (report is null)
 			return;
 		var percentage = Math.Round(report.GraphCoverage * 100, MidpointRounding.AwayFromZero);
-		var historySuffix = report.GitUnavailableReason != ProjectGitHistoryUnavailableReason.None
-			? localization.Format(
-				"Terminal.Ranking.GitUnavailableSuffix",
-				report.GitUnavailableReason.ToString())
-			: report.RedistributedMissingSignals
-				? localization["Terminal.Ranking.RedistributedSuffix"]
-				: string.Empty;
+		var historySuffix = report.HasMissingSignals
+			? $" · missing signals: {PolicyToken(report.MissingSignalPolicy)}"
+			: string.Empty;
 		writer.WriteLine(localization.Format(
 			"Terminal.Ranking.Summary",
 			report.Algorithm,
@@ -29,7 +25,19 @@ internal static class RankingOutput
 			report.CandidateCount,
 			report.GitWindow,
 			historySuffix,
-			report.GraphVariant));
+			$"{report.GraphVariant} · facts"));
+		writer.WriteLine(
+			$"[Ranking coverage] facts {percentage.ToString(CultureInfo.InvariantCulture)}% · " +
+			$"resolved internal references {report.ResolvedInternalReferences.ToString(CultureInfo.InvariantCulture)}/" +
+			$"{report.InternalReferenceCandidates.ToString(CultureInfo.InvariantCulture)} " +
+			$"({Math.Round(report.ResolvedInternalReferenceCoverage * 100, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture)}%) · " +
+			$"files with resolved edges {report.FilesWithResolvedEdges.ToString(CultureInfo.InvariantCulture)}");
+		if (report.GitHistoryIsShallow && !report.GitHistoryIsComplete)
+		{
+			writer.WriteLine(
+				$"[Ranking git] read {report.GitCommitCount.ToString(CultureInfo.InvariantCulture)}/" +
+				$"{report.GitWindow.ToString(CultureInfo.InvariantCulture)} commits; shallow history");
+		}
 		foreach (var entry in report.TopEntries.Take(10))
 		{
 			var commits = entry.Commits?.ToString(CultureInfo.InvariantCulture) ??
@@ -41,15 +49,43 @@ internal static class RankingOutput
 				entry.Dependencies,
 				commits,
 				report.GitWindow,
-				RoleSuffix(entry.Role, localization)));
+				RoleSuffix(entry, localization) + ContributionSuffix(entry)));
 		}
 	}
 
-	private static string RoleSuffix(ImportanceFileRole role, LocalizationService localization) => role switch
+	private static string RoleSuffix(ImportanceRankingEntry entry, LocalizationService localization)
 	{
-		ImportanceFileRole.TestSource => localization["Terminal.Ranking.TestSourceSuffix"],
-		ImportanceFileRole.Manifest => localization["Terminal.Ranking.ManifestSuffix"],
-		ImportanceFileRole.EntryPoint => localization["Terminal.Ranking.EntryPointSuffix"],
-		_ => string.Empty
+		if (entry.IsCoordinator)
+			return " · coordinator";
+		return entry.Role switch
+		{
+			ImportanceFileRole.TestSource => localization["Terminal.Ranking.TestSourceSuffix"],
+			ImportanceFileRole.Manifest => localization["Terminal.Ranking.ManifestSuffix"],
+			ImportanceFileRole.EntryPoint => localization["Terminal.Ranking.EntryPointSuffix"],
+			_ => string.Empty
+		};
+	}
+
+	private static string ContributionSuffix(ImportanceRankingEntry entry) =>
+		$" · priority {entry.Priority.ToString(CultureInfo.InvariantCulture)}; " +
+		$"graph {(entry.HasGraphFacts ? "available" : "unavailable")}; " +
+		$"git {(entry.HasGitHistory ? "available" : "unavailable")}; " +
+		$"main contribution: {SignalToken(entry.MainContribution)}" +
+		(entry.ConfidenceLimited ? "; confidence limited" : string.Empty);
+
+	private static string SignalToken(ImportanceRankingSignal signal) => signal switch
+	{
+		ImportanceRankingSignal.Graph => "graph",
+		ImportanceRankingSignal.Git => "git",
+		ImportanceRankingSignal.Role => "role",
+		_ => "none"
+	};
+
+	private static string PolicyToken(ImportanceMissingSignalPolicy policy) => policy switch
+	{
+		ImportanceMissingSignalPolicy.Redistribute => "redistributed",
+		ImportanceMissingSignalPolicy.NeutralFill => "neutral fill",
+		ImportanceMissingSignalPolicy.ConfidenceLimited => "confidence limited",
+		_ => throw new ArgumentOutOfRangeException(nameof(policy), policy, null)
 	};
 }

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -419,11 +419,19 @@ existing greedy admission pass; without a budget, all candidates are serialized
 in descending importance. A tree-only pack rejects `rank`, and `get_tree` does
 not expose it. Unknown values return `DPX-MCP-INVALID-ARGUMENTS`.
 
-The ranking uses resolved dependency PageRank, a safe offline 200-commit Git
-history window, and a small file-role signal. Its bounded trusted trailer follows
-the untrusted project block and reports graph coverage, unavailable signals, up
-to ten top entries, and ranked skips. Omitting `rank` retains the ordinary order
-and performs neither dependency indexing nor Git history work. See
+The ranking uses quantized resolved-dependency PageRank, a safe offline
+200-commit Git history window, and a small file-role signal. Missing evidence
+limits confidence instead of being renormalized into an advantage. A shallow
+window reports the number of commits actually read. Progress has three bounded
+stages: fact indexing, history reading, and priority computation.
+
+The bounded trailer follows the untrusted project block. Trusted status lines
+report facts coverage, resolved internal-link coverage, files touching an edge,
+history completeness, and the missing-signal policy. The up-to-ten top entries
+and ranked skips contain project-derived paths, so they are placed in a separate
+standard spotlighted `untrusted-data` block rather than being trusted as control
+text. Omitting `rank` retains the ordinary order and performs neither dependency
+indexing, Git history work, nor ranking content hashes. See
 [Ranking.md](Ranking.md) for the algorithm, fixed weights, evaluation protocol,
 and measured limitations.
 

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -46,62 +46,80 @@ Pinned inputs:
 
 ## Protocol
 
-For every repository, the effective manifest, source bytes, `full` detail, per-file estimated cost, and existing greedy admission pass are held constant. The compared orders are current path order, Git activity only, unique resolved graph degree only, PageRank over the same deduplicated graph, and the combined candidate. Budgets are 4,000, 8,000, and 16,000 estimated tokens.
+The review run was frozen before execution and performed on 2026-09-07. Every order reused one standard-profile manifest, the same source bytes, `full` detail, the existing `(characters + 3) / 4` per-file estimate, and the unchanged greedy admission pass. Budgets were 4,000, 8,000, and 16,000 estimated tokens. The compared global orders were tree order, Git activity, unique resolved graph degree, PageRank, and the combined product order.
 
-This recorded run is the protocol's primary `full`-detail series. Compact and signatures output were not used to select `importance-v1`: changing detail can change whether a required body is present and would therefore test a different gold condition.
+For each task and budget the protocol records `Recall@B`, `AllRequired@B`, irrelevant-token share, and the oracle-feasible ceiling. `Recall@B` is the best fraction admitted from a sufficient set. `AllRequired@B` is one only when one complete sufficient set is admitted. The oracle is feasible when the total cost of at least one sufficient set fits the budget; an individually oversized required file is therefore not charged to an ordering strategy.
 
-For each task and budget the protocol records `Recall@B`, `AllRequired@B`, irrelevant-token share, and the oracle-feasible ceiling. `Recall@B` is the fraction of a task's smallest sufficient set admitted. `AllRequired@B` is one only when at least one complete sufficient set is admitted. A required file larger than the entire budget lowers the oracle ceiling rather than being counted as a ranking failure.
+The localization series also records a directed baseline. Its search vocabulary was fixed before the run from the task wording, never from ranked output: `LargestSkippedFiles`/`remaining budget`, `mandatory`/`SecretRedactionFeatures`, `GitScopeSelection`/`NestedRepository`, `pack_id`/`read_pack`, `repositorySourceUrl`/`RepoCache`; `gitSort`/`git log`, `symlink`/`path scope`, `remote config`/`trust`, `processFiles`/`generate output`, `pack_codebase`/`mcpToolRuntime`; `error_handler_spec`/`register_error_handler`, `save_session`/`SESSION_COOKIE`, `find_best_app`/`ScriptInfo`, `open_session`/`do_teardown`, and `json_provider_class`/`JSONProvider`. The scripted workflow performs search, takes its first five deterministic hits, follows resolved dependencies and dependents, then packs only those paths. It uses the same search and dependency services as the MCP tools, but the evaluation harness calls the service contracts directly rather than measuring JSON-RPC transport.
 
-Weights are chosen on two repositories and evaluated on the held-out third, rotating the held-out repository. The fifteen task-budget rows are not treated as independent observations when one global order produces them. Gold paths never enter a scoring function. Historical fix commits are not used as labels, compressed output is not credited when the required body is absent, and Flask is not presented as a mixed-monorepo sample.
+Gold paths never enter a score or search query. Historical fixes are not labels, one global order is not treated as 15 independent samples, compressed output is not credited when a required body is absent, and Flask is not described as a mixed monorepo. The three repository registries are used as groups; the original leave-one-repository-out weight selection remains the guard against answer leakage and pseudoreplication.
 
-## Product algorithm
+## Product algorithm after review
 
-The frozen run was performed on 2026-09-07. The full-detail effective selection was built with the ordinary standard profile. For every repository, all five orders reused that one file manifest and exact `FileContentAnalyzer` character counts; the cost was the existing per-file `(characters + 3) / 4` estimate. No gold path was supplied to the ranker. Git used the last 200 commits by position. The graph included only unique, resolved, non-self edges.
+The `importance-v1` constants remain graph `0.85`, Git `0.10`, and role `0.05`; v5.2 is not released, so the corrected implementation retains the algorithm id. The graph is built once as canonical numeric node ids and sorted adjacency arrays. Only unique resolved non-self file pairs participate. The same graph supplies PageRank, dependents, dependencies, and coverage counts. PageRank uses 30 deterministic sequential iterations on two `double[]` buffers. Before dense-rank normalization, values are quantized to an absolute `1e-12` grid with midpoint-to-even rounding. This is a transitive equivalence relation; pairwise epsilon comparison is deliberately not used. At the graph sizes in this protocol, `1e-12` is well below a meaningful rank separation while absorbing observed symmetric-node noise near `1e-17`.
 
-The graph variant comparison tied at zero complete sufficient sets. PageRank won the next metric, aggregate mean `Recall@B`: `0.0519` against degree's `0.0444`. Degree had a nearly identical mean irrelevant-token share (`0.9789` against `0.9792`). Under the predeclared priority of `AllRequired@B`, then `Recall@B`, PageRank therefore became the `importance-v1` graph signal. Unsupported and extraction-failed files receive no PageRank signal.
+Extracted-facts coverage is `Supported / candidates`. `Supported`, `Unsupported`, and `ExtractionFailed` are mutually exclusive, so failures are not subtracted from `Supported`. Reports separately state facts coverage, unique resolved internal references over all non-external reference records, and the number of files touching a resolved edge. A high facts percentage can no longer be presented as high link coverage when the graph is sparse.
 
-The weight grid kept graph strictly larger than Git and limited role to `0.05`, `0.10`, or `0.15`. Selection on two repositories and evaluation on the third produced:
+Git activity is commit count plus recency by position in a safe 200-commit LocalRead window. History is cached only after success, by repository identity, pinned HEAD, window, shallow state, and completeness. An incomplete shallow window has confidence `commits read / 200`; it is reported as, for example, `read 1/200 commits; shallow history`, and is not treated as evidence of low activity. Candidate repository boundaries are indexed once per operation. History paths are parsed as NUL-delimited fields; one Git-generated framing LF is removed from the first path field, while newline and `0x1e` bytes belonging to a filename are preserved.
 
-| Held-out repository | Training choice graph / Git / role | Held-out AllRequired / oracle-feasible | Mean Recall | Mean irrelevant tokens |
-|---|---:|---:|---:|---:|
-| DevProjex | `0.55 / 0.40 / 0.05` | `0 / 5` | `0.0000` | `1.0000` |
-| Repomix | `0.85 / 0.10 / 0.05` | `0 / 9` | `0.0000` | `1.0000` |
-| Flask | `0.85 / 0.10 / 0.05` | `0 / 2` | `0.0667` | `0.9412` |
+Manifests and explicit `Main` or executable-module evidence are entry points. A source with no dependents and at least three dependencies is only a `coordinator`, not an inferred entry point. Tests are deprioritized but never excluded. The final tie-break is the canonical relative path.
 
-After the leave-one-repository-out check, fitting the same constrained grid to all three registries selected graph `0.85`, Git `0.10`, and role `0.05`. These are the frozen `importance-v1` constants. The weak held-out results are recorded rather than described as a win: generic project-wide ranking did not admit a complete task set in this deliberately small full-detail budget range. Only 16 of 45 task-budget rows were oracle-feasible, chiefly because several required files individually cost more than 16,000 estimated tokens.
+Facts, preparation, cost, and emitted bytes are bound to one source identity. SHA-256 content plus length and last-write metadata are captured around fact indexing and checked while the coherent output snapshot is opened, copied, and disposed. A mismatch fails closed with guidance to repeat the export. Ranking still never widens the effective selection. Without `rank`, it performs no fact indexing, Git work, or content hashing and preserves the existing bytes.
 
-The product always uses rank normalization within the effective selection, scales the graph contribution by `(supported - extraction-failed) / candidates`, redistributes unavailable signal weight, and uses canonical relative path as the final tie-break. Git activity combines commit count and most-recent position in the fixed window. Manifests and inferred entry points receive a small lift; test sources receive a visible penalty but are never excluded.
+### Missing-signal ablation
 
-Facts and emitted content are guarded as one per-file source version. Length and
-last-write metadata are captured around indexing and checked when the coherent
-content snapshot is opened, copied, and disposed. A concurrent change fails the
-pack instead of combining scores from one version with bytes from another; this
-uses the same metadata-freshness tradeoff as the existing content pipeline.
+The fixed `0.85 / 0.10 / 0.05` weights were rerun under all three policies. Each row aggregates the nine repository/budget groups; `AllRequired` and oracle counts cover the underlying 45 task-budget cases.
 
-## Full-detail results
+| Policy | AllRequired / oracle-feasible | Mean Recall | Mean irrelevant tokens |
+|---|---:|---:|---:|
+| Renormalize available weights | `0 / 16` | `0.0333` | `0.9784` |
+| Fill unavailable signals with neutral `0.5` | `0 / 16` | `0.0111` | `0.9935` |
+| Limit score by available confidence | `0 / 16` | `0.0111` | `0.9935` |
 
-Each cell is `mean Recall · AllRequired/oracle-feasible · mean irrelevant-token share`, averaged over the five frozen tasks for that repository and budget. `Combined` uses the final `0.85 / 0.10 / 0.05` weights. Oracle feasibility is reported independently of the order.
+Renormalization had better recall in this small sample, but it also reproduced the correctness defect: a manifest with only its role signal becomes `1.0`, above a strongly linked file whose graph confidence is 90%. Neutral fill avoids that exact maximum but still manufactures evidence. `importance-v1` therefore uses confidence limitation: missing weight contributes zero and the score cannot exceed available signal weight. The report names the policy and marks affected top entries `confidence limited`. This is a semantic choice favoring honest uncertainty over the `0.0222` aggregate recall advantage of renormalization; it is not presented as an empirical quality win.
 
-| Repository / budget | Current | Git only | Degree only | PageRank only | Combined |
+## Architecture overview series
+
+Before the run, a human central-file checklist was recorded for each repository: eight orchestration and boundary files in DevProjex, seven packing/config/MCP files in Repomix, and eight application/context/session/CLI files in Flask. The table counts checklist members in the first 15 non-test files; it is a manual sanity check, not task-completion evidence.
+
+| Repository | Tree | Git only | Degree only | PageRank only | Combined |
 |---|---:|---:|---:|---:|---:|
-| DevProjex / 4,000 | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` |
-| DevProjex / 8,000 | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0667 · 0/2 · 0.9769` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` |
-| DevProjex / 16,000 | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0667 · 0/2 · 0.8612` |
-| Repomix / 4,000 | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` |
-| Repomix / 8,000 | `0.0000 · 0/3 · 1.0000` | `0.0667 · 0/3 · 0.9041` | `0.0000 · 0/3 · 1.0000` | `0.0000 · 0/3 · 1.0000` | `0.0000 · 0/3 · 1.0000` |
-| Repomix / 16,000 | `0.0000 · 0/5 · 1.0000` | `0.0667 · 0/5 · 0.9520` | `0.2333 · 0/5 · 0.8694` | `0.1667 · 0/5 · 0.9147` | `0.0000 · 0/5 · 1.0000` |
-| Flask / 4,000 | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` |
-| Flask / 8,000 | `0.0000 · 0/0 · 1.0000` | `0.1000 · 0/0 · 0.8825` | `0.1000 · 0/0 · 0.9640` | `0.1000 · 0/0 · 0.9640` | `0.1000 · 0/0 · 0.8825` |
-| Flask / 16,000 | `0.0000 · 0/2 · 1.0000` | `0.1667 · 0/2 · 0.7468` | `0.0000 · 0/2 · 1.0000` | `0.2000 · 0/2 · 0.9340` | `0.1000 · 0/2 · 0.9412` |
+| DevProjex | `1/15` | `1/15` | `1/15` | `0/15` | `2/15` |
+| Repomix | `0/15` | `0/15` | `3/15` | `1/15` | `1/15` |
+| Flask | `0/15` | `6/15` | `7/15` | `6/15` | `7/15` |
 
-Coverage was `1,471 / 2,299` supported candidates for DevProjex (`63.98%`), `389 / 951` for Repomix (`40.90%`), and `80 / 212` for Flask (`37.74%`); all three extractions had zero failures and a complete 200-commit Git window. The low coverage is why graph weight is reduced at run time and the report names the measured share.
+The manual review calls the Flask combined list credible: it contains `app.py`, `sansio/app.py`, `ctx.py`, `sessions.py`, `cli.py`, helpers, wrappers, and JSON/application boundaries. DevProjex improves only modestly, surfacing `TerminalServiceFactory.cs` and `GitRepositoryService.cs` but missing several central files. Repomix is the counterexample: degree alone finds three checklist files, while PageRank and combined find only `mcpToolRuntime.ts`. Thus the combined order is not uniformly better even for seedless architecture review.
 
-On the pinned DevProjex input the resulting report starts:
+Measured coverage was:
+
+| Repository | Facts-supported candidates | Resolved internal references | Files with resolved edges |
+|---|---:|---:|---:|
+| DevProjex | `1,471 / 2,299 (63.98%)` | `5,138 / 11,567 (44.42%)` | `1,221` |
+| Repomix | `389 / 951 (40.90%)` | `1,025 / 2,612 (39.24%)` | `359` |
+| Flask | `80 / 212 (37.74%)` | `175 / 512 (34.18%)` | `75` |
+
+## Localization-task budget series
+
+Each cell is `mean Recall · AllRequired/oracle-feasible · mean irrelevant-token share`, averaged over the five frozen tasks for that repository and budget. `Combined` is the confidence-limited product order. `Directed` varies by task because its explicit `paths` are the result of that task's fixed search and related-files workflow.
+
+| Repository / budget | Tree | Git only | Degree only | PageRank only | Combined | Directed |
+|---|---:|---:|---:|---:|---:|---:|
+| DevProjex / 4,000 | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.2000 · 0/1 · 0.9202` |
+| DevProjex / 8,000 | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.2000 · 0/2 · 0.9600` |
+| DevProjex / 16,000 | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.0000 · 0/2 · 1.0000` | `0.1333 · 0/2 · 0.8189` |
+| Repomix / 4,000 | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` | `0.0000 · 0/1 · 1.0000` |
+| Repomix / 8,000 | `0.0000 · 0/3 · 1.0000` | `0.0667 · 0/3 · 0.9041` | `0.0000 · 0/3 · 1.0000` | `0.0000 · 0/3 · 1.0000` | `0.0000 · 0/3 · 1.0000` | `0.0000 · 0/3 · 1.0000` |
+| Repomix / 16,000 | `0.0000 · 0/5 · 1.0000` | `0.0667 · 0/5 · 0.9520` | `0.0667 · 0/5 · 0.9547` | `0.1667 · 0/5 · 0.9147` | `0.0000 · 0/5 · 1.0000` | `0.1667 · 0/5 · 0.9662` |
+| Flask / 4,000 | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.0000 · 0/0 · 1.0000` | `0.2000 · 0/0 · 0.7001` |
+| Flask / 8,000 | `0.0000 · 0/0 · 1.0000` | `0.1000 · 0/0 · 0.8825` | `0.0000 · 0/0 · 1.0000` | `0.1000 · 0/0 · 0.9640` | `0.0000 · 0/0 · 1.0000` | `0.2000 · 0/0 · 0.8520` |
+| Flask / 16,000 | `0.0000 · 0/2 · 1.0000` | `0.1667 · 0/2 · 0.7468` | `0.1667 · 0/2 · 0.7468` | `0.2000 · 0/2 · 0.9340` | `0.1000 · 0/2 · 0.9412` | `0.6000 · 2/2 · 0.6201` |
+
+Across the nine groups, combined mean recall is `0.0111`, below Git-only `0.0444`, PageRank-only `0.0519`, and directed `0.1889`. Combined admits no complete sufficient set; directed admits both oracle-feasible Flask sets at 16,000. This is a clear loss for generic ranking on localized tasks. The cause is not hidden: global importance rewards broadly connected and recently active infrastructure, while a task asks for a narrow semantic slice. Use `search_project` → `related_files` → `pack_context(paths: ...)` when a seed is known; importance ranking is an experimental seedless overview order.
+
+On the pinned DevProjex corpus, the beginning of the reviewed report is representative:
 
 ```text
-[Ranking] importance-v1 · graph pagerank 64% of 2,299 sources · git window 200 commits · tests deprioritized
-[Ranking top] Infrastructure/Git/GitRepositoryService.cs — dependents 21 · dependencies 6 · commits 7/200
-[Ranking top] Apps/Terminal/Execution/TerminalServiceFactory.cs — dependents 40 · dependencies 60 · commits 3/200
+[Ranking] importance-v1 · graph pagerank · facts 64% of 2,299 sources · git window 200 commits · tests deprioritized · missing signals: confidence limited
+[Ranking coverage] facts 64% · resolved internal references 5,138/11,567 (44%) · files with resolved edges 1,221
+[Ranking top] Kernel/Models/IgnoreRules.cs — dependents 138 · dependencies 5 · commits 2/200 · priority 1; graph available; git available; main contribution: graph; confidence limited
 ```
-
-These results are experimental. They show that importance order can recover individual required files that path order misses, but they do not establish better task completion. Callers with a seed should continue to use `search_project`, `get_file`, and `related_files`, then pass explicit `paths`; importance ranking is intended for seedless overview packs.

--- a/Infrastructure/Git/GitProcessOperation.cs
+++ b/Infrastructure/Git/GitProcessOperation.cs
@@ -30,7 +30,8 @@ internal enum GitOperationKind
 	ManagedWorktreePrune,
 	ManagedWorktreeList,
 	ManagedConfigWrite,
-	ReadHistoryWindow
+	ReadHistoryWindow,
+	ReadShallowRepositoryState
 }
 
 internal enum GitConfigReadKind
@@ -302,6 +303,9 @@ internal sealed record GitProcessOperation
 	public static GitProcessOperation ReadHistoryWindow() =>
 		new(GitOperationKind.ReadHistoryWindow, GitProcessProfile.LocalRead, depth: 200);
 
+	public static GitProcessOperation ReadShallowRepositoryState() =>
+		new(GitOperationKind.ReadShallowRepositoryState, GitProcessProfile.LocalRead);
+
 	internal IReadOnlyList<string> BuildArguments(GitIsolationPaths isolation)
 	{
 		ArgumentNullException.ThrowIfNull(isolation);
@@ -333,6 +337,8 @@ internal sealed record GitProcessOperation
 			GitOperationKind.ManagedConfigWrite => BuildConfigWriteArguments(),
 			GitOperationKind.ReadHistoryWindow =>
 				["log", "--topo-order", "--no-renames", "--no-decorate", "--format=%x1e%H%x00", "--name-only", "-z", "-n", Depth.ToString(CultureInfo.InvariantCulture), "--"],
+			GitOperationKind.ReadShallowRepositoryState =>
+				["rev-parse", "--is-shallow-repository"],
 			_ => throw new ArgumentOutOfRangeException()
 		};
 	}

--- a/Infrastructure/Git/ProjectGitHistoryReader.cs
+++ b/Infrastructure/Git/ProjectGitHistoryReader.cs
@@ -122,30 +122,24 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 			static _ => new MutableActivity(),
 			StringComparer.Ordinal);
 		var commitPosition = 0;
-		foreach (var record in output.Split('\x1e', StringSplitOptions.RemoveEmptyEntries))
+		HashSet<string>? changedInCommit = null;
+		foreach (var field in output.Split('\0', StringSplitOptions.None))
 		{
-			var fields = record.Split('\0', StringSplitOptions.RemoveEmptyEntries);
-			if (fields.Length == 0)
+			if (TryReadRecordHeader(field, out _))
+			{
+				ApplyCommit(changedInCommit, counts, commitPosition);
+				commitPosition++;
+				changedInCommit = new HashSet<string>(StringComparer.Ordinal);
 				continue;
-			var hash = fields[0].Trim();
-			if (hash.Length < 7 || !hash.All(Uri.IsHexDigit))
+			}
+			if (field.Length == 0)
+				continue;
+			if (changedInCommit is null)
 				return Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput);
-			commitPosition++;
-			var changedInCommit = new HashSet<string>(StringComparer.Ordinal);
-			foreach (var field in fields.Skip(1))
-			{
-				var path = field.Trim('\r', '\n');
-				if (path.Length > 0 && counts.ContainsKey(path))
-					changedInCommit.Add(path);
-			}
-			foreach (var path in changedInCommit)
-			{
-				var activity = counts[path];
-				activity.CommitCount++;
-				if (activity.MostRecentCommitPosition == 0)
-					activity.MostRecentCommitPosition = commitPosition;
-			}
+			if (counts.ContainsKey(field))
+				changedInCommit.Add(field);
 		}
+		ApplyCommit(changedInCommit, counts, commitPosition);
 
 		var files = counts.ToDictionary(
 			pair => canonicalCandidates[pair.Key],
@@ -158,6 +152,37 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 			commitPosition,
 			files,
 			unavailable);
+	}
+
+	private static bool TryReadRecordHeader(string field, out string hash)
+	{
+		hash = string.Empty;
+		if (field.Length is not (41 or 65) || field[0] != '\x1e')
+			return false;
+		var candidate = field.AsSpan(1);
+		foreach (var character in candidate)
+		{
+			if (character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f') and not (>= 'A' and <= 'F'))
+				return false;
+		}
+		hash = candidate.ToString();
+		return true;
+	}
+
+	private static void ApplyCommit(
+		HashSet<string>? changedPaths,
+		IReadOnlyDictionary<string, MutableActivity> counts,
+		int commitPosition)
+	{
+		if (changedPaths is null)
+			return;
+		foreach (var path in changedPaths)
+		{
+			var activity = counts[path];
+			activity.CommitCount++;
+			if (activity.MostRecentCommitPosition == 0)
+				activity.MostRecentCommitPosition = commitPosition;
+		}
 	}
 
 	private static ProjectGitHistorySnapshot Unavailable(

--- a/Infrastructure/Git/ProjectGitHistoryReader.cs
+++ b/Infrastructure/Git/ProjectGitHistoryReader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using DevProjex.Application.Ranking;
 using DevProjex.Infrastructure.Processes;
@@ -8,6 +9,9 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 {
 	public const int CommitWindow = 200;
 	private const int MaximumOutputCharacters = 8 * 1024 * 1024;
+	private const int MaximumCachedRepositories = 16;
+	private static readonly ConcurrentDictionary<HistoryCacheKey, RepositoryHistory> HistoryCache = new();
+	private static readonly ConcurrentQueue<HistoryCacheKey> HistoryCacheOrder = new();
 
 	public async Task<ProjectGitHistorySnapshot> ReadAsync(
 		string sourceRoot,
@@ -37,6 +41,17 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 		if (safety.OldGitPromisorRepository)
 			return Unavailable(ProjectGitHistoryUnavailableReason.OldGitPromisorRepository);
 
+		var headResult = await RunLocalReadAsync(
+			repositoryRoot,
+			GitProcessOperation.ResolveCommit("HEAD"),
+			maximumOutputCharacters: 128,
+			cancellationToken).ConfigureAwait(false);
+		if (!headResult.IsSuccess)
+			return Unavailable(headResult.FailureReason, headResult.Detail);
+		var head = headResult.Output.TrimEnd('\r', '\n');
+		if (!IsObjectId(head))
+			return Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput);
+
 		var shallowResult = await RunLocalReadAsync(
 			repositoryRoot,
 			GitProcessOperation.ReadShallowRepositoryState(),
@@ -48,14 +63,24 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 		if (!bool.TryParse(shallowText, out var isShallow))
 			return Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput);
 
-		var historyResult = await RunLocalReadAsync(
-			repositoryRoot,
-			GitProcessOperation.ReadHistoryWindow(),
-			MaximumOutputCharacters,
-			cancellationToken).ConfigureAwait(false);
-		if (!historyResult.IsSuccess)
-			return Unavailable(historyResult.FailureReason, historyResult.Detail);
-		return Parse(repositoryRoot, candidateFiles, historyResult.Output, isShallow);
+		var completeCacheKey = new HistoryCacheKey(repositoryRoot, head, CommitWindow, isShallow, IsComplete: true);
+		if (!HistoryCache.TryGetValue(completeCacheKey, out var history))
+		{
+			var historyResult = await RunLocalReadAsync(
+				repositoryRoot,
+				GitProcessOperation.ReadHistoryWindow(),
+				MaximumOutputCharacters,
+				cancellationToken).ConfigureAwait(false);
+			if (!historyResult.IsSuccess)
+				return Unavailable(historyResult.FailureReason, historyResult.Detail);
+			history = ParseRepositoryHistory(historyResult.Output, isShallow);
+			if (history is null)
+				return Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput);
+			if (history.IsComplete)
+				StoreHistory(completeCacheKey, history);
+		}
+
+		return SelectCandidates(repositoryRoot, candidateFiles, history);
 	}
 
 	internal static ProjectGitHistorySnapshot Parse(
@@ -64,28 +89,18 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 		string output,
 		bool isShallow = false)
 	{
-		var root = Path.GetFullPath(repositoryRoot);
-		var canonicalCandidates = new Dictionary<string, string>(StringComparer.Ordinal);
-		var unavailable = new Dictionary<string, ProjectGitHistoryUnavailableReason>(StringComparer.Ordinal);
-		foreach (var candidate in candidateFiles)
-		{
-			var fullPath = Path.GetFullPath(candidate);
-			var relative = PortableRelative(root, fullPath);
-			var owner = FindOwningRepository(Path.GetDirectoryName(fullPath) ?? fullPath);
-			if (owner is null || !PathComparer.Default.Equals(owner, root))
-			{
-				unavailable[fullPath] = ProjectGitHistoryUnavailableReason.NestedRepository;
-				continue;
-			}
-			canonicalCandidates[relative] = fullPath;
-		}
+		var history = ParseRepositoryHistory(output, isShallow);
+		return history is null
+			? Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput)
+			: SelectCandidates(repositoryRoot, candidateFiles, history);
+	}
 
-		var counts = canonicalCandidates.Keys.ToDictionary(
-			static path => path,
-			static _ => new MutableActivity(),
-			StringComparer.Ordinal);
+	private static RepositoryHistory? ParseRepositoryHistory(string output, bool isShallow)
+	{
+		var counts = new Dictionary<string, MutableActivity>(StringComparer.Ordinal);
 		var commitPosition = 0;
 		HashSet<string>? changedInCommit = null;
+		var firstPathField = false;
 		foreach (var field in output.Split('\0', StringSplitOptions.None))
 		{
 			if (TryReadRecordHeader(field, out _))
@@ -93,32 +108,118 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 				ApplyCommit(changedInCommit, counts, commitPosition);
 				commitPosition++;
 				changedInCommit = new HashSet<string>(StringComparer.Ordinal);
+				firstPathField = true;
 				continue;
 			}
 			if (field.Length == 0)
 				continue;
 			if (changedInCommit is null)
-				return Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput);
-			if (counts.ContainsKey(field))
-				changedInCommit.Add(field);
+				return null;
+			// Git inserts one LF between the pretty-format header and the first -z path.
+			// Remove that framing byte exactly once; every byte belonging to the path remains intact.
+			var path = firstPathField && field[0] == '\n' ? field[1..] : field;
+			firstPathField = false;
+			if (path.Length > 0)
+				changedInCommit.Add(path);
 		}
 		ApplyCommit(changedInCommit, counts, commitPosition);
 
-		var files = counts.ToDictionary(
-			pair => canonicalCandidates[pair.Key],
+		var activities = counts.ToDictionary(
+			static pair => pair.Key,
 			static pair => new ProjectGitFileActivity(
 				pair.Value.CommitCount,
 				pair.Value.MostRecentCommitPosition),
-			PathComparer.Default);
+			StringComparer.Ordinal);
+		return new RepositoryHistory(
+			commitPosition,
+			activities,
+			isShallow,
+			!isShallow || commitPosition >= CommitWindow);
+	}
+
+	private static ProjectGitHistorySnapshot SelectCandidates(
+		string repositoryRoot,
+		IReadOnlyList<string> candidateFiles,
+		RepositoryHistory history)
+	{
+		var root = Path.GetFullPath(repositoryRoot);
+		var boundaryIndex = new Dictionary<string, string?>(PathComparer.Default)
+		{
+			[root] = root
+		};
+		var files = new Dictionary<string, ProjectGitFileActivity>(PathComparer.Default);
+		var unavailable = new Dictionary<string, ProjectGitHistoryUnavailableReason>(PathComparer.Default);
+		foreach (var candidate in candidateFiles)
+		{
+			var fullPath = Path.GetFullPath(candidate);
+			var directory = Path.GetDirectoryName(fullPath) ?? fullPath;
+			var owner = FindOwningRepository(directory, boundaryIndex);
+			if (owner is null || !PathComparer.Default.Equals(owner, root))
+			{
+				unavailable[fullPath] = ProjectGitHistoryUnavailableReason.NestedRepository;
+				continue;
+			}
+			var relative = PortableRelative(root, fullPath);
+			files[fullPath] = history.Files.TryGetValue(relative, out var activity)
+				? activity
+				: new ProjectGitFileActivity(0, 0);
+		}
+
 		return new ProjectGitHistorySnapshot(
 			CommitWindow,
-			commitPosition,
+			history.CommitCount,
 			files,
 			unavailable)
 		{
-			IsShallow = isShallow,
-			IsComplete = !isShallow || commitPosition >= CommitWindow
+			IsShallow = history.IsShallow,
+			IsComplete = history.IsComplete
 		};
+	}
+
+	private static bool TryReadRecordHeader(string field, out string hash)
+	{
+		hash = string.Empty;
+		if (field.Length is not (41 or 65) || field[0] != '\x1e')
+			return false;
+		var candidate = field.AsSpan(1);
+		if (!IsObjectId(candidate))
+			return false;
+		hash = candidate.ToString();
+		return true;
+	}
+
+	private static bool IsObjectId(string value) => IsObjectId(value.AsSpan());
+
+	private static bool IsObjectId(ReadOnlySpan<char> value)
+	{
+		if (value.Length is not (40 or 64))
+			return false;
+		foreach (var character in value)
+		{
+			if (character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f') and not (>= 'A' and <= 'F'))
+				return false;
+		}
+		return true;
+	}
+
+	private static void ApplyCommit(
+		HashSet<string>? changedPaths,
+		IDictionary<string, MutableActivity> counts,
+		int commitPosition)
+	{
+		if (changedPaths is null)
+			return;
+		foreach (var path in changedPaths)
+		{
+			if (!counts.TryGetValue(path, out var activity))
+			{
+				activity = new MutableActivity();
+				counts[path] = activity;
+			}
+			activity.CommitCount++;
+			if (activity.MostRecentCommitPosition == 0)
+				activity.MostRecentCommitPosition = commitPosition;
+		}
 	}
 
 	private static async Task<LocalReadResult> RunLocalReadAsync(
@@ -189,35 +290,13 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 		}
 	}
 
-	private static bool TryReadRecordHeader(string field, out string hash)
+	private static void StoreHistory(HistoryCacheKey key, RepositoryHistory history)
 	{
-		hash = string.Empty;
-		if (field.Length is not (41 or 65) || field[0] != '\x1e')
-			return false;
-		var candidate = field.AsSpan(1);
-		foreach (var character in candidate)
-		{
-			if (character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f') and not (>= 'A' and <= 'F'))
-				return false;
-		}
-		hash = candidate.ToString();
-		return true;
-	}
-
-	private static void ApplyCommit(
-		HashSet<string>? changedPaths,
-		IReadOnlyDictionary<string, MutableActivity> counts,
-		int commitPosition)
-	{
-		if (changedPaths is null)
+		if (!HistoryCache.TryAdd(key, history))
 			return;
-		foreach (var path in changedPaths)
-		{
-			var activity = counts[path];
-			activity.CommitCount++;
-			if (activity.MostRecentCommitPosition == 0)
-				activity.MostRecentCommitPosition = commitPosition;
-		}
+		HistoryCacheOrder.Enqueue(key);
+		while (HistoryCache.Count > MaximumCachedRepositories && HistoryCacheOrder.TryDequeue(out var oldest))
+			HistoryCache.TryRemove(oldest, out _);
 	}
 
 	private static ProjectGitHistorySnapshot Unavailable(
@@ -229,23 +308,39 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 			reason,
 			detail);
 
-	private static string? FindOwningRepository(string startPath)
+	private static string? FindOwningRepository(string startPath) =>
+		FindOwningRepository(startPath, new Dictionary<string, string?>(PathComparer.Default));
+
+	private static string? FindOwningRepository(
+		string startPath,
+		IDictionary<string, string?> boundaryIndex)
 	{
+		var visited = new List<string>();
+		string? owner = null;
 		try
 		{
 			var current = new DirectoryInfo(Path.GetFullPath(startPath));
 			while (current is not null)
 			{
+				if (boundaryIndex.TryGetValue(current.FullName, out owner))
+					break;
+				visited.Add(current.FullName);
 				var marker = Path.Combine(current.FullName, ".git");
 				if (Directory.Exists(marker) || File.Exists(marker))
-					return current.FullName;
+				{
+					owner = current.FullName;
+					break;
+				}
 				current = current.Parent;
 			}
 		}
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
 		{
+			owner = null;
 		}
-		return null;
+		foreach (var directory in visited)
+			boundaryIndex[directory] = owner;
+		return owner;
 	}
 
 	private static string PortableRelative(string root, string path) =>
@@ -259,6 +354,19 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 		public int CommitCount { get; set; }
 		public int MostRecentCommitPosition { get; set; }
 	}
+
+	private sealed record RepositoryHistory(
+		int CommitCount,
+		IReadOnlyDictionary<string, ProjectGitFileActivity> Files,
+		bool IsShallow,
+		bool IsComplete);
+
+	private readonly record struct HistoryCacheKey(
+		string RepositoryRoot,
+		string Head,
+		int Window,
+		bool IsShallow,
+		bool IsComplete);
 
 	private readonly record struct LocalReadResult(
 		bool IsSuccess,

--- a/Infrastructure/Git/ProjectGitHistoryReader.cs
+++ b/Infrastructure/Git/ProjectGitHistoryReader.cs
@@ -37,69 +37,32 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 		if (safety.OldGitPromisorRepository)
 			return Unavailable(ProjectGitHistoryUnavailableReason.OldGitPromisorRepository);
 
-		var operation = GitProcessOperation.ReadHistoryWindow();
-		using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		deadline.CancelAfter(operation.Deadline);
-		using var process = new Process
-		{
-			StartInfo = GitProcessStartInfoFactory.Create(repositoryRoot, operation)
-		};
-		try
-		{
-			if (!process.Start())
-				return Unavailable(ProjectGitHistoryUnavailableReason.ProcessFailed);
-			process.StandardInput.Close();
-		}
-		catch (Win32Exception)
-		{
-			return Unavailable(ProjectGitHistoryUnavailableReason.GitUnavailable);
-		}
-		catch (InvalidOperationException exception)
-		{
-			return Unavailable(ProjectGitHistoryUnavailableReason.ProcessFailed, exception.Message);
-		}
+		var shallowResult = await RunLocalReadAsync(
+			repositoryRoot,
+			GitProcessOperation.ReadShallowRepositoryState(),
+			maximumOutputCharacters: 64,
+			cancellationToken).ConfigureAwait(false);
+		if (!shallowResult.IsSuccess)
+			return Unavailable(shallowResult.FailureReason, shallowResult.Detail);
+		var shallowText = shallowResult.Output.TrimEnd('\r', '\n');
+		if (!bool.TryParse(shallowText, out var isShallow))
+			return Unavailable(ProjectGitHistoryUnavailableReason.InvalidOutput);
 
-		var outputTask = GitProcessOutputReader.ReadAsync(
-			process.StandardOutput,
+		var historyResult = await RunLocalReadAsync(
+			repositoryRoot,
+			GitProcessOperation.ReadHistoryWindow(),
 			MaximumOutputCharacters,
-			deadline.Token);
-		var errorTask = GitProcessOutputReader.ReadAsync(
-			process.StandardError,
-			GitProcessOutputReader.MaximumOutputCharacters,
-			deadline.Token);
-		try
-		{
-			await GitRepositoryService.WaitForExitOrTerminateAsync(process, deadline.Token)
-				.ConfigureAwait(false);
-			if (!await GitProcessOutputReader
-				    .WaitForCompletionAfterExitAsync(process, outputTask, errorTask)
-				    .ConfigureAwait(false))
-			{
-				return Unavailable(ProjectGitHistoryUnavailableReason.ProcessFailed);
-			}
-			var output = await outputTask.ConfigureAwait(false);
-			var error = await errorTask.ConfigureAwait(false);
-			if (output.ExceededLimit || error.ExceededLimit)
-				return Unavailable(ProjectGitHistoryUnavailableReason.OutputLimitExceeded);
-			if (process.ExitCode != 0)
-				return Unavailable(ProjectGitHistoryUnavailableReason.ProcessFailed, FirstLine(error.Text));
-			return Parse(repositoryRoot, candidateFiles, output.Text);
-		}
-		catch (OperationCanceledException)
-		{
-			await GitProcessOutputReader
-				.ObserveAfterTerminationAsync(process, outputTask, errorTask)
-				.ConfigureAwait(false);
-			if (cancellationToken.IsCancellationRequested)
-				throw;
-			return Unavailable(ProjectGitHistoryUnavailableReason.ProcessFailed, "Git history read exceeded its safety deadline.");
-		}
+			cancellationToken).ConfigureAwait(false);
+		if (!historyResult.IsSuccess)
+			return Unavailable(historyResult.FailureReason, historyResult.Detail);
+		return Parse(repositoryRoot, candidateFiles, historyResult.Output, isShallow);
 	}
 
 	internal static ProjectGitHistorySnapshot Parse(
 		string repositoryRoot,
 		IReadOnlyList<string> candidateFiles,
-		string output)
+		string output,
+		bool isShallow = false)
 	{
 		var root = Path.GetFullPath(repositoryRoot);
 		var canonicalCandidates = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -151,7 +114,79 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 			CommitWindow,
 			commitPosition,
 			files,
-			unavailable);
+			unavailable)
+		{
+			IsShallow = isShallow,
+			IsComplete = !isShallow || commitPosition >= CommitWindow
+		};
+	}
+
+	private static async Task<LocalReadResult> RunLocalReadAsync(
+		string repositoryRoot,
+		GitProcessOperation operation,
+		int maximumOutputCharacters,
+		CancellationToken cancellationToken)
+	{
+		using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		deadline.CancelAfter(operation.Deadline);
+		using var process = new Process
+		{
+			StartInfo = GitProcessStartInfoFactory.Create(repositoryRoot, operation)
+		};
+		try
+		{
+			if (!process.Start())
+				return LocalReadResult.Failed(ProjectGitHistoryUnavailableReason.ProcessFailed);
+			process.StandardInput.Close();
+		}
+		catch (Win32Exception)
+		{
+			return LocalReadResult.Failed(ProjectGitHistoryUnavailableReason.GitUnavailable);
+		}
+		catch (InvalidOperationException exception)
+		{
+			return LocalReadResult.Failed(ProjectGitHistoryUnavailableReason.ProcessFailed, exception.Message);
+		}
+
+		var outputTask = GitProcessOutputReader.ReadAsync(
+			process.StandardOutput,
+			maximumOutputCharacters,
+			deadline.Token);
+		var errorTask = GitProcessOutputReader.ReadAsync(
+			process.StandardError,
+			GitProcessOutputReader.MaximumOutputCharacters,
+			deadline.Token);
+		try
+		{
+			await GitRepositoryService.WaitForExitOrTerminateAsync(process, deadline.Token)
+				.ConfigureAwait(false);
+			if (!await GitProcessOutputReader
+				    .WaitForCompletionAfterExitAsync(process, outputTask, errorTask)
+				    .ConfigureAwait(false))
+			{
+				return LocalReadResult.Failed(ProjectGitHistoryUnavailableReason.ProcessFailed);
+			}
+			var output = await outputTask.ConfigureAwait(false);
+			var error = await errorTask.ConfigureAwait(false);
+			if (output.ExceededLimit || error.ExceededLimit)
+				return LocalReadResult.Failed(ProjectGitHistoryUnavailableReason.OutputLimitExceeded);
+			return process.ExitCode == 0
+				? LocalReadResult.Succeeded(output.Text)
+				: LocalReadResult.Failed(
+					ProjectGitHistoryUnavailableReason.ProcessFailed,
+					FirstLine(error.Text));
+		}
+		catch (OperationCanceledException)
+		{
+			await GitProcessOutputReader
+				.ObserveAfterTerminationAsync(process, outputTask, errorTask)
+				.ConfigureAwait(false);
+			if (cancellationToken.IsCancellationRequested)
+				throw;
+			return LocalReadResult.Failed(
+				ProjectGitHistoryUnavailableReason.ProcessFailed,
+				"Git history read exceeded its safety deadline.");
+		}
 	}
 
 	private static bool TryReadRecordHeader(string field, out string hash)
@@ -223,5 +258,20 @@ public sealed class ProjectGitHistoryReader : IProjectGitHistoryReader
 	{
 		public int CommitCount { get; set; }
 		public int MostRecentCommitPosition { get; set; }
+	}
+
+	private readonly record struct LocalReadResult(
+		bool IsSuccess,
+		string Output,
+		ProjectGitHistoryUnavailableReason FailureReason,
+		string? Detail)
+	{
+		public static LocalReadResult Succeeded(string output) =>
+			new(true, output, ProjectGitHistoryUnavailableReason.None, null);
+
+		public static LocalReadResult Failed(
+			ProjectGitHistoryUnavailableReason reason,
+			string? detail = null) =>
+			new(false, string.Empty, reason, detail);
 	}
 }

--- a/Tests/DevProjex.Tests.Integration/GitSafeProfileAdversarialIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitSafeProfileAdversarialIntegrationTests.cs
@@ -76,6 +76,33 @@ public sealed class GitSafeProfileAdversarialIntegrationTests
 	}
 
 	[Fact]
+	public async Task RankingHistoryUsesLocalReadWithoutExecutingHostileRepositoryPrograms()
+	{
+		using var fixture = await HostileGitFixture.CreateAsync(TestContext.Current.CancellationToken);
+		fixture.RunGit("config", "core.fsmonitor", fixture.CreateMarkerCommand("fsmonitor"));
+		fixture.RunGit("config", "diff.external", fixture.CreateMarkerCommand("diff-external"));
+		fixture.RunGit("config", "diff.hostile.command", fixture.CreateMarkerCommand("diff-command"));
+		fixture.RunGit("config", "diff.hostile.textconv", fixture.CreateMarkerCommand("textconv"));
+		fixture.RunGit("config", "log.showSignature", "true");
+		fixture.RunGit("config", "gpg.program", fixture.CreateMarkerCommand("gpg"));
+		fixture.RunGit("config", "core.pager", fixture.CreateMarkerCommand("pager"));
+		fixture.RunGit("config", "alias.rev-parse", "!" + fixture.CreateMarkerCommand("alias-rev-parse"));
+		fixture.RunGit("config", "credential.helper", fixture.CreateMarkerCommand("credential"));
+		fixture.RunGit("config", "core.gitProxy", fixture.CreateMarkerCommand("proxy"));
+		fixture.RunGit("config", "core.sshCommand", fixture.CreateMarkerCommand("ssh-command"));
+		var tracked = Path.Combine(fixture.RepositoryPath, "tracked.txt");
+
+		var history = await new ProjectGitHistoryReader().ReadAsync(
+			fixture.RepositoryPath,
+			[tracked],
+			TestContext.Current.CancellationToken);
+
+		Assert.True(history.IsAvailable, history.Detail);
+		Assert.True(history.Files[tracked].CommitCount > 0);
+		Assert.Empty(Directory.EnumerateFiles(fixture.MarkersDirectory));
+	}
+
+	[Fact]
 	public async Task ManagedCheckoutAndWorktreeUseEmptyHooksAndFilterOverrides()
 	{
 		using var fixture = await HostileGitFixture.CreateAsync(TestContext.Current.CancellationToken);

--- a/Tests/DevProjex.Tests.Integration/ProjectGitHistoryReaderIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ProjectGitHistoryReaderIntegrationTests.cs
@@ -109,6 +109,55 @@ public sealed class ProjectGitHistoryReaderIntegrationTests
 		Assert.Equal(new ProjectGitFileActivity(1, 3), history.Files[ordinaryPath]);
 	}
 
+	[Fact]
+	public async Task ReadAsync_ReportsShallowHistoryAsIncomplete()
+	{
+		using var source = new HistoryRepositoryFixture();
+		source.Write("source.cs", "class Source;\n");
+		source.Commit("initial");
+		using var cloneDirectory = new TemporaryDirectory();
+		var clone = cloneDirectory.CreateDirectory("shallow");
+		RunGitOutsideRepository(
+			"clone",
+			"--quiet",
+			"--depth",
+			"1",
+			new Uri(source.RepositoryPath).AbsoluteUri,
+			clone);
+		var path = Path.Combine(clone, "source.cs");
+
+		var history = await new ProjectGitHistoryReader().ReadAsync(
+			clone,
+			[path],
+			TestContext.Current.CancellationToken);
+
+		Assert.True(history.IsAvailable, history.Detail);
+		Assert.True(history.IsShallow);
+		Assert.False(history.IsComplete);
+		Assert.Equal(1, history.CommitCount);
+		Assert.Equal(200, history.WindowSize);
+	}
+
+	private static void RunGitOutsideRepository(params string[] arguments)
+	{
+		var startInfo = new ProcessStartInfo(GitRuntime.GitExecutable)
+		{
+			UseShellExecute = false,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		foreach (var argument in arguments)
+			startInfo.ArgumentList.Add(argument);
+		using var process = Process.Start(startInfo);
+		Assert.NotNull(process);
+		process.StandardInput.Close();
+		var output = process.StandardOutput.ReadToEnd();
+		var error = process.StandardError.ReadToEnd();
+		Assert.True(process.WaitForExit(30_000), "Fixture Git command timed out.");
+		Assert.True(process.ExitCode == 0, $"git {string.Join(' ', arguments)} failed: {error}{output}");
+	}
+
 	private sealed class HistoryRepositoryFixture : IDisposable
 	{
 		private readonly TemporaryDirectory _temporary = new();

--- a/Tests/DevProjex.Tests.Integration/ProjectGitHistoryReaderIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ProjectGitHistoryReaderIntegrationTests.cs
@@ -76,6 +76,39 @@ public sealed class ProjectGitHistoryReaderIntegrationTests
 		Assert.False(File.Exists(markerPath), "Protected history read executed a repository program.");
 	}
 
+	[Fact]
+	public async Task ReadAsync_PreservesNewlineAndRecordSeparatorInGitPaths()
+	{
+		if (OperatingSystem.IsWindows())
+			return;
+
+		using var fixture = new HistoryRepositoryFixture();
+		const string newlineName = "\nleading.cs";
+		const string separatorName = "unit\x1erecord.cs";
+		const string ordinaryName = "ordinary.cs";
+		fixture.Write(newlineName, "one\n");
+		fixture.Write(separatorName, "one\n");
+		fixture.Write(ordinaryName, "one\n");
+		fixture.Commit("initial");
+		fixture.Write(newlineName, "two\n");
+		fixture.Commit("update newline name");
+		fixture.Write(separatorName, "two\n");
+		fixture.Commit("update record separator name");
+		var newlinePath = Path.Combine(fixture.RepositoryPath, newlineName);
+		var separatorPath = Path.Combine(fixture.RepositoryPath, separatorName);
+		var ordinaryPath = Path.Combine(fixture.RepositoryPath, ordinaryName);
+
+		var history = await new ProjectGitHistoryReader().ReadAsync(
+			fixture.RepositoryPath,
+			[newlinePath, separatorPath, ordinaryPath],
+			TestContext.Current.CancellationToken);
+
+		Assert.True(history.IsAvailable, history.Detail);
+		Assert.Equal(new ProjectGitFileActivity(2, 2), history.Files[newlinePath]);
+		Assert.Equal(new ProjectGitFileActivity(2, 1), history.Files[separatorPath]);
+		Assert.Equal(new ProjectGitFileActivity(1, 3), history.Files[ordinaryPath]);
+	}
+
 	private sealed class HistoryRepositoryFixture : IDisposable
 	{
 		private readonly TemporaryDirectory _temporary = new();

--- a/Tests/DevProjex.Tests.Terminal/ImportanceRankedContextDocumentTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ImportanceRankedContextDocumentTests.cs
@@ -26,6 +26,41 @@ public sealed class ImportanceRankedContextDocumentTests
 	}
 
 	[Fact]
+	public async Task RankingPreservesCompressedAndRedactedPayloadsAndPlaceholderIdentities()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile(
+			"project/A.cs",
+			"class A { const string Token = \"ghp_a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL\"; void Run() { int hidden = 1; } }\n");
+		workspace.WriteFile(
+			"project/B.cs",
+			"class B { const string Token = \"ghp_Q7wE9rT2yU4iO6pA8sD0fG1hJ3kL5zX7cV9b\"; void Run() { int hidden = 2; } }\n");
+		using var services = new TerminalServiceFactory(
+				() => workspace.CreateDirectory("app-data"))
+			.Create(AppLanguage.En);
+		var plan = await services.ContextFactory.BuildAsync(
+			project,
+			new ProjectSelectionSpec(
+				GitMode: GitFilteringMode.None,
+				Exclusions: [],
+				HideSecrets: true,
+				CompressCode: true),
+			cancellationToken: TestContext.Current.CancellationToken);
+		var ranking = CreateRanking(plan, "B.cs", "A.cs");
+
+		var ordinary = await WriteJsonAsync(services.ContextDocumentService, plan, ranking: null);
+		var ranked = await WriteJsonAsync(services.ContextDocumentService, plan, ranking);
+
+		Assert.Equal(ordinary.OrderBy(static pair => pair.Key), ranked.OrderBy(static pair => pair.Key));
+		Assert.All(ranked.Values, content =>
+		{
+			Assert.Contains("DEVPROJEX_REDACTED", content, StringComparison.Ordinal);
+			Assert.DoesNotContain("ghp_", content, StringComparison.Ordinal);
+		});
+	}
+
+	[Fact]
 	public async Task RankingControlsGreedyAdmissionAndRecordsPriorityAtSkipTime()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -138,6 +173,26 @@ public sealed class ImportanceRankedContextDocumentTests
 			maximumEstimatedTokens: maximumTokens,
 			ranking: ranking);
 		return (Encoding.UTF8.GetString(destination.ToArray()), report);
+	}
+
+	private static async Task<IReadOnlyDictionary<string, string>> WriteJsonAsync(
+		ProjectContextDocumentService service,
+		ProjectContextPlan plan,
+		ImportanceRankingReport? ranking)
+	{
+		await using var destination = new MemoryStream();
+		await service.WriteCompleteWithReportAsync(
+			plan,
+			ProjectContextView.Content,
+			ProjectContextDocumentFormat.Json,
+			destination,
+			TestContext.Current.CancellationToken,
+			ranking: ranking);
+		using var document = JsonDocument.Parse(destination.ToArray());
+		return document.RootElement.GetProperty("files").EnumerateArray().ToDictionary(
+			static file => file.GetProperty("path").GetString()!,
+			static file => file.GetProperty("content").GetString()!,
+			StringComparer.Ordinal);
 	}
 
 	private static ImportanceRankingReport CreateRanking(

--- a/Tests/DevProjex.Tests.Terminal/ImportanceRankingProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ImportanceRankingProcessTests.cs
@@ -32,9 +32,16 @@ public sealed partial class McpServerProcessTests
 		Assert.True(text.IndexOf("B.cs:", StringComparison.Ordinal) < text.IndexOf("A.cs:", StringComparison.Ordinal), text);
 		Assert.Contains("[Ranking] importance-v1", text, StringComparison.Ordinal);
 		Assert.Contains("[Ranking top] B.cs", text, StringComparison.Ordinal);
+		var rankingIndex = text.IndexOf("[Ranking] importance-v1", StringComparison.Ordinal);
+		var rankingTopIndex = text.IndexOf("[Ranking top] B.cs", StringComparison.Ordinal);
+		var mainDataClose = text.IndexOf("</untrusted-data-", StringComparison.Ordinal);
+		var rankingDataOpen = text.LastIndexOf("<untrusted-data-", rankingTopIndex, StringComparison.Ordinal);
+		var rankingDataClose = text.IndexOf("</untrusted-data-", rankingTopIndex, StringComparison.Ordinal);
 		Assert.True(
-			text.IndexOf("[Ranking] importance-v1", StringComparison.Ordinal) >
-			text.LastIndexOf("</untrusted-data-", StringComparison.Ordinal),
+			rankingIndex > mainDataClose,
+			text);
+		Assert.True(
+			rankingDataOpen > rankingIndex && rankingTopIndex > rankingDataOpen && rankingDataClose > rankingTopIndex,
 			text);
 
 		foreach (var invalidArguments in new[]

--- a/Tests/DevProjex.Tests.Terminal/ImportanceRankingProgressTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ImportanceRankingProgressTests.cs
@@ -1,0 +1,47 @@
+using DevProjex.Application.Ranking;
+using DevProjex.Infrastructure.Git;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed class ImportanceRankingProgressTests
+{
+	[Fact]
+	public async Task RankAsyncReportsThreeOrderedBoundedStages()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var files = new[]
+		{
+			workspace.WriteFile("project/A.cs", "class A { B Value = new(); }"),
+			workspace.WriteFile("project/B.cs", "class B { }"),
+			workspace.WriteFile("project/C.cs", "class C { B Value = new(); }")
+		};
+		using var services = new TerminalServiceFactory(
+				() => workspace.CreateDirectory("data"))
+			.Create(AppLanguage.En);
+		var events = new List<ImportanceRankingProgress>();
+		var progress = new SynchronousProgress<ImportanceRankingProgress>(events.Add);
+
+		await new ImportanceRankingService(
+				services.DependencyFactsEngine,
+				new ProjectGitHistoryReader())
+			.RankAsync(project, files, progress, TestContext.Current.CancellationToken);
+
+		Assert.NotEmpty(events);
+		Assert.True(events.Count <= 150, $"Progress emitted {events.Count} events.");
+		Assert.Equal(
+			[
+				ImportanceRankingStage.IndexingFacts,
+				ImportanceRankingStage.ReadingHistory,
+				ImportanceRankingStage.ComputingPriorities
+			],
+			events.Select(static value => value.Stage).Distinct().ToArray());
+		Assert.All(events, value => Assert.InRange(value.Completed, 0, value.Total));
+		Assert.Equal(events[^1].Total, events[^1].Completed);
+	}
+
+	private sealed class SynchronousProgress<T>(Action<T> callback) : IProgress<T>
+	{
+		public void Report(T value) => callback(value);
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/ImportanceRankingSnapshotConsistencyTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ImportanceRankingSnapshotConsistencyTests.cs
@@ -1,0 +1,112 @@
+using System.Collections;
+using System.Reflection;
+using DevProjex.Application.Ranking;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed class ImportanceRankingSnapshotConsistencyTests
+{
+	[Fact]
+	public async Task ExportFailsClosedWhenSourceChangesAfterRankingBeforePreparation()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var source = workspace.WriteFile("project/Source.cs", "class VersionA;");
+		using var services = new TerminalServiceFactory(
+				() => workspace.CreateDirectory("data"))
+			.Create(AppLanguage.En);
+		var environment = new TestTerminalEnvironment();
+		var ranker = new MutatingRankingService(source, "class VersionB;");
+		var request = new ExportContextCommandRequest(
+			ProjectPath: project,
+			Selection: new ProjectSelectionSpec(
+				GitMode: GitFilteringMode.None,
+				Exclusions: [],
+				HideSecrets: true),
+			View: ProjectContextView.Content,
+			Format: ProjectContextDocumentFormat.Text,
+			OutputPath: "-",
+			Force: false,
+			DryRun: false,
+			MaximumEstimatedTokens: null,
+			Output: new TerminalOutputOptions(Progress: TerminalProgressMode.Never),
+			Rank: ProjectContextRank.Importance);
+
+		var exception = await Assert.ThrowsAsync<IOException>(() =>
+			new ExportContextCommandHandler(services, environment, ranker)
+				.ExecuteAsync(request, TestContext.Current.CancellationToken));
+
+		Assert.Contains("repeat the export", exception.Message, StringComparison.Ordinal);
+		Assert.DoesNotContain("class VersionA", environment.StandardOutput, StringComparison.Ordinal);
+		Assert.DoesNotContain("class VersionB", environment.StandardOutput, StringComparison.Ordinal);
+	}
+
+	private sealed class MutatingRankingService(string sourcePath, string replacement) : IImportanceRankingService
+	{
+		public Task<ImportanceRankingReport> RankAsync(
+			string sourceRoot,
+			IReadOnlyList<string> candidateFiles,
+			CancellationToken cancellationToken = default)
+		{
+			var capturedWriteTime = File.GetLastWriteTimeUtc(sourcePath);
+			var report = CreateReport(sourcePath);
+			var version = CaptureRankingVersion(sourcePath);
+			SetSourceVersions(report, sourcePath, version);
+			File.WriteAllText(sourcePath, replacement, new UTF8Encoding(false));
+			File.SetLastWriteTimeUtc(sourcePath, capturedWriteTime);
+			return Task.FromResult(report);
+		}
+
+		private static ImportanceRankingReport CreateReport(string path)
+		{
+			var entry = new ImportanceRankingEntry(
+				path,
+				Path.GetFileName(path),
+				1,
+				1,
+				0,
+				0,
+				null,
+				null,
+				ImportanceFileRole.Source,
+				true,
+				false);
+			return new ImportanceRankingReport(
+				ImportanceRankingService.AlgorithmId,
+				[entry],
+				[entry],
+				1,
+				1,
+				0,
+				1,
+				200,
+				0,
+				ProjectGitHistoryUnavailableReason.NotRepository,
+				true,
+				ImportanceRankingService.GraphVariant);
+		}
+
+		private static object CaptureRankingVersion(string path)
+		{
+			var type = typeof(ImportanceRankingReport).Assembly.GetType(
+				"DevProjex.Application.Ranking.RankingSourceVersion",
+				throwOnError: true)!;
+			return type.GetMethod("Capture", BindingFlags.Static | BindingFlags.NonPublic)!
+				.Invoke(null, [path])!;
+		}
+
+		private static void SetSourceVersions(
+			ImportanceRankingReport report,
+			string path,
+			object version)
+		{
+			var versionType = version.GetType();
+			var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), versionType);
+			var versions = (IDictionary)Activator.CreateInstance(dictionaryType)!;
+			versions.Add(Path.GetFullPath(path), version);
+			typeof(ImportanceRankingReport)
+				.GetProperty("SourceVersions", BindingFlags.Instance | BindingFlags.NonPublic)!
+				.SetValue(report, versions);
+		}
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/ImportanceRankingSnapshotOwnershipTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ImportanceRankingSnapshotOwnershipTests.cs
@@ -1,0 +1,143 @@
+using System.Collections;
+using System.Reflection;
+using DevProjex.Application.Ranking;
+using DevProjex.Kernel.Abstractions;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed class ImportanceRankingSnapshotOwnershipTests
+{
+	[Fact]
+	public async Task ChangedSourceAfterSnapshotOpenDisposesOwnedSnapshotExactlyOnce()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var path = workspace.WriteFile("project/Source.cs", "class VersionA;");
+		using var services = new TerminalServiceFactory(
+				() => workspace.CreateDirectory("data"))
+			.Create(AppLanguage.En);
+		var analyzer = new MutatingTrackingAnalyzer(path, "class VersionB;");
+		var documentService = new ProjectContextDocumentService(
+			services.TreeExportService,
+			analyzer);
+		var ranking = CreateRanking(path);
+		await using var destination = new MemoryStream();
+
+		var exception = await Assert.ThrowsAsync<IOException>(() =>
+			documentService.WriteCompleteWithReportAsync(
+				services.ContextFactory.BuildAsync(
+					project,
+					new ProjectSelectionSpec(GitMode: GitFilteringMode.None, Exclusions: []),
+					cancellationToken: TestContext.Current.CancellationToken).GetAwaiter().GetResult(),
+				ProjectContextView.Content,
+				ProjectContextDocumentFormat.Text,
+				destination,
+				TestContext.Current.CancellationToken,
+				ranking: ranking));
+
+		Assert.Contains("repeat the export", exception.Message, StringComparison.Ordinal);
+		Assert.Equal(1, analyzer.DisposeCount);
+	}
+
+	private static ImportanceRankingReport CreateRanking(string path)
+	{
+		var entry = new ImportanceRankingEntry(
+			path,
+			Path.GetFileName(path),
+			1,
+			1,
+			0,
+			0,
+			null,
+			null,
+			ImportanceFileRole.Source,
+			true,
+			false);
+		var report = new ImportanceRankingReport(
+			ImportanceRankingService.AlgorithmId,
+			[entry],
+			[entry],
+			1,
+			1,
+			0,
+			1,
+			200,
+			0,
+			ProjectGitHistoryUnavailableReason.NotRepository,
+			true,
+			ImportanceRankingService.GraphVariant);
+		var versionType = typeof(ImportanceRankingReport).Assembly.GetType(
+			"DevProjex.Application.Ranking.RankingSourceVersion",
+			throwOnError: true)!;
+		var version = versionType.GetMethod("Capture", BindingFlags.Static | BindingFlags.NonPublic)!
+			.Invoke(null, [path])!;
+		var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), versionType);
+		var versions = (IDictionary)Activator.CreateInstance(dictionaryType)!;
+		versions.Add(Path.GetFullPath(path), version);
+		typeof(ImportanceRankingReport)
+			.GetProperty("SourceVersions", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(report, versions);
+		return report;
+	}
+
+	private sealed class MutatingTrackingAnalyzer(string pathToMutate, string replacement) : IFileContentAnalyzer
+	{
+		private readonly FileContentAnalyzer _inner = new();
+
+		public int DisposeCount { get; private set; }
+
+		public async ValueTask<IFileContentSnapshot> OpenCompleteSnapshotAsync(
+			string path,
+			CancellationToken cancellationToken = default)
+		{
+			var snapshot = await _inner.OpenCompleteSnapshotAsync(path, cancellationToken)
+				.ConfigureAwait(false);
+			var writeTime = File.GetLastWriteTimeUtc(pathToMutate);
+			var replacementPath = pathToMutate + ".replacement";
+			File.WriteAllText(replacementPath, replacement, new UTF8Encoding(false));
+			File.Replace(replacementPath, pathToMutate, destinationBackupFileName: null);
+			File.SetLastWriteTimeUtc(pathToMutate, writeTime);
+			return new TrackingSnapshot(snapshot, () => DisposeCount++);
+		}
+
+		public ValueTask<bool> IsTextFileAsync(string path, CancellationToken cancellationToken = default) =>
+			_inner.IsTextFileAsync(path, cancellationToken);
+
+		public ValueTask<TextFileMetrics?> GetTextFileMetricsAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			_inner.GetTextFileMetricsAsync(path, cancellationToken);
+
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			_inner.TryReadAsTextAsync(path, cancellationToken);
+
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			long maxSizeForFullRead,
+			CancellationToken cancellationToken = default) =>
+			_inner.TryReadAsTextAsync(path, maxSizeForFullRead, cancellationToken);
+	}
+
+	private sealed class TrackingSnapshot(IFileContentSnapshot inner, Action onDispose) : IFileContentSnapshot
+	{
+		private int _disposed;
+
+		public FileContentMetricsResult Result => inner.Result;
+
+		public ValueTask CopyTextToAsync(
+			int maximumCharacters,
+			Func<ReadOnlyMemory<char>, CancellationToken, ValueTask> writeChunk,
+			CancellationToken cancellationToken = default) =>
+			inner.CopyTextToAsync(maximumCharacters, writeChunk, cancellationToken);
+
+		public async ValueTask DisposeAsync()
+		{
+			if (Interlocked.Exchange(ref _disposed, 1) != 0)
+				return;
+			onDispose();
+			await inner.DisposeAsync().ConfigureAwait(false);
+		}
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/RankingOutputContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RankingOutputContractTests.cs
@@ -1,0 +1,67 @@
+using DevProjex.Application.Ranking;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed class RankingOutputContractTests
+{
+	[Fact]
+	public void WriteExplainsCoverageShallowHistoryAndConfidenceLimitedContribution()
+	{
+		using var workspace = new TemporaryDirectory();
+		using var services = new TerminalServiceFactory(
+				() => workspace.CreateDirectory("data"))
+			.Create(AppLanguage.En);
+		var entry = new ImportanceRankingEntry(
+			"Coordinator.cs",
+			"Coordinator.cs",
+			3,
+			0.04,
+			0,
+			4,
+			1,
+			1,
+			ImportanceFileRole.Source,
+			false,
+			true)
+		{
+			Confidence = 0.05,
+			MainContribution = ImportanceRankingSignal.Role,
+			ConfidenceLimited = true,
+			IsCoordinator = true
+		};
+		var report = new ImportanceRankingReport(
+			ImportanceRankingService.AlgorithmId,
+			[entry],
+			[entry],
+			100,
+			60,
+			20,
+			0.6,
+			200,
+			1,
+			ProjectGitHistoryUnavailableReason.None,
+			false,
+			ImportanceRankingService.GraphVariant)
+		{
+			ResolvedInternalReferences = 2,
+			InternalReferenceCandidates = 20,
+			ResolvedInternalReferenceCoverage = 0.1,
+			FilesWithResolvedEdges = 3,
+			GitHistoryIsShallow = true,
+			GitHistoryIsComplete = false,
+			HasMissingSignals = true,
+			MissingSignalPolicy = ImportanceMissingSignalPolicy.ConfidenceLimited
+		};
+		using var output = new StringWriter();
+
+		RankingOutput.Write(output, report, tokenBudget: null, services.Localization);
+
+		var text = output.ToString();
+		Assert.Contains("facts 60%", text, StringComparison.Ordinal);
+		Assert.Contains("resolved internal references 2/20 (10%)", text, StringComparison.Ordinal);
+		Assert.Contains("files with resolved edges 3", text, StringComparison.Ordinal);
+		Assert.Contains("read 1/200 commits; shallow history", text, StringComparison.Ordinal);
+		Assert.Contains("coordinator", text, StringComparison.Ordinal);
+		Assert.Contains("priority 3; graph unavailable; git available; main contribution: role; confidence limited", text, StringComparison.Ordinal);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/GitHistoryOperationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitHistoryOperationTests.cs
@@ -1,0 +1,23 @@
+using DevProjex.Infrastructure.Git;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class GitHistoryOperationTests
+{
+	[Fact]
+	public void ShallowRepositoryProbeIsPinnedToLocalReadRevParse()
+	{
+		var startInfo = GitProcessStartInfoFactory.Create(
+			Path.GetFullPath("repository"),
+			GitProcessOperation.ReadShallowRepositoryState());
+		var arguments = startInfo.ArgumentList.ToArray();
+
+		Assert.Equal("--no-pager", arguments[0]);
+		Assert.Contains("core.fsmonitor=false", arguments);
+		Assert.Equal(
+			["rev-parse", "--is-shallow-repository"],
+			arguments[^2..]);
+		Assert.Equal("", startInfo.Environment["GIT_ALLOW_PROTOCOL"]);
+		Assert.Equal("1", startInfo.Environment["GIT_NO_LAZY_FETCH"]);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
@@ -40,7 +40,8 @@ public sealed class ImportanceRankingServiceTests
 				["ordinary.cs"] = 10,
 				["giant.cs"] = 10_000,
 				["missing.cs"] = null
-			});
+			},
+			TestContext.Current.CancellationToken);
 
 		Assert.Equal(0, normalized["small.cs"]);
 		Assert.Equal(0, normalized["peer.cs"]);
@@ -109,7 +110,8 @@ public sealed class ImportanceRankingServiceTests
 				(FullPath: "b.cs", RelativePath: "b.cs"),
 				(FullPath: "c.cs", RelativePath: "c.cs")
 			},
-			snapshot);
+			snapshot,
+			TestContext.Current.CancellationToken);
 
 		Assert.True(ranks["b.cs"] > ranks["a.cs"]);
 		Assert.Equal(ranks["a.cs"], ranks["c.cs"], precision: 10);
@@ -142,11 +144,48 @@ public sealed class ImportanceRankingServiceTests
 			(FullPath: "a.cs", RelativePath: "a.cs")
 		};
 
-		var first = ImportanceRankingService.CalculatePageRank(candidates, firstSnapshot);
-		var second = ImportanceRankingService.CalculatePageRank(candidates.Reverse().ToArray(), secondSnapshot);
+		var first = ImportanceRankingService.CalculatePageRank(
+			candidates,
+			firstSnapshot,
+			TestContext.Current.CancellationToken);
+		var second = ImportanceRankingService.CalculatePageRank(
+			candidates.Reverse().ToArray(),
+			secondSnapshot,
+			TestContext.Current.CancellationToken);
 
 		Assert.DoesNotContain("notes.md", first.Keys);
 		Assert.Equal(first.OrderBy(static pair => pair.Key), second.OrderBy(static pair => pair.Key));
+	}
+
+	[Fact]
+	public void CalculatePageRank_ObservesCancellationInsideIterations()
+	{
+		const int count = 2_000;
+		var candidates = Enumerable.Range(0, count)
+			.Select(index => (
+				FullPath: $"{index:D4}.cs",
+				RelativePath: $"{index:D4}.cs"))
+			.ToArray();
+		var edges = Enumerable.Range(0, count)
+			.Select(index => Edge($"{index:D4}.cs", $"{(index + 1) % count:D4}.cs"))
+			.ToArray();
+		var snapshot = Snapshot(edges) with
+		{
+			Files = candidates.Select(candidate => CreateFacts(candidate.RelativePath, null)).ToArray()
+		};
+		using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+			TestContext.Current.CancellationToken);
+
+		Assert.Throws<OperationCanceledException>(() =>
+			ImportanceRankingService.CalculatePageRank(
+				candidates,
+				snapshot,
+				cancellation.Token,
+				iteration =>
+				{
+					if (iteration == 1)
+						cancellation.Cancel();
+				}));
 	}
 
 	private static FileFacts CreateFacts(string path, string? importedFramework)

--- a/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class ImportanceRankingServiceTests
 	}
 
 	[Fact]
-	public void CalculateScore_ScalesGraphWeightByCoverageAndRedistributesMissingSignals()
+	public void CalculateScore_ConfidenceLimitsMissingSignals()
 	{
 		var fullCoverage = ImportanceRankingService.CalculateScore(graph: 1, git: 0, role: 0, graphCoverage: 1);
 		var halfCoverage = ImportanceRankingService.CalculateScore(graph: 1, git: 0, role: 0, graphCoverage: 0.5);
@@ -59,11 +59,42 @@ public sealed class ImportanceRankingServiceTests
 
 		Assert.Equal(ImportanceRankingService.GraphWeight, fullCoverage, precision: 10);
 		Assert.True(halfCoverage < fullCoverage);
-		Assert.Equal(
-			ImportanceRankingService.GitWeight /
-			(ImportanceRankingService.GitWeight + ImportanceRankingService.RoleWeight),
-			noGraph,
-			precision: 10);
+		Assert.Equal(ImportanceRankingService.GitWeight, noGraph, precision: 10);
+	}
+
+	[Fact]
+	public void MissingSignalPolicies_DoNotLetUnknownSignalsMasqueradeAsEvidence()
+	{
+		var redistributed = ImportanceRankingService.CalculateScoreBreakdown(
+			graph: null,
+			git: null,
+			role: 1,
+			graphCoverage: 0.9,
+			ImportanceMissingSignalPolicy.Redistribute);
+		var neutral = ImportanceRankingService.CalculateScoreBreakdown(
+			graph: null,
+			git: null,
+			role: 1,
+			graphCoverage: 0.9,
+			ImportanceMissingSignalPolicy.NeutralFill);
+		var limited = ImportanceRankingService.CalculateScoreBreakdown(
+			graph: null,
+			git: null,
+			role: 1,
+			graphCoverage: 0.9,
+			ImportanceMissingSignalPolicy.ConfidenceLimited);
+		var strongGraph = ImportanceRankingService.CalculateScoreBreakdown(
+			graph: 1,
+			git: 0,
+			role: 0.5,
+			graphCoverage: 0.9,
+			ImportanceMissingSignalPolicy.ConfidenceLimited);
+
+		Assert.Equal(1, redistributed.Score, precision: 10);
+		Assert.True(neutral.Score < strongGraph.Score);
+		Assert.True(limited.Score < neutral.Score);
+		Assert.Equal(ImportanceRankingService.RoleWeight, limited.Score, precision: 10);
+		Assert.Equal(ImportanceRankingService.RoleWeight, limited.Confidence, precision: 10);
 	}
 
 	[Theory]
@@ -73,7 +104,7 @@ public sealed class ImportanceRankingServiceTests
 	[InlineData("src/service.cs", "NUnit.Framework", ImportanceFileRole.TestSource)]
 	[InlineData("src/App.csproj", null, ImportanceFileRole.Manifest)]
 	[InlineData("package.json", null, ImportanceFileRole.Manifest)]
-	[InlineData("src/main.cs", null, ImportanceFileRole.EntryPoint)]
+	[InlineData("src/main.cs", null, ImportanceFileRole.Source)]
 	[InlineData("src/model.cs", null, ImportanceFileRole.Source)]
 	public void ClassifyRole_UsesFactsBeforePathConventions(
 		string path,
@@ -84,10 +115,38 @@ public sealed class ImportanceRankingServiceTests
 		var role = ImportanceRankingService.ClassifyRole(
 			path,
 			facts,
-			dependents: expected == ImportanceFileRole.EntryPoint ? 0 : 1,
-			dependencies: expected == ImportanceFileRole.EntryPoint ? 3 : 0);
+			dependents: path == "src/main.cs" ? 0 : 1,
+			dependencies: path == "src/main.cs" ? 3 : 0);
 
 		Assert.Equal(expected, role);
+		Assert.Equal(
+			path == "src/main.cs",
+			ImportanceRankingService.IsCoordinatorCandidate(
+				role,
+				path == "src/main.cs" ? 0 : 1,
+				path == "src/main.cs" ? 3 : 0));
+	}
+
+	[Fact]
+	public void ClassifyRole_ReservesEntryPointForExplicitMainEvidence()
+	{
+		var facts = CreateFacts("src/Program.cs", null) with
+		{
+			Declarations =
+			[
+				new DeclarationFact(
+					new SymbolIdentity("scope", LanguageId.CSharp, SymbolKind.Function, "Program.Main", 0),
+					[new SourceSite("src/Program.cs", 1, "method")])
+			]
+		};
+
+		var role = ImportanceRankingService.ClassifyRole(
+			"src/Program.cs",
+			facts,
+			dependents: 4,
+			dependencies: 2);
+
+		Assert.Equal(ImportanceFileRole.EntryPoint, role);
 	}
 
 	[Fact]
@@ -155,6 +214,25 @@ public sealed class ImportanceRankingServiceTests
 
 		Assert.DoesNotContain("notes.md", first.Keys);
 		Assert.Equal(first.OrderBy(static pair => pair.Key), second.OrderBy(static pair => pair.Key));
+	}
+
+	[Fact]
+	public void PageRankQuantization_GivesSymmetricNodesOneDenseRank()
+	{
+		var values = new Dictionary<string, double?>
+		{
+			["left.cs"] = ImportanceRankingService.QuantizePageRank(0.25),
+			["right.cs"] = ImportanceRankingService.QuantizePageRank(0.25 + 1e-17),
+			["higher.cs"] = ImportanceRankingService.QuantizePageRank(0.5)
+		};
+
+		var normalized = ImportanceRankingService.RankNormalize(
+			values,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(normalized["left.cs"], normalized["right.cs"]);
+		Assert.Equal(0, normalized["left.cs"]);
+		Assert.Equal(1, normalized["higher.cs"]);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
@@ -5,6 +5,30 @@ namespace DevProjex.Tests.Unit;
 
 public sealed class ImportanceRankingServiceTests
 {
+	[Theory]
+	[InlineData(100, 60, 20, 20, 0.60)]
+	[InlineData(10, 5, 0, 5, 0.50)]
+	public void ExtractedFactsCoverage_DoesNotSubtractMutuallyExclusiveFailures(
+		int candidates,
+		int supported,
+		int unsupported,
+		int extractionFailed,
+		double expected)
+	{
+		var coverage = new DependencyFactsCoverage(
+			candidates,
+			supported,
+			unsupported,
+			extractionFailed,
+			new Dictionary<string, int>(),
+			new Dictionary<string, int>());
+
+		var actual = ImportanceRankingService.CalculateExtractedFactsCoverage(coverage, candidates);
+
+		Assert.Equal(expected, actual, precision: 10);
+		Assert.Equal(candidates, coverage.Supported + coverage.Unsupported + coverage.ExtractionFailed);
+	}
+
 	[Fact]
 	public void RankNormalize_UsesRanksAndPreservesMissingSignals()
 	{


### PR DESCRIPTION
Follow-up to #296 for #262. Corrects facts and link coverage, source snapshot consistency, Git history parsing and shallow completeness, PageRank stability and cancellation, missing-signal confidence, and MCP trust boundaries. Reruns and documents the frozen 15-task protocol. Targeted unit, terminal, integration, documentation, and Release builds pass locally.