### PR TITLE
fix(dependencies): correct resolution and cache isolation

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -54,7 +54,8 @@ public sealed record DependencyScopeDescriptor(
 	IReadOnlySet<string> PythonExternalPackages,
 	IReadOnlyList<string> PythonRoots,
 	bool HasConfiguration,
-	string? PythonVersion = null);
+	string? PythonVersion = null,
+	bool AllowJavaScript = false);
 
 public sealed record PackageMapDescriptor(
 	string Directory,

--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -9,7 +9,8 @@ public sealed record PreparedDependencySource(
 	string ExtractorIdentity,
 	string Source,
 	DependencyFileStatus PreparedStatus = DependencyFileStatus.Supported,
-	string? PreparedStatusReason = null);
+	string? PreparedStatusReason = null,
+	bool CanCache = true);
 
 public sealed class DependencyManifestContentIdentities
 {

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1037,10 +1037,12 @@ public sealed class DependencyFactsEngine : IDisposable
 			var extension = Path.GetExtension(source.Path).ToLowerInvariant();
 			if (extension is ".cjs" or ".cts") return true;
 			if (extension is ".mjs" or ".mts") return false;
+			if (extension is not (".ts" or ".tsx" or ".js" or ".jsx"))
+				return scope.LegacyTypeScriptConfiguration;
 			var moduleType = FindNearestPackageMap(source)?.ModuleType;
 			if (string.Equals(moduleType, "commonjs", StringComparison.OrdinalIgnoreCase)) return true;
 			if (string.Equals(moduleType, "module", StringComparison.OrdinalIgnoreCase)) return false;
-			return extension == ".js" || scope.LegacyTypeScriptConfiguration;
+			return true;
 		}
 
 		private static bool IsRequire(ImportFact import) =>
@@ -1061,23 +1063,26 @@ public sealed class DependencyFactsEngine : IDisposable
 		{
 			if (scope is null)
 				return [];
-			foreach (var mapping in scope.TypeScriptPaths
-				         .Select(pair => (pair.Key, pair.Value, Star: pair.Key.IndexOf('*')))
-				         .Where(item => Matches(item.Key, item.Star, specifier))
-				         .OrderBy(static item => item.Star >= 0)
-				         .ThenByDescending(static item => item.Key.Length))
+			var mappings = scope.TypeScriptPaths
+				.Select(pair => (pair.Key, pair.Value, Star: pair.Key.IndexOf('*')))
+				.Where(item => Matches(item.Key, item.Star, specifier))
+				.OrderBy(static item => item.Star >= 0)
+				.ThenByDescending(static item => item.Star)
+				.ThenBy(static item => item.Key, StringComparer.Ordinal)
+				.ToArray();
+			if (mappings.Length == 0)
+				return [];
+			var mapping = mappings[0];
+			var wildcard = mapping.Star < 0 ? string.Empty :
+				specifier[mapping.Star..(specifier.Length - (mapping.Key.Length - mapping.Star - 1))];
+			foreach (var target in mapping.Value)
 			{
-				var wildcard = mapping.Star < 0 ? string.Empty :
-					specifier[mapping.Star..(specifier.Length - (mapping.Key.Length - mapping.Star - 1))];
-				foreach (var target in mapping.Value)
-				{
-					var resolved = ProbeTypeScript(
-						Path.GetFullPath(Path.Combine(scope.Root, target.Replace("*", wildcard, StringComparison.Ordinal))),
-						scope,
-						source).FirstOrDefault();
-					if (resolved is not null)
-						return [resolved];
-				}
+				var resolved = ProbeTypeScript(
+					Path.GetFullPath(Path.Combine(scope.Root, target.Replace("*", wildcard, StringComparison.Ordinal))),
+					scope,
+					source).FirstOrDefault();
+				if (resolved is not null)
+					return [resolved];
 			}
 			return [];
 		}
@@ -1188,9 +1193,12 @@ public sealed class DependencyFactsEngine : IDisposable
 				probes.Add(candidate);
 			else
 			{
-				probes.AddRange([candidate + ".ts", candidate + ".tsx", candidate + ".d.ts"]);
-				if (scope?.AllowJavaScript == true || source.LanguageId is LanguageId.JavaScript)
-					probes.AddRange([candidate + ".js", candidate + ".jsx"]);
+				probes.AddRange([
+					candidate + ".ts",
+					candidate + ".tsx",
+					candidate + ".d.ts",
+					candidate + ".js",
+					candidate + ".jsx"]);
 			}
 			var mode = scope?.ModuleResolution ?? "bundler";
 			if (SupportsDirectoryIndex(mode, source, scope))
@@ -1198,9 +1206,9 @@ public sealed class DependencyFactsEngine : IDisposable
 				probes.AddRange([
 					Path.Combine(candidate, "index.ts"),
 					Path.Combine(candidate, "index.tsx"),
-					Path.Combine(candidate, "index.d.ts")]);
-				if (scope?.AllowJavaScript == true || source.LanguageId is LanguageId.JavaScript)
-					probes.AddRange([Path.Combine(candidate, "index.js"), Path.Combine(candidate, "index.jsx")]);
+					Path.Combine(candidate, "index.d.ts"),
+					Path.Combine(candidate, "index.js"),
+					Path.Combine(candidate, "index.jsx")]);
 			}
 			foreach (var probe in probes)
 			{

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -359,7 +359,11 @@ public sealed class DependencyFactsEngine : IDisposable
 					.Distinct()
 					.OrderBy(static site => site.File, StringComparer.Ordinal)
 					.ThenBy(static site => site.Line)
-					.ToArray()))
+					.ToArray())
+			{
+				ContainingNamespace = group.Select(static item => item.ContainingNamespace)
+					.Order(StringComparer.Ordinal).FirstOrDefault() ?? string.Empty
+			})
 			.OrderBy(static declaration => declaration.Identity.ScopeId, StringComparer.Ordinal)
 			.ThenBy(static declaration => declaration.Identity.QualifiedName, StringComparer.Ordinal)
 			.ThenBy(static declaration => declaration.Identity.GenericArity)
@@ -523,12 +527,13 @@ public sealed class DependencyFactsEngine : IDisposable
 		facts.ErrorNodeKinds.Sum(static pair => StringBytes(pair.Key) + 16) +
 		facts.Declarations.Sum(static declaration => 160 + StringBytes(declaration.Identity.ScopeId) +
 			StringBytes(declaration.Identity.QualifiedName) + StringBytes(declaration.Identity.FileScope) +
+			StringBytes(declaration.ContainingNamespace) +
 			declaration.DeclarationSites.Sum(SiteBytes)) +
 		facts.Imports.Sum(static import => 128 + StringBytes(import.Specifier) + StringBytes(import.ImportedName) +
 			StringBytes(import.Alias) + SiteBytes(import.Site)) +
 		facts.References.Sum(static reference => 160 + StringBytes(reference.Name) + StringBytes(reference.SyntaxKind) +
 			StringBytes(reference.Reason) + StringBytes(reference.Target) + (reference.Candidates?.Sum(StringBytes) ?? 0) +
-			SiteBytes(reference.Site)) +
+			StringBytes(reference.ContainingNamespace) + StringBytes(reference.ContainingType) + SiteBytes(reference.Site)) +
 		facts.ContextNamespaces.Sum(StringBytes) + facts.Aliases.Sum(static pair => StringBytes(pair.Key) + StringBytes(pair.Value)) +
 		facts.GlobalContextNamespaces.Sum(StringBytes) + facts.GlobalAliases.Sum(static pair => StringBytes(pair.Key) + StringBytes(pair.Value)) +
 		facts.TypeParameters.Sum(StringBytes);
@@ -1283,14 +1288,8 @@ public sealed class DependencyFactsEngine : IDisposable
 				if (source.Aliases.TryGetValue(simpleName, out var alias) ||
 				    globalAliases?.TryGetValue(simpleName, out alias) == true)
 					candidates = LookupQualified(source, alias, reference.GenericArity);
-				else
-				{
-					var namespaces = _contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [];
-					var contextual = candidates.Where(symbol => namespaces.Any(ns =>
-						symbol.Identity.QualifiedName.StartsWith(ns + '.', StringComparison.Ordinal))).ToArray();
-					if (contextual.Length > 0)
-						candidates = contextual;
-				}
+				else if (!reference.Name.Contains('.'))
+					candidates = SelectVisibleCSharpCandidates(source, reference, candidates);
 			}
 			if (candidates.Length == 0)
 			{
@@ -1338,6 +1337,44 @@ public sealed class DependencyFactsEngine : IDisposable
 						(matches ??= []).Add(candidate);
 			}
 			return matches?.ToArray() ?? [];
+		}
+
+		private DeclarationFact[] SelectVisibleCSharpCandidates(
+			FileFacts source,
+			ReferenceFact reference,
+			IReadOnlyList<DeclarationFact> candidates)
+		{
+			if (reference.ContainingType is { Length: > 0 } containingType)
+			{
+				var nested = candidates.Where(candidate =>
+				{
+					var separator = candidate.Identity.QualifiedName.LastIndexOf('.');
+					if (separator < 0) return false;
+					var parent = candidate.Identity.QualifiedName[..separator];
+					return parent == containingType || containingType.StartsWith(parent + '.', StringComparison.Ordinal);
+				}).ToArray();
+				if (nested.Length > 0)
+					return nested;
+			}
+
+			var namespaceName = reference.ContainingNamespace;
+			while (namespaceName.Length > 0)
+			{
+				var lexical = candidates.Where(candidate =>
+					candidate.ContainingNamespace.Equals(namespaceName, StringComparison.Ordinal)).ToArray();
+				if (lexical.Length > 0)
+					return lexical;
+				var separator = namespaceName.LastIndexOf('.');
+				namespaceName = separator < 0 ? string.Empty : namespaceName[..separator];
+			}
+
+			var importedNamespaces = _contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [];
+			var imported = candidates.Where(candidate =>
+				importedNamespaces.Contains(candidate.ContainingNamespace, StringComparer.Ordinal)).ToArray();
+			if (imported.Length > 0)
+				return imported;
+
+			return candidates.Where(static candidate => candidate.ContainingNamespace.Length == 0).ToArray();
 		}
 
 		private IReadOnlyList<string> VisibleScopeIds(string scopeId) =>

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -278,32 +278,63 @@ public sealed class DependencyFactsEngine : IDisposable
 	private static IReadOnlyList<RelatedFile> ProjectDependencies(
 		string seed,
 		IReadOnlyList<DependencyEdge> sourceEdges,
-		IReadOnlyDictionary<string, FileFacts> files) =>
-		sourceEdges.Where(edge => edge.Target != seed &&
-		                    (edge.Target is not null || edge.Status == ResolutionStatus.Ambiguous))
-			.GroupBy(edge => edge.Target ?? edge.Candidates.Order(StringComparer.Ordinal).FirstOrDefault() ??
-				$"[{edge.Status.ToString().ToLowerInvariant()}] {edge.Reference}", StringComparer.Ordinal)
-			.Select(group => ToRelated(group.Key, group, files))
+		IReadOnlyDictionary<string, FileFacts> files)
+	{
+		var resolved = sourceEdges
+			.Where(edge => edge.Status == ResolutionStatus.Resolved && edge.Target is not null && edge.Target != seed)
+			.GroupBy(static edge => edge.Target!, StringComparer.Ordinal)
+			.Select(group => ToRelated(group.Key, ResolutionStatus.Resolved, group, files));
+		var ambiguous = sourceEdges
+			.Where(static edge => edge.Status == ResolutionStatus.Ambiguous)
+			.Select(edge => (Edge: edge, Path: edge.Candidates.Order(StringComparer.Ordinal)
+				.FirstOrDefault(candidate => candidate != seed)))
+			.Where(static item => item.Path is not null)
+			.GroupBy(item => new RelatedGroupKey(
+				item.Path!,
+				item.Edge.Layer,
+				item.Edge.Reference,
+				Hash(item.Edge.Candidates.Order(StringComparer.Ordinal))))
+			.Select(group => ToRelated(group.Key.Path, ResolutionStatus.Ambiguous,
+				group.Select(static item => item.Edge), files));
+		return resolved.Concat(ambiguous)
 			.OrderBy(static item => item.Path, StringComparer.Ordinal)
+			.ThenBy(static item => item.Status)
+			.ThenBy(static item => string.Join('\0', item.Candidates), StringComparer.Ordinal)
 			.ToArray();
+	}
 
 	private static IReadOnlyList<RelatedFile> ProjectDependents(
 		string seed,
 		IReadOnlyList<DependencyEdge> targetEdges,
-		IReadOnlyDictionary<string, FileFacts> files) =>
-		targetEdges.Where(edge => edge.Source != seed)
+		IReadOnlyDictionary<string, FileFacts> files)
+	{
+		var eligible = targetEdges.Where(edge => edge.Source != seed).ToArray();
+		var resolved = eligible
+			.Where(static edge => edge.Status == ResolutionStatus.Resolved)
 			.GroupBy(static edge => edge.Source, StringComparer.Ordinal)
-			.Select(group => ToRelated(group.Key, group, files))
+			.Select(group => ToRelated(group.Key, ResolutionStatus.Resolved, group, files));
+		var ambiguous = eligible
+			.Where(static edge => edge.Status == ResolutionStatus.Ambiguous)
+			.GroupBy(edge => new RelatedGroupKey(
+				edge.Source,
+				edge.Layer,
+				edge.Reference,
+				Hash(edge.Candidates.Order(StringComparer.Ordinal))))
+			.Select(group => ToRelated(group.Key.Path, ResolutionStatus.Ambiguous, group, files));
+		return resolved.Concat(ambiguous)
 			.OrderBy(static item => item.Path, StringComparer.Ordinal)
+			.ThenBy(static item => item.Status)
+			.ThenBy(static item => string.Join('\0', item.Candidates), StringComparer.Ordinal)
 			.ToArray();
+	}
 
 	private static RelatedFile ToRelated(
 		string path,
+		ResolutionStatus status,
 		IEnumerable<DependencyEdge> groupedEdges,
 		IReadOnlyDictionary<string, FileFacts> files)
 	{
 		var edges = groupedEdges.ToArray();
-		var status = edges.Select(static edge => edge.Status).OrderBy(static value => value).First();
 		return new RelatedFile(
 			path,
 			status,
@@ -676,6 +707,12 @@ public sealed class DependencyFactsEngine : IDisposable
 	private readonly record struct ManifestRequestKey(
 		string SourceRoot,
 		string ManifestPathsFingerprint);
+
+	private readonly record struct RelatedGroupKey(
+		string Path,
+		EvidenceLayer Layer,
+		string Reference,
+		string CandidatesFingerprint);
 
 	private readonly record struct FileStamp(
 		long Length,

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -393,7 +393,9 @@ public sealed class DependencyFactsEngine : IDisposable
 					.ToArray())
 			{
 				ContainingNamespace = group.Select(static item => item.ContainingNamespace)
-					.Order(StringComparer.Ordinal).FirstOrDefault() ?? string.Empty
+					.Order(StringComparer.Ordinal).FirstOrDefault() ?? string.Empty,
+				ContainingType = group.Select(static item => item.ContainingType)
+					.Order(StringComparer.Ordinal).FirstOrDefault()
 			})
 			.OrderBy(static declaration => declaration.Identity.ScopeId, StringComparer.Ordinal)
 			.ThenBy(static declaration => declaration.Identity.QualifiedName, StringComparer.Ordinal)
@@ -1361,8 +1363,9 @@ public sealed class DependencyFactsEngine : IDisposable
 			}
 			if (source.TypeParameters.Contains(simpleName, StringComparer.Ordinal))
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, "type parameter shadows declarations", []);
+			var expandedName = ExpandQualifiedAlias(source, reference.Name);
 			var candidates = reference.Name.Contains('.')
-				? LookupQualified(source, ExpandQualifiedAlias(source, reference.Name), reference.GenericArity)
+				? LookupQualified(source, expandedName, reference.GenericArity)
 				: LookupSimple(source, simpleName, reference.GenericArity);
 			var attributeName = reference.SyntaxKind == "attribute"
 				? reference.Name + "Attribute"
@@ -1379,6 +1382,8 @@ public sealed class DependencyFactsEngine : IDisposable
 				if (source.Aliases.TryGetValue(simpleName, out var alias) ||
 				    globalAliases?.TryGetValue(simpleName, out alias) == true)
 					candidates = LookupQualified(source, alias, reference.GenericArity);
+				else if (reference.Name.Contains('.') && candidates.Length == 0)
+					candidates = LookupContextualCSharpQualified(source, reference, expandedName);
 				else if (!reference.Name.Contains('.'))
 					candidates = SelectVisibleCSharpCandidates(source, reference, candidates);
 			}
