### PR TITLE
ci: tier checks by event and keep packaging off feature pushes

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# Configuration for actionlint, run by the "Workflow syntax" job in .github/workflows/dotnet.yml.
+# actionlint ships a fixed list of GitHub-hosted runner labels; the labels below are real
+# GitHub-hosted images that are newer than that list (actionlint v1.7.7), not self-hosted runners.
+# Without this file the linter reports them as unknown. Add a label here when a workflow starts
+# using a new hosted image; remove it when the image retires (see .github/workflows/README.md).
+self-hosted-runner:
+  labels:
+    - windows-11-arm
+    - macos-15-intel
+    - windows-2025-vs2026

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,66 @@
+# CI policy: three tiers, one rule
+
+Checks are tiered by how close a commit is to a release. A feature push must be fast, a merge
+into a version branch must prove the product still builds and ships, and master must prove
+every channel from one commit. Every workflow header names its tier; this file is the policy
+they point to. The contract test
+`Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs`
+(`HeadlessWorkflowsCoverMasterCoreChangesAndReleaseCandidatePinsOneSha`) pins the rules below.
+Change the policy and the test together; never delete an assertion to make a change pass.
+
+| Tier | Event | What runs | Budget |
+|---|---|---|---|
+| 1 Feature | `pull_request` to any branch except master | `.NET CI` and `Release Validation`, both filtered by the change planner; `Grammar Delivery` only for grammar paths; packaging workflows only when their own packaging inputs change | about 31 checks, 13 to 17 minutes |
+| 2 Merge | `push` to `v*` | tier 1 unfiltered by event, plus headless archives, container and package dry-runs, AppImage | about 50 checks, once per merge |
+| 3 Release | `pull_request` to master, `push` to master, `release: published`, `workflow_dispatch` of `release-candidate.yml` | tier 2 plus Store smoke; the release candidate runs every read-only gate on one SHA with `force_full` | before the tag |
+
+The merge tier attaches its check runs to the commit itself, so the open `v5.x -> master`
+pull request shows them without running anything twice.
+
+## Rules that keep this cheap
+
+1. Packaging workflows (`package-headless.yml`, `publish-container.yml`, `publish-packages.yml`,
+   `package-appimage.yml`) run on feature pull requests only when their own packaging inputs
+   change: that is what their `pull_request.paths` list. Core code paths (`Application/**`,
+   `Kernel/**`, `Apps/**`, `Infrastructure/**`) belong to the `push` trigger. Copying the push
+   paths into `pull_request` doubles every feature push by roughly 120 machine minutes and
+   30 minutes of wall time; that is exactly what happened in September 2026 and why this file exists.
+2. Packaging and grammar workflows keep `pull_request: branches-ignore: [master]`. A merge into
+   `v5.x` is also a synchronize of the open release pull request; the push run already attached
+   its checks to the same SHA, and a pull-request-triggered run on the release PR would repeat
+   them. Never replace this with `branches: [master]`, and never remove it.
+3. `release-candidate.yml` is `workflow_dispatch` only. It calls every reusable gate, so any
+   `pull_request` or `push` trigger on it doubles the whole matrix (this was also tried and
+   reverted). Composition changes are covered by the `actionlint` job in `dotnet.yml`.
+4. Reusable `*-build.yml` workflows have `workflow_call` only, `contents: read`, and no write
+   permission. GitHub validates nested job permissions against the caller regardless of `if:`
+   guards, so uploads, registry pushes, and OIDC exchanges live only in the outer publishing
+   workflows.
+5. Every workflow that runs on `pull_request` or `push` has a `concurrency` group keyed by the
+   pull request number or the ref, with `cancel-in-progress` for those two events only. Release
+   and dispatch runs are never cancelled.
+6. Planner skips (`Scripts/ci/Select-CiPlan.ps1`) belong to `pull_request` and `push`. The
+   `force_full: true` inputs are for the release candidate only; a gate that runs under
+   `force_full` fails when any of its jobs is skipped.
+7. Runner images are chosen on purpose: `ubuntu-22.04` in `appimage-build.yml` is the glibc floor
+   for AppImage portability (GitHub deprecates it from 2026-09-17 and retires it on 2027-04-17,
+   move to `container: ubuntu:22.04` on `ubuntu-latest` before then); `macos-15-intel` in
+   `grammar-delivery.yml` is the last x86_64 image (retires autumn 2027);
+   `windows-2025-vs2026` carries the Store toolchain.
+
+## Where a new check belongs
+
+Pick the cheapest tier that can prove the property. In order:
+
+1. A test for product code goes into an existing suite (Unit, Integration, Terminal, UI). The
+   change planner routes it to the right matrix cells; no workflow edit is needed.
+2. A documentation or contract check goes into the `documentation-contracts` job of `dotnet.yml`
+   (Linux, about one minute). The planner runs it when `Docs/**` or the contract sources change.
+3. A new artifact or channel gets a read-only `<name>-build.yml` (`workflow_call`, `contents:
+   read`), a publishing wrapper with `push: [master, 'v*']` and `release: published` triggers,
+   one job in `release-candidate.yml` plus one row in its report table, and one entry in the
+   contract test.
+4. A smoke that needs a special runner (Store, Intel macOS, arm64) is tier 3 only: `push` to
+   master and the release candidate, never tier 1.
+5. Timing and memory measurements go to `tools/ScanBenchmark` and `Docs/Benchmarks.md`. A CI
+   assertion on wall-clock time is a flake generator, not a check.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,7 +46,8 @@ pull request shows them without running anything twice.
    for AppImage portability (GitHub deprecates it from 2026-09-17 and retires it on 2027-04-17,
    move to `container: ubuntu:22.04` on `ubuntu-latest` before then); `macos-15-intel` in
    `grammar-delivery.yml` is the last x86_64 image (retires autumn 2027);
-   `windows-2025-vs2026` carries the Store toolchain.
+   `windows-2025-vs2026` carries the Store toolchain. actionlint does not know these newer
+   hosted labels; they are listed in `.github/actionlint.yaml`, keep that list in sync.
 
 ## Where a new check belongs
 