@@ -1437,21 +1442,20 @@ public sealed class DependencyFactsEngine : IDisposable
 		{
 			if (reference.ContainingType is { Length: > 0 } containingType)
 			{
-				var nested = candidates.Where(candidate =>
+				foreach (var enclosingType in EnumerateContainingTypes(containingType, reference.ContainingNamespace))
 				{
-					var separator = candidate.Identity.QualifiedName.LastIndexOf('.');
-					if (separator < 0) return false;
-					var parent = candidate.Identity.QualifiedName[..separator];
-					return parent == containingType || containingType.StartsWith(parent + '.', StringComparison.Ordinal);
-				}).ToArray();
-				if (nested.Length > 0)
-					return nested;
+					var nested = candidates.Where(candidate =>
+						string.Equals(candidate.ContainingType, enclosingType, StringComparison.Ordinal)).ToArray();
+					if (nested.Length > 0)
+						return nested;
+				}
 			}
 
 			var namespaceName = reference.ContainingNamespace;
 			while (namespaceName.Length > 0)
 			{
 				var lexical = candidates.Where(candidate =>
+					candidate.ContainingType is null &&
 					candidate.ContainingNamespace.Equals(namespaceName, StringComparison.Ordinal)).ToArray();
 				if (lexical.Length > 0)
 					return lexical;
@@ -1461,11 +1465,52 @@ public sealed class DependencyFactsEngine : IDisposable
 
 			var importedNamespaces = _contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [];
 			var imported = candidates.Where(candidate =>
+				candidate.ContainingType is null &&
 				importedNamespaces.Contains(candidate.ContainingNamespace, StringComparer.Ordinal)).ToArray();
 			if (imported.Length > 0)
 				return imported;
 
-			return candidates.Where(static candidate => candidate.ContainingNamespace.Length == 0).ToArray();
+			return candidates.Where(static candidate =>
+				candidate.ContainingType is null && candidate.ContainingNamespace.Length == 0).ToArray();
+		}
+
+		private DeclarationFact[] LookupContextualCSharpQualified(
+			FileFacts source,
+			ReferenceFact reference,
+			string qualifiedName)
+		{
+			var namespaceName = reference.ContainingNamespace;
+			while (namespaceName.Length > 0)
+			{
+				var lexical = LookupQualified(source, namespaceName + "." + qualifiedName, reference.GenericArity);
+				if (lexical.Length > 0)
+					return lexical;
+				var separator = namespaceName.LastIndexOf('.');
+				namespaceName = separator < 0 ? string.Empty : namespaceName[..separator];
+			}
+
+			return (_contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [])
+				.SelectMany(namespaceValue => LookupQualified(
+					source,
+					namespaceValue + "." + qualifiedName,
+					reference.GenericArity))
+				.Distinct()
+				.ToArray();
+		}
+
+		private static IEnumerable<string> EnumerateContainingTypes(
+			string containingType,
+			string containingNamespace)
+		{
+			var current = containingType;
+			while (current.Length > containingNamespace.Length)
+			{
+				yield return current;
+				var separator = current.LastIndexOf('.');
+				if (separator < 0)
+					yield break;
+				current = current[..separator];
+			}
 		}
 
 		private IReadOnlyList<string> VisibleScopeIds(string scopeId) =>

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -954,8 +954,13 @@ public sealed class DependencyFactsEngine : IDisposable
 			IEnumerable<string> candidates;
 			if (import.Specifier.StartsWith(".", StringComparison.Ordinal))
 			{
+				if (Path.GetExtension(import.Specifier).Length == 0 && RequiresExplicitRelativeExtension(source, scope))
+				{
+					return Edge(source, import, ResolutionStatus.Unresolved, null,
+						"extension required for a relative ESM import under node16/nodenext", []);
+				}
 				var directory = Path.GetDirectoryName(Path.Combine(_root, source.Path))!;
-				candidates = ProbeTypeScript(Path.GetFullPath(Path.Combine(directory, import.Specifier)), scope);
+				candidates = ProbeTypeScript(Path.GetFullPath(Path.Combine(directory, import.Specifier)), scope, source);
 			}
 			else if (import.Specifier.StartsWith("#", StringComparison.Ordinal))
 			{
@@ -973,7 +978,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			}
 			else
 			{
-				var mapped = ResolvePaths(scope, import.Specifier).ToArray();
+				var mapped = ResolvePaths(scope, source, import.Specifier).ToArray();
 				if (mapped.Length > 0)
 					return FinishImport(source, import, mapped,
 						$"one module target under {scope.ModuleResolution} in {scope.ScopeId}");
@@ -1002,7 +1007,18 @@ public sealed class DependencyFactsEngine : IDisposable
 		private static bool IsRequire(ImportFact import) =>
 			import.Site.Evidence.TrimStart().StartsWith("require", StringComparison.Ordinal);
 
-		private IEnumerable<string> ResolvePaths(DependencyScopeDescriptor? scope, string specifier)
+		private bool RequiresExplicitRelativeExtension(FileFacts source, DependencyScopeDescriptor scope)
+		{
+			var mode = scope.ModuleResolution ?? "bundler";
+			return (mode.Equals("node16", StringComparison.OrdinalIgnoreCase) ||
+			        mode.Equals("nodenext", StringComparison.OrdinalIgnoreCase)) &&
+			       !SupportsCommonJs(source, scope);
+		}
+
+		private IEnumerable<string> ResolvePaths(
+			DependencyScopeDescriptor? scope,
+			FileFacts source,
+			string specifier)
 		{
 			if (scope is null)
 				return [];
@@ -1014,11 +1030,15 @@ public sealed class DependencyFactsEngine : IDisposable
 			{
 				var wildcard = mapping.Star < 0 ? string.Empty :
 					specifier[mapping.Star..(specifier.Length - (mapping.Key.Length - mapping.Star - 1))];
-				var targets = mapping.Value.SelectMany(target => ProbeTypeScript(
-					Path.GetFullPath(Path.Combine(scope.Root, target.Replace("*", wildcard, StringComparison.Ordinal))),
-					scope)).ToArray();
-				if (targets.Length > 0)
-					return targets;
+				foreach (var target in mapping.Value)
+				{
+					var resolved = ProbeTypeScript(
+						Path.GetFullPath(Path.Combine(scope.Root, target.Replace("*", wildcard, StringComparison.Ordinal))),
+						scope,
+						source).FirstOrDefault();
+					if (resolved is not null)
+						return [resolved];
+				}
 			}
 			return [];
 		}
@@ -1047,7 +1067,10 @@ public sealed class DependencyFactsEngine : IDisposable
 					var values = exports ? map.Exports : map.Imports;
 					var key = exports ? (specifier.Length == 0 ? "." : "./" + specifier) : specifier;
 					if (TryMap(values, key, out var target) && target is not null)
-						return ProbeTypeScript(Path.GetFullPath(Path.Combine(directory, target)), FindScope(source.ScopeId));
+						return ProbeTypeScript(
+							Path.GetFullPath(Path.Combine(directory, target)),
+							FindScope(source.ScopeId),
+							source);
 					return [];
 				}
 				if (Path.GetFullPath(directory) == Path.GetFullPath(_root))
@@ -1105,29 +1128,60 @@ public sealed class DependencyFactsEngine : IDisposable
 			return false;
 		}
 
-		private IEnumerable<string> ProbeTypeScript(string candidate, DependencyScopeDescriptor? scope)
+		private IEnumerable<string> ProbeTypeScript(
+			string candidate,
+			DependencyScopeDescriptor? scope,
+			FileFacts source)
 		{
-			var extension = Path.GetExtension(candidate);
+			var extension = Path.GetExtension(candidate).ToLowerInvariant();
 			var probes = new List<string>();
 			if (extension is ".js" or ".mjs" or ".cjs")
 			{
 				var stem = candidate[..^extension.Length];
 				probes.AddRange(extension switch
 				{
-					".mjs" => [stem + ".mts", stem + ".d.mts"],
-					".cjs" => [stem + ".cts", stem + ".d.cts"],
-					_ => [stem + ".ts", stem + ".tsx", stem + ".d.ts"]
+					".mjs" => [stem + ".mts", stem + ".d.mts", candidate],
+					".cjs" => [stem + ".cts", stem + ".d.cts", candidate],
+					_ => [stem + ".ts", stem + ".tsx", stem + ".d.ts", candidate]
 				});
 			}
 			else if (extension.Length > 0)
 				probes.Add(candidate);
 			else
-				probes.AddRange([candidate + ".ts", candidate + ".tsx", candidate + ".d.ts", candidate + ".js"]);
+			{
+				probes.AddRange([candidate + ".ts", candidate + ".tsx", candidate + ".d.ts"]);
+				if (scope?.AllowJavaScript == true || source.LanguageId is LanguageId.JavaScript)
+					probes.AddRange([candidate + ".js", candidate + ".jsx"]);
+			}
 			var mode = scope?.ModuleResolution ?? "bundler";
-			if (mode.Equals("node", StringComparison.OrdinalIgnoreCase) || mode.Equals("node16", StringComparison.OrdinalIgnoreCase))
-				probes.AddRange([Path.Combine(candidate, "index.ts"), Path.Combine(candidate, "index.tsx"), Path.Combine(candidate, "index.d.ts")]);
-			return probes.Select(path => PortableRelative(_root, path)).Where(_files.ContainsKey).Distinct(StringComparer.Ordinal);
+			if (SupportsDirectoryIndex(mode, source, scope))
+			{
+				probes.AddRange([
+					Path.Combine(candidate, "index.ts"),
+					Path.Combine(candidate, "index.tsx"),
+					Path.Combine(candidate, "index.d.ts")]);
+				if (scope?.AllowJavaScript == true || source.LanguageId is LanguageId.JavaScript)
+					probes.AddRange([Path.Combine(candidate, "index.js"), Path.Combine(candidate, "index.jsx")]);
+			}
+			foreach (var probe in probes)
+			{
+				var relative = PortableRelative(_root, probe);
+				if (_files.ContainsKey(relative))
+					return [relative];
+			}
+			return [];
 		}
+
+		private bool SupportsDirectoryIndex(
+			string mode,
+			FileFacts source,
+			DependencyScopeDescriptor? scope) =>
+			mode.Equals("bundler", StringComparison.OrdinalIgnoreCase) ||
+			mode.Equals("node", StringComparison.OrdinalIgnoreCase) ||
+			mode.Equals("node10", StringComparison.OrdinalIgnoreCase) ||
+			(mode.Equals("node16", StringComparison.OrdinalIgnoreCase) ||
+			 mode.Equals("nodenext", StringComparison.OrdinalIgnoreCase)) &&
+			SupportsCommonJs(source, scope!);
 
 		private DependencyEdge ResolvePythonImport(FileFacts source, ImportFact import)
 		{

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Security.Cryptography;
@@ -55,13 +56,15 @@ public sealed class DependencyFactsEngine : IDisposable
 			.Distinct(PathComparer)
 			.OrderBy(path => PortableRelative(root, path), StringComparer.Ordinal)
 			.ToArray();
+		var manifestRelativePaths = manifest.Select(path => PortableRelative(root, path)).ToArray();
 		var manifestRequestKey = new ManifestRequestKey(
 			root,
-			Hash(manifest.Select(path => PortableRelative(root, path))));
+			Hash(manifestRelativePaths));
 		var initialStamps = TryCaptureFileStamps(manifest);
 		var alignedContentIdentities = AlignContentIdentities(manifest, contentIdentities);
 		if (initialStamps is not null &&
 		    _manifestSnapshots.TryGetValue(manifestRequestKey, out var cachedSnapshot) &&
+		    cachedSnapshot.ManifestPaths.SequenceEqual(manifestRelativePaths, StringComparer.Ordinal) &&
 		    cachedSnapshot.Stamps.SequenceEqual(initialStamps) &&
 		    ContentIdentitiesMatch(cachedSnapshot.ContentIdentities, alignedContentIdentities) &&
 		    _indexCache.ContainsKey(cachedSnapshot.IndexCacheKey))
@@ -200,6 +203,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (_indexCache.ContainsKey(cacheKey))
 				StoreManifestSnapshot(
 					manifestRequestKey,
+					manifestRelativePaths,
 					initialStamps,
 					alignedContentIdentities,
 					cacheKey,
@@ -419,6 +423,7 @@ public sealed class DependencyFactsEngine : IDisposable
 
 	private void StoreManifestSnapshot(
 		ManifestRequestKey key,
+		IReadOnlyList<string> manifestPaths,
 		IReadOnlyList<FileStamp> stamps,
 		IReadOnlyList<string>? contentIdentities,
 		IndexCacheKey indexCacheKey,
@@ -427,7 +432,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		lock (_cacheTrimSync)
 		{
 			if (!_indexCache.ContainsKey(indexCacheKey)) return;
-			var entry = new ManifestSnapshotCacheEntry(stamps, contentIdentities, indexCacheKey, snapshot);
+			var entry = new ManifestSnapshotCacheEntry(manifestPaths, stamps, contentIdentities, indexCacheKey, snapshot);
 			if (_manifestSnapshots.TryAdd(key, entry))
 				_manifestSnapshotOrder.Enqueue(key);
 			else
@@ -593,9 +598,20 @@ public sealed class DependencyFactsEngine : IDisposable
 		}).ToArray();
 	}
 
-	private static string Hash(IEnumerable<string> values) =>
-		Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(string.Join('\n', values))))
-			.ToLowerInvariant();
+	private static string Hash(IEnumerable<string> values)
+	{
+		using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+		Span<byte> lengthPrefix = stackalloc byte[sizeof(int)];
+		foreach (var value in values)
+		{
+			var bytes = Encoding.UTF8.GetBytes(value);
+			BinaryPrimitives.WriteInt32BigEndian(lengthPrefix, bytes.Length);
+			hash.AppendData(lengthPrefix);
+			hash.AppendData(bytes);
+		}
+
+		return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+	}
 
 	private static bool IsWithin(string root, string path)
 	{
@@ -646,6 +662,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		long CreationTimeUtcTicks);
 
 	private sealed record ManifestSnapshotCacheEntry(
+		IReadOnlyList<string> ManifestPaths,
 		IReadOnlyList<FileStamp> Stamps,
 		IReadOnlyList<string>? ContentIdentities,
 		IndexCacheKey IndexCacheKey,

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -87,6 +87,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		var prepared = new PreparedDependencyIdentity[manifest.Length];
 		var parsedBefore = _extractor.ParseCount;
 		var facts = new FileFacts[prepared.Length];
+		var cacheable = new bool[prepared.Length];
 		var completed = 0;
 		var reusedFiles = 0;
 		await Parallel.ForEachAsync(
@@ -108,7 +109,9 @@ public sealed class DependencyFactsEngine : IDisposable
 					source.LanguageId);
 				if (source.PreparedStatus != DependencyFileStatus.Supported)
 				{
-					facts[index] = _extractor.Extract(source, _limits);
+					var extracted = _extractor.Extract(source, _limits);
+					facts[index] = extracted;
+					cacheable[index] = source.CanCache && extracted.CanCache;
 					progress?.Report(new DependencyIndexProgress(
 						Interlocked.Increment(ref completed),
 						prepared.Length));
@@ -126,9 +129,12 @@ public sealed class DependencyFactsEngine : IDisposable
 				try
 				{
 					var extracted = await lazy.Value.ConfigureAwait(false);
-					if (ReferenceEquals(lazy, created))
+					if (!extracted.CanCache)
+						_fileCache.TryRemove(new KeyValuePair<FileCacheKey, Lazy<Task<FileFacts>>>(key, lazy));
+					else if (ReferenceEquals(lazy, created))
 						RegisterFileCacheWeight(key, lazy, EstimateFileFactsBytes(extracted));
 					facts[index] = RebindScope(extracted, source.ScopeId);
+					cacheable[index] = source.CanCache && extracted.CanCache;
 				}
 				catch
 				{
@@ -151,6 +157,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			declarationRevision,
 			configuration.Fingerprint);
 		var allowed = orderedFacts.Select(static fact => fact.Path).ToHashSet(StringComparer.Ordinal);
+		var canCacheIndex = cacheable.All(static value => value);
 		var createdIndex = new Lazy<Task<ResolvedIndex>>(
 			() => Task.FromResult(GateResolvedIndex(
 				DependencyResolver.Resolve(
@@ -162,21 +169,30 @@ public sealed class DependencyFactsEngine : IDisposable
 					cancellationToken),
 				allowed)),
 			LazyThreadSafetyMode.ExecutionAndPublication);
-		var cachedIndex = _indexCache.GetOrAdd(cacheKey, createdIndex);
-		if (ReferenceEquals(cachedIndex, createdIndex))
-			_indexCacheOrder.Enqueue(cacheKey);
 		ResolvedIndex resolved;
-		try
+		var resolutionCacheHit = false;
+		if (!canCacheIndex)
 		{
-			resolved = await cachedIndex.Value.ConfigureAwait(false);
+			resolved = await createdIndex.Value.ConfigureAwait(false);
 		}
-		catch
+		else
 		{
-			_indexCache.TryRemove(new KeyValuePair<IndexCacheKey, Lazy<Task<ResolvedIndex>>>(cacheKey, cachedIndex));
-			throw;
+			var cachedIndex = _indexCache.GetOrAdd(cacheKey, createdIndex);
+			if (ReferenceEquals(cachedIndex, createdIndex))
+				_indexCacheOrder.Enqueue(cacheKey);
+			try
+			{
+				resolved = await cachedIndex.Value.ConfigureAwait(false);
+			}
+			catch
+			{
+				_indexCache.TryRemove(new KeyValuePair<IndexCacheKey, Lazy<Task<ResolvedIndex>>>(cacheKey, cachedIndex));
+				throw;
+			}
+			resolutionCacheHit = !ReferenceEquals(cachedIndex, createdIndex);
+			if (!resolutionCacheHit)
+				RegisterIndexCacheWeight(cacheKey, cachedIndex, EstimateResolvedIndexBytes(resolved));
 		}
-		if (ReferenceEquals(cachedIndex, createdIndex))
-			RegisterIndexCacheWeight(cacheKey, cachedIndex, EstimateResolvedIndexBytes(resolved));
 		var coverage = BuildCoverage(resolved.Files);
 		var result = new DependencyIndexSnapshot(
 			root,
@@ -191,14 +207,14 @@ public sealed class DependencyFactsEngine : IDisposable
 			new DependencyIndexMetrics(
 				parsedFiles,
 				reusedFiles,
-				ReferenceEquals(cachedIndex, createdIndex) ? orderedFacts.Length : 0,
+				resolutionCacheHit ? 0 : orderedFacts.Length,
 				started.ElapsedMilliseconds,
-				!ReferenceEquals(cachedIndex, createdIndex)))
+				resolutionCacheHit))
 		{
 			FileByPath = resolved.FileByPath
 		};
 		var finalStamps = TryCaptureFileStamps(manifest);
-		if (initialStamps is not null && finalStamps is not null && initialStamps.SequenceEqual(finalStamps))
+		if (canCacheIndex && initialStamps is not null && finalStamps is not null && initialStamps.SequenceEqual(finalStamps))
 		{
 			if (_indexCache.ContainsKey(cacheKey))
 				StoreManifestSnapshot(

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -65,6 +65,7 @@ public sealed record DeclarationFact(
 	IReadOnlyList<SourceSite> DeclarationSites)
 {
 	public string ContainingNamespace { get; init; } = string.Empty;
+	public string? ContainingType { get; init; }
 }
 
 public sealed record ImportFact(

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -62,7 +62,10 @@ public sealed record SymbolIdentity(
 
 public sealed record DeclarationFact(
 	SymbolIdentity Identity,
-	IReadOnlyList<SourceSite> DeclarationSites);
+	IReadOnlyList<SourceSite> DeclarationSites)
+{
+	public string ContainingNamespace { get; init; } = string.Empty;
+}
 
 public sealed record ImportFact(
 	string Specifier,
@@ -85,7 +88,11 @@ public sealed record ReferenceFact(
 	ResolutionStatus Status = ResolutionStatus.Unresolved,
 	string Reason = "not resolved yet",
 	IReadOnlyList<string>? Candidates = null,
-	string? Target = null);
+	string? Target = null)
+{
+	public string ContainingNamespace { get; init; } = string.Empty;
+	public string? ContainingType { get; init; }
+}
 
 public sealed record FileFacts(
 	string Path,

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -104,7 +104,10 @@ public sealed record FileFacts(
 	IReadOnlyDictionary<string, string> Aliases,
 	IReadOnlyList<string> GlobalContextNamespaces,
 	IReadOnlyDictionary<string, string> GlobalAliases,
-	IReadOnlyList<string> TypeParameters);
+	IReadOnlyList<string> TypeParameters)
+{
+	public bool CanCache { get; init; } = true;
+}
 
 public sealed record DependencyEdge(
 	string Source,

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -46,17 +46,28 @@ reason can cross the current manifest gate, and self-file relationships are supp
 C# compilation scopes come from `.csproj` ownership and `ProjectReference` entries read as XML.
 Global usings and aliases are shared within the owning scope; type parameters shadow global symbols;
 nested generic names preserve the arity of every containing type. `InternalsVisibleTo` does not create
-an edge, target-typed `new()` stays unresolved, and source-generator output is unavailable. Without
-an owning `.csproj` inside the effective manifest, cross-file C# type references stay unresolved.
+an edge, target-typed `new()` stays unresolved, and source-generator output is unavailable. A simple
+type name can resolve only to a declaration in the current or an enclosing namespace, an exactly
+imported namespace, the current type's nesting chain, or the global namespace. Importing `Company`
+does not expose `Company.Internal`, and a sole same-named declaration elsewhere in the project is not
+guessed as the target. Current and enclosing namespaces take precedence over imported namespaces;
+multiple visible imported declarations remain ambiguous. Without an owning `.csproj` inside the
+effective manifest, cross-file C# type references stay unresolved.
 
 TypeScript and JavaScript use the nearest `tsconfig.json` or `jsconfig.json`. The resolver distinguishes
-relative, bare, package-self, and `#imports` specifiers; performs `.js` to `.ts`, `.tsx`, and `.d.ts`
-substitution; applies exact `paths` entries before wildcard entries; and respects `package.json`
-`exports`, conditions, and explicit `null` blocking. Directory-index fallback is mode-dependent.
-Literal `require(...)` calls are import evidence only in a supported CommonJS context; ESM contexts
-remain unresolved. `node10` (including its `node` alias) and `baseUrl` are marked legacy under the
-TypeScript 7 contract. DevProjex never guesses a `dist` to `src` mapping without configuration, and module references without an owning
-`tsconfig.json` or `jsconfig.json` stay unresolved.
+relative, bare, package-self, and `#imports` specifiers and follows ordered substitution: the first
+existing probe wins, so multiple files found later in the same probe sequence are not ambiguity.
+`.js`, `.mjs`, and `.cjs` specifiers probe their TypeScript and declaration counterparts before the
+literal JavaScript file. Extensionless imports probe TypeScript first and JavaScript only for an
+`allowJs` project or JavaScript source. Exact `paths` entries precede wildcard entries, and fallback
+targets are tried in declaration order. `package.json` `exports`, conditions, and explicit `null`
+blocking remain authoritative. Directory-index fallback is allowed by `node10` and `bundler`; under
+`node16`/`nodenext`, an ESM relative import needs an explicit extension while a supported CommonJS
+context can use extensionless and directory probes. Literal `require(...)` calls are import evidence
+only in such a CommonJS context. `node10` (including its `node` alias) and `baseUrl` are marked legacy
+under the TypeScript 7 contract. DevProjex never guesses a `dist` to `src` mapping without
+configuration, and module references without an owning `tsconfig.json` or `jsconfig.json` stay
+unresolved.
 
 Python relative imports start at the source package. Regular and namespace-package portions are
 combined, `.py` is preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and
@@ -105,6 +116,11 @@ Concurrent requests share one lazy computation. The default caches are bounded b
 and estimated retained size: 64 MiB for compact file facts and 128 MiB for resolved edges. Eviction
 changes latency, not results.
 
+Access failures, missing files, and other transient I/O failures are not retained in either the
+prepared-source cache or a manifest snapshot. A later request retries extraction even when file stamps
+are unchanged. Stable outcomes such as an unsupported language, a content parse failure, or a safety
+limit remain cacheable.
+
 The engine has two metadata shortcuts above those content-fingerprinted facts: the extractor retains
 prepared decoded text, and the engine retains resolved snapshots for a manifest. Importance ranking
 supplies the SHA-256 identity it already captured from each source to both shortcuts, so a cache hit
@@ -113,6 +129,11 @@ requires matching file metadata and the same opaque content identity. `related_f
 length, modification-time, and creation-time compromise. A same-length replacement whose timestamps
 are deliberately restored can therefore remain cached for those two related-file surfaces until the
 entry is evicted or its metadata changes.
+
+The content identity passed to the extractor is an observed cache label; the extractor does not hash
+the bytes again while reading. An adversarial `hash A -> read B -> restore A -> hash A` sequence between
+the two observations is therefore not detected. This is a known coherence limitation, not evidence
+that the intermediate bytes belonged to identity A.
 
 Changing one source reparses that source. Changing resolver configuration invalidates resolution but
 reuses file facts, so no source parse is required. Before every result is exposed, it is gated against

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -51,23 +51,28 @@ type name can resolve only to a declaration in the current or an enclosing names
 imported namespace, the current type's nesting chain, or the global namespace. Importing `Company`
 does not expose `Company.Internal`, and a sole same-named declaration elsewhere in the project is not
 guessed as the target. Current and enclosing namespaces take precedence over imported namespaces;
-multiple visible imported declarations remain ambiguous. Without an owning `.csproj` inside the
-effective manifest, cross-file C# type references stay unresolved.
+multiple visible imported declarations remain ambiguous. Namespace lookup considers only immediate
+members of that namespace: a nested type is visible through an explicit qualification such as
+`Holder.Task` or through the source type's nearest-to-farthest containing-type chain. Without an
+owning `.csproj` inside the effective manifest, cross-file C# type references stay unresolved.
 
 TypeScript and JavaScript use the nearest `tsconfig.json` or `jsconfig.json`. The resolver distinguishes
 relative, bare, package-self, and `#imports` specifiers and follows ordered substitution: the first
 existing probe wins, so multiple files found later in the same probe sequence are not ambiguity.
 `.js`, `.mjs`, and `.cjs` specifiers probe their TypeScript and declaration counterparts before the
-literal JavaScript file. Extensionless imports probe TypeScript first and JavaScript only for an
-`allowJs` project or JavaScript source. Exact `paths` entries precede wildcard entries, and fallback
-targets are tried in declaration order. `package.json` `exports`, conditions, and explicit `null`
-blocking remain authoritative. Directory-index fallback is allowed by `node10` and `bundler`; under
-`node16`/`nodenext`, an ESM relative import needs an explicit extension while a supported CommonJS
-context can use extensionless and directory probes. Literal `require(...)` calls are import evidence
-only in such a CommonJS context. `node10` (including its `node` alias) and `baseUrl` are marked legacy
-under the TypeScript 7 contract. DevProjex never guesses a `dist` to `src` mapping without
-configuration, and module references without an owning `tsconfig.json` or `jsconfig.json` stay
-unresolved.
+literal JavaScript file. Extensionless imports and directory indexes always probe `.js` and `.jsx`
+after `.ts`, `.tsx`, and `.d.ts`; `allowJs` controls compilation membership, not resolution of files
+already present in the manifest. Exact `paths` entries precede wildcard entries; among matching
+wildcards, the longest prefix before `*` wins. Only that pattern's targets are tried, in declaration
+order. `package.json` `exports`, conditions, and explicit `null` blocking remain authoritative.
+Directory-index fallback is allowed by `node10` and `bundler`; under `node16`/`nodenext`, an ESM
+relative import needs an explicit extension while a supported CommonJS context can use extensionless
+and directory probes. `.mts`/`.mjs` are ESM, `.cts`/`.cjs` are CommonJS, and ordinary
+`.ts`/`.tsx`/`.js`/`.jsx` files default to CommonJS unless the nearest `package.json` has
+`"type": "module"`. Literal `require(...)` calls are import evidence only in such a CommonJS context.
+`node10` (including its `node` alias) and `baseUrl` are marked legacy under the TypeScript 7 contract.
+DevProjex never guesses a `dist` to `src` mapping without configuration, and module references without
+an owning `tsconfig.json` or `jsconfig.json` stay unresolved.
 
 Python relative imports start at the source package. Regular and namespace-package portions are
 combined, `.py` is preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-run are both `67af9eb88752a1cd3f6deab32bb226439eda3c00`.
+run are both `15a34d2918f14581c876e712e727ba628eb6b9ca`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -212,9 +212,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2704.29 / 2705.74` | `956.28 / 994.05` | `+37.76 ms (3.95%)` | `299.01 / 298.98` | `309.36 / 315.06` | `1.84%` |
-| Repomix | `867.43 / 898.28` | `483.23 / 472.25` | `-10.98 ms (-2.27%)` | `109.64 / 110.05` | `107.43 / 107.14` | `0.38%` |
-| Flask | `616.27 / 632.54` | `330.75 / 354.80` | `+24.05 ms (7.27%)` | `84.02 / 84.11` | `86.88 / 87.56` | `0.78%` |
+| DevProjex | `3106.95 / 2880.17` | `937.81 / 933.23` | `-4.58 ms (-0.49%)` | `299.51 / 299.30` | `310.43 / 311.43` | `0.32%` |
+| Repomix | `806.86 / 808.08` | `408.20 / 410.02` | `+1.81 ms (0.44%)` | `109.58 / 110.18` | `107.21 / 107.45` | `0.55%` |
+| Flask | `578.64 / 698.38` | `289.08 / 314.33` | `+25.24 ms (8.73%)` | `84.10 / 84.03` | `86.75 / 87.30` | `0.63%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-run are both `15a34d2918f14581c876e712e727ba628eb6b9ca`.
+run are both `25b4acb6283913afe989374be60883694cb090a9`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -212,9 +212,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `3106.95 / 2880.17` | `937.81 / 933.23` | `-4.58 ms (-0.49%)` | `299.51 / 299.30` | `310.43 / 311.43` | `0.32%` |
-| Repomix | `806.86 / 808.08` | `408.20 / 410.02` | `+1.81 ms (0.44%)` | `109.58 / 110.18` | `107.21 / 107.45` | `0.55%` |
-| Flask | `578.64 / 698.38` | `289.08 / 314.33` | `+25.24 ms (8.73%)` | `84.10 / 84.03` | `86.75 / 87.30` | `0.63%` |
+| DevProjex | `2726.33 / 2779.00` | `963.22 / 1047.16` | `+83.94 ms (8.71%)` | `286.54 / 288.83` | `299.23 / 302.76` | `1.18%` |
+| Repomix | `807.94 / 809.41` | `404.52 / 412.87` | `+8.35 ms (2.06%)` | `109.84 / 109.79` | `107.02 / 107.32` | `0.28%` |
+| Flask | `541.79 / 561.06` | `276.24 / 265.36` | `-10.88 ms (-3.94%)` | `83.75 / 84.09` | `87.28 / 87.23` | `0.40%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-run are both `533e796de6360cab1b7deef9fdc6622399c8bbc6`.
+run are both `67af9eb88752a1cd3f6deab32bb226439eda3c00`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -212,9 +212,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2730.19 / 2724.33` | `901.93 / 912.95` | `+11.02 ms (1.22%)` | `282.34 / 283.85` | `291.89 / 297.72` | `2.00%` |
-| Repomix | `815.47 / 848.59` | `424.31 / 417.79` | `-6.52 ms (-1.54%)` | `109.83 / 109.89` | `107.22 / 107.47` | `0.23%` |
-| Flask | `587.95 / 588.12` | `275.44 / 294.17` | `+18.73 ms (6.80%)` | `84.15 / 84.17` | `84.95 / 85.17` | `0.25%` |
+| DevProjex | `2704.29 / 2705.74` | `956.28 / 994.05` | `+37.76 ms (3.95%)` | `299.01 / 298.98` | `309.36 / 315.06` | `1.84%` |
+| Repomix | `867.43 / 898.28` | `483.23 / 472.25` | `-10.98 ms (-2.27%)` | `109.64 / 110.05` | `107.43 / 107.14` | `0.38%` |
+| Flask | `616.27 / 632.54` | `330.75 / 354.80` | `+24.05 ms (7.27%)` | `84.02 / 84.11` | `86.88 / 87.56` | `0.78%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -128,53 +128,44 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 				.Select(static match => match.Groups["name"].Value))
 			.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
 		var declarationCaptures = context.Declarations
-			.Where(capture => Kinds.ContainsKey(capture.Name)).ToArray();
+			.Where(capture => Kinds.ContainsKey(capture.Name) && !string.IsNullOrEmpty(capture.CapturedName))
+			.ToArray();
+		var declarationScopes = BuildDeclarationScopes(declarationCaptures, namespaces);
 		var declarations = new List<DeclarationFact>(declarationCaptures.Length);
 		foreach (var capture in declarationCaptures)
 		{
-			if (string.IsNullOrEmpty(capture.CapturedName))
-				continue;
-			var containingNamespace = namespaces
-				.Where(item => item.Start <= capture.StartIndex && item.End >= capture.EndIndex)
-				.OrderBy(item => item.End - item.Start).Select(static item => item.Name)
-				.FirstOrDefault() ?? namespaces.FirstOrDefault(static item => item.FileScoped)?.Name ?? string.Empty;
-			var parents = declarationCaptures
-				.Where(item => item.StartIndex < capture.StartIndex && item.EndIndex >= capture.EndIndex)
-				.OrderBy(static item => item.StartIndex)
-				.Select(static item => string.IsNullOrEmpty(item.CapturedName)
-					? null
-					: item.CapturedName + AritySuffix(item.GenericArity))
-				.OfType<string>()
-				.ToArray();
-			var name = capture.CapturedName;
-			var qualified = string.Join('.', new[] { containingNamespace }
-				.Concat(parents).Append(name + AritySuffix(capture.GenericArity))
-				.Where(static value => value.Length > 0));
-			var containingType = parents.Length == 0
-				? null
-				: string.Join('.', new[] { containingNamespace }.Concat(parents)
-					.Where(static value => value.Length > 0));
+			var declarationScope = declarationScopes.ByCapture[capture];
 			declarations.Add(new DeclarationFact(
 				new SymbolIdentity(
 					context.ScopeId,
 					context.LanguageId,
 					Kinds[capture.Name],
-					qualified,
+					declarationScope.QualifiedName,
 					capture.GenericArity,
 					capture.IsFileLocal ? context.RelativePath : null),
 				[Site(context, capture)])
 			{
-				ContainingNamespace = containingNamespace,
-				ContainingType = containingType
+				ContainingNamespace = declarationScope.ContainingNamespace,
+				ContainingType = declarationScope.ContainingType
 			});
 		}
 
-		var references = context.References
+		var referenceCaptures = context.References
 			.Where(static capture => capture.Name.StartsWith("reference.", StringComparison.Ordinal))
-			.SelectMany(capture => ExtractReferences(context, capture, declarationCaptures, namespaces))
-			.Where(reference => !declarations.Any(declaration =>
-				declaration.DeclarationSites[0].Line == reference.Site.Line &&
-				SimpleName(declaration.Identity.QualifiedName) == reference.Name))
+			.ToArray();
+		var referenceScopes = BuildReferenceScopes(referenceCaptures, declarationScopes.Ordered);
+		var declarationSites = declarations
+			.Select(static declaration => (
+				declaration.DeclarationSites[0].Line,
+				Name: SimpleName(declaration.Identity.QualifiedName)))
+			.ToHashSet();
+		var references = referenceCaptures
+			.SelectMany(capture => ExtractReferences(
+				context,
+				capture,
+				referenceScopes.GetValueOrDefault(capture),
+				namespaces))
+			.Where(reference => !declarationSites.Contains((reference.Site.Line, reference.Name)))
 			.Take(limits.MaximumFactsPerFile + 1).ToArray();
 		if (declarations.Count + references.Length > limits.MaximumFactsPerFile)
 			return Failure(context, "fact limit exceeded");
@@ -193,25 +184,11 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 	private static IEnumerable<ReferenceFact> ExtractReferences(
 		DependencyExtractionContext context,
 		DependencySyntaxCapture capture,
-		IReadOnlyList<DependencySyntaxCapture> declarationCaptures,
+		DeclarationScope? declarationScope,
 		IReadOnlyList<NamespaceSpan> namespaces)
 	{
-		var containingNamespace = namespaces
-			.Where(item => item.Start <= capture.StartIndex && item.End >= capture.EndIndex)
-			.OrderBy(item => item.End - item.Start).Select(static item => item.Name)
-			.FirstOrDefault() ?? namespaces.FirstOrDefault(static item => item.FileScoped)?.Name ?? string.Empty;
-		var containingTypes = declarationCaptures
-			.Where(item => item.StartIndex < capture.StartIndex && item.EndIndex >= capture.EndIndex)
-			.OrderBy(static item => item.StartIndex)
-			.Select(static item => string.IsNullOrEmpty(item.CapturedName)
-				? null
-				: item.CapturedName + AritySuffix(item.GenericArity))
-			.OfType<string>()
-			.ToArray();
-		var containingType = containingTypes.Length == 0
-			? null
-			: string.Join('.', new[] { containingNamespace }.Concat(containingTypes)
-				.Where(static value => value.Length > 0));
+		var containingNamespace = declarationScope?.ContainingNamespace ?? FindContainingNamespace(capture, namespaces);
+		var containingType = declarationScope?.QualifiedName;
 		if (capture.Name == "reference.target_typed_object_creation")
 		{
 			yield return NewReference(context, capture, "<target-typed-new>", 0, containingNamespace, containingType);
@@ -233,6 +210,73 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 					containingType);
 		}
 	}
+
+	private static DeclarationScopeIndex BuildDeclarationScopes(
+		IReadOnlyList<DependencySyntaxCapture> declarations,
+		IReadOnlyList<NamespaceSpan> namespaces)
+	{
+		var byCapture = new Dictionary<DependencySyntaxCapture, DeclarationScope>(ReferenceEqualityComparer.Instance);
+		var orderedScopes = new List<DeclarationScope>(declarations.Count);
+		var active = new Stack<DeclarationScope>();
+		foreach (var capture in declarations
+			         .OrderBy(static item => item.StartIndex)
+			         .ThenByDescending(static item => item.EndIndex)
+			         .ThenBy(static item => item.CapturedName, StringComparer.Ordinal))
+		{
+			while (active.TryPeek(out var current) && !Contains(current.Capture, capture))
+				active.Pop();
+			var containingNamespace = FindContainingNamespace(capture, namespaces);
+			var containingType = active.TryPeek(out var parent) ? parent.QualifiedName : null;
+			var qualifiedName = string.Join('.', new[]
+				{
+					containingType ?? containingNamespace,
+					capture.CapturedName + AritySuffix(capture.GenericArity)
+				}.Where(static value => value.Length > 0));
+			var scope = new DeclarationScope(capture, containingNamespace, qualifiedName, containingType);
+			byCapture.Add(capture, scope);
+			orderedScopes.Add(scope);
+			active.Push(scope);
+		}
+		return new DeclarationScopeIndex(byCapture, orderedScopes);
+	}
+
+	private static IReadOnlyDictionary<DependencySyntaxCapture, DeclarationScope?> BuildReferenceScopes(
+		IReadOnlyList<DependencySyntaxCapture> references,
+		IReadOnlyList<DeclarationScope> declarations)
+	{
+		var result = new Dictionary<DependencySyntaxCapture, DeclarationScope?>(ReferenceEqualityComparer.Instance);
+		var active = new Stack<DeclarationScope>();
+		var declarationIndex = 0;
+		foreach (var reference in references
+			         .OrderBy(static item => item.StartIndex)
+			         .ThenBy(static item => item.EndIndex))
+		{
+			while (declarationIndex < declarations.Count &&
+			       declarations[declarationIndex].Capture.StartIndex < reference.StartIndex)
+			{
+				var declaration = declarations[declarationIndex++];
+				while (active.TryPeek(out var current) && !Contains(current.Capture, declaration.Capture))
+					active.Pop();
+				active.Push(declaration);
+			}
+			while (active.TryPeek(out var current) && !Contains(current.Capture, reference))
+				active.Pop();
+			result[reference] = active.TryPeek(out var containing) ? containing : null;
+		}
+		return result;
+	}
+
+	private static bool Contains(DependencySyntaxCapture container, DependencySyntaxCapture item) =>
+		container.StartIndex < item.StartIndex && container.EndIndex >= item.EndIndex;
+
+	private static string FindContainingNamespace(
+		DependencySyntaxCapture capture,
+		IReadOnlyList<NamespaceSpan> namespaces) =>
+		namespaces
+			.Where(item => item.Start <= capture.StartIndex && item.End >= capture.EndIndex)
+			.OrderBy(item => item.End - item.Start)
+			.Select(static item => item.Name)
+			.FirstOrDefault() ?? namespaces.FirstOrDefault(static item => item.FileScoped)?.Name ?? string.Empty;
 
 	private static ReferenceFact NewReference(
 		DependencyExtractionContext context,
@@ -295,6 +339,14 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		return arity < 0 ? value : value[..arity];
 	}
 	private static string AritySuffix(int arity) => arity == 0 ? string.Empty : $"`{arity}";
+	private sealed record DeclarationScope(
+		DependencySyntaxCapture Capture,
+		string ContainingNamespace,
+		string QualifiedName,
+		string? ContainingType);
+	private sealed record DeclarationScopeIndex(
+		IReadOnlyDictionary<DependencySyntaxCapture, DeclarationScope> ByCapture,
+		IReadOnlyList<DeclarationScope> Ordered);
 	private sealed record NamespaceSpan(string Name, int Start, int End, bool FileScoped);
 	private static readonly HashSet<string> Keywords = new(
 		["public", "private", "protected", "internal", "static", "readonly", "ref", "out", "in", "params", "this", "where", "new", "class", "struct", "interface", "record", "enum", "delegate", "void", "var", "get", "set", "init", "return", "true", "false", "null"],

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -144,11 +144,16 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 				.Select(static item => string.IsNullOrEmpty(item.CapturedName)
 					? null
 					: item.CapturedName + AritySuffix(item.GenericArity))
-				.OfType<string>();
+				.OfType<string>()
+				.ToArray();
 			var name = capture.CapturedName;
 			var qualified = string.Join('.', new[] { containingNamespace }
 				.Concat(parents).Append(name + AritySuffix(capture.GenericArity))
 				.Where(static value => value.Length > 0));
+			var containingType = parents.Length == 0
+				? null
+				: string.Join('.', new[] { containingNamespace }.Concat(parents)
+					.Where(static value => value.Length > 0));
 			declarations.Add(new DeclarationFact(
 				new SymbolIdentity(
 					context.ScopeId,
@@ -159,7 +164,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 					capture.IsFileLocal ? context.RelativePath : null),
 				[Site(context, capture)])
 			{
-				ContainingNamespace = containingNamespace
+				ContainingNamespace = containingNamespace,
+				ContainingType = containingType
 			});
 		}
 

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -122,7 +122,6 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 			out var usingNamespaces,
 			out var globalNamespaces,
 			out var globalAliases);
-		usingNamespaces.UnionWith(namespaces.Select(static item => item.Name));
 		var typeParameters = context.References
 			.Where(static capture => capture.Name == "context.type_parameters")
 			.SelectMany(static capture => TypeParameterRegex().Matches(capture.Text)
@@ -158,12 +157,15 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 					qualified,
 					capture.GenericArity,
 					capture.IsFileLocal ? context.RelativePath : null),
-				[Site(context, capture)]));
+				[Site(context, capture)])
+			{
+				ContainingNamespace = containingNamespace
+			});
 		}
 
 		var references = context.References
 			.Where(static capture => capture.Name.StartsWith("reference.", StringComparison.Ordinal))