--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -1,0 +1,542 @@
+name: AppImage Build
+
+# CI tier: reusable read-only gate, `workflow_call` only. Policy: .github/workflows/README.md
+# Called by package-appimage.yml (push to v*, release, dispatch) and by release-candidate.yml.
+# Keep `contents: read` and no write permission here: a called job may not request more than the
+# caller grants, and the release-candidate aggregator is read-only by design.
+# ubuntu-22.04 is the deliberate glibc floor for AppImage portability, not a stale pin. GitHub
+# deprecates this image from 2026-09-17 and retires it on 2027-04-17: before that date move the
+# matrix to `runs-on: ubuntu-latest` with `container: ubuntu:22.04`, which keeps the same floor.
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Commit or ref to build
+        required: true
+        type: string
+      version:
+        description: Version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  APPSTREAM_VERSION: 0.16.4
+  APPSTREAM_SHA256: d4f722d79c6a2f29d9dc5c6f464927469543353f386581c778c9bed7c60a54ed
+  LIBXMLB_VERSION: 0.3.14
+  LIBXMLB_SHA256: 92bea792c6a33d243e7b6f210519bd6ba71b010463fbec1b5a71ddd35736ec20
+  MESON_VERSION: 1.4.0
+  MESON_SHA256: 476a458d51fcfa322a6bdc64da5138997c542d08e6b2e49b9fa68c46fd7c4475
+
+jobs:
+  package:
+    name: AppImage (${{ matrix.appimage_arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            rid: linux-x64
+            appimage_arch: x86_64
+            appimagetool_sha256: a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0
+          - runner: ubuntu-22.04-arm
+            rid: linux-arm64
+            appimage_arch: aarch64
+            appimagetool_sha256: 1b00524ba8c6b678dc15ef88a5c25ec24def36cdfc7e3abb32ddcd068e8007fe
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install packaging and smoke-test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential \
+            desktop-file-utils \
+            file \
+            gettext \
+            gperf \
+            itstool \
+            jq \
+            libcurl4-openssl-dev \
+            libfile-mimeinfo-perl \
+            libglib2.0-dev \
+            liblzma-dev \
+            libxml2-dev \
+            libyaml-dev \
+            ninja-build \
+            pkg-config \
+            unzip \
+            xsltproc \
+            xvfb
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: appimage-nuget-${{ matrix.rid }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}
+          restore-keys: |
+            appimage-nuget-${{ matrix.rid }}-
+
+      - name: Publish the release single file
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          receipt_root="${GITHUB_WORKSPACE}/artifacts/appimage-release/appimage/v${VERSION}"
+          publish_dir="${receipt_root}/${{ matrix.rid }}"
+          mkdir -p -- "${receipt_root}"
+          dotnet publish Apps/Avalonia/DevProjex.Avalonia.csproj \
+            -c Release \
+            -r "${{ matrix.rid }}" \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:IncludeNativeLibrariesForSelfExtract=true \
+            /p:PublishReadyToRun=true \
+            /p:PublishTrimmed=false \
+            /p:DebugType=None \
+            /p:DebugSymbols=false \
+            /p:DevProjexGenerateReleasePayloadReceipt=true \
+            "/p:DevProjexPayloadReceiptDirectory=${receipt_root}" \
+            "/p:DevProjexVersion=${VERSION}" \
+            -o "${publish_dir}"
+
+          mapfile -t published_files < <(find "${publish_dir}" -type f -print)
+          if [[ "${#published_files[@]}" -ne 1 || "$(basename "${published_files[0]}")" != "DevProjex" ]]; then
+            printf 'Expected exactly one published file named DevProjex; found:\n%s\n' "${published_files[*]}"
+            exit 1
+          fi
+
+      - name: Validate the AppImage publish receipt
+        shell: pwsh
+        run: >
+          ./Scripts/Test-ReleaseArtifacts.ps1
+          -PublishRoot artifacts/appimage-release
+          -Version '${{ inputs.version }}'
+          -Channels appimage
+          -Rids '${{ matrix.rid }}'
+
+      - name: Prove AppImage receipt mutations fail closed
+        shell: pwsh
+        run: >
+          ./Scripts/Test-ReleaseArtifactGateMutation.ps1
+          -PublishRoot artifacts/appimage-release
+          -Version '${{ inputs.version }}'
+          -Channels appimage
+          -Rids '${{ matrix.rid }}'
+
+      - name: Cache the pinned AppStream validator
+        id: appstream_validator_cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/appstream-validator
+          key: appstream-validator-${{ runner.os }}-${{ matrix.rid }}-${{ env.APPSTREAM_VERSION }}-${{ env.APPSTREAM_SHA256 }}-${{ env.LIBXMLB_VERSION }}-${{ env.LIBXMLB_SHA256 }}-${{ env.MESON_VERSION }}-${{ env.MESON_SHA256 }}
+
+      - name: Build and verify the pinned AppStream validator
+        if: steps.appstream_validator_cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          validator_root="${RUNNER_TEMP}/appstream-validator"
+          source_root="${validator_root}/AppStream-${APPSTREAM_VERSION}"
+          build_root="${validator_root}/build"
+          meson_root="${validator_root}/meson"
+          rm -rf -- "${validator_root}"
+          mkdir -p -- "${validator_root}" "${meson_root}"
+
+          curl --fail --location --retry 3 \
+            "https://www.freedesktop.org/software/appstream/releases/AppStream-${APPSTREAM_VERSION}.tar.xz" \
+            --output "${validator_root}/AppStream.tar.xz"
+          echo "${APPSTREAM_SHA256}  ${validator_root}/AppStream.tar.xz" | \
+            sha256sum --check --strict
+          tar -xf "${validator_root}/AppStream.tar.xz" -C "${validator_root}"
+
+          curl --fail --location --retry 3 \
+            "https://github.com/hughsie/libxmlb/archive/refs/tags/${LIBXMLB_VERSION}.tar.gz" \
+            --output "${validator_root}/libxmlb.tar.gz"
+          echo "${LIBXMLB_SHA256}  ${validator_root}/libxmlb.tar.gz" | \
+            sha256sum --check --strict
+          mkdir -p -- "${source_root}/subprojects/libxmlb"
+          tar -xf "${validator_root}/libxmlb.tar.gz" \
+            --strip-components=1 \
+            -C "${source_root}/subprojects/libxmlb"
+
+          curl --fail --location --retry 3 \
+            "https://files.pythonhosted.org/packages/33/75/b1a37fa7b2dbca8c0dbb04d5cdd7e2720c8ef6febe41b4a74866350e041c/meson-${MESON_VERSION}-py3-none-any.whl" \
+            --output "${validator_root}/meson.whl"
+          echo "${MESON_SHA256}  ${validator_root}/meson.whl" | \
+            sha256sum --check --strict
+          unzip -q "${validator_root}/meson.whl" -d "${meson_root}"
+
+          export PYTHONPATH="${meson_root}"
+          python3 -m mesonbuild.mesonmain setup \
+            "${build_root}" \
+            "${source_root}" \
+            -Dstemming=false \
+            -Dsystemd=false \
+            -Dgir=false \
+            -Dqt=false \
+            -Dcompose=false \
+            -Dapt-support=false \
+            -Ddocs=false \
+            -Dapidocs=false \
+            -Dinstall-docs=false \
+            -Dlibxmlb:gtkdoc=false \
+            -Dlibxmlb:introspection=false \
+            -Dlibxmlb:tests=false \
+            -Dlibxmlb:cli=false \
+            -Dlibxmlb:zstd=false
+          python3 -m mesonbuild.mesonmain compile -C "${build_root}" appstreamcli
+
+          validator_path="${build_root}/tools/appstreamcli"
+          [[ -x "${validator_path}" ]]
+          "${validator_path}" --version | grep --fixed-strings "${APPSTREAM_VERSION}"
+
+      - name: Verify and activate the pinned AppStream validator
+        shell: bash
+        run: |
+          set -euo pipefail
+          validator_root="${RUNNER_TEMP}/appstream-validator"
+          build_root="${validator_root}/build"
+
+          echo "${APPSTREAM_SHA256}  ${validator_root}/AppStream.tar.xz" | \
+            sha256sum --check --strict
+          echo "${LIBXMLB_SHA256}  ${validator_root}/libxmlb.tar.gz" | \
+            sha256sum --check --strict
+          echo "${MESON_SHA256}  ${validator_root}/meson.whl" | \
+            sha256sum --check --strict
+
+          validator_path="${build_root}/tools/appstreamcli"
+          [[ -x "${validator_path}" ]]
+          "${validator_path}" --version | grep --fixed-strings "${APPSTREAM_VERSION}"
+          echo "${build_root}/tools" >> "${GITHUB_PATH}"
+          echo "LD_LIBRARY_PATH=${build_root}/src:${build_root}/subprojects/libxmlb/src" >> \
+            "${GITHUB_ENV}"
+
+      - name: Assemble and validate the AppDir
+        shell: bash
+        env:
+          APP_ID: io.github.Avazbek22.DevProjex
+          APPIMAGE_LINT_COMMIT: 19e30b276ffedf4d3b4b56bc6320f463625a74f8
+        run: |
+          set -euo pipefail
+          publish_dir="${GITHUB_WORKSPACE}/artifacts/appimage-release/appimage/v${{ inputs.version }}/${{ matrix.rid }}"
+          build_root="${GITHUB_WORKSPACE}/artifacts/appimage/${{ matrix.appimage_arch }}"
+          app_dir="${build_root}/DevProjex.AppDir"
+          rm -rf -- "${build_root}"
+          mkdir -p -- \
+            "${app_dir}/usr/bin" \
+            "${app_dir}/usr/share/applications" \
+            "${app_dir}/usr/share/metainfo"
+
+          install -m 755 "${publish_dir}/DevProjex" "${app_dir}/usr/bin/DevProjex"
+          ln -s DevProjex "${app_dir}/usr/bin/devprojex"
+          ln -s usr/bin/DevProjex "${app_dir}/AppRun"
+
+          desktop_source="Packaging/Linux/${APP_ID}.desktop"
+          metainfo_source="Packaging/Linux/${APP_ID}.metainfo.xml"
+          install -m 644 "${desktop_source}" "${app_dir}/${APP_ID}.desktop"
+          install -m 644 "${desktop_source}" "${app_dir}/usr/share/applications/${APP_ID}.desktop"
+          install -m 644 "${metainfo_source}" "${app_dir}/usr/share/metainfo/${APP_ID}.metainfo.xml"
+          # appimagetool and AppImageHub still probe the legacy suffix. Keep one
+          # canonical metadata file and expose a compatibility symlink to it.
+          ln -s "${APP_ID}.metainfo.xml" "${app_dir}/usr/share/metainfo/${APP_ID}.appdata.xml"
+
+          for size in 128 256 512; do
+            icon_dir="${app_dir}/usr/share/icons/hicolor/${size}x${size}/apps"
+            mkdir -p -- "${icon_dir}"
+            install -m 644 "Assets/AppIcon/Linux/png/${size}.png" "${icon_dir}/${APP_ID}.png"
+          done
+          install -m 644 "Assets/AppIcon/Linux/png/512.png" "${app_dir}/${APP_ID}.png"
+          ln -s "${APP_ID}.png" "${app_dir}/.DirIcon"
+
+          published_sha="$(sha256sum "${publish_dir}/DevProjex" | cut -d ' ' -f 1)"
+          appdir_sha="$(sha256sum "${app_dir}/usr/bin/DevProjex" | cut -d ' ' -f 1)"
+          [[ "${published_sha}" == "${appdir_sha}" ]]
+          [[ ! -e "${app_dir}/usr/share/icons/hicolor/scalable/apps/${APP_ID}.svg" ]]
+
+          desktop-file-validate "${desktop_source}"
+          appstreamcli validate --strict --explain "${metainfo_source}"
+
+          lint_dir="${RUNNER_TEMP}/appimagehub-lint"
+          rm -rf -- "${lint_dir}"
+          mkdir -p -- "${lint_dir}"
+          curl --fail --location --retry 3 \
+            "https://raw.githubusercontent.com/AppImage/AppImages/${APPIMAGE_LINT_COMMIT}/appdir-lint.sh" \
+            --output "${lint_dir}/appdir-lint.sh"
+          curl --fail --location --retry 3 \
+            "https://raw.githubusercontent.com/AppImage/AppImages/${APPIMAGE_LINT_COMMIT}/excludelist" \
+            --output "${lint_dir}/excludelist"
+          bash "${lint_dir}/appdir-lint.sh" "${app_dir}"
+
+      - name: Download and verify appimagetool
+        shell: bash
+        env:
+          APPIMAGETOOL_SHA256: ${{ matrix.appimagetool_sha256 }}
+        run: |
+          set -euo pipefail
+          tool_path="${RUNNER_TEMP}/appimagetool-${{ matrix.appimage_arch }}.AppImage"
+          curl --fail --location --retry 3 \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${{ matrix.appimage_arch }}.AppImage" \
+            --output "${tool_path}"
+          echo "${APPIMAGETOOL_SHA256}  ${tool_path}" | sha256sum --check --strict
+          chmod 755 "${tool_path}"
+
+      - name: Build AppImage
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.appimage_arch }}
+        run: |
+          set -euo pipefail
+          tool_path="${RUNNER_TEMP}/appimagetool-${ARCH}.AppImage"
+          app_dir="${GITHUB_WORKSPACE}/artifacts/appimage/${ARCH}/DevProjex.AppDir"
+          output_path="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
+          APPIMAGE_EXTRACT_AND_RUN=1 "${tool_path}" "${app_dir}" "${output_path}"
+          chmod 755 "${output_path}"
+          [[ -s "${output_path}" ]]
+          [[ ! -e "${output_path}.zsync" ]]
+
+      - name: Verify packaged binary identity
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.appimage_arch }}
+        run: |
+          set -euo pipefail
+          output_path="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
+          extraction_root="${RUNNER_TEMP}/appimage-verification-${ARCH}"
+          rm -rf -- "${extraction_root}"
+          mkdir -p -- "${extraction_root}"
+          (
+            cd "${extraction_root}"
+            "${output_path}" --appimage-extract >/dev/null
+          )
+
+          packaged_binary="${extraction_root}/squashfs-root/usr/bin/DevProjex"
+          published_binary="${GITHUB_WORKSPACE}/artifacts/appimage-release/appimage/v${VERSION}/${{ matrix.rid }}/DevProjex"
+          [[ -x "${packaged_binary}" ]]
+          [[ "$(sha256sum "${published_binary}" | cut -d ' ' -f 1)" == \
+             "$(sha256sum "${packaged_binary}" | cut -d ' ' -f 1)" ]]
+          [[ ! -e "${extraction_root}/squashfs-root/usr/share/icons/hicolor/scalable/apps/io.github.Avazbek22.DevProjex.svg" ]]
+
+      - name: AppImage CLI smoke
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.appimage_arch }}
+        run: |
+          set -euo pipefail
+          appimage="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
+          smoke_root="${RUNNER_TEMP}/devprojex-appimage-smoke-${ARCH}"
+          sample_project="${smoke_root}/sample"
+          rm -rf -- "${smoke_root}"
+          mkdir -p -- \
+            "${sample_project}/src" \
+            "${smoke_root}/bundle-extract" \
+            "${smoke_root}/config" \
+            "${smoke_root}/data" \
+            "${smoke_root}/state" \
+            "${smoke_root}/cache" \
+            "${smoke_root}/runtime"
+          chmod 700 "${smoke_root}/runtime"
+          cat > "${sample_project}/src/App.cs" <<'SOURCE'
+          namespace Sample;
+
+          public static class App
+          {
+              public static int Calculate(int left, int right)
+              {
+                  var sum = left + right;
+                  var doubled = sum * 2;
+                  return doubled;
+              }
+          }
+          SOURCE
+          cat > "${sample_project}/appsettings.json" <<'SOURCE'
+          { "githubToken": "ghp_Q7wE9rT2yU4iO6pA8sD0fG1hJ3kL5zX7cV9b" }
+          SOURCE
+
+          export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${smoke_root}/bundle-extract"
+          export XDG_CONFIG_HOME="${smoke_root}/config"
+          export XDG_DATA_HOME="${smoke_root}/data"
+          export XDG_STATE_HOME="${smoke_root}/state"
+          export XDG_CACHE_HOME="${smoke_root}/cache"
+          export XDG_RUNTIME_DIR="${smoke_root}/runtime"
+
+          actual_version="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" --version)"
+          [[ "${actual_version}" == "${VERSION}" ]]
+
+          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" tree "${sample_project}" \
+            --git-mode none --exclude none --format text --plain --language en -o - \
+            > "${smoke_root}/tree.txt"
+          grep --fixed-strings "App.cs" "${smoke_root}/tree.txt"
+
+          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" analyze "${sample_project}" \
+            --git-mode none --exclude none --format json --plain --language en -o - \
+            > "${smoke_root}/analysis-full.json"
+          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" analyze "${sample_project}" \
+            --git-mode none --exclude none --compress-code --format json --plain --language en -o - \
+            > "${smoke_root}/analysis-compressed.json"
+          full_chars="$(jq -r '.metrics.content.chars' "${smoke_root}/analysis-full.json")"
+          compressed_chars="$(jq -r '.metrics.content.chars' "${smoke_root}/analysis-compressed.json")"
+          compressed_files="$(jq -r '.compression.compressedFiles' "${smoke_root}/analysis-compressed.json")"
+          [[ "${compressed_files}" -gt 0 ]]
+          [[ "${compressed_chars}" -lt "${full_chars}" ]]
+
+          set +e
+          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" analyze "${sample_project}" \
+            --git-mode none --exclude none --hide-secrets --findings --fail-on-findings \
+            --format json --plain --language en -o - \
+            > "${smoke_root}/analysis-secrets.json"
+          findings_exit=$?
+          set -e
+          [[ "${findings_exit}" -eq 3 ]]
+          jq --exit-status '.findingCount > 0 and (.findings | length > 0)' \
+            "${smoke_root}/analysis-secrets.json" >/dev/null
+          if grep --fixed-strings --quiet "ghp_Q7wE9rT2yU4iO6pA8sD0fG1hJ3kL5zX7cV9b" \
+            "${smoke_root}/analysis-secrets.json"; then
+            echo "::error::Secret value leaked into AppImage smoke output"
+            exit 1
+          fi
+
+      - name: AppImage GUI smoke under Xvfb
+        id: gui_smoke
+        continue-on-error: true
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.appimage_arch }}
+        run: |
+          set -euo pipefail
+          appimage="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
+          smoke_root="${RUNNER_TEMP}/devprojex-appimage-gui-${ARCH}"
+          sample_project="${smoke_root}/sample"
+          log_path="${smoke_root}/gui-smoke.log"
+          rm -rf -- "${smoke_root}"
+          mkdir -p -- \
+            "${sample_project}" \
+            "${smoke_root}/bundle-extract" \
+            "${smoke_root}/config" \
+            "${smoke_root}/data" \
+            "${smoke_root}/state" \
+            "${smoke_root}/cache" \
+            "${smoke_root}/runtime"
+          chmod 700 "${smoke_root}/runtime"
+          printf 'public sealed class App {}\n' > "${sample_project}/App.cs"
+
+          timeout --kill-after=10s 180s xvfb-run -a bash -s -- \
+            "${appimage}" "${sample_project}" "${smoke_root}" <<'SMOKE' 2>&1 | tee "${log_path}"
+          set -euo pipefail
+          appimage="$1"
+          sample_project="$2"
+          smoke_root="$3"
+          export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${smoke_root}/bundle-extract"
+          export XDG_CONFIG_HOME="${smoke_root}/config"
+          export XDG_DATA_HOME="${smoke_root}/data"
+          export XDG_STATE_HOME="${smoke_root}/state"
+          export XDG_CACHE_HOME="${smoke_root}/cache"
+          export XDG_RUNTIME_DIR="${smoke_root}/runtime"
+
+          runtime_pid=""
+          desktop_pid=""
+          cleanup() {
+            cleanup_exit=$?
+            set +e
+            [[ -n "${desktop_pid}" ]] && kill "${desktop_pid}" 2>/dev/null
+            [[ -n "${runtime_pid}" ]] && kill "${runtime_pid}" 2>/dev/null
+            if [[ "${cleanup_exit}" -ne 0 && -s "${smoke_root}/desktop.stderr" ]]; then
+              echo "Desktop stderr:"
+              tail -n 30 "${smoke_root}/desktop.stderr"
+            fi
+            exit "${cleanup_exit}"
+          }
+          trap cleanup EXIT
+
+          env -u CI APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" \
+            </dev/null >"${smoke_root}/desktop.stdout" 2>"${smoke_root}/desktop.stderr" &
+          runtime_pid=$!
+
+          instance_id=""
+          for _ in $(seq 1 60); do
+            if ! kill -0 "${runtime_pid}" 2>/dev/null; then
+              wait "${runtime_pid}"
+              exit 1
+            fi
+            list_json="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" ui list \
+              --format json --language en)"
+            instance_id="$(jq -r '.instances[0].instanceId // empty' <<<"${list_json}")"
+            desktop_pid="$(jq -r '.instances[0].processId // empty' <<<"${list_json}")"
+            [[ -n "${instance_id}" ]] && break
+            sleep 1
+          done
+          if [[ -z "${instance_id}" ]]; then
+            echo "Desktop did not register within 60 seconds."
+            exit 1
+          fi
+
+          open_output="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" open "${sample_project}" \
+            --wait --preview --view tree --language en)"
+          [[ "${open_output}" == "$(realpath "${sample_project}")" ]]
+
+          status_json="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" ui status \
+            --instance "${instance_id}" --language en)"
+          jq --exit-status \
+            '.ok == true and .state.startupReady == true and .state.projectLoaded == true and .state.previewOpen == true and .state.previewView == "tree"' \
+            <<<"${status_json}" >/dev/null
+          printf '%s\n' "${status_json}"
+          SMOKE
+
+      - name: Write AppImage job summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.appimage_arch }}
+          GUI_OUTCOME: ${{ steps.gui_smoke.outcome }}
+        run: |
+          set -euo pipefail
+          output_path="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
+          {
+            echo "### DevProjex AppImage (${ARCH})"
+            if [[ -s "${output_path}" ]]; then
+              bytes="$(stat --format=%s "${output_path}")"
+              human_size="$(numfmt --to=iec-i --suffix=B "${bytes}")"
+              echo "- File: \`$(basename "${output_path}")\`"
+              echo "- Size: ${human_size} (${bytes} bytes)"
+            else
+              echo "- AppImage was not produced."
+            fi
+            echo "- GUI smoke under Xvfb: ${GUI_OUTCOME}"
+            if [[ "${GUI_OUTCOME}" != "success" ]]; then
+              echo "- GUI smoke diagnostics:"
+              echo '```text'
+              tail -n 30 "${RUNNER_TEMP}/devprojex-appimage-gui-${ARCH}/gui-smoke.log" 2>/dev/null || \
+                echo "No GUI smoke log was produced."
+              echo '```'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: DevProjex-${{ inputs.version }}-${{ matrix.appimage_arch }}.AppImage
+          path: artifacts/DevProjex-${{ inputs.version }}-${{ matrix.appimage_arch }}.AppImage
+          if-no-files-found: error

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,5 +1,10 @@
 name: Headless Container Build
 
+# CI tier: reusable read-only gate, `workflow_call` only. Policy: .github/workflows/README.md
+# Called by publish-container.yml and release-candidate.yml. Keep `contents: read` and no write
+# permission: a called job may not request more than the caller grants. Never add pull_request
+# or push triggers here; the publishing wrapper owns the events.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,13 @@
 name: .NET CI
 
+# CI tier 1, 2, and 3. Policy: .github/workflows/README.md
+# The change planner (Scripts/ci/Select-CiPlan.ps1) decides which suites and operating systems
+# run for a pull request; unclassified paths fall back to the full plan. A new product test goes
+# into an existing suite and needs no edit here. Do not add a `push: v*` trigger: every merge
+# into v5.x is also a synchronize of the open release PR, which already runs this workflow.
+# The three-OS matrix stays on pull requests on purpose: Windows and macOS path, PTY, and file
+# system differences are found here, not later.
+
 on:
   push:
     branches:
@@ -98,6 +106,13 @@ jobs:
           .github/workflows/headless-build.yml
           .github/workflows/container-build.yml
           .github/workflows/packages-build.yml
+          .github/workflows/appimage-build.yml
+          .github/workflows/package-headless.yml
+          .github/workflows/publish-container.yml
+          .github/workflows/publish-packages.yml
+          .github/workflows/package-appimage.yml
+          .github/workflows/grammar-delivery.yml
+          .github/workflows/store-package-smoke.yml
 
   test-suite:
     name: CI (${{ matrix.os_name }} / ${{ matrix.suite_name }})

--- a/.github/workflows/grammar-delivery.yml
+++ b/.github/workflows/grammar-delivery.yml
@@ -7,12 +7,24 @@ name: Grammar Delivery
 # and under PublishSingleFile the native extraction directory is not on the OS loader search path,
 # so grammars cannot be loaded by name at all. Both are re-checked here on every RID DevProjex
 # ships, every time the binding version, the curated set or the delivery code changes.
+#
+# CI tier 1 (pull_request, grammar paths only), 2 (push to v*), 3 (master, release candidate).
+# Policy: .github/workflows/README.md. The pull_request paths are deliberately narrow: this gate
+# publishes six RIDs including an Intel macOS leg, so it must not run on unrelated feature pushes.
+# workflow_call exists for release-candidate.yml; keep `contents: read` and no write permission.
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Commit or ref to validate
+        required: false
+        type: string
   push:
     branches:
       - master
+      - 'v*'
     paths:
       - 'Packaging/GrammarDeliveryProbe/**'
       - 'Application/Compression/**'
@@ -24,6 +36,8 @@ on:
       - 'Directory.Packages.props'
       - '.github/workflows/grammar-delivery.yml'
   pull_request:
+    # The release PR (v* -> master) is excluded: its head commit already carries the push run.
+    branches-ignore: [master]
     paths:
       - 'Packaging/GrammarDeliveryProbe/**'
       - 'Application/Compression/**'
@@ -44,9 +58,10 @@ env:
   # Loader traces are the only diagnostic available when a RID-specific load fails.
   TREESITTER_DEBUG_LOADER: 1
 
+# One run per pull request or branch head; release-candidate calls are never cancelled.
 concurrency:
-  group: grammar-delivery-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: grammar-delivery-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   portable:
@@ -82,6 +97,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v6
@@ -230,6 +247,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/headless-build.yml
+++ b/.github/workflows/headless-build.yml
@@ -1,5 +1,10 @@
 name: Headless Archive Build
 
+# CI tier: reusable read-only gate, `workflow_call` only. Policy: .github/workflows/README.md
+# Called by package-headless.yml and release-candidate.yml. Keep `contents: read` and no write
+# permission: a called job may not request more than the caller grants. Never add pull_request
+# or push triggers here; the publishing wrapper owns the events.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/package-appimage.yml
+++ b/.github/workflows/package-appimage.yml
@@ -1,10 +1,39 @@
 ---
 name: Package AppImage
 
+# CI tier 2 (push to v*) and 3 (master, release). Policy: .github/workflows/README.md
+# - `pull_request` runs ONLY when the Linux packaging inputs themselves change (paths below).
+#   Core code paths belong to `push`; copying them here makes every feature push build two
+#   AppImages. `branches-ignore: [master]` keeps the release PR out: the push run on v* already
+#   attaches its checks to the same commit the release PR shows. Never replace it with `branches:`.
+# - The read-only build is appimage-build.yml (also used by release-candidate.yml). Only
+#   release-upload may write, and only for `release: published` or an explicit release_tag.
+
 on:
-  pull_request:
+  push:
+    branches: [master, 'v*']
     paths:
       - .github/workflows/package-appimage.yml
+      - .github/workflows/appimage-build.yml
+      - Apps/**
+      - Application/**
+      - Infrastructure/**
+      - Kernel/**
+      - Assets/AppIcon/Linux/png/**
+      - Assets/Localization/**
+      - Packaging/Linux/**
+      - Scripts/Test-ReleaseArtifacts.ps1
+      - Scripts/Test-ReleaseArtifactGateMutation.ps1
+      - Scripts/ci/Test-ReleaseVersion.ps1
+      - Directory.Build.props
+      - Directory.Build.targets
+      - Directory.Packages.props
+  pull_request:
+    # The release PR (v* -> master) is excluded: its head commit already carries the push run.
+    branches-ignore: [master]
+    paths:
+      - .github/workflows/package-appimage.yml
+      - .github/workflows/appimage-build.yml
       - Apps/Avalonia/Services/AvaloniaDeveloperCommandRunner.cs
       - Apps/Avalonia/Services/CommandLineBenchmarkRunner.cs
       - Apps/Terminal/DesktopControl/DesktopProcessLauncher.cs
@@ -33,20 +62,20 @@ on:
 permissions:
   contents: read
 
+# One run per pull request or branch head. Feature pushes and branch merges cancel their own
+# superseded runs; release and dispatch runs are never cancelled.
+concurrency:
+  group: package-appimage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  APPSTREAM_VERSION: 0.16.4
-  APPSTREAM_SHA256: d4f722d79c6a2f29d9dc5c6f464927469543353f386581c778c9bed7c60a54ed
-  LIBXMLB_VERSION: 0.3.14
-  LIBXMLB_SHA256: 92bea792c6a33d243e7b6f210519bd6ba71b010463fbec1b5a71ddd35736ec20
-  MESON_VERSION: 1.4.0
-  MESON_SHA256: 476a458d51fcfa322a6bdc64da5138997c542d08e6b2e49b9fa68c46fd7c4475
 
 jobs:
   prepare:
     name: Resolve AppImage release metadata
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       version: ${{ steps.metadata.outputs.version }}
@@ -68,7 +97,8 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             version="${PUBLISHED_RELEASE_TAG#v}"
             release_tag="${PUBLISHED_RELEASE_TAG}"
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" || "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # Validation-only runs (tiers 1 and 2) take the repository version and never upload.
             version="$(sed -n 's:.*<DevProjexVersion[^>]*>\([^<]*\)</DevProjexVersion>.*:\1:p' Directory.Build.props)"
             release_tag=""
           else
@@ -101,517 +131,19 @@ jobs:
           -EventName '${{ github.event_name }}'
           -ReleaseTag '${{ github.event.release.tag_name }}'
 
-  package:
-    name: AppImage (${{ matrix.appimage_arch }})
+  build:
+    name: Read-only AppImage gates
     needs: prepare
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-22.04
-            rid: linux-x64
-            appimage_arch: x86_64
-            appimagetool_sha256: a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0
-          - runner: ubuntu-22.04-arm
-            rid: linux-arm64
-            appimage_arch: aarch64
-            appimagetool_sha256: 1b00524ba8c6b678dc15ef88a5c25ec24def36cdfc7e3abb32ddcd068e8007fe
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Install packaging and smoke-test dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            build-essential \
-            desktop-file-utils \
-            file \
-            gettext \
-            gperf \
-            itstool \
-            jq \
-            libcurl4-openssl-dev \
-            libfile-mimeinfo-perl \
-            libglib2.0-dev \
-            liblzma-dev \
-            libxml2-dev \
-            libyaml-dev \
-            ninja-build \
-            pkg-config \
-            unzip \
-            xsltproc \
-            xvfb
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v6
-        with:
-          path: ~/.nuget/packages
-          key: appimage-nuget-${{ matrix.rid }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Packages.props') }}
-          restore-keys: |
-            appimage-nuget-${{ matrix.rid }}-
-
-      - name: Publish the release single file
-        shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          set -euo pipefail
-          receipt_root="${GITHUB_WORKSPACE}/artifacts/appimage-release/appimage/v${VERSION}"
-          publish_dir="${receipt_root}/${{ matrix.rid }}"
-          mkdir -p -- "${receipt_root}"
-          dotnet publish Apps/Avalonia/DevProjex.Avalonia.csproj \
-            -c Release \
-            -r "${{ matrix.rid }}" \
-            --self-contained true \
-            /p:PublishSingleFile=true \
-            /p:IncludeNativeLibrariesForSelfExtract=true \
-            /p:PublishReadyToRun=true \
-            /p:PublishTrimmed=false \
-            /p:DebugType=None \
-            /p:DebugSymbols=false \
-            /p:DevProjexGenerateReleasePayloadReceipt=true \
-            "/p:DevProjexPayloadReceiptDirectory=${receipt_root}" \
-            "/p:DevProjexVersion=${VERSION}" \
-            -o "${publish_dir}"
-
-          mapfile -t published_files < <(find "${publish_dir}" -type f -print)
-          if [[ "${#published_files[@]}" -ne 1 || "$(basename "${published_files[0]}")" != "DevProjex" ]]; then
-            printf 'Expected exactly one published file named DevProjex; found:\n%s\n' "${published_files[*]}"
-            exit 1
-          fi
-
-      - name: Validate the AppImage publish receipt
-        shell: pwsh
-        run: >
-          ./Scripts/Test-ReleaseArtifacts.ps1
-          -PublishRoot artifacts/appimage-release
-          -Version '${{ needs.prepare.outputs.version }}'
-          -Channels appimage
-          -Rids '${{ matrix.rid }}'
-
-      - name: Prove AppImage receipt mutations fail closed
-        shell: pwsh
-        run: >
-          ./Scripts/Test-ReleaseArtifactGateMutation.ps1
-          -PublishRoot artifacts/appimage-release
-          -Version '${{ needs.prepare.outputs.version }}'
-          -Channels appimage
-          -Rids '${{ matrix.rid }}'
-
-      - name: Cache the pinned AppStream validator
-        id: appstream_validator_cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/appstream-validator
-          key: appstream-validator-${{ runner.os }}-${{ matrix.rid }}-${{ env.APPSTREAM_VERSION }}-${{ env.APPSTREAM_SHA256 }}-${{ env.LIBXMLB_VERSION }}-${{ env.LIBXMLB_SHA256 }}-${{ env.MESON_VERSION }}-${{ env.MESON_SHA256 }}
-
-      - name: Build and verify the pinned AppStream validator
-        if: steps.appstream_validator_cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          validator_root="${RUNNER_TEMP}/appstream-validator"
-          source_root="${validator_root}/AppStream-${APPSTREAM_VERSION}"
-          build_root="${validator_root}/build"
-          meson_root="${validator_root}/meson"
-          rm -rf -- "${validator_root}"
-          mkdir -p -- "${validator_root}" "${meson_root}"
-
-          curl --fail --location --retry 3 \
-            "https://www.freedesktop.org/software/appstream/releases/AppStream-${APPSTREAM_VERSION}.tar.xz" \
-            --output "${validator_root}/AppStream.tar.xz"
-          echo "${APPSTREAM_SHA256}  ${validator_root}/AppStream.tar.xz" | \
-            sha256sum --check --strict
-          tar -xf "${validator_root}/AppStream.tar.xz" -C "${validator_root}"
-
-          curl --fail --location --retry 3 \
-            "https://github.com/hughsie/libxmlb/archive/refs/tags/${LIBXMLB_VERSION}.tar.gz" \
-            --output "${validator_root}/libxmlb.tar.gz"
-          echo "${LIBXMLB_SHA256}  ${validator_root}/libxmlb.tar.gz" | \
-            sha256sum --check --strict
-          mkdir -p -- "${source_root}/subprojects/libxmlb"
-          tar -xf "${validator_root}/libxmlb.tar.gz" \
-            --strip-components=1 \
-            -C "${source_root}/subprojects/libxmlb"
-
-          curl --fail --location --retry 3 \
-            "https://files.pythonhosted.org/packages/33/75/b1a37fa7b2dbca8c0dbb04d5cdd7e2720c8ef6febe41b4a74866350e041c/meson-${MESON_VERSION}-py3-none-any.whl" \
-            --output "${validator_root}/meson.whl"
-          echo "${MESON_SHA256}  ${validator_root}/meson.whl" | \
-            sha256sum --check --strict
-          unzip -q "${validator_root}/meson.whl" -d "${meson_root}"
-
-          export PYTHONPATH="${meson_root}"
-          python3 -m mesonbuild.mesonmain setup \
-            "${build_root}" \
-            "${source_root}" \
-            -Dstemming=false \
-            -Dsystemd=false \
-            -Dgir=false \
-            -Dqt=false \
-            -Dcompose=false \
-            -Dapt-support=false \
-            -Ddocs=false \
-            -Dapidocs=false \
-            -Dinstall-docs=false \
-            -Dlibxmlb:gtkdoc=false \
-            -Dlibxmlb:introspection=false \
-            -Dlibxmlb:tests=false \
-            -Dlibxmlb:cli=false \
-            -Dlibxmlb:zstd=false
-          python3 -m mesonbuild.mesonmain compile -C "${build_root}" appstreamcli
-
-          validator_path="${build_root}/tools/appstreamcli"
-          [[ -x "${validator_path}" ]]
-          "${validator_path}" --version | grep --fixed-strings "${APPSTREAM_VERSION}"
-
-      - name: Verify and activate the pinned AppStream validator
-        shell: bash
-        run: |
-          set -euo pipefail
-          validator_root="${RUNNER_TEMP}/appstream-validator"
-          build_root="${validator_root}/build"
-
-          echo "${APPSTREAM_SHA256}  ${validator_root}/AppStream.tar.xz" | \
-            sha256sum --check --strict
-          echo "${LIBXMLB_SHA256}  ${validator_root}/libxmlb.tar.gz" | \
-            sha256sum --check --strict
-          echo "${MESON_SHA256}  ${validator_root}/meson.whl" | \
-            sha256sum --check --strict
-
-          validator_path="${build_root}/tools/appstreamcli"
-          [[ -x "${validator_path}" ]]
-          "${validator_path}" --version | grep --fixed-strings "${APPSTREAM_VERSION}"
-          echo "${build_root}/tools" >> "${GITHUB_PATH}"
-          echo "LD_LIBRARY_PATH=${build_root}/src:${build_root}/subprojects/libxmlb/src" >> \
-            "${GITHUB_ENV}"
-
-      - name: Assemble and validate the AppDir
-        shell: bash
-        env:
-          APP_ID: io.github.Avazbek22.DevProjex
-          APPIMAGE_LINT_COMMIT: 19e30b276ffedf4d3b4b56bc6320f463625a74f8
-        run: |
-          set -euo pipefail
-          publish_dir="${GITHUB_WORKSPACE}/artifacts/appimage-release/appimage/v${{ needs.prepare.outputs.version }}/${{ matrix.rid }}"
-          build_root="${GITHUB_WORKSPACE}/artifacts/appimage/${{ matrix.appimage_arch }}"
-          app_dir="${build_root}/DevProjex.AppDir"
-          rm -rf -- "${build_root}"
-          mkdir -p -- \
-            "${app_dir}/usr/bin" \
-            "${app_dir}/usr/share/applications" \
-            "${app_dir}/usr/share/metainfo"
-
-          install -m 755 "${publish_dir}/DevProjex" "${app_dir}/usr/bin/DevProjex"
-          ln -s DevProjex "${app_dir}/usr/bin/devprojex"
-          ln -s usr/bin/DevProjex "${app_dir}/AppRun"
-
-          desktop_source="Packaging/Linux/${APP_ID}.desktop"
-          metainfo_source="Packaging/Linux/${APP_ID}.metainfo.xml"
-          install -m 644 "${desktop_source}" "${app_dir}/${APP_ID}.desktop"
-          install -m 644 "${desktop_source}" "${app_dir}/usr/share/applications/${APP_ID}.desktop"
-          install -m 644 "${metainfo_source}" "${app_dir}/usr/share/metainfo/${APP_ID}.metainfo.xml"
-          # appimagetool and AppImageHub still probe the legacy suffix. Keep one
-          # canonical metadata file and expose a compatibility symlink to it.
-          ln -s "${APP_ID}.metainfo.xml" "${app_dir}/usr/share/metainfo/${APP_ID}.appdata.xml"
-
-          for size in 128 256 512; do
-            icon_dir="${app_dir}/usr/share/icons/hicolor/${size}x${size}/apps"
-            mkdir -p -- "${icon_dir}"
-            install -m 644 "Assets/AppIcon/Linux/png/${size}.png" "${icon_dir}/${APP_ID}.png"
-          done
-          install -m 644 "Assets/AppIcon/Linux/png/512.png" "${app_dir}/${APP_ID}.png"
-          ln -s "${APP_ID}.png" "${app_dir}/.DirIcon"
-
-          published_sha="$(sha256sum "${publish_dir}/DevProjex" | cut -d ' ' -f 1)"
-          appdir_sha="$(sha256sum "${app_dir}/usr/bin/DevProjex" | cut -d ' ' -f 1)"
-          [[ "${published_sha}" == "${appdir_sha}" ]]
-          [[ ! -e "${app_dir}/usr/share/icons/hicolor/scalable/apps/${APP_ID}.svg" ]]
-
-          desktop-file-validate "${desktop_source}"
-          appstreamcli validate --strict --explain "${metainfo_source}"
-
-          lint_dir="${RUNNER_TEMP}/appimagehub-lint"
-          rm -rf -- "${lint_dir}"
-          mkdir -p -- "${lint_dir}"
-          curl --fail --location --retry 3 \
-            "https://raw.githubusercontent.com/AppImage/AppImages/${APPIMAGE_LINT_COMMIT}/appdir-lint.sh" \
-            --output "${lint_dir}/appdir-lint.sh"
-          curl --fail --location --retry 3 \
-            "https://raw.githubusercontent.com/AppImage/AppImages/${APPIMAGE_LINT_COMMIT}/excludelist" \
-            --output "${lint_dir}/excludelist"
-          bash "${lint_dir}/appdir-lint.sh" "${app_dir}"
-
-      - name: Download and verify appimagetool
-        shell: bash
-        env:
-          APPIMAGETOOL_SHA256: ${{ matrix.appimagetool_sha256 }}
-        run: |
-          set -euo pipefail
-          tool_path="${RUNNER_TEMP}/appimagetool-${{ matrix.appimage_arch }}.AppImage"
-          curl --fail --location --retry 3 \
-            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${{ matrix.appimage_arch }}.AppImage" \
-            --output "${tool_path}"
-          echo "${APPIMAGETOOL_SHA256}  ${tool_path}" | sha256sum --check --strict
-          chmod 755 "${tool_path}"
-
-      - name: Build AppImage
-        shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          ARCH: ${{ matrix.appimage_arch }}
-        run: |
-          set -euo pipefail
-          tool_path="${RUNNER_TEMP}/appimagetool-${ARCH}.AppImage"
-          app_dir="${GITHUB_WORKSPACE}/artifacts/appimage/${ARCH}/DevProjex.AppDir"
-          output_path="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
-          APPIMAGE_EXTRACT_AND_RUN=1 "${tool_path}" "${app_dir}" "${output_path}"
-          chmod 755 "${output_path}"
-          [[ -s "${output_path}" ]]
-          [[ ! -e "${output_path}.zsync" ]]
-
-      - name: Verify packaged binary identity
-        shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          ARCH: ${{ matrix.appimage_arch }}
-        run: |
-          set -euo pipefail
-          output_path="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
-          extraction_root="${RUNNER_TEMP}/appimage-verification-${ARCH}"
-          rm -rf -- "${extraction_root}"
-          mkdir -p -- "${extraction_root}"
-          (
-            cd "${extraction_root}"
-            "${output_path}" --appimage-extract >/dev/null
-          )
-
-          packaged_binary="${extraction_root}/squashfs-root/usr/bin/DevProjex"
-          published_binary="${GITHUB_WORKSPACE}/artifacts/appimage-release/appimage/v${VERSION}/${{ matrix.rid }}/DevProjex"
-          [[ -x "${packaged_binary}" ]]
-          [[ "$(sha256sum "${published_binary}" | cut -d ' ' -f 1)" == \
-             "$(sha256sum "${packaged_binary}" | cut -d ' ' -f 1)" ]]
-          [[ ! -e "${extraction_root}/squashfs-root/usr/share/icons/hicolor/scalable/apps/io.github.Avazbek22.DevProjex.svg" ]]
-
-      - name: AppImage CLI smoke
-        shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          ARCH: ${{ matrix.appimage_arch }}
-        run: |
-          set -euo pipefail
-          appimage="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
-          smoke_root="${RUNNER_TEMP}/devprojex-appimage-smoke-${ARCH}"
-          sample_project="${smoke_root}/sample"
-          rm -rf -- "${smoke_root}"
-          mkdir -p -- \
-            "${sample_project}/src" \
-            "${smoke_root}/bundle-extract" \
-            "${smoke_root}/config" \
-            "${smoke_root}/data" \
-            "${smoke_root}/state" \
-            "${smoke_root}/cache" \
-            "${smoke_root}/runtime"
-          chmod 700 "${smoke_root}/runtime"
-          cat > "${sample_project}/src/App.cs" <<'SOURCE'
-          namespace Sample;
-
-          public static class App
-          {
-              public static int Calculate(int left, int right)
-              {
-                  var sum = left + right;
-                  var doubled = sum * 2;
-                  return doubled;
-              }
-          }
-          SOURCE
-          cat > "${sample_project}/appsettings.json" <<'SOURCE'
-          { "githubToken": "ghp_Q7wE9rT2yU4iO6pA8sD0fG1hJ3kL5zX7cV9b" }
-          SOURCE
-
-          export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${smoke_root}/bundle-extract"
-          export XDG_CONFIG_HOME="${smoke_root}/config"
-          export XDG_DATA_HOME="${smoke_root}/data"
-          export XDG_STATE_HOME="${smoke_root}/state"
-          export XDG_CACHE_HOME="${smoke_root}/cache"
-          export XDG_RUNTIME_DIR="${smoke_root}/runtime"
-
-          actual_version="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" --version)"
-          [[ "${actual_version}" == "${VERSION}" ]]
-
-          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" tree "${sample_project}" \
-            --git-mode none --exclude none --format text --plain --language en -o - \
-            > "${smoke_root}/tree.txt"
-          grep --fixed-strings "App.cs" "${smoke_root}/tree.txt"
-
-          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" analyze "${sample_project}" \
-            --git-mode none --exclude none --format json --plain --language en -o - \
-            > "${smoke_root}/analysis-full.json"
-          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" analyze "${sample_project}" \
-            --git-mode none --exclude none --compress-code --format json --plain --language en -o - \
-            > "${smoke_root}/analysis-compressed.json"
-          full_chars="$(jq -r '.metrics.content.chars' "${smoke_root}/analysis-full.json")"
-          compressed_chars="$(jq -r '.metrics.content.chars' "${smoke_root}/analysis-compressed.json")"
-          compressed_files="$(jq -r '.compression.compressedFiles' "${smoke_root}/analysis-compressed.json")"
-          [[ "${compressed_files}" -gt 0 ]]
-          [[ "${compressed_chars}" -lt "${full_chars}" ]]
-
-          set +e
-          APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" analyze "${sample_project}" \
-            --git-mode none --exclude none --hide-secrets --findings --fail-on-findings \
-            --format json --plain --language en -o - \
-            > "${smoke_root}/analysis-secrets.json"
-          findings_exit=$?
-          set -e
-          [[ "${findings_exit}" -eq 3 ]]
-          jq --exit-status '.findingCount > 0 and (.findings | length > 0)' \
-            "${smoke_root}/analysis-secrets.json" >/dev/null
-          if grep --fixed-strings --quiet "ghp_Q7wE9rT2yU4iO6pA8sD0fG1hJ3kL5zX7cV9b" \
-            "${smoke_root}/analysis-secrets.json"; then
-            echo "::error::Secret value leaked into AppImage smoke output"
-            exit 1
-          fi
-
-      - name: AppImage GUI smoke under Xvfb
-        id: gui_smoke
-        continue-on-error: true
-        shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          ARCH: ${{ matrix.appimage_arch }}
-        run: |
-          set -euo pipefail
-          appimage="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
-          smoke_root="${RUNNER_TEMP}/devprojex-appimage-gui-${ARCH}"
-          sample_project="${smoke_root}/sample"
-          log_path="${smoke_root}/gui-smoke.log"
-          rm -rf -- "${smoke_root}"
-          mkdir -p -- \
-            "${sample_project}" \
-            "${smoke_root}/bundle-extract" \
-            "${smoke_root}/config" \
-            "${smoke_root}/data" \
-            "${smoke_root}/state" \
-            "${smoke_root}/cache" \
-            "${smoke_root}/runtime"
-          chmod 700 "${smoke_root}/runtime"
-          printf 'public sealed class App {}\n' > "${sample_project}/App.cs"
-
-          timeout --kill-after=10s 180s xvfb-run -a bash -s -- \
-            "${appimage}" "${sample_project}" "${smoke_root}" <<'SMOKE' 2>&1 | tee "${log_path}"
-          set -euo pipefail
-          appimage="$1"
-          sample_project="$2"
-          smoke_root="$3"
-          export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${smoke_root}/bundle-extract"
-          export XDG_CONFIG_HOME="${smoke_root}/config"
-          export XDG_DATA_HOME="${smoke_root}/data"
-          export XDG_STATE_HOME="${smoke_root}/state"
-          export XDG_CACHE_HOME="${smoke_root}/cache"
-          export XDG_RUNTIME_DIR="${smoke_root}/runtime"
-
-          runtime_pid=""
-          desktop_pid=""
-          cleanup() {
-            cleanup_exit=$?
-            set +e
-            [[ -n "${desktop_pid}" ]] && kill "${desktop_pid}" 2>/dev/null
-            [[ -n "${runtime_pid}" ]] && kill "${runtime_pid}" 2>/dev/null
-            if [[ "${cleanup_exit}" -ne 0 && -s "${smoke_root}/desktop.stderr" ]]; then
-              echo "Desktop stderr:"
-              tail -n 30 "${smoke_root}/desktop.stderr"
-            fi
-            exit "${cleanup_exit}"
-          }
-          trap cleanup EXIT
-
-          env -u CI APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" \
-            </dev/null >"${smoke_root}/desktop.stdout" 2>"${smoke_root}/desktop.stderr" &
-          runtime_pid=$!
-
-          instance_id=""
-          for _ in $(seq 1 60); do
-            if ! kill -0 "${runtime_pid}" 2>/dev/null; then
-              wait "${runtime_pid}"
-              exit 1
-            fi
-            list_json="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" ui list \
-              --format json --language en)"
-            instance_id="$(jq -r '.instances[0].instanceId // empty' <<<"${list_json}")"
-            desktop_pid="$(jq -r '.instances[0].processId // empty' <<<"${list_json}")"
-            [[ -n "${instance_id}" ]] && break
-            sleep 1
-          done
-          if [[ -z "${instance_id}" ]]; then
-            echo "Desktop did not register within 60 seconds."
-            exit 1
-          fi
-
-          open_output="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" open "${sample_project}" \
-            --wait --preview --view tree --language en)"
-          [[ "${open_output}" == "$(realpath "${sample_project}")" ]]
-
-          status_json="$(APPIMAGE_EXTRACT_AND_RUN=1 "${appimage}" ui status \
-            --instance "${instance_id}" --language en)"
-          jq --exit-status \
-            '.ok == true and .state.startupReady == true and .state.projectLoaded == true and .state.previewOpen == true and .state.previewView == "tree"' \
-            <<<"${status_json}" >/dev/null
-          printf '%s\n' "${status_json}"
-          SMOKE
-
-      - name: Write AppImage job summary
-        if: ${{ always() }}
-        shell: bash
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          ARCH: ${{ matrix.appimage_arch }}
-          GUI_OUTCOME: ${{ steps.gui_smoke.outcome }}
-        run: |
-          set -euo pipefail
-          output_path="${GITHUB_WORKSPACE}/artifacts/DevProjex-${VERSION}-${ARCH}.AppImage"
-          {
-            echo "### DevProjex AppImage (${ARCH})"
-            if [[ -s "${output_path}" ]]; then
-              bytes="$(stat --format=%s "${output_path}")"
-              human_size="$(numfmt --to=iec-i --suffix=B "${bytes}")"
-              echo "- File: \`$(basename "${output_path}")\`"
-              echo "- Size: ${human_size} (${bytes} bytes)"
-            else
-              echo "- AppImage was not produced."
-            fi
-            echo "- GUI smoke under Xvfb: ${GUI_OUTCOME}"
-            if [[ "${GUI_OUTCOME}" != "success" ]]; then
-              echo "- GUI smoke diagnostics:"
-              echo '```text'
-              tail -n 30 "${RUNNER_TEMP}/devprojex-appimage-gui-${ARCH}/gui-smoke.log" 2>/dev/null || \
-                echo "No GUI smoke log was produced."
-              echo '```'
-            fi
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: DevProjex-${{ needs.prepare.outputs.version }}-${{ matrix.appimage_arch }}.AppImage
-          path: artifacts/DevProjex-${{ needs.prepare.outputs.version }}-${{ matrix.appimage_arch }}.AppImage
-          if-no-files-found: error
+    uses: ./.github/workflows/appimage-build.yml
+    with:
+      checkout_ref: ${{ github.ref }}
+      version: ${{ needs.prepare.outputs.version }}
 
   release-upload:
     name: Upload complete AppImage set to GitHub release
     if: ${{ needs.prepare.outputs.upload_release == 'true' }}
-    needs: [prepare, package]
-    runs-on: ubuntu-22.04
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/package-headless.yml
+++ b/.github/workflows/package-headless.yml
@@ -1,8 +1,16 @@
 name: Package Headless Release Archives
 
+# CI tier 2 (push to v*) and 3 (master, release). Policy: .github/workflows/README.md
+# - `pull_request` runs ONLY when the archive packaging itself changes (paths below). Core code
+#   paths belong to `push`; copying them here makes every feature push build six archives.
+# - `branches-ignore: [master]` keeps the release PR (v* -> master) out: the push run on v* already
+#   attaches its checks to the same commit the release PR shows. Never replace it with `branches:`.
+# - The read-only build is headless-build.yml (also used by release-candidate.yml). Only
+#   release-upload may write, and only for a published release or an explicit release_tag.
+
 on:
-  pull_request:
-    branches: [v5.2, master]
+  push:
+    branches: [master, 'v*']
     paths:
       - '.github/workflows/package-headless.yml'
       - '.github/workflows/headless-build.yml'
@@ -19,6 +27,18 @@ on:
       - 'Scripts/ci/Test-ReleaseVersion.ps1'
       - 'Directory.Build.*'
       - 'Directory.Packages.props'
+  pull_request:
+    # The release PR (v* -> master) is excluded: its head commit already carries the push run.
+    branches-ignore: [master]
+    paths:
+      - '.github/workflows/package-headless.yml'
+      - '.github/workflows/headless-build.yml'
+      - 'Packaging/Headless/**'
+      - 'Scripts/*Headless*'
+      - 'Scripts/*Release*'
+      - 'Scripts/release-archive-helpers.ps1'
+      - 'Scripts/ci/Test-ReleaseVersion.ps1'
+      - 'Directory.Build.targets'
   workflow_dispatch:
     inputs:
       version:
@@ -48,6 +68,12 @@ on:
 
 permissions:
   contents: read
+
+# One run per pull request or branch head. Feature pushes and branch merges cancel their own
+# superseded runs; release, dispatch, and workflow_call runs are never cancelled.
+concurrency:
+  group: package-headless-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/packages-build.yml
+++ b/.github/workflows/packages-build.yml
@@ -1,5 +1,10 @@
 name: Headless Packages Build
 
+# CI tier: reusable read-only gate, `workflow_call` only. Policy: .github/workflows/README.md
+# Called by publish-packages.yml and release-candidate.yml. Keep `contents: read` and no write
+# permission: a called job may not request more than the caller grants. Never add pull_request
+# or push triggers here; the publishing wrapper owns the events.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,8 +1,16 @@
 name: Publish Headless Container
 
+# CI tier 2 (push to v*) and 3 (master, release). Policy: .github/workflows/README.md
+# - `pull_request` runs ONLY when the container inputs themselves change (paths below). Core code
+#   paths belong to `push`; copying them here makes every feature push cross-build the image.
+# - `branches-ignore: [master]` keeps the release PR (v* -> master) out: the push run on v* already
+#   attaches its checks to the same commit the release PR shows. Never replace it with `branches:`.
+# - The read-only build is container-build.yml (also used by release-candidate.yml). Only the
+#   publish job may push to GHCR, and only for `release: published`.
+
 on:
-  pull_request:
-    branches: [v5.2, master]
+  push:
+    branches: [master, 'v*']
     paths:
       - '.github/workflows/publish-container.yml'
       - '.github/workflows/container-build.yml'
@@ -23,6 +31,21 @@ on:
       - 'Scripts/ci/Test-ReleaseVersion.ps1'
       - 'Directory.Build.*'
       - 'Directory.Packages.props'
+  pull_request:
+    # The release PR (v* -> master) is excluded: its head commit already carries the push run.
+    branches-ignore: [master]
+    paths:
+      - '.github/workflows/publish-container.yml'
+      - '.github/workflows/container-build.yml'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'glama.json'
+      - 'Packaging/Headless/**'
+      - 'Scripts/*Headless*'
+      - 'Scripts/*Release*'
+      - 'Scripts/release-archive-helpers.ps1'
+      - 'Scripts/ci/Test-ReleaseVersion.ps1'
+      - 'Directory.Build.targets'
   workflow_dispatch:
     inputs:
       version:
@@ -44,6 +67,12 @@ on:
 
 permissions:
   contents: read
+
+# One run per pull request or branch head. Feature pushes and branch merges cancel their own
+# superseded runs; release, dispatch, and workflow_call runs are never cancelled.
+concurrency:
+  group: publish-container-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,10 +1,19 @@
 name: Publish Headless Packages
 
+# CI tier 2 (push to v*) and 3 (master, release, dispatch). Policy: .github/workflows/README.md
+# - `pull_request` runs ONLY when the package inputs themselves change (paths below). Core code
+#   paths belong to `push`; copying them here makes every feature push pack and smoke npm and
+#   NuGet on three operating systems.
+# - `branches-ignore: [master]` keeps the release PR (v* -> master) out: the push run on v* already
+#   attaches its checks to the same commit the release PR shows. Never replace it with `branches:`.
+# - The read-only build is packages-build.yml (also used by release-candidate.yml). Publishing
+#   needs an explicit workflow_dispatch with dry_run=false; nothing else may publish.
+
 on:
   release:
     types: [published]
-  pull_request:
-    branches: [v5.2, master]
+  push:
+    branches: [master, 'v*']
     paths:
       - '.github/workflows/publish-packages.yml'
       - '.github/workflows/packages-build.yml'
@@ -23,6 +32,17 @@ on:
       - 'Directory.Build.targets'
       - 'Directory.Packages.props'
       - 'Scripts/ci/Test-ReleaseVersion.ps1'
+  pull_request:
+    # The release PR (v* -> master) is excluded: its head commit already carries the push run.
+    branches-ignore: [master]
+    paths:
+      - '.github/workflows/publish-packages.yml'
+      - '.github/workflows/packages-build.yml'
+      - 'Packaging/Headless/**'
+      - 'Packaging/Npm/**'
+      - 'Scripts/*Headless*'
+      - 'Scripts/ci/Test-ReleaseVersion.ps1'
+      - 'Directory.Build.targets'
   workflow_dispatch:
     inputs:
       version:
@@ -65,9 +85,11 @@ on:
 permissions:
   contents: read
 
+# One run per pull request or branch head. Feature pushes and branch merges cancel their own
+# superseded runs; release, dispatch, and workflow_call runs are never cancelled.
 concurrency:
-  group: publish-headless-packages-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: publish-headless-packages-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,5 +1,15 @@
 name: Release Candidate
 
+# CI tier 3, `workflow_dispatch` only. Policy: .github/workflows/README.md
+# This aggregator calls every read-only gate for ONE pinned commit and fails if any gate is
+# skipped. Never add pull_request or push triggers: they would duplicate the whole matrix on
+# every push (tried in September 2026 and reverted). Composition changes are covered by the
+# actionlint job in dotnet.yml; a real dispatch on the candidate SHA is the acceptance test.
+# Keep `contents: read` here and call only workflows without write permissions: GitHub rejects
+# nested jobs that request more than the caller grants, `if:` guards do not help.
+# Adding a channel: one reusable read-only workflow, one job below, one row in the report, one
+# entry in the contract test (HeadlessWorkflowsCoverMasterCoreChangesAndReleaseCandidatePinsOneSha).
+
 on:
   workflow_dispatch:
     inputs:
@@ -105,6 +115,29 @@ jobs:
       display_version: ${{ needs.validate-sha.outputs.display_version }}
       package_version: ${{ needs.validate-sha.outputs.package_version }}
 
+  appimage:
+    name: AppImage dry-run
+    needs: validate-sha
+    uses: ./.github/workflows/appimage-build.yml
+    with:
+      checkout_ref: ${{ needs.validate-sha.outputs.candidate_sha }}
+      version: ${{ needs.validate-sha.outputs.display_version }}
+
+  grammar-delivery:
+    name: Grammar Delivery
+    needs: validate-sha
+    uses: ./.github/workflows/grammar-delivery.yml
+    with:
+      checkout_ref: ${{ needs.validate-sha.outputs.candidate_sha }}
+
+  store-smoke:
+    name: Store Package Smoke
+    needs: validate-sha
+    uses: ./.github/workflows/store-package-smoke.yml
+    with:
+      checkout_ref: ${{ needs.validate-sha.outputs.candidate_sha }}
+      force_full: true
+
   report:
     name: Release candidate report
     if: ${{ always() }}
@@ -115,6 +148,9 @@ jobs:
       - headless-archives
       - container
       - packages
+      - appimage
+      - grammar-delivery
+      - store-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -128,6 +164,9 @@ jobs:
           ARCHIVES_RESULT: ${{ needs.headless-archives.result }}
           CONTAINER_RESULT: ${{ needs.container.result }}
           PACKAGES_RESULT: ${{ needs.packages.result }}
+          APPIMAGE_RESULT: ${{ needs.appimage.result }}
+          GRAMMAR_RESULT: ${{ needs.grammar-delivery.result }}
+          STORE_RESULT: ${{ needs.store-smoke.result }}
         run: |
           $results = [ordered]@{
             'Pinned SHA' = $env:PIN_RESULT
@@ -136,6 +175,9 @@ jobs:
             'Headless archives' = $env:ARCHIVES_RESULT
             'Container dry-run' = $env:CONTAINER_RESULT
             'Package dry-run' = $env:PACKAGES_RESULT
+            'AppImage dry-run' = $env:APPIMAGE_RESULT
+            'Grammar Delivery' = $env:GRAMMAR_RESULT
+            'Store Package Smoke' = $env:STORE_RESULT
           }
           "## Release candidate ``$env:CANDIDATE_SHA``" >> $env:GITHUB_STEP_SUMMARY
           '' >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -1,10 +1,15 @@
 name: Release Validation
 
+# CI tier 1, 2, and 3. Policy: .github/workflows/README.md
+# Runs on every pull request (the planner limits it to the touched release paths) because the
+# publish smoke exercises published single-file binaries per RID, which no test suite covers.
+# Do not add a `push: v*` trigger: every merge into v5.x is also a synchronize of the open
+# release PR, so the pull_request run already covers the merge tier without a second run.
+
 on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master", "v5.1", "v5.2" ]
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/.github/workflows/store-package-smoke.yml
+++ b/.github/workflows/store-package-smoke.yml
@@ -1,9 +1,26 @@
 name: Store Package Smoke
 
+# CI tier 3 only. Policy: .github/workflows/README.md
+# The Store package needs the Visual Studio 2026 runner image and about 45 minutes, so it runs
+# on `push` to master, on manual dispatch, and inside release-candidate.yml with force_full.
+# Never add a pull_request or v* trigger here; a Store regression is caught by the release
+# candidate before the tag, which is the only moment the Store package is produced anyway.
+
 on:
   push:
     branches: [ "master" ]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Commit or ref to validate
+        required: false
+        type: string
+      force_full:
+        description: Run the Store smoke without changed-path filtering
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -15,7 +32,7 @@ env:
 
 concurrency:
   group: store-package-smoke-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   plan-store:
@@ -28,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
           fetch-depth: 0
 
       - name: Validate CI planner contracts
@@ -40,12 +58,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PREVIOUS_GATE_NAME: Store Gate
-        run: >
-          ./Scripts/ci/Select-CiPlan.ps1
-          -GitHubEventPath $env:GITHUB_EVENT_PATH
-          -GitHubEventName $env:GITHUB_EVENT_NAME
-          -PreviousGateName $env:PREVIOUS_GATE_NAME
-          -GitHubOutputPath $env:GITHUB_OUTPUT
+          FORCE_FULL: ${{ inputs.force_full }}
+        run: |
+          $common = @{
+            PreviousGateName = $env:PREVIOUS_GATE_NAME
+            GitHubOutputPath = $env:GITHUB_OUTPUT
+          }
+          if ($env:FORCE_FULL -eq 'true') {
+            ./Scripts/ci/Select-CiPlan.ps1 -Full @common
+          }
+          else {
+            ./Scripts/ci/Select-CiPlan.ps1 `
+              -GitHubEventPath $env:GITHUB_EVENT_PATH `
+              -GitHubEventName $env:GITHUB_EVENT_NAME `
+              @common
+          }
 
   store-package-smoke:
     name: Store Package Smoke
@@ -56,6 +83,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v6
@@ -89,12 +118,15 @@ jobs:
         env:
           PLAN_RESULT: ${{ needs.plan-store.result }}
           STORE_RESULT: ${{ needs.store-package-smoke.result }}
+          FORCE_FULL: ${{ inputs.force_full }}
         run: |
           $results = @{
             plan = $env:PLAN_RESULT
             store = $env:STORE_RESULT
           }
-          $failed = @($results.GetEnumerator() | Where-Object { $_.Value -notin @('success', 'skipped') })
+          # Under force_full (release candidate) a skipped smoke is a failure, not a pass.
+          $allowed = if ($env:FORCE_FULL -eq 'true') { @('success') } else { @('success', 'skipped') }
+          $failed = @($results.GetEnumerator() | Where-Object { $_.Value -notin $allowed })
           if ($failed.Count -gt 0) {
             throw "Selected Store jobs failed: $($failed.ForEach({ \"$($_.Key)=$($_.Value)\" }) -join ', ')"
           }

--- a/Docs/Release-Process.md
+++ b/Docs/Release-Process.md
@@ -25,6 +25,17 @@ gate damages a copy of an embedded resource and proves that validation fails whi
 naming the AppImage publish payload and the changed entry. Packaging continues
 only after both checks pass.
 
+## CI tiers
+
+Checks are tiered by how close a commit is to a release; the policy and the
+rules that keep it cheap live in `.github/workflows/README.md`. A pull request
+into a version branch runs `.NET CI` and Release Validation, both narrowed by
+the change planner. A merge into `v*` additionally runs the headless archive,
+container, package, and AppImage dry-runs once per merge; those check runs are
+attached to the merged commit, so the open release pull request shows them
+without a second run. Master adds the Store smoke, and the release candidate
+below runs every read-only gate for one commit.
+
 ## Release candidate gate
 
 Before creating a release tag, dispatch `.github/workflows/release-candidate.yml`
@@ -43,17 +54,18 @@ instead, so edits to workflow composition are checked without duplicating every
 matrix and packaging build.
 
 The gate checks out that exact SHA and runs reusable `.NET CI`, Release
-Validation, read-only headless archive, container, and headless-package builds.
-The two test planners receive `force_full: true`; every test, documentation,
-release-config, local-channel, and publish-smoke job must run, and either reusable
-gate fails if one of those jobs is skipped. The three read-only build workflows
-have no direct pull-request trigger and are invoked once by their publishing
-workflow during ordinary PR validation.
-The container and package paths never publish from the RC: write and OIDC
-permissions exist only in the outer release workflows. The final job writes one
-table covering all five gates and fails if any called workflow was skipped,
-canceled, or unsuccessful. A green manually dispatched release-candidate report
-for the exact commit is required before the tag is created.
+Validation, the read-only headless archive, container, headless-package, and
+AppImage builds, Grammar Delivery, and the Store package smoke. The three
+planners receive `force_full: true`; every test, documentation, release-config,
+local-channel, publish-smoke, and Store job must run, and each reusable gate
+fails if one of its jobs is skipped. The four read-only build workflows have no
+direct pull-request trigger and are invoked by their publishing workflow on a
+merge into `v*` or on a published release.
+No channel publishes from the RC: write and OIDC permissions exist only in the
+outer release workflows. The final job writes one table covering all eight gates
+and fails if any called workflow was skipped, canceled, or unsuccessful. A green
+manually dispatched release-candidate report for the exact commit is required
+before the tag is created.
 
 ## Local channel model
 

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -449,7 +449,17 @@ public sealed class DocumentationAndPackagingContractTests
 	[Fact]
 	public void HeadlessWorkflowsCoverMasterCoreChangesAndReleaseCandidatePinsOneSha()
 	{
+		// CI tier policy: .github/workflows/README.md. Packaging runs on feature pull requests only
+		// for its own inputs; core code paths trigger the merge tier (push to v*) instead. Change
+		// the policy and these assertions together; never drop an assertion to make a change pass.
 		var rootPath = FindRepositoryRoot();
+		var policy = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "README.md"));
+		Assert.Contains("| 1 Feature |", policy, StringComparison.Ordinal);
+		Assert.Contains("| 2 Merge |", policy, StringComparison.Ordinal);
+		Assert.Contains("| 3 Release |", policy, StringComparison.Ordinal);
+		Assert.Contains("HeadlessWorkflowsCoverMasterCoreChangesAndReleaseCandidatePinsOneSha", policy, StringComparison.Ordinal);
+
+		var corePathPatterns = new[] { "'Apps/Mcp/**'", "'Application/**'", "'Kernel/**'", "'Infrastructure/**'" };
 		foreach (var workflowName in new[]
 		         {
 			         "publish-packages.yml",
@@ -462,12 +472,54 @@ public sealed class DocumentationAndPackagingContractTests
 				".github",
 				"workflows",
 				workflowName));
-			Assert.Contains("master", workflow, StringComparison.Ordinal);
-			Assert.Contains("'Apps/Mcp/**'", workflow, StringComparison.Ordinal);
-			Assert.Contains("'Application/**'", workflow, StringComparison.Ordinal);
-			Assert.Contains("'Kernel/**'", workflow, StringComparison.Ordinal);
-			Assert.Contains("'Directory.Packages.props'", workflow, StringComparison.Ordinal);
+			Assert.Contains("Policy: .github/workflows/README.md", workflow, StringComparison.Ordinal);
+			Assert.Contains("concurrency:", workflow, StringComparison.Ordinal);
+			Assert.Contains("github.event.pull_request.number || github.ref", workflow, StringComparison.Ordinal);
+			Assert.Contains(
+				"cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}",
+				workflow,
+				StringComparison.Ordinal);
+
+			var push = TriggerSection(workflow, "push");
+			Assert.Contains("master", push, StringComparison.Ordinal);
+			Assert.Contains("'v*'", push, StringComparison.Ordinal);
+			Assert.Contains("'Directory.Packages.props'", push, StringComparison.Ordinal);
+			foreach (var pattern in corePathPatterns)
+				Assert.Contains(pattern, push, StringComparison.Ordinal);
+
+			var pullRequest = TriggerSection(workflow, "pull_request");
+			Assert.DoesNotContain("branches:", pullRequest, StringComparison.Ordinal);
+			Assert.Contains("branches-ignore: [master]", pullRequest, StringComparison.Ordinal);
+			Assert.Contains("paths:", pullRequest, StringComparison.Ordinal);
+			foreach (var pattern in corePathPatterns)
+				Assert.DoesNotContain(pattern, pullRequest, StringComparison.Ordinal);
+			Assert.DoesNotContain("'Apps/Terminal/**'", pullRequest, StringComparison.Ordinal);
 		}
+
+		var appImage = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "package-appimage.yml"));
+		Assert.Contains("Policy: .github/workflows/README.md", appImage, StringComparison.Ordinal);
+		Assert.Contains("uses: ./.github/workflows/appimage-build.yml", appImage, StringComparison.Ordinal);
+		var appImagePush = TriggerSection(appImage, "push");
+		Assert.Contains("'v*'", appImagePush, StringComparison.Ordinal);
+		Assert.Contains("Application/**", appImagePush, StringComparison.Ordinal);
+		var appImagePullRequest = TriggerSection(appImage, "pull_request");
+		Assert.DoesNotContain("branches:", appImagePullRequest, StringComparison.Ordinal);
+		Assert.Contains("branches-ignore: [master]", appImagePullRequest, StringComparison.Ordinal);
+		Assert.DoesNotContain("Application/**", appImagePullRequest, StringComparison.Ordinal);
+		Assert.Contains("Packaging/Linux/**", appImagePullRequest, StringComparison.Ordinal);
+
+		var storeSmoke = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "store-package-smoke.yml"));
+		Assert.DoesNotContain("pull_request:", storeSmoke, StringComparison.Ordinal);
+		Assert.Contains("workflow_call:", storeSmoke, StringComparison.Ordinal);
+		Assert.Contains("force_full:", storeSmoke, StringComparison.Ordinal);
+		Assert.Contains("Select-CiPlan.ps1 -Full", storeSmoke, StringComparison.Ordinal);
+		Assert.DoesNotContain(": write", storeSmoke, StringComparison.Ordinal);
+
+		var grammarDelivery = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "grammar-delivery.yml"));
+		Assert.Contains("workflow_call:", grammarDelivery, StringComparison.Ordinal);
+		Assert.Contains("- 'v*'", grammarDelivery, StringComparison.Ordinal);
+		Assert.Contains("branches-ignore: [master]", TriggerSection(grammarDelivery, "pull_request"), StringComparison.Ordinal);
+		Assert.DoesNotContain(": write", grammarDelivery, StringComparison.Ordinal);
 
 		var releaseCandidate = File.ReadAllText(Path.Combine(
 			rootPath,
@@ -477,6 +529,7 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("sha:", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("workflow_dispatch:", releaseCandidate, StringComparison.Ordinal);
 		Assert.DoesNotContain("pull_request:", releaseCandidate, StringComparison.Ordinal);
+		Assert.DoesNotContain("\n  push:", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("must equal workflow ref SHA", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("printf 'Validated release candidate `%s`.\\n'", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("uses: ./.github/workflows/dotnet.yml", releaseCandidate, StringComparison.Ordinal);
@@ -484,9 +537,21 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("uses: ./.github/workflows/headless-build.yml", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("uses: ./.github/workflows/container-build.yml", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("uses: ./.github/workflows/packages-build.yml", releaseCandidate, StringComparison.Ordinal);
+		Assert.Contains("uses: ./.github/workflows/appimage-build.yml", releaseCandidate, StringComparison.Ordinal);
+		Assert.Contains("uses: ./.github/workflows/grammar-delivery.yml", releaseCandidate, StringComparison.Ordinal);
+		Assert.Contains("uses: ./.github/workflows/store-package-smoke.yml", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("Release candidate report", releaseCandidate, StringComparison.Ordinal);
+		foreach (var gate in new[]
+		         {
+			         "'AppImage dry-run' = $env:APPIMAGE_RESULT",
+			         "'Grammar Delivery' = $env:GRAMMAR_RESULT",
+			         "'Store Package Smoke' = $env:STORE_RESULT"
+		         })
+		{
+			Assert.Contains(gate, releaseCandidate, StringComparison.Ordinal);
+		}
 		Assert.Equal(
-			2,
+			3,
 			Regex.Matches(
 				releaseCandidate,
 				@"^\s+force_full:\s+true\s*$",
@@ -516,7 +581,8 @@ public sealed class DocumentationAndPackagingContractTests
 		{
 			["headless-build.yml"] = "package-headless.yml",
 			["container-build.yml"] = "publish-container.yml",
-			["packages-build.yml"] = "publish-packages.yml"
+			["packages-build.yml"] = "publish-packages.yml",
+			["appimage-build.yml"] = "package-appimage.yml"
 		};
 		foreach (var (buildWorkflowName, publishingWorkflowName) in buildWorkflows)
 		{
@@ -571,15 +637,19 @@ public sealed class DocumentationAndPackagingContractTests
 			packagesWorkflow,
 			StringComparison.Ordinal);
 
-		var appImageWorkflow = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "package-appimage.yml"));
-		Assert.Contains("DevProjexGenerateReleasePayloadReceipt=true", appImageWorkflow, StringComparison.Ordinal);
+		// The receipt gates moved with the read-only build into appimage-build.yml; the publishing
+		// wrapper keeps only version resolution and the release upload.
+		var appImageBuildWorkflow = File.ReadAllText(Path.Combine(rootPath, ".github", "workflows", "appimage-build.yml"));
+		Assert.Contains("DevProjexGenerateReleasePayloadReceipt=true", appImageBuildWorkflow, StringComparison.Ordinal);
 		Assert.Contains(
 			"receipt_root=\"${GITHUB_WORKSPACE}/artifacts/appimage-release",
-			appImageWorkflow,
+			appImageBuildWorkflow,
 			StringComparison.Ordinal);
-		Assert.Contains("Test-ReleaseArtifacts.ps1", appImageWorkflow, StringComparison.Ordinal);
-		Assert.Contains("Test-ReleaseArtifactGateMutation.ps1", appImageWorkflow, StringComparison.Ordinal);
-		Assert.Contains("-Channels appimage", appImageWorkflow, StringComparison.Ordinal);
+		Assert.Contains("Test-ReleaseArtifacts.ps1", appImageBuildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("Test-ReleaseArtifactGateMutation.ps1", appImageBuildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("-Channels appimage", appImageBuildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("ref: ${{ inputs.checkout_ref }}", appImageBuildWorkflow, StringComparison.Ordinal);
+		Assert.DoesNotContain("needs.prepare", appImageBuildWorkflow, StringComparison.Ordinal);
 
 		var releaseProcess = File.ReadAllText(Path.Combine(rootPath, "Docs", "Release-Process.md"));
 		Assert.Contains("must match", releaseProcess, StringComparison.Ordinal);
@@ -974,7 +1044,12 @@ public sealed class DocumentationAndPackagingContractTests
 			StringComparison.Ordinal);
 		Assert.Contains("Published Broken Pipe Smoke", workflow, StringComparison.Ordinal);
 		Assert.Contains("Startup Smoke (macOS)", workflow, StringComparison.Ordinal);
-		Assert.Contains("branches: [ \"master\", \"v5.1\", \"v5.2\" ]", workflow, StringComparison.Ordinal);
+		// Release Validation is tier 1: every pull request, no base-branch list to go stale, and no
+		// `push: v*` because the open release PR already covers each merge into a version branch.
+		Assert.Contains("Policy: .github/workflows/README.md", workflow, StringComparison.Ordinal);
+		Assert.DoesNotContain("branches:", TriggerSection(workflow, "pull_request"), StringComparison.Ordinal);
+		Assert.Contains("branches: [ \"master\" ]", TriggerSection(workflow, "push"), StringComparison.Ordinal);
+		Assert.DoesNotContain("'v*'", TriggerSection(workflow, "push"), StringComparison.Ordinal);
 		Assert.Contains("Smart Secrets context contract", workflow, StringComparison.Ordinal);
 		Assert.Contains(
 			"Password=DEVPROJEX_REDACTED[connection-password#1]",
@@ -1312,38 +1387,77 @@ public sealed class DocumentationAndPackagingContractTests
 			"Linux",
 			"README.md"));
 
+		// The publishing wrapper owns the events and the release upload; the read-only build
+		// (runners, publish flags, validators) lives in appimage-build.yml so that the release
+		// candidate can call it without write permissions.
+		var buildWorkflow = File.ReadAllText(Path.Combine(
+			rootPath,
+			".github",
+			"workflows",
+			"appimage-build.yml"));
+
 		Assert.Contains("workflow_dispatch:", workflow, StringComparison.Ordinal);
 		Assert.Contains("pull_request:", workflow, StringComparison.Ordinal);
 		Assert.Contains("- Packaging/Linux/**", workflow, StringComparison.Ordinal);
 		Assert.Contains("- Kernel/ProcessEntryPointResolver.cs", workflow, StringComparison.Ordinal);
 		Assert.Contains("types: [published]", workflow, StringComparison.Ordinal);
-		Assert.Contains("runner: ubuntu-22.04", workflow, StringComparison.Ordinal);
-		Assert.Contains("runner: ubuntu-22.04-arm", workflow, StringComparison.Ordinal);
-		Assert.Contains("/p:PublishSingleFile=true", workflow, StringComparison.Ordinal);
-		Assert.Contains("/p:IncludeNativeLibrariesForSelfExtract=true", workflow, StringComparison.Ordinal);
-		Assert.Contains("/p:PublishReadyToRun=true", workflow, StringComparison.Ordinal);
-		Assert.Contains("/p:PublishTrimmed=false", workflow, StringComparison.Ordinal);
-		Assert.Contains("appstreamcli validate --strict --explain", workflow, StringComparison.Ordinal);
-		Assert.Contains("APPSTREAM_VERSION: 0.16.4", workflow, StringComparison.Ordinal);
-		Assert.Contains("APPSTREAM_SHA256:", workflow, StringComparison.Ordinal);
-		Assert.Contains("LIBXMLB_SHA256:", workflow, StringComparison.Ordinal);
-		Assert.Contains("MESON_SHA256:", workflow, StringComparison.Ordinal);
-		Assert.Contains("desktop-file-validate", workflow, StringComparison.Ordinal);
-		Assert.Contains("appdir-lint.sh", workflow, StringComparison.Ordinal);
-		Assert.Contains("Verify packaged binary identity", workflow, StringComparison.Ordinal);
-		Assert.Contains("needs: [prepare, package]", workflow, StringComparison.Ordinal);
+		Assert.Contains("uses: ./.github/workflows/appimage-build.yml", workflow, StringComparison.Ordinal);
+		Assert.Contains("needs: [prepare, build]", workflow, StringComparison.Ordinal);
 		Assert.Contains(
 			"if: ${{ needs.prepare.outputs.upload_release == 'true' }}",
 			workflow,
 			StringComparison.Ordinal);
 		Assert.Contains("gh release upload", workflow, StringComparison.Ordinal);
 		Assert.DoesNotContain("--updateinformation", workflow, StringComparison.Ordinal);
-		Assert.Contains("output_path}.zsync", workflow, StringComparison.Ordinal);
+
+		Assert.Contains("workflow_call:", buildWorkflow, StringComparison.Ordinal);
+		Assert.DoesNotContain(": write", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("runner: ubuntu-22.04", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("runner: ubuntu-22.04-arm", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("/p:PublishSingleFile=true", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("/p:IncludeNativeLibrariesForSelfExtract=true", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("/p:PublishReadyToRun=true", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("/p:PublishTrimmed=false", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("appstreamcli validate --strict --explain", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("APPSTREAM_VERSION: 0.16.4", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("APPSTREAM_SHA256:", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("LIBXMLB_SHA256:", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("MESON_SHA256:", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("desktop-file-validate", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("appdir-lint.sh", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("Verify packaged binary identity", buildWorkflow, StringComparison.Ordinal);
+		Assert.DoesNotContain("--updateinformation", buildWorkflow, StringComparison.Ordinal);
+		Assert.Contains("output_path}.zsync", buildWorkflow, StringComparison.Ordinal);
 		Assert.Contains("DevProjex-<version>-x86_64.AppImage", installation, StringComparison.Ordinal);
 		Assert.Contains("--appimage-extract-and-run", installation, StringComparison.Ordinal);
 		Assert.Contains("Open Anyway", installation, StringComparison.Ordinal);
 		Assert.Contains("data/DevProjex", linuxPackaging, StringComparison.Ordinal);
 		Assert.Contains("https://github.com/Avazbek22/DevProjex", linuxPackaging, StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// Returns the body of one <c>on:</c> trigger (for example <c>push</c>) of a workflow file: the
+	/// lines after <c>  eventName:</c> up to the next two-space-indented key. Comments and blank
+	/// lines inside the block are kept.
+	/// </summary>
+	private static string TriggerSection(string workflow, string eventName)
+	{
+		var lines = workflow.Split('\n');
+		var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == $"  {eventName}:");
+		Assert.True(start >= 0, $"Trigger '{eventName}' is missing.");
+		var section = new System.Text.StringBuilder();
+		for (var index = start + 1; index < lines.Length; index++)
+		{
+			var line = lines[index].TrimEnd('\r');
+			if (line.Length > 0 &&
+			    !line.StartsWith("    ", StringComparison.Ordinal) &&
+			    !line.StartsWith("  #", StringComparison.Ordinal))
+			{
+				break;
+			}
+			section.Append(line).Append('\n');
+		}
+		return section.ToString();
 	}
 
 	private static string FindRepositoryRoot()


### PR DESCRIPTION
## Why

A feature pull request in v5.2 runs 49 checks and takes about 30 minutes; the same PR in v5.1 ran 31 checks in 13 to 17 minutes. The difference is the five headless distribution channels added in v5.2, whose workflows ran on every push to every feature branch, and the release-candidate self-test, which briefly doubled the whole matrix.

## What changes

Checks are tiered by how close a commit is to a release. The policy lives in `.github/workflows/README.md`; every workflow header points to it and states its tier.

| Tier | Event | Runs |
|---|---|---|
| 1 Feature | `pull_request` to a version branch | `.NET CI` and `Release Validation`, planner-filtered (the v5.1 shape, about 31 checks) |
| 2 Merge | `push` to `v*` | tier 1 plus headless archives, container and package dry-runs, AppImage, once per merge |
| 3 Release | `pull_request`/`push` to master, `release`, release-candidate dispatch | tier 2 plus Store smoke; the release candidate runs every read-only gate on one SHA |

- Packaging workflows (`package-headless`, `publish-container`, `publish-packages`, `package-appimage`) keep `pull_request` only for their own packaging inputs, exclude the release PR with `branches-ignore: [master]`, and take core code paths on `push: [master, 'v*']`. Merge-tier check runs attach to the merged commit, so the open `v5.2 -> master` PR shows them without a second run.
- Every PR- or push-triggered workflow has a concurrency group keyed by PR number or ref; release, dispatch, and `workflow_call` runs are never cancelled.
- The AppImage build moved into `appimage-build.yml` (`workflow_call`, `contents: read`), so the release candidate can call it. `grammar-delivery.yml` and `store-package-smoke.yml` gained `workflow_call` with `checkout_ref` (and `force_full` for the Store plan).
- `release-candidate.yml` now covers eight gates: .NET CI, Release Validation, archives, container, packages, AppImage, Grammar Delivery, Store smoke. It stays `workflow_dispatch` only.
- `release-validate.yml` runs on every pull request instead of a stale branch list; `dotnet.yml` lints all thirteen workflows.
- `DocumentationAndPackagingContractTests` pins the trigger shape per tier, the `branches-ignore` rule, the read-only build set, and the release-candidate composition. `Docs/Release-Process.md` describes the tiers and the extended candidate gate.

## Expected effect

Feature pushes: about 31 checks and 13 to 17 minutes. Each merge into v5.2: about 50 checks once. This PR itself still triggers the packaging workflows because it edits their files, which is the intended tier 1 exception.

## Verification

- All 13 workflows parse; the `Workflow syntax` job runs actionlint over every file.
- `DocumentationAndPackagingContractTests`: 26 passed locally with the targeted filter.
- No full local suites; CI is the arbiter.