-			.SelectMany(capture => ExtractReferences(context, capture))
+			.SelectMany(capture => ExtractReferences(context, capture, declarationCaptures, namespaces))
 			.Where(reference => !declarations.Any(declaration =>
 				declaration.DeclarationSites[0].Line == reference.Site.Line &&
 				SimpleName(declaration.Identity.QualifiedName) == reference.Name))
@@ -184,11 +186,29 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 
 	private static IEnumerable<ReferenceFact> ExtractReferences(
 		DependencyExtractionContext context,
-		DependencySyntaxCapture capture)
+		DependencySyntaxCapture capture,
+		IReadOnlyList<DependencySyntaxCapture> declarationCaptures,
+		IReadOnlyList<NamespaceSpan> namespaces)
 	{
+		var containingNamespace = namespaces
+			.Where(item => item.Start <= capture.StartIndex && item.End >= capture.EndIndex)
+			.OrderBy(item => item.End - item.Start).Select(static item => item.Name)
+			.FirstOrDefault() ?? namespaces.FirstOrDefault(static item => item.FileScoped)?.Name ?? string.Empty;
+		var containingTypes = declarationCaptures
+			.Where(item => item.StartIndex < capture.StartIndex && item.EndIndex >= capture.EndIndex)
+			.OrderBy(static item => item.StartIndex)
+			.Select(static item => string.IsNullOrEmpty(item.CapturedName)
+				? null
+				: item.CapturedName + AritySuffix(item.GenericArity))
+			.OfType<string>()
+			.ToArray();
+		var containingType = containingTypes.Length == 0
+			? null
+			: string.Join('.', new[] { containingNamespace }.Concat(containingTypes)
+				.Where(static value => value.Length > 0));
 		if (capture.Name == "reference.target_typed_object_creation")
 		{
-			yield return NewReference(context, capture, "<target-typed-new>", 0);
+			yield return NewReference(context, capture, "<target-typed-new>", 0, containingNamespace, containingType);
 			yield break;
 		}
 		var typeText = capture.Text;
@@ -198,16 +218,32 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 				.Replace("::", ".", StringComparison.Ordinal);
 			var simpleName = name.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? name;
 			if (!Keywords.Contains(simpleName))
-				yield return NewReference(context, capture, name, GenericArityAt(typeText, match.Index + match.Length));
+				yield return NewReference(
+					context,
+					capture,
+					name,
+					GenericArityAt(typeText, match.Index + match.Length),
+					containingNamespace,
+					containingType);
 		}
 	}
 
-	private static ReferenceFact NewReference(DependencyExtractionContext context, DependencySyntaxCapture capture, string name, int arity) =>
+	private static ReferenceFact NewReference(
+		DependencyExtractionContext context,
+		DependencySyntaxCapture capture,
+		string name,
+		int arity,
+		string containingNamespace,
+		string? containingType) =>
 		new(EvidenceLayer.TypeReference, name, arity,
 			capture.Name.StartsWith("reference.", StringComparison.Ordinal)
 				? capture.Name["reference.".Length..]
 				: capture.NodeType,
-			Site(context, capture));
+			Site(context, capture))
+		{
+			ContainingNamespace = containingNamespace,
+			ContainingType = containingType
+		};
 
 	private static FileFacts Failure(DependencyExtractionContext context, string reason) => new(
 		context.RelativePath, context.ScopeId, context.LanguageId, context.ContentFingerprint,

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -68,7 +68,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				packageName,
 				new HashSet<string>(),
 				[],
-				true));
+				true,
+				AllowJavaScript: parsed.AllowJavaScript));
 		}
 
 		foreach (var configPath in manifest.Where(IsPythonConfig).Order(StringComparer.Ordinal))
@@ -170,6 +171,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			var legacy = moduleResolution.Equals("node10", StringComparison.OrdinalIgnoreCase) ||
 			             moduleResolution.Equals("node", StringComparison.OrdinalIgnoreCase) ||
 			             options.TryGetProperty("baseUrl", out _);
+			var allowJavaScript = options.TryGetProperty("allowJs", out var allowJs) &&
+			                      allowJs.ValueKind is JsonValueKind.True;
 			var paths = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
 			if (options.TryGetProperty("paths", out var mappings) && mappings.ValueKind == JsonValueKind.Object)
 			{
@@ -179,7 +182,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 							.Select(static item => item.GetString()!).ToArray()
 						: [];
 			}
-			return new TypeScriptConfiguration(moduleResolution, legacy, paths);
+			return new TypeScriptConfiguration(moduleResolution, legacy, paths, allowJavaScript);
 		}
 		catch (JsonException)
 		{
@@ -413,8 +416,16 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		return relative != ".." && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) && !Path.IsPathRooted(relative);
 	}
 	private static StringComparer PathComparer => OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-	private sealed record TypeScriptConfiguration(string ModuleResolution, bool Legacy, IReadOnlyDictionary<string, IReadOnlyList<string>> Paths)
+	private sealed record TypeScriptConfiguration(
+		string ModuleResolution,
+		bool Legacy,
+		IReadOnlyDictionary<string, IReadOnlyList<string>> Paths,
+		bool AllowJavaScript)
 	{
-		public static readonly TypeScriptConfiguration Default = new("bundler", false, new Dictionary<string, IReadOnlyList<string>>());
+		public static readonly TypeScriptConfiguration Default = new(
+			"bundler",
+			false,
+			new Dictionary<string, IReadOnlyList<string>>(),
+			false);
 	}
 }

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -93,7 +93,9 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			try
 			{
 				content = await entry.Value.Value.ConfigureAwait(false);
-				if (ownsEntry)
+				if (!content.CanCache)
+					RemovePreparedSource(key, entry);
+				else if (ownsEntry)
 					RegisterPreparedSourceWeight(key, entry, EstimatePreparedSourceBytes(content));
 			}
 			catch
@@ -111,14 +113,27 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				content.ExtractorIdentity,
 				content.Source,
 				content.Status,
-				content.StatusReason);
+				content.StatusReason,
+				content.CanCache);
 		}
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Security.SecurityException)
 		{
 			return new PreparedDependencySource(fullPath, relative, scope, language,
 				Hash(Encoding.UTF8.GetBytes(exception.GetType().Name)), GetExtractorIdentity(language),
 				string.Empty, DependencyFileStatus.ExtractionFailed,
-				$"{exception.GetType().Name}: {OneLine(exception.Message)}");
+				$"{exception.GetType().Name}: {OneLine(exception.Message)}",
+				CanCache: false);
+		}
+	}
+
+	private void RemovePreparedSource(PreparedSourceCacheKey key, PreparedSourceCacheEntry entry)
+	{
+		lock (_preparedSourceTrimSync)
+		{
+			_preparedSources.TryRemove(
+				new KeyValuePair<PreparedSourceCacheKey, PreparedSourceCacheEntry>(key, entry));
+			if (_preparedSourceWeights.TryRemove(key, out var removedWeight))
+				_preparedSourceBytes -= removedWeight;
 		}
 	}
 
@@ -167,12 +182,17 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		var extractorIdentity = GetExtractorIdentity(language);
 		if (result.Classification != FileContentClassification.Text || result.Metrics is null)
 		{
+			var canCache = result.Classification is not (
+				FileContentClassification.AccessDenied or
+				FileContentClassification.Missing or
+				FileContentClassification.Unreadable);
 			return new PreparedSourceContent(
 				FingerprintForUnavailableFile(fullPath, result.Classification),
 				extractorIdentity,
 				string.Empty,
 				DependencyFileStatus.ExtractionFailed,
-				$"source is {result.Classification.ToString().ToLowerInvariant()}");
+				$"source is {result.Classification.ToString().ToLowerInvariant()}",
+				canCache);
 		}
 		if (result.Metrics.CharCount > maximumCharacters)
 		{
@@ -292,7 +312,13 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			return runtime.Adapter.Extract(context, limits);
 		}
 		catch (Exception exception) when (exception is
-		       IOException or UnauthorizedAccessException or DllNotFoundException or BadImageFormatException or
+		       IOException or UnauthorizedAccessException or System.Security.SecurityException)
+		{
+			return StatusOnly(source, DependencyFileStatus.ExtractionFailed,
+				$"{exception.GetType().Name}: {OneLine(exception.Message)}") with { CanCache = false };
+		}
+		catch (Exception exception) when (exception is
+		       DllNotFoundException or BadImageFormatException or
 		       EntryPointNotFoundException or InvalidOperationException)
 		{
 			return StatusOnly(source, DependencyFileStatus.ExtractionFailed,
@@ -491,7 +517,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		string ExtractorIdentity,
 		string Source,
 		DependencyFileStatus Status = DependencyFileStatus.Supported,
-		string? StatusReason = null);
+		string? StatusReason = null,
+		bool CanCache = true);
 
 	private sealed record LanguageDefinition(
 		string Library,

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -18,16 +18,16 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	private const long MaximumPreparedSourceBytes = 64L * 1024 * 1024;
 	private const string DiagnosticErrorQuery = "(ERROR) @diagnostic.error";
 	private readonly IGrammarLibraryLocator _locator;
-	private readonly IFileContentAnalyzer _contentAnalyzer = new FileContentAnalyzer();
+	private readonly IFileContentAnalyzer _contentAnalyzer;
 	private readonly IReadOnlyDictionary<LanguageId, LanguageDefinition> _definitions;
 	private readonly ConcurrentDictionary<LanguageId, Lazy<LanguageRuntime>> _runtimes = [];
 	private readonly ConcurrentDictionary<LanguageId, string> _extractorIdentities = [];
 	private readonly ConcurrentDictionary<PreparedSourceCacheKey, PreparedSourceCacheEntry> _preparedSources = [];
-	private readonly ConcurrentDictionary<PreparedSourceCacheKey, long> _preparedSourceWeights = [];
-	private readonly ConcurrentQueue<PreparedSourceCacheKey> _preparedSourceOrder = [];
+	private readonly LinkedList<PreparedSourceCacheEntry> _preparedSourceOrder = [];
 	private readonly SemaphoreSlim _workerBudget = new(Math.Clamp(Environment.ProcessorCount, 1, MaximumWorkers));
 	private readonly object _preparedSourceTrimSync = new();
 	private long _preparedSourceBytes;
+	private long _preparedSourceGeneration;
 	private int _parseCount;
 	private int _compiledQuerySetCount;
 	private int _disposed;
@@ -38,13 +38,29 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	}
 
 	internal TreeSitterDependencyFactExtractor(IGrammarLibraryLocator locator)
+		: this(locator, new FileContentAnalyzer())
+	{
+	}
+
+	internal TreeSitterDependencyFactExtractor(
+		IGrammarLibraryLocator locator,
+		IFileContentAnalyzer contentAnalyzer)
 	{
 		_locator = locator ?? throw new ArgumentNullException(nameof(locator));
+		_contentAnalyzer = contentAnalyzer ?? throw new ArgumentNullException(nameof(contentAnalyzer));
 		_definitions = LanguageDefinition.CreateAll();
 	}
 
 	public int ParseCount => Volatile.Read(ref _parseCount);
 	public int CompiledQuerySetCount => Volatile.Read(ref _compiledQuerySetCount);
+	internal PreparedSourceCacheState CacheState
+	{
+		get
+		{
+			lock (_preparedSourceTrimSync)
+				return new(_preparedSources.Count, _preparedSourceOrder.Count, _preparedSourceBytes);
+		}
+	}
 
 	public async ValueTask<PreparedDependencySource> PrepareAsync(
 		string sourceRoot,
@@ -84,6 +100,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				language,
 				limits.MaximumCharactersPerFile);
 			var created = new PreparedSourceCacheEntry(
+				key,
+				Interlocked.Increment(ref _preparedSourceGeneration),
 				contentIdentity,
 				new Lazy<Task<PreparedSourceContent>>(
 					() => ReadPreparedSourceAsync(fullPath, language, limits.MaximumCharactersPerFile, cancellationToken),
@@ -100,8 +118,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			}
 			catch
 			{
-				_preparedSources.TryRemove(
-					new KeyValuePair<PreparedSourceCacheKey, PreparedSourceCacheEntry>(key, entry));
+				RemovePreparedSource(key, entry);
 				throw;
 			}
 			return new PreparedDependencySource(
@@ -129,12 +146,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	private void RemovePreparedSource(PreparedSourceCacheKey key, PreparedSourceCacheEntry entry)
 	{
 		lock (_preparedSourceTrimSync)
-		{
-			_preparedSources.TryRemove(
-				new KeyValuePair<PreparedSourceCacheKey, PreparedSourceCacheEntry>(key, entry));
-			if (_preparedSourceWeights.TryRemove(key, out var removedWeight))
-				_preparedSourceBytes -= removedWeight;
-		}
+			RemovePreparedSourceUnderLock(key, entry);
 	}
 
 	private (PreparedSourceCacheEntry Entry, bool OwnsEntry) GetOrReplacePreparedSource(
@@ -143,30 +155,48 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		string? requestedIdentity,
 		CancellationToken cancellationToken)
 	{
-		while (true)
+		cancellationToken.ThrowIfCancellationRequested();
+		lock (_preparedSourceTrimSync)
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			var entry = _preparedSources.GetOrAdd(key, created);
-			if (ReferenceEquals(entry, created))
+			if (!_preparedSources.TryGetValue(key, out var entry))
 			{
-				_preparedSourceOrder.Enqueue(key);
-				return (entry, true);
+				AddPreparedSourceUnderLock(key, created);
+				return (created, true);
 			}
 			if (requestedIdentity is null ||
 			    entry.ContentIdentity is not null &&
 			    string.Equals(entry.ContentIdentity, requestedIdentity, StringComparison.Ordinal))
 				return (entry, false);
 
-			lock (_preparedSourceTrimSync)
-			{
-				if (!_preparedSources.TryGetValue(key, out var current) || !ReferenceEquals(current, entry))
-					continue;
-				_preparedSources[key] = created;
-				if (_preparedSourceWeights.TryRemove(key, out var removedWeight))
-					_preparedSourceBytes -= removedWeight;
-				return (created, true);
-			}
+			RemovePreparedSourceUnderLock(key, entry);
+			AddPreparedSourceUnderLock(key, created);
+			return (created, true);
 		}
+	}
+
+	private void AddPreparedSourceUnderLock(
+		PreparedSourceCacheKey key,
+		PreparedSourceCacheEntry entry)
+	{
+		_preparedSources[key] = entry;
+		entry.OrderNode = _preparedSourceOrder.AddLast(entry);
+		TrimPreparedSourcesUnderLock();
+	}
+
+	private bool RemovePreparedSourceUnderLock(
+		PreparedSourceCacheKey key,
+		PreparedSourceCacheEntry entry)
+	{
+		if (!_preparedSources.TryRemove(
+			    new KeyValuePair<PreparedSourceCacheKey, PreparedSourceCacheEntry>(key, entry)))
+			return false;
+		if (entry.OrderNode is not null)
+		{
+			_preparedSourceOrder.Remove(entry.OrderNode);
+			entry.OrderNode = null;
+		}
+		ReleasePreparedSourceWeightUnderLock(entry);
+		return true;
 	}
 
 	private async Task<PreparedSourceContent> ReadPreparedSourceAsync(
@@ -253,17 +283,29 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		lock (_preparedSourceTrimSync)
 		{
 			if (_preparedSources.TryGetValue(key, out var current) && ReferenceEquals(current, entry) &&
-			    _preparedSourceWeights.TryAdd(key, weight))
-				_preparedSourceBytes += weight;
-			while ((_preparedSources.Count > MaximumPreparedSources ||
-			        _preparedSourceBytes > MaximumPreparedSourceBytes) &&
-			       _preparedSourceOrder.TryDequeue(out var oldest))
+			    entry.RegisteredWeight == 0)
 			{
-				_preparedSources.TryRemove(oldest, out _);
-				if (_preparedSourceWeights.TryRemove(oldest, out var removedWeight))
-					_preparedSourceBytes -= removedWeight;
+				entry.RegisteredWeight = weight;
+				_preparedSourceBytes += weight;
 			}
+			TrimPreparedSourcesUnderLock();
 		}
+	}
+
+	private void TrimPreparedSourcesUnderLock()
+	{
+		while ((_preparedSources.Count > MaximumPreparedSources ||
+		        _preparedSourceBytes > MaximumPreparedSourceBytes) &&
+		       _preparedSourceOrder.First is { Value: var oldest })
+			RemovePreparedSourceUnderLock(oldest.Key, oldest);
+	}
+
+	private void ReleasePreparedSourceWeightUnderLock(PreparedSourceCacheEntry entry)
+	{
+		if (entry.RegisteredWeight == 0)
+			return;
+		_preparedSourceBytes -= entry.RegisteredWeight;
+		entry.RegisteredWeight = 0;
 	}
 
 	private static long EstimatePreparedSourceBytes(PreparedSourceContent content) =>
@@ -492,8 +534,12 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	public void Dispose()
 	{
 		if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-		_preparedSources.Clear();
-		_preparedSourceWeights.Clear();
+		lock (_preparedSourceTrimSync)
+		{
+			_preparedSources.Clear();
+			_preparedSourceOrder.Clear();
+			_preparedSourceBytes = 0;
+		}
 		foreach (var runtime in _runtimes.Values.Where(static value => value.IsValueCreated))
 			runtime.Value.Dispose();
 		_workerBudget.Dispose();
@@ -508,9 +554,24 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		LanguageId LanguageId,
 		int MaximumCharacters);
 
-	private sealed record PreparedSourceCacheEntry(
-		string? ContentIdentity,
-		Lazy<Task<PreparedSourceContent>> Value);
+	private sealed class PreparedSourceCacheEntry(
+		PreparedSourceCacheKey key,
+		long generation,
+		string? contentIdentity,
+		Lazy<Task<PreparedSourceContent>> value)
+	{
+		public PreparedSourceCacheKey Key { get; } = key;
+		public long Generation { get; } = generation;
+		public string? ContentIdentity { get; } = contentIdentity;
+		public Lazy<Task<PreparedSourceContent>> Value { get; } = value;
+		public long RegisteredWeight { get; set; }
+		public LinkedListNode<PreparedSourceCacheEntry>? OrderNode { get; set; }
+	}
+
+	internal readonly record struct PreparedSourceCacheState(
+		int Entries,
+		int EvictionEntries,
+		long RetainedBytes);
 
 	private sealed record PreparedSourceContent(
 		string Fingerprint,

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -445,12 +445,12 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			// the fast gate instead of treating a physical line as a semantic boundary.
 			var keyWindowStart = Math.Max(0, delimiterStart - 40);
 			var keyWindow = content[keyWindowStart..delimiterStart];
-			if (!HasCompatibleGenericKey(keyWindow))
+			if (!TryFindCompatibleGenericKey(keyWindow, out var signalStart))
 				continue;
 			// UserSecretsId is project metadata, and the pinned Gitleaks generic rule already
 			// allowlists it. Recognising it before lazy regex construction preserves that
 			// upstream decision without paying for the large generic allowlist on every csproj.
-			if (!keyWindow.Contains("UserSecretsId", StringComparison.OrdinalIgnoreCase))
+			if (!IsUserSecretsIdSignal(keyWindow, signalStart))
 				return true;
 		}
 		return false;
@@ -504,7 +504,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		return length;
 	}
 
-	private static bool HasCompatibleGenericKey(ReadOnlySpan<char> keyWindow)
+	private static bool TryFindCompatibleGenericKey(ReadOnlySpan<char> keyWindow, out int matchedSignalStart)
 	{
 		var suffixEnd = keyWindow.Length;
 		var punctuationCount = 0;
@@ -525,9 +525,31 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 					break;
 				var suffix = key[(signalStart + signal.Length)..];
 				if (suffix.Length <= 20 && IsGenericKeySuffix(suffix))
+				{
+					matchedSignalStart = signalStart;
 					return true;
+				}
 				searchEnd = signalStart;
 			}
+		}
+		matchedSignalStart = -1;
+		return false;
+	}
+
+	private static bool IsUserSecretsIdSignal(ReadOnlySpan<char> keyWindow, int signalStart)
+	{
+		const string userSecretsId = "UserSecretsId";
+		var searchStart = 0;
+		while (searchStart <= keyWindow.Length - userSecretsId.Length)
+		{
+			var relativeStart = keyWindow[searchStart..]
+				.IndexOf(userSecretsId, StringComparison.OrdinalIgnoreCase);
+			if (relativeStart < 0)
+				return false;
+			var identifierStart = searchStart + relativeStart;
+			if (signalStart >= identifierStart && signalStart < identifierStart + userSecretsId.Length)
+				return true;
+			searchStart = identifierStart + 1;
 		}
 		return false;
 	}

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -440,8 +440,10 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 			// Values reject the overwhelming majority of source-code delimiters. Only a
 			// plausible literal pays for the bounded key-vocabulary probe.
-			var lineStart = content[..delimiterStart].LastIndexOfAny('\r', '\n') + 1;
-			var keyWindowStart = Math.Max(lineStart, delimiterStart - 40);
+			// The pinned rule permits up to three whitespace or quote characters between the
+			// key expression and delimiter, including CR and LF. Keep that grammar visible to
+			// the fast gate instead of treating a physical line as a semantic boundary.
+			var keyWindowStart = Math.Max(0, delimiterStart - 40);
 			var keyWindow = content[keyWindowStart..delimiterStart];
 			if (!HasCompatibleGenericKey(keyWindow))
 				continue;

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -136,7 +136,7 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
-	public async Task TypeScriptFacts_ApplyJsSubstitutionPathsAndNoBundlerIndexFallback()
+	public async Task TypeScriptFacts_ApplyOrderedJsSubstitutionPathsAndBundlerIndexFallback()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("tsconfig.json", """
@@ -164,7 +164,76 @@ public sealed class DependencyFactsEngineIntegrationTests
 		Assert.Equal("src/x.ts", resolvedImport.Target);
 		Assert.Contains(result.Edges, edge => edge.Source == "src/main.ts" && edge.Target == "src/exact.ts");
 		Assert.Contains(result.Edges, edge => edge.Source == "src/main.ts" && edge.Target == "src/lib/item.ts");
-		Assert.Contains(result.Edges, edge => edge.Source == "src/main.ts" && edge.Reference == "./dir" && edge.Status == ResolutionStatus.Unresolved);
+		Assert.Contains(result.Edges, edge => edge.Source == "src/main.ts" && edge.Reference == "./dir" && edge.Target == "src/dir/index.ts");
+	}
+
+	[Fact]
+	public async Task TypeScriptRelativeResolution_UsesTheFirstExistingProbeAndPreservesJavaScriptFallback()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var source = fixture.CreateFile("main.ts", "import one from './worker.js'; import two from './plain.js';");
+		var workerTypeScript = fixture.CreateFile("worker.ts", "export default 1;");
+		var workerDeclaration = fixture.CreateFile("worker.d.ts", "declare const value: number; export default value;");
+		var plainJavaScript = fixture.CreateFile("plain.js", "export default 2;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, workerTypeScript, workerDeclaration, plainJavaScript],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Reference == "./worker.js" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "worker.ts");
+		Assert.Contains(result.Edges, edge => edge.Reference == "./plain.js" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "plain.js");
+		Assert.DoesNotContain(result.Edges, edge => edge.Reference == "./worker.js" &&
+			edge.Status == ResolutionStatus.Ambiguous);
+	}
+
+	[Fact]
+	public async Task TypeScriptDirectoryResolution_DistinguishesBundlerFromNodeEsm()
+	{
+		using var fixture = new TemporaryDirectory();
+		var bundlerConfig = fixture.CreateFile("bundler/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var bundlerSource = fixture.CreateFile("bundler/main.ts", "import value from './dir';");
+		var bundlerIndex = fixture.CreateFile("bundler/dir/index.ts", "export default 1;");
+		var nodeConfig = fixture.CreateFile("node/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var nodePackage = fixture.CreateFile("node/package.json", "{\"type\":\"module\"}");
+		var nodeSource = fixture.CreateFile("node/main.mts", "import value from './dir';");
+		var nodeIndex = fixture.CreateFile("node/dir/index.ts", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[bundlerConfig, bundlerSource, bundlerIndex, nodeConfig, nodePackage, nodeSource, nodeIndex],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "bundler/main.ts" &&
+			edge.Reference == "./dir" && edge.Target == "bundler/dir/index.ts");
+		Assert.Contains(result.Edges, edge => edge.Source == "node/main.mts" &&
+			edge.Reference == "./dir" && edge.Status == ResolutionStatus.Unresolved &&
+			edge.Reasons.Contains("extension required for a relative ESM import under node16/nodenext"));
+	}
+
+	[Fact]
+	public async Task TypeScriptPaths_UsesTheFirstFallbackTargetThatExists()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", """
+			{"compilerOptions":{"moduleResolution":"bundler","paths":{"alias":["missing.ts","src/value.ts"]}}}
+			""");
+		var source = fixture.CreateFile("main.ts", "import value from 'alias';");
+		var target = fixture.CreateFile("src/value.ts", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Reference == "alias" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "src/value.ts");
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -192,6 +192,42 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task TypeScriptExtensionlessResolution_ProbesJavaScriptWithoutAllowJs()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var source = fixture.CreateFile("main.ts", "import value from './dep';");
+		var target = fixture.CreateFile("dep.js", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "main.ts" &&
+			edge.Reference == "./dep" && edge.Status == ResolutionStatus.Resolved && edge.Target == "dep.js");
+	}
+
+	[Fact]
+	public async Task TypeScriptNode16_DefaultsOrdinaryTypeScriptFilesToCommonJsWithoutPackageType()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var source = fixture.CreateFile("main.ts", "import value from './dep';");
+		var target = fixture.CreateFile("dep.ts", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "main.ts" &&
+			edge.Reference == "./dep" && edge.Status == ResolutionStatus.Resolved && edge.Target == "dep.ts");
+	}
+
+	[Fact]
 	public async Task TypeScriptDirectoryResolution_DistinguishesBundlerFromNodeEsm()
 	{
 		using var fixture = new TemporaryDirectory();
@@ -234,6 +270,55 @@ public sealed class DependencyFactsEngineIntegrationTests
 
 		Assert.Contains(result.Edges, edge => edge.Reference == "alias" &&
 			edge.Status == ResolutionStatus.Resolved && edge.Target == "src/value.ts");
+	}
+
+	[Fact]
+	public async Task TypeScriptPaths_SelectsTheLongestPrefixBeforeTheWildcard()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", """
+			{"compilerOptions":{"moduleResolution":"bundler","paths":{
+				"foo/*":["correct/*"],
+				"f*tail":["wrong/*"]
+			}}}
+			""");
+		var source = fixture.CreateFile("main.ts", "import value from 'foo/xtail';");
+		var correct = fixture.CreateFile("correct/xtail.ts", "export default 1;");
+		var wrong = fixture.CreateFile("wrong/oo/x.ts", "export default 2;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, correct, wrong],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Reference == "foo/xtail" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "correct/xtail.ts");
+		Assert.DoesNotContain(result.Edges, edge => edge.Reference == "foo/xtail" && edge.Target == "wrong/oo/x.ts");
+	}
+
+	[Fact]
+	public async Task TypeScriptPaths_DoesNotFallBackToALessSpecificPattern()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", """
+			{"compilerOptions":{"moduleResolution":"bundler","paths":{
+				"foo/*":["missing/*"],
+				"*":["fallback/*"]
+			}}}
+			""");
+		var source = fixture.CreateFile("main.ts", "import value from 'foo/item';");
+		var fallback = fixture.CreateFile("fallback/foo/item.ts", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, fallback],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Reference == "foo/item");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -434,6 +434,64 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task TransientExtractionFailure_IsRetriedAtThePreparedAndManifestCacheLayers()
+	{
+		using var fixture = new TemporaryDirectory();
+		var source = fixture.CreateFile("Source.cs", "public sealed class Source { }\n");
+		var extractor = new FailOnceDependencyFactExtractor();
+		using var engine = new DependencyFactsEngine(extractor, new EmptyDependencyConfigurationProvider());
+
+		var failed = await engine.IndexAsync(
+			fixture.Path,
+			[source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var recovered = await engine.IndexAsync(
+			fixture.Path,
+			[source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var warm = await engine.IndexAsync(
+			fixture.Path,
+			[source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal(DependencyFileStatus.ExtractionFailed, Assert.Single(failed.Files).Status);
+		Assert.Equal(DependencyFileStatus.Supported, Assert.Single(recovered.Files).Status);
+		Assert.False(recovered.Metrics.ResolutionCacheHit);
+		Assert.True(warm.Metrics.ResolutionCacheHit);
+		Assert.Equal(2, extractor.PrepareCount);
+	}
+
+	[Fact]
+	public async Task WindowsExclusiveSourceLock_IsRetriedAfterTheLockIsReleased()
+	{
+		if (!OperatingSystem.IsWindows())
+			Assert.Skip("Exclusive source locking has the required access-denied behavior only on Windows.");
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var source = fixture.CreateFile("Source.cs", "public sealed class Source { }\n");
+		using var engine = CreateEngine();
+		DependencyIndexSnapshot failed;
+		using (File.Open(source, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+		{
+			failed = await engine.IndexAsync(
+				fixture.Path,
+				[project, source],
+				cancellationToken: TestContext.Current.CancellationToken);
+		}
+
+		var recovered = await engine.IndexAsync(
+			fixture.Path,
+			[project, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal(DependencyFileStatus.ExtractionFailed,
+			Assert.Single(failed.Files, file => file.Path == "Source.cs").Status);
+		Assert.Equal(DependencyFileStatus.Supported,
+			Assert.Single(recovered.Files, file => file.Path == "Source.cs").Status);
+		Assert.False(recovered.Metrics.ResolutionCacheHit);
+	}
+
+	[Fact]
 	public async Task PreparedSourceCacheIdentityMismatchReadsSameStampReplacement()
 	{
 		using var fixture = new TemporaryDirectory();
@@ -953,6 +1011,62 @@ public sealed class DependencyFactsEngineIntegrationTests
 				new Dictionary<string, string>(StringComparer.Ordinal),
 				[]);
 		}
+
+		public void Dispose()
+		{
+		}
+	}
+
+	private sealed class FailOnceDependencyFactExtractor : IDependencyFactExtractor
+	{
+		private int _prepareCount;
+
+		public int PrepareCount => Volatile.Read(ref _prepareCount);
+		public int ParseCount => 0;
+		public int CompiledQuerySetCount => 0;
+
+		public ValueTask<PreparedDependencySource> PrepareAsync(
+			string sourceRoot,
+			string fullPath,
+			DependencyResolverConfiguration configuration,
+			DependencyFactsLimits limits,
+			CancellationToken cancellationToken,
+			string? contentIdentity = null)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var relativePath = PathUtility.GetPortableRelativePath(sourceRoot, fullPath);
+			var failed = Interlocked.Increment(ref _prepareCount) == 1;
+			return ValueTask.FromResult(new PreparedDependencySource(
+				fullPath,
+				relativePath,
+				"fixture",
+				LanguageId.CSharp,
+				failed ? "transient" : "recovered",
+				"fail-once-fixture",
+				string.Empty,
+				failed ? DependencyFileStatus.ExtractionFailed : DependencyFileStatus.Supported,
+				failed ? "IOException: sharing violation" : null,
+				CanCache: !failed));
+		}
+
+		public FileFacts Extract(PreparedDependencySource source, DependencyFactsLimits limits) => new(
+			source.RelativePath,
+			source.ScopeId,
+			source.LanguageId,
+			source.ContentFingerprint,
+			0,
+			source.PreparedStatus,
+			source.PreparedStatusReason,
+			HasSyntaxErrors: false,
+			new Dictionary<string, int>(StringComparer.Ordinal),
+			[], [], [], [],
+			new Dictionary<string, string>(StringComparer.Ordinal),
+			[],
+			new Dictionary<string, string>(StringComparer.Ordinal),
+			[])
+		{
+			CanCache = source.CanCache
+		};
 
 		public void Dispose()
 		{

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -598,6 +598,39 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task ManifestSnapshot_LengthPrefixesPathsAndVerifiesTheCanonicalManifest()
+	{
+		if (OperatingSystem.IsWindows())
+			Assert.Skip("Windows does not permit line-feed characters in file names.");
+		using var fixture = new TemporaryDirectory();
+		var backing = fixture.CreateFile("backing", "public sealed class Shared { }\n");
+		var a = Path.Combine(fixture.Path, "A.cs");
+		var bc = Path.Combine(fixture.Path, "B.cs\nC.cs");
+		var ab = Path.Combine(fixture.Path, "A.cs\nB.cs");
+		var c = Path.Combine(fixture.Path, "C.cs");
+		foreach (var link in new[] { a, bc, ab, c })
+			CreateHardLinkOrSkip(link, backing);
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var seed = fixture.CreateFile("Seed.cs", "public sealed class Seed { }\n");
+		using var engine = CreateEngine();
+
+		_ = await engine.FindRelatedAsync(
+			fixture.Path,
+			[a, bc, project, seed],
+			["Seed.cs"],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var second = await engine.FindRelatedAsync(
+			fixture.Path,
+			[ab, c, project, seed],
+			["Seed.cs"],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.DoesNotContain(second.Index.Files, file => file.Path is "A.cs" or "B.cs\nC.cs");
+		Assert.Contains(second.Index.Files, file => file.Path == "A.cs\nB.cs");
+		Assert.Contains(second.Index.Files, file => file.Path == "C.cs");
+	}
+
+	[Fact]
 	public async Task ConcurrentColdRequests_DeduplicateFileParsingAndResolution()
 	{
 		using var fixture = new TemporaryDirectory();
@@ -815,6 +848,29 @@ public sealed class DependencyFactsEngineIntegrationTests
 				$"The file system did not preserve the complete file stamp: " +
 				$"length {length}/{after.Length}, mtime {lastWrite:o}/{after.LastWriteTimeUtc:o}, " +
 				$"creation {creation:o}/{after.CreationTimeUtc:o}.");
+		}
+	}
+
+	private static void CreateHardLinkOrSkip(string linkPath, string targetPath)
+	{
+		var startInfo = new ProcessStartInfo("ln")
+		{
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		startInfo.ArgumentList.Add(targetPath);
+		startInfo.ArgumentList.Add(linkPath);
+		try
+		{
+			using var process = Process.Start(startInfo);
+			if (process is null || !process.WaitForExit(TimeSpan.FromSeconds(10)) || process.ExitCode != 0)
+				Assert.Skip("Hard links are unavailable in this test environment.");
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+		{
+			Assert.Skip($"Hard links are unavailable: {exception.GetType().Name}.");
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -879,6 +879,62 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task RelatedFiles_KeepResolvedAndDistinctAmbiguousReferencesInSeparateRows()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var a = fixture.CreateFile("A.cs", """
+			namespace Targets { public sealed class ResolvedType { } }
+			namespace One { public sealed class SharedAB { } public sealed class SharedAC { } }
+			""");
+		var b = fixture.CreateFile("B.cs", "namespace Two; public sealed class SharedAB { }\n");
+		var c = fixture.CreateFile("C.cs", "namespace Three; public sealed class SharedAC { }\n");
+		var seed = fixture.CreateFile("Seed.cs", """
+			using Targets;
+			using One;
+			using Two;
+			using Three;
+			public sealed class Seed
+			{
+				public ResolvedType Resolved { get; }
+				public SharedAB FirstAmbiguous { get; }
+				public SharedAC SecondAmbiguous { get; }
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var fromSeed = await engine.FindRelatedAsync(
+			fixture.Path,
+			[project, a, b, c, seed],
+			["Seed.cs"],
+			DependencyDirection.Dependencies,
+			cancellationToken: TestContext.Current.CancellationToken);
+		var toA = await engine.FindRelatedAsync(
+			fixture.Path,
+			[project, a, b, c, seed],
+			["A.cs"],
+			DependencyDirection.Dependents,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		AssertRelatedOverlap(Assert.Single(fromSeed.Seeds).Dependencies, "A.cs", fromSeed.Index.Edges);
+		AssertRelatedOverlap(Assert.Single(toA.Seeds).Dependents, "Seed.cs", toA.Index.Edges);
+	}
+
+	private static void AssertRelatedOverlap(
+		IReadOnlyList<RelatedFile> related,
+		string expectedPath,
+		IReadOnlyList<DependencyEdge> edges)
+	{
+		Assert.True(related.Count == 3, JsonSerializer.Serialize(edges));
+		Assert.All(related, item => Assert.Equal(expectedPath, item.Path));
+		Assert.Single(related, static item => item.Status == ResolutionStatus.Resolved);
+		var ambiguous = related.Where(static item => item.Status == ResolutionStatus.Ambiguous).ToArray();
+		Assert.Equal(2, ambiguous.Length);
+		Assert.Contains(ambiguous, item => item.Candidates.SequenceEqual(["A.cs", "B.cs"]));
+		Assert.Contains(ambiguous, item => item.Candidates.SequenceEqual(["A.cs", "C.cs"]));
+	}
+
+	[Fact]
 	public async Task MissingGrammar_IsAnExtractionFailureWithAReason()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -1,6 +1,8 @@
+using System.Text;
 using DevProjex.Application.Dependencies;
 using DevProjex.Infrastructure.Compression;
 using DevProjex.Infrastructure.Dependencies;
+using DevProjex.Kernel.Abstractions;
 
 namespace DevProjex.Tests.Integration;
 
@@ -851,6 +853,81 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task PreparedSourceCache_TransientFailuresDoNotAccumulateEvictionEntries()
+	{
+		using var fixture = new TemporaryDirectory();
+		var source = fixture.CreateFile("Source.cs", "public sealed class Source { }\n");
+		var analyzer = new TransientPreparedSourceAnalyzer();
+		using var extractor = new TreeSitterDependencyFactExtractor(new MissingGrammarLocator(), analyzer);
+		var configuration = EmptyConfiguration();
+
+		for (var attempt = 0; attempt < 10_000; attempt++)
+		{
+			var prepared = await extractor.PrepareAsync(
+				fixture.Path,
+				source,
+				configuration,
+				new DependencyFactsLimits(),
+				TestContext.Current.CancellationToken,
+				$"attempt-{attempt}");
+			Assert.False(prepared.CanCache);
+		}
+
+		Assert.Equal(10_000, analyzer.OpenCount);
+		Assert.Equal(new TreeSitterDependencyFactExtractor.PreparedSourceCacheState(0, 0, 0), extractor.CacheState);
+	}
+
+	[Fact]
+	public async Task PreparedSourceCache_StaleCompletionCannotRemoveReplacementWeight()
+	{
+		using var fixture = new TemporaryDirectory();
+		var source = fixture.CreateFile("Source.cs", "public sealed class Source { }\n");
+		var analyzer = new CoordinatedPreparedSourceAnalyzer();
+		using var extractor = new TreeSitterDependencyFactExtractor(new MissingGrammarLocator(), analyzer);
+		var configuration = EmptyConfiguration();
+
+		var staleTask = extractor.PrepareAsync(
+			fixture.Path,
+			source,
+			configuration,
+			new DependencyFactsLimits(),
+			TestContext.Current.CancellationToken,
+			"identity-v1").AsTask();
+		await analyzer.FirstReadStarted.Task.WaitAsync(
+			TimeSpan.FromSeconds(5),
+			TestContext.Current.CancellationToken);
+
+		var replacement = await extractor.PrepareAsync(
+			fixture.Path,
+			source,
+			configuration,
+			new DependencyFactsLimits(),
+			TestContext.Current.CancellationToken,
+			"identity-v2");
+		var replacementState = extractor.CacheState;
+		analyzer.ReleaseFirstRead();
+		var stale = await staleTask;
+		var afterStaleCompletion = extractor.CacheState;
+		var warm = await extractor.PrepareAsync(
+			fixture.Path,
+			source,
+			configuration,
+			new DependencyFactsLimits(),
+			TestContext.Current.CancellationToken,
+			"identity-v2");
+
+		Assert.Equal("new source", replacement.Source);
+		Assert.Equal("old source", stale.Source);
+		Assert.Same(replacement.Source, warm.Source);
+		Assert.Equal(2, analyzer.OpenCount);
+		Assert.Equal(1, replacementState.Entries);
+		Assert.Equal(1, replacementState.EvictionEntries);
+		Assert.True(replacementState.RetainedBytes > 0);
+		Assert.Equal(replacementState, afterStaleCompletion);
+		Assert.Equal(replacementState, extractor.CacheState);
+	}
+
+	[Fact]
 	public async Task Cache_RebindsFactsWhenConfigurationChangesFileOwnershipWithoutParsingSource()
 	{
 		using var fixture = new TemporaryDirectory();
@@ -1211,6 +1288,14 @@ public sealed class DependencyFactsEngineIntegrationTests
 		new TreeSitterDependencyFactExtractor(),
 		new FileDependencyConfigurationProvider());
 
+	private static DependencyResolverConfiguration EmptyConfiguration() => new(
+		"fixture",
+		[],
+		new Dictionary<string, PackageMapDescriptor>(StringComparer.Ordinal),
+		new HashSet<string>(StringComparer.Ordinal),
+		new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal),
+		new HashSet<string>(StringComparer.Ordinal));
+
 	private static DependencyManifestContentIdentities Identities(
 		params (string Path, string Identity)[] values) =>
 		new(values.ToDictionary(
@@ -1292,6 +1377,112 @@ public sealed class DependencyFactsEngineIntegrationTests
 		public IReadOnlyList<string> EnumerateLibraries() => [];
 		public string Resolve(string libraryBaseName) =>
 			throw new FileNotFoundException($"Grammar '{libraryBaseName}' is unavailable.", libraryBaseName);
+	}
+
+	private sealed class TransientPreparedSourceAnalyzer : IFileContentAnalyzer
+	{
+		private int _openCount;
+
+		public int OpenCount => Volatile.Read(ref _openCount);
+
+		public ValueTask<IFileContentSnapshot> OpenCompleteSnapshotAsync(
+			string path,
+			CancellationToken cancellationToken = default)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			Interlocked.Increment(ref _openCount);
+			return ValueTask.FromResult<IFileContentSnapshot>(
+				new ClassifiedSnapshot(FileContentClassification.Missing));
+		}
+
+		public ValueTask<bool> IsTextFileAsync(string path, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+		public ValueTask<TextFileMetrics?> GetTextFileMetricsAsync(string path, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(string path, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			long maxSizeForFullRead,
+			CancellationToken cancellationToken = default) => throw new NotSupportedException();
+	}
+
+	private sealed class CoordinatedPreparedSourceAnalyzer : IFileContentAnalyzer
+	{
+		private readonly TaskCompletionSource _firstReadStarted =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly TaskCompletionSource _releaseFirstRead =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private int _openCount;
+
+		public TaskCompletionSource FirstReadStarted => _firstReadStarted;
+		public int OpenCount => Volatile.Read(ref _openCount);
+
+		public ValueTask<IFileContentSnapshot> OpenCompleteSnapshotAsync(
+			string path,
+			CancellationToken cancellationToken = default)
+		{
+			var invocation = Interlocked.Increment(ref _openCount);
+			return invocation == 1
+				? AwaitFirstReadAsync(cancellationToken)
+				: ValueTask.FromResult<IFileContentSnapshot>(new TextSnapshot("new source"));
+		}
+
+		public void ReleaseFirstRead() => _releaseFirstRead.TrySetResult();
+
+		private async ValueTask<IFileContentSnapshot> AwaitFirstReadAsync(CancellationToken cancellationToken)
+		{
+			_firstReadStarted.TrySetResult();
+			await _releaseFirstRead.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+			return new TextSnapshot("old source");
+		}
+
+		public ValueTask<bool> IsTextFileAsync(string path, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+		public ValueTask<TextFileMetrics?> GetTextFileMetricsAsync(string path, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(string path, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			long maxSizeForFullRead,
+			CancellationToken cancellationToken = default) => throw new NotSupportedException();
+	}
+
+	private sealed class ClassifiedSnapshot(FileContentClassification classification) : IFileContentSnapshot
+	{
+		public FileContentMetricsResult Result { get; } = new(classification);
+
+		public ValueTask CopyTextToAsync(
+			int maximumCharacters,
+			Func<ReadOnlyMemory<char>, CancellationToken, ValueTask> writeChunk,
+			CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+		public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+	}
+
+	private sealed class TextSnapshot(string content) : IFileContentSnapshot
+	{
+		public FileContentMetricsResult Result { get; } = new(
+			FileContentClassification.Text,
+			new TextFileMetrics(
+				Encoding.UTF8.GetByteCount(content),
+				1,
+				content.Length,
+				content.Length == 0,
+				string.IsNullOrWhiteSpace(content)));
+
+		public async ValueTask CopyTextToAsync(
+			int maximumCharacters,
+			Func<ReadOnlyMemory<char>, CancellationToken, ValueTask> writeChunk,
+			CancellationToken cancellationToken = default)
+		{
+			await writeChunk(
+				content.AsMemory(0, Math.Min(content.Length, maximumCharacters)),
+				cancellationToken).ConfigureAwait(false);
+		}
+
+		public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 	}
 
 	private sealed class CostedFactExtractor(IReadOnlyDictionary<string, int> costs) : IDependencyFactExtractor

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -560,6 +560,77 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task CSharpResolution_KeepsNestedTypesOutOfNamespaceLookupAndUsesTheNearestContainingType()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var holder = fixture.CreateFile("Holder.cs", """
+			namespace App;
+			public partial class Holder { public class Task { } }
+			""");
+		var holderConsumer = fixture.CreateFile("HolderConsumer.cs", """
+			namespace App;
+			public partial class Holder { public Task Inside { get; } }
+			""");
+		var consumer = fixture.CreateFile("Consumer.cs", """
+			using System.Threading.Tasks;
+			namespace App;
+			public sealed class Consumer
+			{
+				public Task External { get; }
+				public Holder.Task Qualified { get; }
+			}
+			""");
+		var globalHolder = fixture.CreateFile(
+			"GlobalHolder.cs",
+			"public sealed class GlobalHolder { public class Task { } }\n");
+		var globalConsumer = fixture.CreateFile(
+			"GlobalConsumer.cs",
+			"using System.Threading.Tasks; public sealed class GlobalConsumer { public Task Value { get; } }\n");
+		var outerTask = fixture.CreateFile("OuterTask.cs", """
+			namespace App;
+			public partial class Outer { public class Task { } }
+			""");
+		var innerTask = fixture.CreateFile("InnerTask.cs", """
+			namespace App;
+			public partial class Outer { public partial class Inner { public class Task { } } }
+			""");
+		var outerConsumer = fixture.CreateFile("OuterConsumer.cs", """
+			namespace App;
+			public partial class Outer { public Task Value { get; } }
+			""");
+		var innerConsumer = fixture.CreateFile("InnerConsumer.cs", """
+			namespace App;
+			public partial class Outer { public partial class Inner { public Task Value { get; } } }
+			""");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[project, holder, holderConsumer, consumer, globalHolder, globalConsumer,
+				outerTask, innerTask, outerConsumer, innerConsumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var appExternal = Assert.Single(index.Edges, edge =>
+			edge.Source == "Consumer.cs" && edge.Reference == "Task");
+		Assert.Equal(ResolutionStatus.External, appExternal.Status);
+		Assert.DoesNotContain("Holder.cs", appExternal.Candidates);
+		Assert.Contains(index.Edges, edge => edge.Source == "Consumer.cs" &&
+			edge.Reference == "Holder.Task" && edge.Target == "Holder.cs");
+		Assert.Contains(index.Edges, edge => edge.Source == "HolderConsumer.cs" &&
+			edge.Reference == "Task" && edge.Target == "Holder.cs");
+
+		var globalExternal = Assert.Single(index.Edges, edge =>
+			edge.Source == "GlobalConsumer.cs" && edge.Reference == "Task");
+		Assert.Equal(ResolutionStatus.External, globalExternal.Status);
+		Assert.DoesNotContain("GlobalHolder.cs", globalExternal.Candidates);
+		Assert.Contains(index.Edges, edge => edge.Source == "OuterConsumer.cs" &&
+			edge.Reference == "Task" && edge.Target == "OuterTask.cs");
+		Assert.Contains(index.Edges, edge => edge.Source == "InnerConsumer.cs" &&
+			edge.Reference == "Task" && edge.Target == "InnerTask.cs");
+	}
+
+	[Fact]
 	public async Task TransientExtractionFailure_IsRetriedAtThePreparedAndManifestCacheLayers()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -434,6 +434,63 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task CSharpResolution_UsesLanguageVisibilityWithoutProjectWideNameFallback()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var hiddenTask = fixture.CreateFile("CompanyTask.cs", "namespace Company.Internal; public sealed class Task { }\n");
+		var nestedWidget = fixture.CreateFile("NestedWidget.cs", "namespace Parent.Child; public sealed class Widget { }\n");
+		var enclosing = fixture.CreateFile("Envelope.cs", "namespace Parent; public sealed class Envelope { }\n");
+		var consumer = fixture.CreateFile("Consumer.cs", """
+			using System.Threading.Tasks;
+			using Parent;
+			namespace App;
+			public sealed class Consumer
+			{
+				public Task ExternalTask { get; }
+				public Widget HiddenChild { get; }
+				public Company.Internal.Task Qualified { get; }
+			}
+			""");
+		var childConsumer = fixture.CreateFile(
+			"ChildConsumer.cs",
+			"namespace Parent.Child; public sealed class Consumer { public Envelope Value { get; } }\n");
+		var nestedConsumer = fixture.CreateFile(
+			"NestedConsumer.cs",
+			"""
+			namespace Nest;
+			public class Outer
+			{
+				public class Inner { }
+				public class Consumer
+				{
+					public Inner Value { get; }
+				}
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[project, hiddenTask, nestedWidget, enclosing, consumer, childConsumer, nestedConsumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var externalTask = Assert.Single(index.Edges, edge => edge.Source == "Consumer.cs" && edge.Reference == "Task");
+		Assert.Equal(ResolutionStatus.External, externalTask.Status);
+		Assert.Null(externalTask.Target);
+		Assert.Empty(externalTask.Candidates);
+		var hiddenChild = Assert.Single(index.Edges, edge => edge.Source == "Consumer.cs" && edge.Reference == "Widget");
+		Assert.Equal(ResolutionStatus.Unresolved, hiddenChild.Status);
+		Assert.Null(hiddenChild.Target);
+		Assert.Contains(index.Edges, edge => edge.Source == "Consumer.cs" &&
+			edge.Reference == "Company.Internal.Task" && edge.Target == "CompanyTask.cs");
+		Assert.Contains(index.Edges, edge => edge.Source == "ChildConsumer.cs" &&
+			edge.Reference == "Envelope" && edge.Target == "Envelope.cs");
+		Assert.Contains(index.Edges, edge => edge.Source == "NestedConsumer.cs" &&
+			edge.Reference == "Inner" && edge.Target == "NestedConsumer.cs");
+	}
+
+	[Fact]
 	public async Task TransientExtractionFailure_IsRetriedAtThePreparedAndManifestCacheLayers()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyLanguageAdapterPerformanceIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyLanguageAdapterPerformanceIntegrationTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using DevProjex.Application.Dependencies;
+using DevProjex.Infrastructure.Dependencies;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class DependencyLanguageAdapterPerformanceIntegrationTests(ITestOutputHelper output)
+{
+	[Fact]
+	[Trait("Category", "LocalPerformance")]
+	public void CSharpExtraction_WithThousandsOfDeclarationsAndReferences_RemainsNearLinear()
+	{
+		_ = Measure(500);
+		var small = MeasureMedian(2_000, 5);
+		var large = MeasureMedian(4_000, 5);
+		var ratio = large.TotalMilliseconds / small.TotalMilliseconds;
+
+		output.WriteLine($"C# fact extraction: 2000={small.TotalMilliseconds:F3} ms; " +
+		                 $"4000={large.TotalMilliseconds:F3} ms; ratio={ratio:F2}x");
+		Assert.True(large < TimeSpan.FromSeconds(5));
+		Assert.True(ratio < 3,
+			$"Doubling declarations and references took {ratio:F2}x; expected sub-quadratic scaling.");
+	}
+
+	private static TimeSpan MeasureMedian(int count, int repetitions)
+	{
+		var samples = Enumerable.Range(0, repetitions)
+			.Select(_ => Measure(count))
+			.OrderBy(static elapsed => elapsed)
+			.ToArray();
+		return samples[samples.Length / 2];
+	}
+
+	private static TimeSpan Measure(int count)
+	{
+		var declarations = new DependencySyntaxCapture[count];
+		var references = new DependencySyntaxCapture[count];
+		for (var index = 0; index < count; index++)
+		{
+			var start = index * 100;
+			declarations[index] = new DependencySyntaxCapture(
+				"declaration.class", "class_declaration", $"class Type{index} {{ }}", index + 1,
+				start, start + 99, $"Type{index}");
+			references[index] = new DependencySyntaxCapture(
+				"reference.property_type", "identifier", "Target", index + 1,
+				start + 20, start + 26);
+		}
+		var context = new DependencyExtractionContext(
+			"Generated.cs", "fixture", LanguageId.CSharp, new string(' ', count * 100), "fixture",
+			false, new Dictionary<string, int>(StringComparer.Ordinal), declarations, references);
+		var adapter = new CSharpDependencyLanguageAdapter();
+
+		var started = Stopwatch.StartNew();
+		var facts = adapter.Extract(context, new DependencyFactsLimits());
+		started.Stop();
+
+		Assert.Equal(count, facts.Declarations.Count);
+		Assert.Equal(count, facts.References.Count);
+		return started.Elapsed;
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
@@ -16,6 +16,7 @@ public sealed class RelatedCommandProcessTests
 		workspace.WriteFile("project/Services/ClockService.cs", "using Contracts; namespace Services; public sealed class ClockService { public IClock Clock { get; } }\n");
 		workspace.WriteFile("project/Consumers/Worker.cs", "using Services; public sealed class Worker { public ClockService Service { get; } }\n");
 		workspace.WriteFile("project/Outside.cs", "public sealed class Outside {}\n");
+		WriteOverlappingRelationsFixture(workspace, "project/Relations");
 
 		var result = Run(
 			workspace,
@@ -48,6 +49,11 @@ public sealed class RelatedCommandProcessTests
 		var seed = Assert.Single(root.GetProperty("seeds").EnumerateArray());
 		Assert.Equal("Contracts/IClock.cs", Assert.Single(seed.GetProperty("dependencies").EnumerateArray()).GetProperty("path").GetString());
 		Assert.Equal("Consumers/Worker.cs", Assert.Single(seed.GetProperty("dependents").EnumerateArray()).GetProperty("path").GetString());
+
+		var dependencies = RunRelatedJson(workspace, project, "Relations/Seed.cs", "dependencies");
+		AssertRelatedOverlap(dependencies.GetProperty("dependencies"), "Relations/A.cs");
+		var dependents = RunRelatedJson(workspace, project, "Relations/A.cs", "dependents");
+		AssertRelatedOverlap(dependents.GetProperty("dependents"), "Relations/Seed.cs");
 	}
 
 	[Fact]
@@ -93,5 +99,62 @@ public sealed class RelatedCommandProcessTests
 		startInfo.ArgumentList.Add("never");
 		startInfo.Environment["DEVPROJEX_INTERNAL_DATA_ROOT"] = workspace.CreateDirectory("data");
 		return TerminalTestProcess.Run(startInfo, TimeSpan.FromMinutes(1));
+	}
+
+	private static JsonElement RunRelatedJson(
+		TemporaryDirectory workspace,
+		string project,
+		string seed,
+		string direction)
+	{
+		var result = Run(
+			workspace,
+			"related", seed,
+			"--project", project,
+			"--direction", direction,
+			"--format", "json",
+			"--select", "Relations",
+			"--select", "Fixture.csproj",
+			"--git-mode", "none",
+			"--exclude", "none");
+		Assert.True(result.ExitCode == 0, result.StandardError + result.StandardOutput);
+		using var document = JsonDocument.Parse(result.StandardOutput);
+		return Assert.Single(document.RootElement.GetProperty("seeds").EnumerateArray()).Clone();
+	}
+
+	private static void AssertRelatedOverlap(JsonElement relatedElement, string expectedPath)
+	{
+		var related = relatedElement.EnumerateArray().ToArray();
+		Assert.Equal(3, related.Length);
+		Assert.All(related, item => Assert.Equal(expectedPath, item.GetProperty("path").GetString()));
+		Assert.Single(related, item => item.GetProperty("status").GetString() == "resolved");
+		var ambiguous = related.Where(item => item.GetProperty("status").GetString() == "ambiguous").ToArray();
+		Assert.Equal(2, ambiguous.Length);
+		Assert.Contains(ambiguous, item => item.GetProperty("candidates").EnumerateArray()
+			.Select(static candidate => candidate.GetString()).SequenceEqual(["Relations/A.cs", "Relations/B.cs"]));
+		Assert.Contains(ambiguous, item => item.GetProperty("candidates").EnumerateArray()
+			.Select(static candidate => candidate.GetString()).SequenceEqual(["Relations/A.cs", "Relations/C.cs"]));
+	}
+
+	private static void WriteOverlappingRelationsFixture(TemporaryDirectory workspace, string directory)
+	{
+		workspace.WriteFile(directory + "/A.cs", """
+			namespace Targets { public sealed class ResolvedType { } }
+			namespace One { public sealed class SharedAB { } public sealed class SharedAC { } }
+			""");
+		workspace.WriteFile(directory + "/B.cs", "namespace Two; public sealed class SharedAB { }\n");
+		workspace.WriteFile(directory + "/C.cs", "namespace Three; public sealed class SharedAC { }\n");
+		workspace.WriteFile(directory + "/Seed.cs", """
+			using Targets;
+			using One;
+			using Two;
+			using Three;
+			public sealed class Seed
+			{
+				public ResolvedType Resolved { get; }
+				public SharedAB FirstAmbiguous { get; }
+				public SharedAC SecondAmbiguous { get; }
+			}
+			""");
 	}
 }

--- a/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
@@ -23,6 +23,24 @@ public sealed partial class McpServerProcessTests
 		workspace.WriteFile("project/src/Consumers/Consumer.cs", "using Services; public sealed class Consumer { public Service Value { get; } }\n");
 		workspace.WriteFile("project/src/Alpha/Widget.cs", "namespace Alpha; public sealed class Widget {}\n");
 		workspace.WriteFile("project/src/Beta/Widget.cs", "namespace Beta; public sealed class Widget {}\n");
+		workspace.WriteFile("project/src/Relations/A.cs", """
+			namespace Targets { public sealed class ResolvedType { } }
+			namespace One { public sealed class SharedAB { } public sealed class SharedAC { } }
+			""");
+		workspace.WriteFile("project/src/Relations/B.cs", "namespace Two; public sealed class SharedAB { }\n");
+		workspace.WriteFile("project/src/Relations/C.cs", "namespace Three; public sealed class SharedAC { }\n");
+		workspace.WriteFile("project/src/Relations/Seed.cs", """
+			using Targets;
+			using One;
+			using Two;
+			using Three;
+			public sealed class Seed
+			{
+				public ResolvedType Resolved { get; }
+				public SharedAB FirstAmbiguous { get; }
+				public SharedAC SecondAmbiguous { get; }
+			}
+			""");
 		workspace.WriteFile("project/outside/Hidden.cs", "using Services; public sealed class Hidden { public Service Value { get; } }\n");
 		workspace.WriteFile("project/README.md", "# Unsupported seed\n");
 		InitializeIsolatedRepository(project);
@@ -79,10 +97,42 @@ public sealed partial class McpServerProcessTests
 			Assert.Contains("src/Consumers/Consumer.cs", text, StringComparison.Ordinal);
 			Assert.Contains("candidates: src/Alpha/Widget.cs, src/Beta/Widget.cs", text, StringComparison.Ordinal);
 			Assert.DoesNotContain("outside/Hidden.cs", text, StringComparison.Ordinal);
-			Assert.Contains("[Facts coverage] files=6, supported=5, unsupported=1, extraction-failed=0", text, StringComparison.Ordinal);
-			Assert.Contains("[Search scope] files=6", text, StringComparison.Ordinal);
+			Assert.Contains("[Facts coverage] files=10, supported=9, unsupported=1, extraction-failed=0", text, StringComparison.Ordinal);
+			Assert.Contains("[Search scope] files=10", text, StringComparison.Ordinal);
 			Assert.Contains("[Effective filters]", text, StringComparison.Ordinal);
 			Assert.NotEmpty(progress.Values);
+
+			var overlappingDependencies = await client.CallToolAsync(
+				"related_files",
+				new Dictionary<string, object?>
+				{
+					["path"] = "src/Relations/Seed.cs",
+					["direction"] = "dependencies",
+					["include_patterns"] = new[] { "src/**" }
+				},
+				progress: null,
+				options: null,
+				TestContext.Current.CancellationToken);
+			var dependenciesText = Assert.IsType<TextContentBlock>(Assert.Single(overlappingDependencies.Content)).Text;
+			Assert.Equal(3, CountLinesStartingWith(dependenciesText, "src/Relations/A.cs —"));
+			Assert.Equal(1, CountLinesContaining(dependenciesText, "src/Relations/A.cs —", " — resolved — "));
+			Assert.Equal(2, CountLinesContaining(dependenciesText, "src/Relations/A.cs —", " — ambiguous — "));
+
+			var overlappingDependents = await client.CallToolAsync(
+				"related_files",
+				new Dictionary<string, object?>
+				{
+					["path"] = "src/Relations/A.cs",
+					["direction"] = "dependents",
+					["include_patterns"] = new[] { "src/**" }
+				},
+				progress: null,
+				options: null,
+				TestContext.Current.CancellationToken);
+			var dependentsText = Assert.IsType<TextContentBlock>(Assert.Single(overlappingDependents.Content)).Text;
+			Assert.Equal(3, CountLinesStartingWith(dependentsText, "src/Relations/Seed.cs —"));
+			Assert.Equal(1, CountLinesContaining(dependentsText, "src/Relations/Seed.cs —", " — resolved — "));
+			Assert.Equal(2, CountLinesContaining(dependentsText, "src/Relations/Seed.cs —", " — ambiguous — "));
 
 			var excluded = await client.CallToolAsync(
 				"related_files",
@@ -131,4 +181,15 @@ public sealed partial class McpServerProcessTests
 		Assert.Equal(0, process.ExitCode);
 		Assert.True(string.IsNullOrWhiteSpace(await errorTask), await errorTask);
 	}
+
+	private static int CountLinesStartingWith(string value, string prefix) =>
+		value.Split('\n').Count(line => line.TrimEnd('\r').StartsWith(prefix, StringComparison.Ordinal));
+
+	private static int CountLinesContaining(string value, string prefix, string fragment) =>
+		value.Split('\n').Count(line =>
+		{
+			var normalized = line.TrimEnd('\r');
+			return normalized.StartsWith(prefix, StringComparison.Ordinal) &&
+			       normalized.Contains(fragment, StringComparison.Ordinal);
+		});
 }

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -347,6 +347,29 @@ public sealed class GitleaksSecretDetectorTests
 		Assert.Equal(genericValue, finding.Value);
 	}
 
+	[Theory]
+	[MemberData(nameof(GenericApiKeyGateWhitespaceVariants))]
+	public void Detect_GenericFastGatePreservesPinnedWhitespaceBeforeDelimiter(string separator)
+	{
+		const string genericValue = "A7d9mQ2xK4vN8sR6tY3uW5zB1cE0fG2h";
+		var content = $"apiKey{separator}= \"{genericValue}\"";
+		Assert.True(Detector.InspectRuleMatch("generic-api-key", content).IsMatch);
+
+		var finding = Assert.Single(
+			Detector.Detect("src/config.txt", content, TestContext.Current.CancellationToken),
+			static match => match.RuleId == "generic-api-key");
+
+		Assert.Equal(genericValue, finding.Value);
+	}
+
+	public static IEnumerable<object[]> GenericApiKeyGateWhitespaceVariants()
+	{
+		yield return [string.Empty];
+		yield return ["\n"];
+		yield return ["\r\n"];
+		yield return ["\r"];
+	}
+
 	[Fact]
 	public void Detect_GitleaksAllowMarker_SuppressesFindingOnThatLine()
 	{

--- a/Tests/Fixtures/DependencyFacts/typescript/expected.json
+++ b/Tests/Fixtures/DependencyFacts/typescript/expected.json
@@ -2,7 +2,7 @@
   "name": "typescript",
   "edges": [
     { "source": "src/main.ts", "reference": "./x.js", "status": "Resolved", "target": "src/x.ts" },
-    { "source": "src/main.ts", "reference": "./dir", "status": "Unresolved", "reasonContains": "no target" },
+    { "source": "src/main.ts", "reference": "./dir", "status": "Unresolved", "reasonContains": "extension required" },
     { "source": "src/main.ts", "reference": "fixture/blocked", "status": "Unresolved", "reasonContains": "null-blocked" },
     { "source": "src/main.ts", "reference": "@exact", "status": "Resolved", "target": "src/exact.ts" },
     { "source": "src/main.ts", "reference": "@lib/item", "status": "Resolved", "target": "src/lib/item.ts" }

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-07",
-  "productSha": "15a34d2918f14581c876e712e727ba628eb6b9ca",
-  "evaluatorSha": "15a34d2918f14581c876e712e727ba628eb6b9ca",
+  "productSha": "25b4acb6283913afe989374be60883694cb090a9",
+  "evaluatorSha": "25b4acb6283913afe989374be60883694cb090a9",
   "repositories": [
     {
       "id": "devprojex",
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 3106.9465,
-          "medianPeakWorkingSetBytes": 314060800,
+          "medianElapsedMilliseconds": 2726.3282,
+          "medianPeakWorkingSetBytes": 300453888,
           "elapsedMilliseconds": [
-            3476.2423,
-            2758.7489,
-            2664.7874,
-            2753.8386,
-            3106.9465,
-            3220.1375,
-            3229.5425
+            2717.9614,
+            2726.3282,
+            2698.6197,
+            2737.7128,
+            2696.9874,
+            2890.9551,
+            2762.2087
           ],
           "peakWorkingSetBytes": [
-            313671680,
-            312934400,
-            314286080,
-            314269696,
-            314060800,
-            314863616,
-            313749504
+            301821952,
+            300449792,
+            301756416,
+            300204032,
+            301486080,
+            300007424,
+            300453888
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2880.1748,
-          "medianPeakWorkingSetBytes": 313835520,
+          "medianElapsedMilliseconds": 2778.9973,
+          "medianPeakWorkingSetBytes": 302862336,
           "elapsedMilliseconds": [
-            2973.9346,
-            2880.1748,
-            3022.8968,
-            2922.9661,
-            2718.0725,
-            2727.5801,
-            2712.1667
+            2767.7627,
+            2753.9851,
+            2844.6242,
+            2778.9973,
+            2762.3726,
+            2814.7969,
+            2791.7261
           ],
           "peakWorkingSetBytes": [
-            313835520,
-            312410112,
-            313749504,
-            314716160,
-            314482688,
-            313417728,
-            314589184
+            305172480,
+            301531136,
+            302862336,
+            302284800,
+            304816128,
+            302735360,
+            303968256
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 937.8076,
-          "medianPeakWorkingSetBytes": 325509120,
+          "medianElapsedMilliseconds": 963.2234,
+          "medianPeakWorkingSetBytes": 313761792,
           "elapsedMilliseconds": [
-            922.3759,
-            1064.3343,
-            923.9317,
-            924.133,
-            937.8076,
-            982.2964,
-            953.1725
+            956.5843,
+            999.0454,
+            963.2234,
+            1083.6795,
+            901.2034,
+            961.8287,
+            983.3566
           ],
           "peakWorkingSetBytes": [
-            325509120,
-            329469952,
-            325947392,
-            317378560,
-            317554688,
-            319852544,
-            328265728
+            313761792,
+            321998848,
+            316080128,
+            317079552,
+            310820864,
+            305303552,
+            310005760
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 933.2271,
-          "medianPeakWorkingSetBytes": 326561792,
+          "medianElapsedMilliseconds": 1047.1624,
+          "medianPeakWorkingSetBytes": 317468672,
           "elapsedMilliseconds": [
-            947.9766,
-            933.2271,
-            946.5025,
-            920.0902,
-            940.668,
-            909.801,
-            932.4599
+            931.4746,
+            966.4111,
+            1223.7262,
+            1398.1819,
+            1565.1181,
+            1047.1624,
+            901.116
           ],
           "peakWorkingSetBytes": [
-            333496320,
-            330563584,
-            322936832,
-            321662976,
-            333520896,
-            325906432,
-            326561792
+            316710912,
+            308109312,
+            319959040,
+            317468672,
+            325844992,
+            322748416,
+            307859456
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 806.8579,
-          "medianPeakWorkingSetBytes": 114900992,
+          "medianElapsedMilliseconds": 807.9358,
+          "medianPeakWorkingSetBytes": 115171328,
           "elapsedMilliseconds": [
-            796.8864,
-            826.8318,
-            806.8579,
-            799.7402,
-            827.1045,
-            815.8833,
-            790.8618
+            822.7609,
+            822.0804,
+            799.3832,
+            804.1743,
+            800.7245,
+            819.1301,
+            807.9358
           ],
           "peakWorkingSetBytes": [
-            115142656,
-            113774592,
-            113115136,
-            113565696,
-            115310592,
-            114900992,
-            114987008
+            113483776,
+            115171328,
+            115089408,
+            115265536,
+            115363840,
+            115073024,
+            115875840
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 808.0846,
-          "medianPeakWorkingSetBytes": 115531776,
+          "medianElapsedMilliseconds": 809.4142,
+          "medianPeakWorkingSetBytes": 115118080,
           "elapsedMilliseconds": [
-            799.588,
-            825.454,
-            801.4304,
-            808.0846,
-            831.2671,
-            804.4821,
-            810.3308
+            863.4567,
+            855.5966,
+            817.3058,
+            806.9406,
+            807.3073,
+            799.7565,
+            809.4142
           ],
           "peakWorkingSetBytes": [
-            115531776,
-            115535872,
-            113475584,
-            113295360,
-            115552256,
-            115392512,
-            115712000
+            115281920,
+            115224576,
+            115724288,
+            115089408,
+            114823168,
+            115118080,
+            114868224
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 408.2035,
-          "medianPeakWorkingSetBytes": 112418816,
+          "medianElapsedMilliseconds": 404.5227,
+          "medianPeakWorkingSetBytes": 112218112,
           "elapsedMilliseconds": [
-            407.8802,
-            406.5904,
-            400.4946,
-            419.6943,
-            408.2035,
-            438.6073,
-            433.2468
+            414.3616,
+            400.5229,
+            403.9158,
+            410.2114,
+            405.5427,
+            404.5227,
+            400.8836
           ],
           "peakWorkingSetBytes": [
-            112680960,
-            112418816,
-            111992832,
-            111828992,
-            112742400,
-            112316416,
-            112701440
+            112283648,
+            111759360,
+            112091136,
+            112218112,
+            112128000,
+            112218112,
+            112308224
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 410.017,
-          "medianPeakWorkingSetBytes": 112672768,
+          "medianElapsedMilliseconds": 412.8746,
+          "medianPeakWorkingSetBytes": 112537600,
           "elapsedMilliseconds": [
-            403.592,
-            403.8261,
-            410.017,
-            437.7942,
-            429.4142,
-            423.4816,
-            406.1372
+            421.067,
+            415.5048,
+            403.0993,
+            410.5365,
+            420.8001,
+            412.8746,
+            403.8871
           ],
           "peakWorkingSetBytes": [
-            112275456,
-            112672768,
-            112771072,
-            113360896,
-            112582656,
-            112586752,
-            113053696
+            111996928,
+            112574464,
+            112300032,
+            112340992,
+            112865280,
+            113086464,
+            112537600
           ]
         }
       ]
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 578.643,
-          "medianPeakWorkingSetBytes": 88182784,
+          "medianElapsedMilliseconds": 541.7877,
+          "medianPeakWorkingSetBytes": 87822336,
           "elapsedMilliseconds": [
-            562.3936,
-            615.9049,
-            593.855,
-            542.0977,
-            564.2873,
-            578.643,
-            631.9968
+            562.9431,
+            541.7877,
+            536.6992,
+            554.1312,
+            540.8867,
+            526.8387,
+            544.967
           ],
           "peakWorkingSetBytes": [
-            88223744,
-            88285184,
-            87777280,
-            88809472,
-            88182784,
-            88047616,
-            87617536
+            87547904,
+            87662592,
+            88039424,
+            87822336,
+            87867392,
+            87490560,
+            88285184
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 698.3756,
-          "medianPeakWorkingSetBytes": 88113152,
+          "medianElapsedMilliseconds": 561.0574,
+          "medianPeakWorkingSetBytes": 88170496,
           "elapsedMilliseconds": [
-            845.194,
-            660.1038,
-            715.329,
-            698.3756,
-            588.6013,
-            734.3685,
-            679.2918
+            560.808,
+            548.2033,
+            561.0574,
+            547.7078,
+            576.9564,
+            621.6922,
+            657.5556
           ],
           "peakWorkingSetBytes": [
-            88784896,
-            87531520,
-            88010752,
-            87912448,
-            88182784,
-            88113152,
-            88657920
+            87793664,
+            88170496,
+            88346624,
+            88211456,
+            88326144,
+            87674880,
+            87744512
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 289.0842,
-          "medianPeakWorkingSetBytes": 90968064,
+          "medianElapsedMilliseconds": 276.2381,
+          "medianPeakWorkingSetBytes": 91521024,
           "elapsedMilliseconds": [
-            323.9465,
-            286.892,
-            289.0842,
-            310.675,
-            272.0716,
-            273.3685,
-            309.7265
+            293.1194,
+            311.9157,
+            286.4159,
+            266.6004,
+            266.8981,
+            268.6043,
+            276.2381
           ],
           "peakWorkingSetBytes": [
-            90406912,
-            90988544,
-            91475968,
-            91058176,
-            90968064,
-            90845184,
-            90923008
+            91693056,
+            90583040,
+            91983872,
+            91521024,
+            91381760,
+            91439104,
+            91594752
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 314.325,
-          "medianPeakWorkingSetBytes": 91537408,
+          "medianElapsedMilliseconds": 265.3574,
+          "medianPeakWorkingSetBytes": 91471872,
           "elapsedMilliseconds": [
-            333.1018,
-            371.7613,
-            314.325,
-            306.225,
-            308.4353,
-            309.2467,
-            328.9807
+            274.8634,
+            265.3574,
+            265.181,
+            270.3878,
+            262.1114,
+            261.917,
+            265.67
           ],
           "peakWorkingSetBytes": [
-            91455488,
-            91590656,
-            90906624,
-            91836416,
-            91856896,
-            91537408,
-            91402240
+            91471872,
+            92033024,
+            91635712,
+            91525120,
+            91107328,
+            91103232,
+            91369472
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": -4.580500000000029,
-      "repomix": 1.8134999999999764,
-      "flask": 25.24079999999998
+      "devprojex": 83.93899999999996,
+      "repomix": 8.3519,
+      "flask": -10.88069999999999
     },
     "warmIncrementalPercent": {
-      "devprojex": -0.48842641070514137,
-      "repomix": 0.44426370670510573,
-      "flask": 8.731296971608957
+      "devprojex": 8.714385468625448,
+      "repomix": 2.0646307364209724,
+      "flask": -3.938884607155925
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 0.3233924751478545,
-      "repomix": 0.548980464850991,
-      "flask": 0.6258723940744744
+      "devprojex": 1.181431294222083,
+      "repomix": 0.2847027046756944,
+      "flask": 0.3964367333613171
     },
     "recallPassed": true,
     "allRequiredPassed": true,

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-07",
-  "productSha": "67af9eb88752a1cd3f6deab32bb226439eda3c00",
-  "evaluatorSha": "67af9eb88752a1cd3f6deab32bb226439eda3c00",
+  "productSha": "15a34d2918f14581c876e712e727ba628eb6b9ca",
+  "evaluatorSha": "15a34d2918f14581c876e712e727ba628eb6b9ca",
   "repositories": [
     {
       "id": "devprojex",
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2704.2904,
-          "medianPeakWorkingSetBytes": 313536512,
+          "medianElapsedMilliseconds": 3106.9465,
+          "medianPeakWorkingSetBytes": 314060800,
           "elapsedMilliseconds": [
-            2644.5414,
-            2592.0344,
-            3745.0616,
-            3467.0423,
-            3205.4981,
-            2688.3199,
-            2704.2904
+            3476.2423,
+            2758.7489,
+            2664.7874,
+            2753.8386,
+            3106.9465,
+            3220.1375,
+            3229.5425
           ],
           "peakWorkingSetBytes": [
-            313430016,
-            312475648,
-            314679296,
-            313421824,
-            313536512,
-            313618432,
-            313548800
+            313671680,
+            312934400,
+            314286080,
+            314269696,
+            314060800,
+            314863616,
+            313749504
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2705.7424,
-          "medianPeakWorkingSetBytes": 313507840,
+          "medianElapsedMilliseconds": 2880.1748,
+          "medianPeakWorkingSetBytes": 313835520,
           "elapsedMilliseconds": [
-            2809.2276,
-            2756.5778,
-            2677.0498,
-            2705.7424,
-            2746.8498,
-            2684.1055,
-            2665.6163
+            2973.9346,
+            2880.1748,
+            3022.8968,
+            2922.9661,
+            2718.0725,
+            2727.5801,
+            2712.1667
           ],
           "peakWorkingSetBytes": [
-            313032704,
-            314298368,
-            313507840,
-            315006976,
-            314617856,
-            312897536,
-            313196544
+            313835520,
+            312410112,
+            313749504,
+            314716160,
+            314482688,
+            313417728,
+            314589184
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 956.2845,
-          "medianPeakWorkingSetBytes": 324390912,
+          "medianElapsedMilliseconds": 937.8076,
+          "medianPeakWorkingSetBytes": 325509120,
           "elapsedMilliseconds": [
-            964.9245,
-            956.2845,
-            989.072,
-            928.4928,
-            967.5964,
-            951.1654,
-            938.1913
+            922.3759,
+            1064.3343,
+            923.9317,
+            924.133,
+            937.8076,
+            982.2964,
+            953.1725
           ],
           "peakWorkingSetBytes": [
-            324390912,
-            320417792,
-            326582272,
-            328429568,
-            321179648,
-            327438336,
-            317087744
+            325509120,
+            329469952,
+            325947392,
+            317378560,
+            317554688,
+            319852544,
+            328265728
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 994.0459,
-          "medianPeakWorkingSetBytes": 330366976,
+          "medianElapsedMilliseconds": 933.2271,
+          "medianPeakWorkingSetBytes": 326561792,
           "elapsedMilliseconds": [
-            949.013,
-            994.0459,
-            988.4477,
-            1099.0648,
-            1097.0191,
-            949.0748,
-            1001.6184
+            947.9766,
+            933.2271,
+            946.5025,
+            920.0902,
+            940.668,
+            909.801,
+            932.4599
           ],
           "peakWorkingSetBytes": [
-            330698752,
-            317345792,
-            330268672,
-            330993664,
-            335036416,
-            330366976,
-            323514368
+            333496320,
+            330563584,
+            322936832,
+            321662976,
+            333520896,
+            325906432,
+            326561792
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 867.4336,
-          "medianPeakWorkingSetBytes": 114962432,
+          "medianElapsedMilliseconds": 806.8579,
+          "medianPeakWorkingSetBytes": 114900992,
           "elapsedMilliseconds": [
-            857.5132,
-            887.4518,
-            881.9331,
-            863.1379,
-            867.4336,
-            859.7905,
-            878.6185
+            796.8864,
+            826.8318,
+            806.8579,
+            799.7402,
+            827.1045,
+            815.8833,
+            790.8618
           ],
           "peakWorkingSetBytes": [
-            114806784,
-            113639424,
-            115101696,
-            115412992,
-            114962432,
-            114810880,
-            115560448
+            115142656,
+            113774592,
+            113115136,
+            113565696,
+            115310592,
+            114900992,
+            114987008
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 898.2813,
-          "medianPeakWorkingSetBytes": 115400704,
+          "medianElapsedMilliseconds": 808.0846,
+          "medianPeakWorkingSetBytes": 115531776,
           "elapsedMilliseconds": [
-            904.2374,
-            906.7166,
-            901.4982,
-            862.0811,
-            891.9245,
-            836.6482,
-            898.2813
+            799.588,
+            825.454,
+            801.4304,
+            808.0846,
+            831.2671,
+            804.4821,
+            810.3308
           ],
           "peakWorkingSetBytes": [
-            116191232,
-            114737152,
-            114966528,
-            115400704,
-            110809088,
-            115761152,
-            116359168
+            115531776,
+            115535872,
+            113475584,
+            113295360,
+            115552256,
+            115392512,
+            115712000
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 483.2298,
-          "medianPeakWorkingSetBytes": 112648192,
+          "medianElapsedMilliseconds": 408.2035,
+          "medianPeakWorkingSetBytes": 112418816,
           "elapsedMilliseconds": [
-            443.4734,
-            489.6824,
-            477.3461,
-            483.2298,
-            472.6292,
-            500.7376,
-            538.4204
+            407.8802,
+            406.5904,
+            400.4946,
+            419.6943,
+            408.2035,
+            438.6073,
+            433.2468
           ],
           "peakWorkingSetBytes": [
-            112181248,
-            113094656,
-            112222208,
-            112267264,
-            112648192,
-            112652288,
-            112996352
+            112680960,
+            112418816,
+            111992832,
+            111828992,
+            112742400,
+            112316416,
+            112701440
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 472.2502,
-          "medianPeakWorkingSetBytes": 112345088,
+          "medianElapsedMilliseconds": 410.017,
+          "medianPeakWorkingSetBytes": 112672768,
           "elapsedMilliseconds": [
-            486.1051,
-            472.2502,
-            473.4195,
-            465.1268,
-            463.9931,
-            451.8196,
-            482.7512
+            403.592,
+            403.8261,
+            410.017,
+            437.7942,
+            429.4142,
+            423.4816,
+            406.1372
           ],
           "peakWorkingSetBytes": [
-            112910336,
-            111980544,
-            112345088,
-            112144384,
-            112807936,
-            112234496,
-            112795648
+            112275456,
+            112672768,
+            112771072,
+            113360896,
+            112582656,
+            112586752,
+            113053696
           ]
         }
       ]
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 616.2675,
-          "medianPeakWorkingSetBytes": 88104960,
+          "medianElapsedMilliseconds": 578.643,
+          "medianPeakWorkingSetBytes": 88182784,
           "elapsedMilliseconds": [
-            613.9558,
-            666.5861,
-            614.496,
-            638.8649,
-            615.1231,
-            643.4636,
-            616.2675
+            562.3936,
+            615.9049,
+            593.855,
+            542.0977,
+            564.2873,
+            578.643,
+            631.9968
           ],
           "peakWorkingSetBytes": [
-            87621632,
             88223744,
-            88104960,
-            87482368,
-            87859200,
-            88104960,
-            89157632
+            88285184,
+            87777280,
+            88809472,
+            88182784,
+            88047616,
+            87617536
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 632.541,
-          "medianPeakWorkingSetBytes": 88190976,
+          "medianElapsedMilliseconds": 698.3756,
+          "medianPeakWorkingSetBytes": 88113152,
           "elapsedMilliseconds": [
-            655.6512,
-            616.7729,
-            618.9541,
-            664.7201,
-            632.541,
-            603.9263,
-            633.5274
+            845.194,
+            660.1038,
+            715.329,
+            698.3756,
+            588.6013,
+            734.3685,
+            679.2918
           ],
           "peakWorkingSetBytes": [
-            88363008,
-            88334336,
-            87961600,
-            87830528,
-            87883776,
-            88338432,
-            88190976
+            88784896,
+            87531520,
+            88010752,
+            87912448,
+            88182784,
+            88113152,
+            88657920
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 330.7501,
-          "medianPeakWorkingSetBytes": 91103232,
+          "medianElapsedMilliseconds": 289.0842,
+          "medianPeakWorkingSetBytes": 90968064,
           "elapsedMilliseconds": [
-            292.6195,
-            308.6625,
-            388.0843,
-            364.2601,
-            330.7501,
-            339.7878,
-            327.0484
+            323.9465,
+            286.892,
+            289.0842,
+            310.675,
+            272.0716,
+            273.3685,
+            309.7265
           ],
           "peakWorkingSetBytes": [
-            90644480,
-            91099136,
-            90517504,
-            91631616,
-            91103232,
-            91762688,
-            91332608
+            90406912,
+            90988544,
+            91475968,
+            91058176,
+            90968064,
+            90845184,
+            90923008
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 354.7978,
-          "medianPeakWorkingSetBytes": 91811840,
+          "medianElapsedMilliseconds": 314.325,
+          "medianPeakWorkingSetBytes": 91537408,
           "elapsedMilliseconds": [
-            354.7978,
-            365.1127,
-            371.7404,
-            366.4784,
-            333.8672,
-            311.7762,
-            315.8771
+            333.1018,
+            371.7613,
+            314.325,
+            306.225,
+            308.4353,
+            309.2467,
+            328.9807
           ],
           "peakWorkingSetBytes": [
-            91697152,
-            91897856,
-            91963392,
-            91811840,
-            91578368,
-            90636288,
-            92721152
+            91455488,
+            91590656,
+            90906624,
+            91836416,
+            91856896,
+            91537408,
+            91402240
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": 37.76139999999998,
-      "repomix": -10.979600000000005,
-      "flask": 24.04770000000002
+      "devprojex": -4.580500000000029,
+      "repomix": 1.8134999999999764,
+      "flask": 25.24079999999998
     },
     "warmIncrementalPercent": {
-      "devprojex": 3.9487621100206036,
-      "repomix": -2.272128084815962,
-      "flask": 7.270655398138964
+      "devprojex": -0.48842641070514137,
+      "repomix": 0.44426370670510573,
+      "flask": 8.731296971608957
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 1.842241499046681,
-      "repomix": 0.3812306267146471,
-      "flask": 0.7778077511015197
+      "devprojex": 0.3233924751478545,
+      "repomix": 0.548980464850991,
+      "flask": 0.6258723940744744
     },
     "recallPassed": true,
     "allRequiredPassed": true,

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-07",
-  "productSha": "533e796de6360cab1b7deef9fdc6622399c8bbc6",
-  "evaluatorSha": "533e796de6360cab1b7deef9fdc6622399c8bbc6",
+  "productSha": "67af9eb88752a1cd3f6deab32bb226439eda3c00",
+  "evaluatorSha": "67af9eb88752a1cd3f6deab32bb226439eda3c00",
   "repositories": [
     {
       "id": "devprojex",
@@ -303,7 +303,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9716214526815852,
+              "irrelevantTokenShare": 0.971625,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2730.1856,
-          "medianPeakWorkingSetBytes": 296058880,
+          "medianElapsedMilliseconds": 2704.2904,
+          "medianPeakWorkingSetBytes": 313536512,
           "elapsedMilliseconds": [
-            2748.3256,
-            2752.4187,
-            2730.1856,
-            2671.8692,
-            2698.8649,
-            2752.4952,
-            2715.8323
+            2644.5414,
+            2592.0344,
+            3745.0616,
+            3467.0423,
+            3205.4981,
+            2688.3199,
+            2704.2904
           ],
           "peakWorkingSetBytes": [
-            297058304,
-            295174144,
-            296058880,
-            295129088,
-            295624704,
-            296484864,
-            298008576
+            313430016,
+            312475648,
+            314679296,
+            313421824,
+            313536512,
+            313618432,
+            313548800
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2724.3276,
-          "medianPeakWorkingSetBytes": 297635840,
+          "medianElapsedMilliseconds": 2705.7424,
+          "medianPeakWorkingSetBytes": 313507840,
           "elapsedMilliseconds": [
-            2746.3077,
-            2744.6248,
-            2710.8149,
-            2697.3052,
-            2724.3276,
-            2696.5703,
-            2734.1866
+            2809.2276,
+            2756.5778,
+            2677.0498,
+            2705.7424,
+            2746.8498,
+            2684.1055,
+            2665.6163
           ],
           "peakWorkingSetBytes": [
-            295985152,
-            297730048,
-            296644608,
-            297697280,
-            297725952,
-            297635840,
-            297586688
+            313032704,
+            314298368,
+            313507840,
+            315006976,
+            314617856,
+            312897536,
+            313196544
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 901.9258,
-          "medianPeakWorkingSetBytes": 306069504,
+          "medianElapsedMilliseconds": 956.2845,
+          "medianPeakWorkingSetBytes": 324390912,
           "elapsedMilliseconds": [
-            881.6342,
-            904.1257,
-            934.4422,
-            900.5557,
-            903.6244,
-            890.9522,
-            901.9258
+            964.9245,
+            956.2845,
+            989.072,
+            928.4928,
+            967.5964,
+            951.1654,
+            938.1913
           ],
           "peakWorkingSetBytes": [
-            308842496,
-            305737728,
-            309444608,
-            306069504,
-            310059008,
-            305168384,
-            302915584
+            324390912,
+            320417792,
+            326582272,
+            328429568,
+            321179648,
+            327438336,
+            317087744
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 912.9495,
-          "medianPeakWorkingSetBytes": 312180736,
+          "medianElapsedMilliseconds": 994.0459,
+          "medianPeakWorkingSetBytes": 330366976,
           "elapsedMilliseconds": [
-            897.8853,
-            911.4496,
-            905.9711,
-            917.5509,
-            912.9495,
-            916.7072,
-            965.9153
+            949.013,
+            994.0459,
+            988.4477,
+            1099.0648,
+            1097.0191,
+            949.0748,
+            1001.6184
           ],
           "peakWorkingSetBytes": [
-            300875776,
-            312180736,
-            306216960,
-            312623104,
-            307343360,
-            312848384,
-            313856000
+            330698752,
+            317345792,
+            330268672,
+            330993664,
+            335036416,
+            330366976,
+            323514368
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 815.4664,
-          "medianPeakWorkingSetBytes": 115163136,
+          "medianElapsedMilliseconds": 867.4336,
+          "medianPeakWorkingSetBytes": 114962432,
           "elapsedMilliseconds": [
-            817.9395,
-            814.5817,
-            873.7193,
-            815.4664,
-            808.2812,
-            823.6094,
-            799.0576
+            857.5132,
+            887.4518,
+            881.9331,
+            863.1379,
+            867.4336,
+            859.7905,
+            878.6185
           ],
           "peakWorkingSetBytes": [
-            115331072,
-            117415936,
-            114991104,
-            115163136,
-            111583232,
-            115113984,
-            117424128
+            114806784,
+            113639424,
+            115101696,
+            115412992,
+            114962432,
+            114810880,
+            115560448
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 848.5921,
-          "medianPeakWorkingSetBytes": 115224576,
+          "medianElapsedMilliseconds": 898.2813,
+          "medianPeakWorkingSetBytes": 115400704,
           "elapsedMilliseconds": [
-            833.6252,
-            835.4849,
-            852.809,
-            835.3253,
-            859.4468,
-            848.5921,
-            853.4294
+            904.2374,
+            906.7166,
+            901.4982,
+            862.0811,
+            891.9245,
+            836.6482,
+            898.2813
           ],
           "peakWorkingSetBytes": [
-            113467392,
-            115224576,
-            111116288,
-            115970048,
-            115314688,
-            115576832,
-            110653440
+            116191232,
+            114737152,
+            114966528,
+            115400704,
+            110809088,
+            115761152,
+            116359168
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 424.3144,
-          "medianPeakWorkingSetBytes": 112431104,
+          "medianElapsedMilliseconds": 483.2298,
+          "medianPeakWorkingSetBytes": 112648192,
           "elapsedMilliseconds": [
-            420.2159,
-            423.0926,
-            390.9013,
-            429.659,
-            424.3144,
-            432.2336,
-            473.3615
+            443.4734,
+            489.6824,
+            477.3461,
+            483.2298,
+            472.6292,
+            500.7376,
+            538.4204
           ],
           "peakWorkingSetBytes": [
-            108670976,
-            112660480,
-            110395392,
-            112431104,
-            113442816,
-            113147904,
-            109305856
+            112181248,
+            113094656,
+            112222208,
+            112267264,
+            112648192,
+            112652288,
+            112996352
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 417.7945,
-          "medianPeakWorkingSetBytes": 112693248,
+          "medianElapsedMilliseconds": 472.2502,
+          "medianPeakWorkingSetBytes": 112345088,
           "elapsedMilliseconds": [
-            417.7945,
-            442.5134,
-            412.3451,
-            424.951,
-            419.144,
-            415.4407,
-            413.8748
+            486.1051,
+            472.2502,
+            473.4195,
+            465.1268,
+            463.9931,
+            451.8196,
+            482.7512
           ],
           "peakWorkingSetBytes": [
-            110067712,
-            111996928,
-            112861184,
-            110927872,
-            112791552,
-            112693248,
-            112791552
+            112910336,
+            111980544,
+            112345088,
+            112144384,
+            112807936,
+            112234496,
+            112795648
           ]
         }
       ]
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 587.9472,
-          "medianPeakWorkingSetBytes": 88236032,
+          "medianElapsedMilliseconds": 616.2675,
+          "medianPeakWorkingSetBytes": 88104960,
           "elapsedMilliseconds": [
-            582.0243,
-            572.539,
-            561.4011,
-            605.4447,
-            591.7219,
-            594.5594,
-            587.9472
+            613.9558,
+            666.5861,
+            614.496,
+            638.8649,
+            615.1231,
+            643.4636,
+            616.2675
           ],
           "peakWorkingSetBytes": [
-            87506944,
-            88236032,
-            87941120,
-            87769088,
-            88756224,
-            88530944,
-            88391680
+            87621632,
+            88223744,
+            88104960,
+            87482368,
+            87859200,
+            88104960,
+            89157632
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 588.1204,
-          "medianPeakWorkingSetBytes": 88256512,
+          "medianElapsedMilliseconds": 632.541,
+          "medianPeakWorkingSetBytes": 88190976,
           "elapsedMilliseconds": [
-            637.5049,
-            577.5588,
-            602.0145,
-            588.1204,
-            597.8332,
-            586.7326,
-            584.5182
+            655.6512,
+            616.7729,
+            618.9541,
+            664.7201,
+            632.541,
+            603.9263,
+            633.5274
           ],
           "peakWorkingSetBytes": [
-            88682496,
-            88141824,
-            88223744,
-            88694784,
-            88465408,
-            88256512,
-            88010752
+            88363008,
+            88334336,
+            87961600,
+            87830528,
+            87883776,
+            88338432,
+            88190976
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 275.439,
-          "medianPeakWorkingSetBytes": 89079808,
+          "medianElapsedMilliseconds": 330.7501,
+          "medianPeakWorkingSetBytes": 91103232,
           "elapsedMilliseconds": [
-            276.8579,
-            274.8164,
-            276.3309,
-            287.0358,
-            275.439,
-            270.8028,
-            275.031
+            292.6195,
+            308.6625,
+            388.0843,
+            364.2601,
+            330.7501,
+            339.7878,
+            327.0484
           ],
           "peakWorkingSetBytes": [
-            88883200,
-            89079808,
-            89919488,
-            89534464,
-            88965120,
-            89362432,
-            88707072
+            90644480,
+            91099136,
+            90517504,
+            91631616,
+            91103232,
+            91762688,
+            91332608
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 294.1687,
-          "medianPeakWorkingSetBytes": 89305088,
+          "medianElapsedMilliseconds": 354.7978,
+          "medianPeakWorkingSetBytes": 91811840,
           "elapsedMilliseconds": [
-            294.1687,
-            262.6406,
-            300.5933,
-            294.8205,
-            274.5787,
-            297.9522,
-            280.1868
+            354.7978,
+            365.1127,
+            371.7404,
+            366.4784,
+            333.8672,
+            311.7762,
+            315.8771
           ],
           "peakWorkingSetBytes": [
-            89686016,
-            89653248,
-            89706496,
-            89288704,
-            89165824,
-            89112576,
-            89305088
+            91697152,
+            91897856,
+            91963392,
+            91811840,
+            91578368,
+            90636288,
+            92721152
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": 11.023699999999963,
-      "repomix": -6.51989999999995,
-      "flask": 18.72969999999998
+      "devprojex": 37.76139999999998,
+      "repomix": -10.979600000000005,
+      "flask": 24.04770000000002
     },
     "warmIncrementalPercent": {
-      "devprojex": 1.2222402330657314,
-      "repomix": -1.5365728808638006,
-      "flask": 6.799944815367461
+      "devprojex": 3.9487621100206036,
+      "repomix": -2.272128084815962,
+      "flask": 7.270655398138964
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 1.9966811198543974,
-      "repomix": 0.2331596779481948,
-      "flask": 0.25289681809821596
+      "devprojex": 1.842241499046681,
+      "repomix": 0.3812306267146471,
+      "flask": 0.7778077511015197
     },
     "recallPassed": true,
     "allRequiredPassed": true,


### PR DESCRIPTION
Fixes #193 correctness follow-ups.

## Summary
- preserve multiline generic-api-key evidence across LF, CRLF, and CR without letting the UserSecretsId fast allowlist suppress a different key
- make manifest cache identities length-prefixed and verify the canonical manifest before fast reuse
- retry transient source I/O failures at both prepared-source and manifest-snapshot cache layers
- enforce C# namespace visibility instead of guessing a sole project-wide same-name type
- apply ordered TypeScript/JavaScript extension, directory, and paths fallback probes
- keep resolved and ambiguous related-file relationships as distinct output rows in both directions

## Compatibility and safety
Public MCP/CLI schemas, status meanings, ranking weights, and parallelism are unchanged. Missing manifest declarations still do not imply External. Access failures fail closed for the current request and are retried rather than becoming durable cache results.

## Focus evaluation
The frozen three-repository focus-v1 protocol still passes all release gates: overall RecallNew delta +0.3000, no AllRequired regression, and all time/RSS thresholds pass. The committed machine result records product/evaluator SHA 15a34d2918f14581c876e712e727ba628eb6b9ca.

## Validation
- Gitleaks tests: 49 passed, 1 benchmark-only test skipped
- dependency/C#/TypeScript integration tests: 41 passed, 1 Unix-only newline-path test skipped on Windows
- real CLI/MCP related process tests: 7 passed
- RankingEval tests: 8 passed
- pinned Godot scan: 14,261 files, 43 findings before and after
- Release TerminalHost build: zero warnings

Full suites are deferred to CI as required.