### PR TITLE
fix(dependencies): preserve graph fidelity and bound caches

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -38,6 +38,8 @@ public sealed record DependencyResolverConfiguration(
 	IReadOnlyDictionary<string, IReadOnlySet<string>> PythonStandardLibraryModules,
 	IReadOnlySet<string> NodeBuiltInModules)
 {
+	public IReadOnlyList<DependencyConfigurationDiagnostic> ConfigurationDiagnostics { get; init; } = [];
+
 	public DependencyScopeDescriptor? FindScope(string scopeId) =>
 		Scopes.FirstOrDefault(scope => string.Equals(scope.ScopeId, scopeId, StringComparison.Ordinal));
 }
@@ -55,7 +57,11 @@ public sealed record DependencyScopeDescriptor(
 	IReadOnlyList<string> PythonRoots,
 	bool HasConfiguration,
 	string? PythonVersion = null,
-	bool AllowJavaScript = false);
+	bool AllowJavaScript = false)
+{
+	public DependencyConfigurationState ConfigurationState { get; init; } = DependencyConfigurationState.Valid;
+	public string? ConfigurationDiagnostic { get; init; }
+}
 
 public sealed record PackageMapDescriptor(
 	string Directory,
@@ -63,7 +69,25 @@ public sealed record PackageMapDescriptor(
 	IReadOnlyDictionary<string, PackageTargetDescriptor> Imports,
 	IReadOnlyDictionary<string, PackageTargetDescriptor> Exports,
 	string? ModuleType,
-	IReadOnlySet<string> ExternalPackages);
+	IReadOnlySet<string> ExternalPackages)
+{
+	public DependencyConfigurationState ConfigurationState { get; init; } = DependencyConfigurationState.Valid;
+	public string? ConfigurationDiagnostic { get; init; }
+}
+
+public enum DependencyConfigurationState
+{
+	Valid,
+	Missing,
+	Corrupt,
+	UnsupportedSemantics
+}
+
+public sealed record DependencyConfigurationDiagnostic(
+	string Path,
+	DependencyConfigurationState State,
+	string Reason,
+	IReadOnlyList<string> ScopeIds);
 
 public enum PackageTargetKind
 {

--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -60,10 +60,26 @@ public sealed record DependencyScopeDescriptor(
 public sealed record PackageMapDescriptor(
 	string Directory,
 	string? PackageName,
-	IReadOnlyDictionary<string, string?> Imports,
-	IReadOnlyDictionary<string, string?> Exports,
+	IReadOnlyDictionary<string, PackageTargetDescriptor> Imports,
+	IReadOnlyDictionary<string, PackageTargetDescriptor> Exports,
 	string? ModuleType,
 	IReadOnlySet<string> ExternalPackages);
+
+public enum PackageTargetKind
+{
+	Path,
+	Blocked,
+	Conditions,
+	Unsupported
+}
+
+public sealed record PackageTargetDescriptor(
+	PackageTargetKind Kind,
+	string? Path,
+	IReadOnlyList<PackageConditionDescriptor> Conditions,
+	string? UnsupportedReason);
+
+public sealed record PackageConditionDescriptor(string Name, PackageTargetDescriptor Target);
 
 public interface IDependencyFactExtractor : IDisposable
 {

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -600,32 +600,49 @@ public sealed class DependencyFactsEngine : IDisposable
 	}
 
 	private static long EstimateFileFactsBytes(FileFacts facts) =>
-		256 + StringBytes(facts.Path) + StringBytes(facts.ScopeId) + StringBytes(facts.ContentFingerprint) +
-		StringBytes(facts.StatusReason) +
-		facts.ErrorNodeKinds.Sum(static pair => StringBytes(pair.Key) + 16) +
-		facts.Declarations.Sum(static declaration => 160 + StringBytes(declaration.Identity.ScopeId) +
-			StringBytes(declaration.Identity.QualifiedName) + StringBytes(declaration.Identity.FileScope) +
-			StringBytes(declaration.ContainingNamespace) +
-			declaration.DeclarationSites.Sum(SiteBytes)) +
-		facts.Imports.Sum(static import => 128 + StringBytes(import.Specifier) + StringBytes(import.ImportedName) +
-			StringBytes(import.Alias) + SiteBytes(import.Site)) +
-		facts.References.Sum(static reference => 160 + StringBytes(reference.Name) + StringBytes(reference.SyntaxKind) +
-			StringBytes(reference.Reason) + StringBytes(reference.Target) + (reference.Candidates?.Sum(StringBytes) ?? 0) +
-			StringBytes(reference.ContainingNamespace) + StringBytes(reference.ContainingType) + SiteBytes(reference.Site)) +
-		facts.ContextNamespaces.Sum(StringBytes) + facts.Aliases.Sum(static pair => StringBytes(pair.Key) + StringBytes(pair.Value)) +
-		facts.GlobalContextNamespaces.Sum(StringBytes) + facts.GlobalAliases.Sum(static pair => StringBytes(pair.Key) + StringBytes(pair.Value)) +
-		facts.TypeParameters.Sum(StringBytes);
+		EstimateFileFactsBytes(facts, new RetainedStringEstimator());
 
-	private static long EstimateResolvedIndexBytes(ResolvedIndex index) =>
-		256 + index.Edges.Sum(static edge => 192 + StringBytes(edge.Source) + StringBytes(edge.Target) +
-			StringBytes(edge.Reference) + edge.Reasons.Sum(StringBytes) + edge.Evidence.Sum(SiteBytes) +
-			edge.Candidates.Sum(StringBytes) + edge.DeclarationFiles.Sum(StringBytes)) +
-		index.Files.Sum(EstimateFileFactsBytes);
+	private static long EstimateFileFactsBytes(FileFacts facts, RetainedStringEstimator strings) =>
+		256 + strings.Add(facts.Path) + strings.Add(facts.ScopeId) + strings.Add(facts.ContentFingerprint) +
+		strings.Add(facts.StatusReason) +
+		facts.ErrorNodeKinds.Sum(pair => strings.Add(pair.Key) + 16) +
+		facts.Declarations.Sum(declaration => 160 + strings.Add(declaration.Identity.ScopeId) +
+			strings.Add(declaration.Identity.QualifiedName) + strings.Add(declaration.Identity.FileScope) +
+			strings.Add(declaration.ContainingNamespace) +
+			declaration.DeclarationSites.Sum(site => SiteBytes(site, strings))) +
+		facts.Imports.Sum(import => 128 + strings.Add(import.Specifier) + strings.Add(import.ImportedName) +
+			strings.Add(import.Alias) + SiteBytes(import.Site, strings)) +
+		facts.References.Sum(reference => 160 + strings.Add(reference.Name) + strings.Add(reference.SyntaxKind) +
+			strings.Add(reference.Reason) + strings.Add(reference.Target) +
+			(reference.Candidates?.Sum(strings.Add) ?? 0) +
+			strings.Add(reference.ContainingNamespace) + strings.Add(reference.ContainingType) +
+			SiteBytes(reference.Site, strings)) +
+		facts.ContextNamespaces.Sum(strings.Add) +
+		facts.Aliases.Sum(pair => strings.Add(pair.Key) + strings.Add(pair.Value)) +
+		facts.GlobalContextNamespaces.Sum(strings.Add) +
+		facts.GlobalAliases.Sum(pair => strings.Add(pair.Key) + strings.Add(pair.Value)) +
+		facts.TypeParameters.Sum(strings.Add);
 
-	private static long SiteBytes(SourceSite site) =>
-		64 + StringBytes(site.File) + StringBytes(site.Evidence);
+	private static long EstimateResolvedIndexBytes(ResolvedIndex index)
+	{
+		var strings = new RetainedStringEstimator();
+		return 256 + index.Edges.Sum(edge => 192 + strings.Add(edge.Source) + strings.Add(edge.Target) +
+			strings.Add(edge.Reference) + edge.Reasons.Sum(strings.Add) +
+			edge.Evidence.Sum(site => SiteBytes(site, strings)) +
+			edge.Candidates.Sum(strings.Add) + edge.DeclarationFiles.Sum(strings.Add)) +
+			index.Files.Sum(file => EstimateFileFactsBytes(file, strings));
+	}
 
-	private static long StringBytes(string? value) => value is null ? 0 : 24 + value.Length * 2L;
+	private static long SiteBytes(SourceSite site, RetainedStringEstimator strings) =>
+		64 + strings.Add(site.File) + strings.Add(site.Evidence);
+
+	private sealed class RetainedStringEstimator
+	{
+		private readonly HashSet<string> _seen = new(ReferenceEqualityComparer.Instance);
+
+		public long Add(string? value) =>
+			value is not null && _seen.Add(value) ? 24 + value.Length * 2L : 0;
+	}
 
 	private static ResolvedIndex GateResolvedIndex(ResolvedIndex index, IReadOnlySet<string> allowed)
 	{

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1318,8 +1318,8 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (import.RelativeLevel > 0)
 			{
 				var remove = import.RelativeLevel - 1;
-				if (remove > parts.Count)
-					return Edge(source, import, ResolutionStatus.Unresolved, null, "relative import escapes package", []);
+				if (remove >= parts.Count)
+					return Edge(source, import, ResolutionStatus.Unresolved, null, "relative import goes beyond the top-level package", []);
 				parts.RemoveRange(parts.Count - remove, remove);
 			}
 			var module = import.RelativeLevel == 0
@@ -1328,14 +1328,23 @@ public sealed class DependencyFactsEngine : IDisposable
 			var candidates = ProbePythonModule(source, module).ToList();
 			if (import.ImportedName is { Length: > 0 } and not "*")
 			{
-				var child = module.Length == 0 ? import.ImportedName : module + "." + import.ImportedName;
-				var children = ProbePythonModule(source, child).ToArray();
-				if (children.Length > 0)
-					candidates = children.ToList();
+				var provided = candidates
+					.Where(static candidate => Path.GetFileName(candidate).StartsWith("__init__.", StringComparison.Ordinal))
+					.SelectMany(candidate => ResolvePythonStaticBinding(
+						candidate,
+						import.ImportedName,
+						0,
+						new HashSet<string>(StringComparer.Ordinal)))
+					.Distinct(StringComparer.Ordinal)
+					.Order(StringComparer.Ordinal)
+					.ToArray();
+				if (provided.Length > 0)
+					candidates = provided.ToList();
 				else
-					candidates = candidates.Where(candidate =>
-						!Path.GetFileName(candidate).StartsWith("__init__.", StringComparison.Ordinal) ||
-						PythonStaticallyProvides(candidate, import.ImportedName, 0, new HashSet<string>(StringComparer.Ordinal))).ToList();
+				{
+					var child = module.Length == 0 ? import.ImportedName : module + "." + import.ImportedName;
+					candidates = ProbePythonModule(source, child).ToList();
+				}
 			}
 			if (candidates.Count == 0)
 			{
@@ -1356,10 +1365,15 @@ public sealed class DependencyFactsEngine : IDisposable
 			return FinishImport(source, import, candidates);
 		}
 
-		private bool PythonStaticallyProvides(string candidate, string name, int depth, ISet<string> visited)
+		private IReadOnlyList<string> ResolvePythonStaticBinding(
+			string candidate,
+			string name,
+			int depth,
+			ISet<string> visited)
 		{
-			if (depth >= 8 || !visited.Add(candidate) || !_files.TryGetValue(candidate, out var facts)) return false;
-			if (facts.Declarations.Any(declaration => SimpleName(declaration.Identity.QualifiedName) == name)) return true;
+			if (depth >= 8 || !visited.Add(candidate) || !_files.TryGetValue(candidate, out var facts)) return [];
+			if (facts.Declarations.Any(declaration => SimpleName(declaration.Identity.QualifiedName) == name))
+				return [candidate];
 			foreach (var import in facts.Imports.Where(import =>
 				string.Equals(import.Alias ?? import.ImportedName ?? import.Specifier.Split('.').Last(), name, StringComparison.Ordinal)))
 			{
@@ -1371,7 +1385,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				if (import.RelativeLevel > 0)
 				{
 					var remove = import.RelativeLevel - 1;
-					if (remove > parts.Count) continue;
+					if (remove >= parts.Count) continue;
 					parts.RemoveRange(parts.Count - remove, remove);
 				}
 				var module = import.RelativeLevel == 0 ? import.Specifier :
@@ -1379,12 +1393,29 @@ public sealed class DependencyFactsEngine : IDisposable
 				if (import.ImportedName is { Length: > 0 } imported)
 				{
 					var child = module.Length == 0 ? imported : module + "." + imported;
-					if (ProbePythonModule(facts, child).Any()) return true;
-					if (ProbePythonModule(facts, module).Any(next => PythonStaticallyProvides(next, imported, depth + 1, visited))) return true;
+					if (import.Specifier.Length == 0)
+					{
+						var directChildTargets = ProbePythonModule(facts, child).ToArray();
+						if (directChildTargets.Length > 0) return directChildTargets;
+					}
+					var moduleTargets = ProbePythonModule(facts, module).ToArray();
+					var nested = moduleTargets
+						.SelectMany(next => ResolvePythonStaticBinding(next, imported, depth + 1, visited))
+						.Distinct(StringComparer.Ordinal)
+						.Order(StringComparer.Ordinal)
+						.ToArray();
+					if (nested.Length > 0) return nested;
+					if (moduleTargets.Length > 0) return moduleTargets;
+					var childTargets = ProbePythonModule(facts, child).ToArray();
+					if (childTargets.Length > 0) return childTargets;
 				}
-				else if (ProbePythonModule(facts, module).Any()) return true;
+				else
+				{
+					var moduleTargets = ProbePythonModule(facts, module).ToArray();
+					if (moduleTargets.Length > 0) return moduleTargets;
+				}
 			}
-			return false;
+			return [];
 		}
 
 		private IEnumerable<string> ProbePythonNamespace(FileFacts source, string module)
@@ -1408,14 +1439,14 @@ public sealed class DependencyFactsEngine : IDisposable
 			foreach (var root in PythonRootPrefixes(source))
 			{
 				var prefix = string.Join('/', new[] { root, relative }.Where(static value => value.Length > 0));
-				var implementation = new[] { prefix + ".py", prefix + "/__init__.py" }
+				var implementation = new[] { prefix + "/__init__.py", prefix + ".py" }
 					.FirstOrDefault(_files.ContainsKey);
 				if (implementation is not null)
 				{
 					yield return implementation;
 					yield break;
 				}
-				var stub = new[] { prefix + ".pyi", prefix + "/__init__.pyi" }
+				var stub = new[] { prefix + "/__init__.pyi", prefix + ".pyi" }
 					.FirstOrDefault(_files.ContainsKey);
 				if (stub is not null)
 				{

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -193,7 +193,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (!resolutionCacheHit)
 				RegisterIndexCacheWeight(cacheKey, cachedIndex, EstimateResolvedIndexBytes(resolved));
 		}
-		var coverage = BuildCoverage(resolved.Files);
+		var coverage = BuildCoverage(resolved.Files, configuration.ConfigurationDiagnostics);
 		var result = new DependencyIndexSnapshot(
 			root,
 			manifestGeneration,
@@ -423,7 +423,9 @@ public sealed class DependencyFactsEngine : IDisposable
 		$"{declaration.Identity.GenericArity}\0{declaration.Identity.FileScope}\0" +
 		string.Join('\0', declaration.DeclarationSites.Select(static site => $"{site.File}:{site.Line}"));
 
-	private static DependencyFactsCoverage BuildCoverage(IReadOnlyList<FileFacts> files) =>
+	private static DependencyFactsCoverage BuildCoverage(
+		IReadOnlyList<FileFacts> files,
+		IReadOnlyList<DependencyConfigurationDiagnostic> configurationDiagnostics) =>
 		new(
 			files.Count,
 			files.Count(static file => file.Status == DependencyFileStatus.Supported),
@@ -435,7 +437,10 @@ public sealed class DependencyFactsEngine : IDisposable
 			files.Where(static file => file.LanguageId == LanguageId.CSharp)
 				.SelectMany(static file => file.ErrorNodeKinds)
 				.GroupBy(static pair => pair.Key)
-				.ToDictionary(static group => group.Key, static group => group.Sum(static pair => pair.Value), StringComparer.Ordinal));
+				.ToDictionary(static group => group.Key, static group => group.Sum(static pair => pair.Value), StringComparer.Ordinal))
+		{
+			ConfigurationDiagnostics = configurationDiagnostics
+		};
 
 	private void RegisterFileCacheWeight(
 		FileCacheKey key,
@@ -1002,6 +1007,11 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (scope is null || !scope.HasConfiguration)
 				return Edge(source, import, ResolutionStatus.Unresolved, null,
 					"no owning tsconfig.json or jsconfig.json in the manifest", []);
+			if (ConfigurationFailure(scope) is { } configurationFailure)
+				return Edge(source, import, ResolutionStatus.Unresolved, null, configurationFailure, []);
+			if (FindNearestPackageMap(source) is { ConfigurationState: not DependencyConfigurationState.Valid } packageMap)
+				return Edge(source, import, ResolutionStatus.Unresolved, null,
+					packageMap.ConfigurationDiagnostic ?? "package.json configuration is unavailable", []);
 			if (IsRequire(import) && !SupportsCommonJs(source, scope))
 				return Edge(source, import, ResolutionStatus.Unresolved, null,
 					"require call is outside a supported CommonJS context", []);
@@ -1310,6 +1320,8 @@ public sealed class DependencyFactsEngine : IDisposable
 
 		private DependencyEdge ResolvePythonImport(FileFacts source, ImportFact import)
 		{
+			if (FindScope(source.ScopeId) is { } scope && ConfigurationFailure(scope) is { } configurationFailure)
+				return Edge(source, import, ResolutionStatus.Unresolved, null, configurationFailure, []);
 			var sourceModule = PythonModule(source);
 			var sourcePackage = Path.GetFileNameWithoutExtension(source.Path) == "__init__"
 				? sourceModule
@@ -1478,6 +1490,8 @@ public sealed class DependencyFactsEngine : IDisposable
 						? "no owning .csproj in the manifest"
 						: "no owning tsconfig.json or jsconfig.json in the manifest", []);
 			}
+			if (scope is not null && ConfigurationFailure(scope) is { } configurationFailure)
+				return Edge(source, reference, ResolutionStatus.Unresolved, null, configurationFailure, []);
 			if (source.TypeParameters.Contains(simpleName, StringComparer.Ordinal))
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, "type parameter shadows declarations", []);
 			var expandedName = ExpandQualifiedAlias(source, reference.Name);
@@ -1743,6 +1757,12 @@ public sealed class DependencyFactsEngine : IDisposable
 
 		private DependencyScopeDescriptor? FindScope(string scopeId) =>
 			_scopesById.GetValueOrDefault(scopeId);
+
+		private static string? ConfigurationFailure(DependencyScopeDescriptor scope) =>
+			scope.ConfigurationState == DependencyConfigurationState.Valid
+				? null
+				: scope.ConfigurationDiagnostic ??
+				  $"{scope.ConfigurationState.ToString().ToLowerInvariant()} dependency configuration";
 
 		private static IReadOnlyDictionary<string, string[]> BuildVisibleScopes(
 			IReadOnlyDictionary<string, DependencyScopeDescriptor> scopes)

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -18,7 +18,7 @@ public sealed class DependencyFactsEngine : IDisposable
 	private readonly ConcurrentQueue<IndexCacheKey> _indexCacheOrder = [];
 	private readonly ConcurrentDictionary<IndexCacheKey, long> _indexCacheWeights = [];
 	private readonly ConcurrentDictionary<ManifestRequestKey, ManifestSnapshotCacheEntry> _manifestSnapshots = [];
-	private readonly ConcurrentQueue<ManifestRequestKey> _manifestSnapshotOrder = [];
+	private readonly LinkedList<ManifestSnapshotCacheEntry> _manifestSnapshotOrder = [];
 	private readonly object _cacheTrimSync = new();
 	private long _fileCacheBytes;
 	private long _indexCacheBytes;
@@ -37,6 +37,18 @@ public sealed class DependencyFactsEngine : IDisposable
 
 	public int ParseCount => _extractor.ParseCount;
 	public int CompiledQuerySetCount => _extractor.CompiledQuerySetCount;
+	internal DependencyFactsCacheState CacheState
+	{
+		get
+		{
+			lock (_cacheTrimSync)
+				return new(
+					_manifestSnapshots.Count,
+					_manifestSnapshotOrder.Count,
+					_indexCache.Count,
+					_indexCacheBytes);
+		}
+	}
 
 	public async Task<DependencyIndexSnapshot> IndexAsync(
 		string sourceRoot,
@@ -488,7 +500,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		{
 			_indexCache.TryRemove(oldest, out _);
 			foreach (var snapshot in _manifestSnapshots.Where(pair => pair.Value.IndexCacheKey == oldest).ToArray())
-				_manifestSnapshots.TryRemove(snapshot.Key, out _);
+				RemoveManifestSnapshotUnderLock(snapshot.Key, snapshot.Value);
 			if (_indexCacheWeights.TryRemove(oldest, out var weight))
 				_indexCacheBytes -= weight;
 		}
@@ -505,15 +517,28 @@ public sealed class DependencyFactsEngine : IDisposable
 		lock (_cacheTrimSync)
 		{
 			if (!_indexCache.ContainsKey(indexCacheKey)) return;
-			var entry = new ManifestSnapshotCacheEntry(manifestPaths, stamps, contentIdentities, indexCacheKey, snapshot);
-			if (_manifestSnapshots.TryAdd(key, entry))
-				_manifestSnapshotOrder.Enqueue(key);
-			else
-				_manifestSnapshots[key] = entry;
+			if (_manifestSnapshots.TryGetValue(key, out var previous))
+				RemoveManifestSnapshotUnderLock(key, previous);
+			var entry = new ManifestSnapshotCacheEntry(key, manifestPaths, stamps, contentIdentities, indexCacheKey, snapshot);
+			_manifestSnapshots[key] = entry;
+			entry.OrderNode = _manifestSnapshotOrder.AddLast(entry);
 			while (_manifestSnapshots.Count > _limits.MaximumCachedIndexes &&
-			       _manifestSnapshotOrder.TryDequeue(out var oldest))
-				_manifestSnapshots.TryRemove(oldest, out _);
+			       _manifestSnapshotOrder.First is { Value: var oldest })
+				RemoveManifestSnapshotUnderLock(oldest.Key, oldest);
 		}
+	}
+
+	private void RemoveManifestSnapshotUnderLock(
+		ManifestRequestKey key,
+		ManifestSnapshotCacheEntry entry)
+	{
+		if (!_manifestSnapshots.TryRemove(
+			    new KeyValuePair<ManifestRequestKey, ManifestSnapshotCacheEntry>(key, entry)))
+			return;
+		if (entry.OrderNode is null)
+			return;
+		_manifestSnapshotOrder.Remove(entry.OrderNode);
+		entry.OrderNode = null;
 	}
 
 	private static FileCacheKey CreateFileCacheKey(PreparedDependencySource source) => new(
@@ -594,13 +619,8 @@ public sealed class DependencyFactsEngine : IDisposable
 	private static long EstimateResolvedIndexBytes(ResolvedIndex index) =>
 		256 + index.Edges.Sum(static edge => 192 + StringBytes(edge.Source) + StringBytes(edge.Target) +
 			StringBytes(edge.Reference) + edge.Reasons.Sum(StringBytes) + edge.Evidence.Sum(SiteBytes) +
-			edge.Candidates.Sum(StringBytes)) +
-		index.Files.Sum(static file => StringBytes(file.Path) + file.Imports.Sum(static fact =>
-			128 + StringBytes(fact.Specifier) + StringBytes(fact.ImportedName) + StringBytes(fact.Alias) +
-			StringBytes(fact.Reason) + StringBytes(fact.Target) + (fact.Candidates?.Sum(StringBytes) ?? 0))) +
-		index.Files.Sum(static file => file.References.Sum(static fact =>
-			128 + StringBytes(fact.Name) + StringBytes(fact.Reason) + StringBytes(fact.Target) +
-			(fact.Candidates?.Sum(StringBytes) ?? 0)));
+			edge.Candidates.Sum(StringBytes) + edge.DeclarationFiles.Sum(StringBytes)) +
+		index.Files.Sum(EstimateFileFactsBytes);
 
 	private static long SiteBytes(SourceSite site) =>
 		64 + StringBytes(site.File) + StringBytes(site.Evidence);
@@ -705,7 +725,11 @@ public sealed class DependencyFactsEngine : IDisposable
 	{
 		if (Interlocked.Exchange(ref _disposed, 1) == 0)
 		{
-			_manifestSnapshots.Clear();
+			lock (_cacheTrimSync)
+			{
+				_manifestSnapshots.Clear();
+				_manifestSnapshotOrder.Clear();
+			}
 			_extractor.Dispose();
 		}
 	}
@@ -743,11 +767,21 @@ public sealed class DependencyFactsEngine : IDisposable
 		long CreationTimeUtcTicks);
 
 	private sealed record ManifestSnapshotCacheEntry(
+		ManifestRequestKey Key,
 		IReadOnlyList<string> ManifestPaths,
 		IReadOnlyList<FileStamp> Stamps,
 		IReadOnlyList<string>? ContentIdentities,
 		IndexCacheKey IndexCacheKey,
-		DependencyIndexSnapshot Snapshot);
+		DependencyIndexSnapshot Snapshot)
+	{
+		public LinkedListNode<ManifestSnapshotCacheEntry>? OrderNode { get; set; }
+	}
+
+	internal readonly record struct DependencyFactsCacheState(
+		int ManifestSnapshots,
+		int ManifestEvictionEntries,
+		int ResolvedIndexes,
+		long ResolvedIndexBytes);
 
 	private sealed record ResolvedIndex(
 		IReadOnlyList<DependencyEdge> Edges,

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -281,9 +281,13 @@ public sealed class DependencyFactsEngine : IDisposable
 		IReadOnlyDictionary<string, FileFacts> files)
 	{
 		var resolved = sourceEdges
-			.Where(edge => edge.Status == ResolutionStatus.Resolved && edge.Target is not null && edge.Target != seed)
-			.GroupBy(static edge => edge.Target!, StringComparer.Ordinal)
-			.Select(group => ToRelated(group.Key, ResolutionStatus.Resolved, group, files));
+			.Where(static edge => edge.Status == ResolutionStatus.Resolved)
+			.SelectMany(edge => ResolvedTargetFiles(edge)
+				.Where(path => path != seed)
+				.Select(path => (Path: path, Edge: edge)))
+			.GroupBy(static item => item.Path, StringComparer.Ordinal)
+			.Select(group => ToRelated(group.Key, ResolutionStatus.Resolved,
+				group.Select(static item => item.Edge), files));
 		var ambiguous = sourceEdges
 			.Where(static edge => edge.Status == ResolutionStatus.Ambiguous)
 			.Select(edge => (Edge: edge, Path: edge.Candidates.Order(StringComparer.Ordinal)
@@ -335,11 +339,15 @@ public sealed class DependencyFactsEngine : IDisposable
 		IReadOnlyDictionary<string, FileFacts> files)
 	{
 		var edges = groupedEdges.ToArray();
+		var declarationPartReasons = edges
+			.Where(static edge => edge.Status == ResolutionStatus.Resolved && edge.DeclarationFiles.Count > 1)
+			.Select(static edge => $"declaration part of one resolved symbol with {edge.DeclarationFiles.Count} files");
 		return new RelatedFile(
 			path,
 			status,
 			edges.SelectMany(static edge => edge.Reasons.Concat(edge.Evidence.Select(site =>
 				$"{EvidenceLabel(edge.Layer)} {edge.Reference} at line {site.Line}")))
+				.Concat(declarationPartReasons)
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
 			edges.SelectMany(static edge => edge.Candidates).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
 			edges.Any(static edge => edge.CrossScope),
@@ -355,6 +363,11 @@ public sealed class DependencyFactsEngine : IDisposable
 
 	private static long EstimateTokens(int characters) => (characters + 3L) / 4L;
 
+	private static IReadOnlyList<string> ResolvedTargetFiles(DependencyEdge edge) =>
+		edge.DeclarationFiles.Count > 0
+			? edge.DeclarationFiles
+			: edge.Target is null ? [] : [edge.Target];
+
 	private static (
 		IReadOnlyDictionary<string, IReadOnlyList<DependencyEdge>> BySource,
 		IReadOnlyDictionary<string, IReadOnlyList<DependencyEdge>> ByTarget) BuildEdgeIndexes(
@@ -368,7 +381,9 @@ public sealed class DependencyFactsEngine : IDisposable
 				static group => (IReadOnlyList<DependencyEdge>)group.ToArray(),
 				StringComparer.Ordinal);
 		var byTarget = edges
-			.SelectMany(static edge => (edge.Target is null ? edge.Candidates : edge.Candidates.Append(edge.Target))
+			.SelectMany(static edge => (edge.Status == ResolutionStatus.Resolved
+					? ResolvedTargetFiles(edge)
+					: edge.Candidates)
 				.Distinct(StringComparer.Ordinal)
 				.Select(target => (Target: target, Edge: edge)))
 			.GroupBy(static item => item.Target, StringComparer.Ordinal)
@@ -596,7 +611,8 @@ public sealed class DependencyFactsEngine : IDisposable
 		}).ToArray();
 		var edges = index.Edges.Where(edge => allowed.Contains(edge.Source) &&
 			(edge.Target is null || allowed.Contains(edge.Target) || edge.Target.StartsWith("namespace:", StringComparison.Ordinal)) &&
-			edge.Candidates.All(allowed.Contains)).ToArray();
+			edge.Candidates.All(allowed.Contains) &&
+			edge.DeclarationFiles.All(allowed.Contains)).ToArray();
 		var (bySource, byTarget) = BuildEdgeIndexes(edges);
 		return index with
 		{
@@ -900,7 +916,11 @@ public sealed class DependencyFactsEngine : IDisposable
 					group.SelectMany(static edge => edge.Reasons).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
 					group.SelectMany(static edge => edge.Evidence).Distinct().OrderBy(static site => site.Line).ToArray(),
 					group.SelectMany(static edge => edge.Candidates).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
-					group.Key.CrossScope))
+					group.Key.CrossScope)
+				{
+					DeclarationFiles = group.SelectMany(static edge => edge.DeclarationFiles)
+						.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray()
+				})
 				.OrderBy(static edge => edge.Source, StringComparer.Ordinal)
 				.ThenBy(static edge => edge.Target, StringComparer.Ordinal)
 				.ThenBy(static edge => edge.Reference, StringComparer.Ordinal)
@@ -1407,7 +1427,10 @@ public sealed class DependencyFactsEngine : IDisposable
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
 			return candidates.Length == 1
 				? Edge(source, reference, ResolutionStatus.Resolved, files[0],
-					$"one visible declaration identity in {source.ScopeId}", files)
+					$"one visible declaration identity in {source.ScopeId}", files) with
+					{
+						DeclarationFiles = files
+					}
 				: Edge(source, reference, ResolutionStatus.Ambiguous, null, "multiple visible declaration identities", files);
 		}
 

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1023,17 +1023,19 @@ public sealed class DependencyFactsEngine : IDisposable
 			}
 			else if (import.Specifier.StartsWith("#", StringComparison.Ordinal))
 			{
-				if (IsPackageMapBlocked(source, import.Specifier, exports: false))
-					return Edge(source, import, ResolutionStatus.Unresolved, null, "package imports target is null-blocked", []);
-				candidates = ResolvePackageMap(source, import.Specifier, exports: false);
+				var packageTarget = ResolvePackageMap(source, import, import.Specifier, exports: false);
+				if (packageTarget.FailureReason is { } reason)
+					return Edge(source, import, ResolutionStatus.Unresolved, null, reason, []);
+				candidates = packageTarget.Candidates;
 			}
 			else if ((scope.PackageName ?? FindNearestPackageMap(source)?.PackageName) is { } package &&
 			         (import.Specifier == package || import.Specifier.StartsWith(package + '/', StringComparison.Ordinal)))
 			{
 				var selfPath = import.Specifier[package.Length..].TrimStart('/');
-				if (IsPackageMapBlocked(source, selfPath, exports: true))
-					return Edge(source, import, ResolutionStatus.Unresolved, null, "package exports target is null-blocked", []);
-				candidates = ResolvePackageMap(source, selfPath, exports: true);
+				var packageTarget = ResolvePackageMap(source, import, selfPath, exports: true);
+				if (packageTarget.FailureReason is { } reason)
+					return Edge(source, import, ResolutionStatus.Unresolved, null, reason, []);
+				candidates = packageTarget.Candidates;
 			}
 			else
 			{
@@ -1120,7 +1122,11 @@ public sealed class DependencyFactsEngine : IDisposable
 				: parts.FirstOrDefault() ?? specifier;
 		}
 
-		private IEnumerable<string> ResolvePackageMap(FileFacts source, string specifier, bool exports)
+		private PackageMapProbe ResolvePackageMap(
+			FileFacts source,
+			ImportFact import,
+			string specifier,
+			bool exports)
 		{
 			var directory = Path.GetDirectoryName(Path.Combine(_root, source.Path))!;
 			while (IsWithin(_root, directory))
@@ -1130,18 +1136,30 @@ public sealed class DependencyFactsEngine : IDisposable
 				{
 					var values = exports ? map.Exports : map.Imports;
 					var key = exports ? (specifier.Length == 0 ? "." : "./" + specifier) : specifier;
-					if (TryMap(values, key, out var target) && target is not null)
-						return ProbeTypeScript(
-							Path.GetFullPath(Path.Combine(directory, target)),
+					if (!TryMap(values, key, out var target, out var wildcard))
+						return new PackageMapProbe([], null);
+					var selected = SelectPackageTarget(target!, PackageCondition(source, import));
+					if (selected.Kind == PackageTargetSelectionKind.Blocked)
+						return new PackageMapProbe([], $"package {(exports ? "exports" : "imports")} target is null-blocked");
+					if (selected.Kind == PackageTargetSelectionKind.Unsupported)
+						return new PackageMapProbe([], selected.Reason);
+					if (selected.Kind != PackageTargetSelectionKind.Path || selected.Path is null)
+						return new PackageMapProbe([], "no applicable package condition");
+					var mappedPath = wildcard.Length == 0
+						? selected.Path
+						: selected.Path.Replace("*", wildcard, StringComparison.Ordinal);
+					return new PackageMapProbe(
+						ProbeTypeScript(
+							Path.GetFullPath(Path.Combine(directory, mappedPath)),
 							FindScope(source.ScopeId),
-							source);
-					return [];
+							source).ToArray(),
+						null);
 				}
 				if (Path.GetFullPath(directory) == Path.GetFullPath(_root))
 					break;
 				directory = Path.GetDirectoryName(directory)!;
 			}
-			return [];
+			return new PackageMapProbe([], null);
 		}
 
 		private PackageMapDescriptor? FindNearestPackageMap(FileFacts source)
@@ -1156,27 +1174,31 @@ public sealed class DependencyFactsEngine : IDisposable
 			return null;
 		}
 
-		private bool IsPackageMapBlocked(FileFacts source, string specifier, bool exports)
+		private string PackageCondition(FileFacts source, ImportFact import)
 		{
-			var directory = Path.GetDirectoryName(Path.Combine(_root, source.Path))!;
-			while (IsWithin(_root, directory))
-			{
-				if (_configuration.PackageMaps.TryGetValue(PortableRelative(_root, directory), out var map))
-				{
-					var values = exports ? map.Exports : map.Imports;
-					var key = exports ? (specifier.Length == 0 ? "." : "./" + specifier) : specifier;
-					return TryMap(values, key, out var target) && target is null;
-				}
-				if (Path.GetFullPath(directory) == Path.GetFullPath(_root)) break;
-				directory = Path.GetDirectoryName(directory)!;
-			}
-			return false;
+			if (IsRequire(import))
+				return "require";
+			var scope = FindScope(source.ScopeId);
+			var mode = scope?.ModuleResolution ?? "bundler";
+			return scope is not null &&
+			       (mode.Equals("node16", StringComparison.OrdinalIgnoreCase) ||
+			        mode.Equals("nodenext", StringComparison.OrdinalIgnoreCase)) &&
+			       SupportsCommonJs(source, scope)
+				? "require"
+				: "import";
 		}
 
-		private static bool TryMap(IReadOnlyDictionary<string, string?> map, string key, out string? target)
+		private static bool TryMap(
+			IReadOnlyDictionary<string, PackageTargetDescriptor> map,
+			string key,
+			out PackageTargetDescriptor? target,
+			out string wildcard)
 		{
 			if (map.TryGetValue(key, out target))
+			{
+				wildcard = string.Empty;
 				return true;
+			}
 			foreach (var pair in map.Where(static pair => pair.Key.Contains('*')).OrderByDescending(static pair => pair.Key.Length))
 			{
 				var star = pair.Key.IndexOf('*');
@@ -1184,13 +1206,49 @@ public sealed class DependencyFactsEngine : IDisposable
 				var suffix = pair.Key[(star + 1)..];
 				if (!key.StartsWith(prefix, StringComparison.Ordinal) || !key.EndsWith(suffix, StringComparison.Ordinal))
 					continue;
-				var wildcard = key[prefix.Length..(key.Length - suffix.Length)];
-				target = pair.Value?.Replace("*", wildcard, StringComparison.Ordinal);
+				wildcard = key[prefix.Length..(key.Length - suffix.Length)];
+				target = pair.Value;
 				return true;
 			}
 			target = null;
+			wildcard = string.Empty;
 			return false;
 		}
+
+		private static PackageTargetSelection SelectPackageTarget(
+			PackageTargetDescriptor target,
+			string moduleCondition)
+		{
+			if (target.Kind == PackageTargetKind.Path)
+				return new PackageTargetSelection(PackageTargetSelectionKind.Path, target.Path, null);
+			if (target.Kind == PackageTargetKind.Blocked)
+				return new PackageTargetSelection(PackageTargetSelectionKind.Blocked, null, null);
+			if (target.Kind == PackageTargetKind.Unsupported)
+				return new PackageTargetSelection(
+					PackageTargetSelectionKind.Unsupported,
+					null,
+					target.UnsupportedReason ?? "unsupported package target");
+			foreach (var branch in target.Conditions)
+			{
+				if (!IsSupportedPackageCondition(branch.Name))
+					return new PackageTargetSelection(
+						PackageTargetSelectionKind.Unsupported,
+						null,
+						$"package condition '{branch.Name}' is not supported");
+				if (!IsActivePackageCondition(branch.Name, moduleCondition))
+					continue;
+				var selected = SelectPackageTarget(branch.Target, moduleCondition);
+				if (selected.Kind != PackageTargetSelectionKind.NoMatch)
+					return selected;
+			}
+			return new PackageTargetSelection(PackageTargetSelectionKind.NoMatch, null, null);
+		}
+
+		private static bool IsSupportedPackageCondition(string condition) =>
+			condition is "types" or "import" or "require" or "node" or "default";
+
+		private static bool IsActivePackageCondition(string condition, string moduleCondition) =>
+			condition is "types" or "node" or "default" || condition == moduleCondition;
 
 		private IEnumerable<string> ProbeTypeScript(
 			string candidate,
@@ -1684,5 +1742,19 @@ public sealed class DependencyFactsEngine : IDisposable
 			LanguageId LanguageId,
 			string QualifiedName,
 			int GenericArity);
+		private readonly record struct PackageMapProbe(
+			IReadOnlyList<string> Candidates,
+			string? FailureReason);
+		private readonly record struct PackageTargetSelection(
+			PackageTargetSelectionKind Kind,
+			string? Path,
+			string? Reason);
+		private enum PackageTargetSelectionKind
+		{
+			NoMatch,
+			Path,
+			Blocked,
+			Unsupported
+		}
 	}
 }

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -126,7 +126,10 @@ public sealed record DependencyEdge(
 	IReadOnlyList<string> Reasons,
 	IReadOnlyList<SourceSite> Evidence,
 	IReadOnlyList<string> Candidates,
-	bool CrossScope);
+	bool CrossScope)
+{
+	public IReadOnlyList<string> DeclarationFiles { get; init; } = [];
+}
 
 public sealed record DependencyFactsCoverage(
 	int Files,

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -137,7 +137,10 @@ public sealed record DependencyFactsCoverage(
 	int Unsupported,
 	int ExtractionFailed,
 	IReadOnlyDictionary<string, int> UnsupportedLanguages,
-	IReadOnlyDictionary<string, int> CSharpErrorNodeKinds);
+	IReadOnlyDictionary<string, int> CSharpErrorNodeKinds)
+{
+	public IReadOnlyList<DependencyConfigurationDiagnostic> ConfigurationDiagnostics { get; init; } = [];
+}
 
 public sealed record DependencyIndexMetrics(
 	int ParsedFiles,

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -440,31 +440,46 @@ public sealed class ImportanceRankingService(
 		var nodeByPath = new Dictionary<string, int>(paths.Length, StringComparer.Ordinal);
 		for (var node = 0; node < paths.Length; node++)
 			nodeByPath.Add(paths[node], node);
-		var outgoingSets = new HashSet<int>[paths.Length];
-		for (var node = 0; node < outgoingSets.Length; node++)
-			outgoingSets[node] = [];
+		var outgoingWeights = new Dictionary<int, double>[paths.Length];
+		for (var node = 0; node < outgoingWeights.Length; node++)
+			outgoingWeights[node] = [];
 		foreach (var edge in snapshot.Edges)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			if (edge.Status != ResolutionStatus.Resolved ||
-				edge.Target is not { } target ||
-				!nodeByPath.TryGetValue(edge.Source, out var sourceNode) ||
-				!nodeByPath.TryGetValue(target, out var targetNode) ||
-				sourceNode == targetNode)
+				!nodeByPath.TryGetValue(edge.Source, out var sourceNode))
 			{
 				continue;
 			}
-			outgoingSets[sourceNode].Add(targetNode);
+			var targets = (edge.DeclarationFiles.Count > 0
+					? edge.DeclarationFiles
+					: edge.Target is null ? [] : [edge.Target])
+				.Distinct(StringComparer.Ordinal)
+				.Where(nodeByPath.ContainsKey)
+				.Select(path => nodeByPath[path])
+				.Where(targetNode => sourceNode != targetNode)
+				.Order()
+				.ToArray();
+			if (targets.Length == 0)
+				continue;
+			var partWeight = 1d / targets.Length;
+			foreach (var targetNode in targets)
+			{
+				if (!outgoingWeights[sourceNode].TryGetValue(targetNode, out var existing) || partWeight > existing)
+					outgoingWeights[sourceNode][targetNode] = partWeight;
+			}
 		}
 
 		var outgoing = new int[paths.Length][];
+		var weights = new double[paths.Length][];
 		var dependents = new int[paths.Length];
 		var filesWithEdges = new bool[paths.Length];
 		var edgeCount = 0;
 		for (var source = 0; source < paths.Length; source++)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			outgoing[source] = outgoingSets[source].Order().ToArray();
+			outgoing[source] = outgoingWeights[source].Keys.Order().ToArray();
+			weights[source] = outgoing[source].Select(target => outgoingWeights[source][target]).ToArray();
 			edgeCount += outgoing[source].Length;
 			if (outgoing[source].Length > 0)
 				filesWithEdges[source] = true;
@@ -478,6 +493,7 @@ public sealed class ImportanceRankingService(
 			paths,
 			nodeByPath,
 			outgoing,
+			weights,
 			dependents,
 			edgeCount,
 			filesWithEdges.Count(static value => value));
@@ -517,9 +533,11 @@ public sealed class ImportanceRankingService(
 				var targets = graph.Outgoing[source];
 				if (targets.Length == 0)
 					continue;
-				var share = damping * rank[source] / targets.Length;
-				foreach (var target in targets)
-					next[target] += share;
+				var weights = graph.OutgoingWeights[source];
+				var totalWeight = weights.Sum();
+				var share = damping * rank[source] / totalWeight;
+				for (var targetIndex = 0; targetIndex < targets.Length; targetIndex++)
+					next[targets[targetIndex]] += share * weights[targetIndex];
 			}
 			(rank, next) = (next, rank);
 			iterationCompleted?.Invoke(iteration);

--- a/Application/Ranking/RankingGraph.cs
+++ b/Application/Ranking/RankingGraph.cs
@@ -4,6 +4,7 @@ internal sealed record RankingGraph(
 	string[] Paths,
 	IReadOnlyDictionary<string, int> NodeByPath,
 	int[][] Outgoing,
+	double[][] OutgoingWeights,
 	int[] Dependents,
 	int EdgeCount,
 	int FilesWithEdges)

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -106,7 +106,9 @@ failures are counted separately as extraction failures.
 The default safety limits are 2 Mi characters per source file, 50,000 facts per file, 20,000 edges
 per file, and 5,000,000 units of resolver work per index pass. A limit produces an explicit
 `Unresolved` fact or extraction status with a reason; it is never reported as an empty successful
-analysis.
+analysis. Source decoding is bounded by decoded characters rather than bytes: UTF-8, UTF-16, and
+UTF-32 BOMs are honored, incomplete sequences fail closed, and reading stops as soon as the engine
+has proved that the character limit is exceeded instead of scanning the rest of the file.
 
 The resolver work limit is an admission budget applied in canonical file order, not a latch that
 stops all later files after one rejection. A file is admitted only when all of its known import and

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -24,8 +24,11 @@ therefore not inferred.
 
 Each declaration is identified by scope, language, symbol kind, qualified name, generic arity, and
 an optional file scope. Partial C# declarations share one identity with multiple source sites;
-file-local types remain distinct even when their names match. Each reference retains its source line
-and a compact source excerpt. Results use four statuses:
+file-local types remain distinct even when their names match. A resolved edge to such a partial
+identity keeps one canonical target and the complete declaration-file list. Related-file projections
+show every declaration file as a resolved part of the same symbol, in both directions; ambiguous
+candidates remain a separate concept. Each reference retains its source line and a compact source
+excerpt. Results use four statuses:
 
 - **Resolved** — exactly one declaration or module in the allowed manifest is supported by the
   resolver evidence;
@@ -84,9 +87,12 @@ once, then derives all scope, package-name, package-map, and external-package pr
 snapshot, so a result cannot mix two versions of one configuration file.
 
 Python relative imports start at the source package. Regular and namespace-package portions are
-combined, `.py` is preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and
-`__all__` affects wildcard imports only. Dynamic `__all__`, `setup.py`, and import hooks are not
-executed and remain unresolved. Separate complete `sys.stdlib_module_names` snapshots cover Python
+combined, and a package initializer takes precedence over a same-named module file. Within a package,
+a statically provided or re-exported name is resolved before a same-named child module. `.py` is
+preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and `__all__` affects
+wildcard imports only. Relative imports that would escape the top-level package remain unresolved.
+Dynamic `__all__`, `setup.py`, and import hooks are not executed and remain unresolved. Separate
+complete `sys.stdlib_module_names` snapshots cover Python
 3.12 and 3.13. A decisive `requires-python`/`python_requires` constraint selects its snapshot;
 otherwise only names found in both snapshots are classified as external.
 

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -128,7 +128,10 @@ a resolver-configuration fingerprint covering `.csproj`/project references/globa
 TypeScript configuration and package maps, Python configuration, and the TypeScript dialect.
 Concurrent requests share one lazy computation. The default caches are bounded by both entry count
 and estimated retained size: 64 MiB for compact file facts and 128 MiB for resolved edges. Eviction
-changes latency, not results.
+changes latency, not results. The resolved-index estimate includes every transitively retained file
+fact, including declarations and all declaration sites, even when the graph has few or no edges.
+Manifest-snapshot eviction entries are generation-bound and removed together with their live
+snapshot, so repeated rebuilds of the same cache keys cannot grow bookkeeping outside the limit.
 
 Access failures, missing files, and other transient I/O failures are not retained in either the
 prepared-source cache or a manifest snapshot. A later request retries extraction even when file stamps

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -74,6 +74,15 @@ and directory probes. `.mts`/`.mjs` are ESM, `.cts`/`.cjs` are CommonJS, and ord
 DevProjex never guesses a `dist` to `src` mapping without configuration, and module references without
 an owning `tsconfig.json` or `jsconfig.json` stay unresolved.
 
+Configuration reads have four explicit outcomes: valid, missing, corrupt, and unsupported semantics.
+A malformed JSON document, a `null` or non-object `compilerOptions`, or an unsupported value shape is
+never replaced by an implicit default. References whose resolution depends on that control file remain
+`Unresolved` with its diagnostic, and machine-readable facts coverage includes the affected control-file
+path, state, reason, and owning scopes. Every `.csproj`, `tsconfig.json`, `jsconfig.json`, `package.json`,
+`pyproject.toml`, and `setup.cfg` is limited to 4 MiB. One operation reads and verifies each control file
+once, then derives all scope, package-name, package-map, and external-package projections from that same
+snapshot, so a result cannot mix two versions of one configuration file.
+
 Python relative imports start at the source package. Regular and namespace-package portions are
 combined, `.py` is preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and
 `__all__` affects wildcard imports only. Dynamic `__all__`, `setup.py`, and import hooks are not

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-2026-09-08 graph-fidelity rerun are both `63fcc291a1379c6e9d03bc1d815aa51f986426c4`.
+2026-09-08 graph-fidelity rerun are both `efe8b7083ccd523202bcc517255c71b1399fd9b4`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -215,9 +215,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2596.13 / 2655.83` | `2370.52 / 2386.56` | `+16.03 ms (0.68%)` | `290.17 / 289.87` | `362.32 / 363.30` | `0.27%` |
-| Repomix | `735.45 / 767.74` | `393.65 / 428.44` | `+34.79 ms (8.84%)` | `111.43 / 111.09` | `111.44 / 112.27` | `0.74%` |
-| Flask | `475.42 / 498.86` | `192.57 / 189.95` | `-2.61 ms (-1.36%)` | `83.66 / 83.86` | `85.58 / 86.50` | `1.07%` |
+| DevProjex | `2446.60 / 2563.08` | `884.74 / 878.64` | `-6.10 ms (-0.69%)` | `301.28 / 300.96` | `306.08 / 308.26` | `0.71%` |
+| Repomix | `712.34 / 726.25` | `355.37 / 354.10` | `-1.27 ms (-0.36%)` | `111.16 / 110.98` | `111.89 / 112.23` | `0.30%` |
+| Flask | `414.64 / 420.79` | `162.80 / 173.29` | `+10.49 ms (6.44%)` | `83.13 / 83.51` | `86.60 / 86.84` | `0.46%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,13 +168,16 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-run are both `25b4acb6283913afe989374be60883694cb090a9`.
+2026-09-08 graph-fidelity rerun are both `63fcc291a1379c6e9d03bc1d815aa51f986426c4`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
 and an explicit seed plus `related_files` in both directions. Personalized PageRank uses
 the registered damping, teleport, dangling-mass, convergence, and quantization rules; it is
 not a product feature. All seeded orders consider the same registered seed first.
+When one resolved symbol has declarations in multiple files, graph traversal connects the source to
+every declaration file. Personalized PageRank divides that logical edge evenly across those files
+(`1/n` each), so splitting one partial type across many files cannot manufacture extra rank weight.
 
 Each table cell is `mean RecallNew · AllRequired/oracle/oracle-after-seeds · mean irrelevant-token share`.
 RecallNew excludes the registered seed and is averaged only where the remaining sufficient
@@ -183,15 +186,15 @@ oracles are counts over the five tasks at that repository and budget.
 
 | Repository / budget | Current | Importance | Seed-first | Focus-v1 | Focus-PPR | Directed-from-seed |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.8628` | `0.1000 · 0/1/1 · 0.8482` | `0.1000 · 0/1/1 · 0.8481` | `0.1000 · 0/1/1 · 0.7511` |
+| DevProjex / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.8628` | `0.1000 · 0/1/1 · 0.8481` | `0.1000 · 0/1/1 · 0.8481` | `0.1000 · 0/1/1 · 0.7511` |
 | DevProjex / 8,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.7997` | `0.2000 · 0/2/2 · 0.7409` | `0.1000 · 0/2/2 · 0.7924` | `0.2000 · 0/2/2 · 0.5611` |
 | DevProjex / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.8999` | `0.1000 · 0/2/2 · 0.8962` | `0.2000 · 0/2/2 · 0.7574` | `0.1000 · 0/2/2 · 0.7375` |
 | Repomix / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.4111` | `0.0000 · 0/1/1 · 0.4110` | `0.0000 · 0/1/1 · 0.4109` | `0.0000 · 0/1/1 · 0.3883` |
 | Repomix / 8,000 | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 0.7055` | `0.2000 · 1/3/3 · 0.6202` | `0.3000 · 1/3/3 · 0.5349` | `0.2000 · 1/3/3 · 0.5965` |
 | Repomix / 16,000 | `0.0000 · 0/5/5 · 1.0000` | `0.0000 · 0/5/5 · 1.0000` | `0.0000 · 0/5/5 · 0.8528` | `0.4000 · 2/5/5 · 0.7538` | `0.3000 · 1/5/5 · 0.7675` | `0.4000 · 2/5/5 · 0.7013` |
-| Flask / 4,000 | `0.0000 · 0/0/0 · 1.0000` | `0.0000 · 0/0/0 · 1.0000` | `0.0000 · 0/0/0 · 0.7098` | `0.0000 · 0/0/0 · 0.7097` | `0.0000 · 0/0/0 · 0.7097` | `0.0000 · 0/0/0 · 0.6845` |
-| Flask / 8,000 | `0.0000 · 0/0/0 · 1.0000` | `0.0000 · 0/0/0 · 1.0000` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5262` |
-| Flask / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.9412` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5368` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5310` |
+| Flask / 4,000 | `0.0000 · 0/0/0 · 1.0000` | `0.0000 · 0/0/0 · 0.8080` | `0.0000 · 0/0/0 · 0.7098` | `0.0000 · 0/0/0 · 0.7097` | `0.0000 · 0/0/0 · 0.7097` | `0.0000 · 0/0/0 · 0.4000` |
+| Flask / 8,000 | `0.0000 · 0/0/0 · 1.0000` | `0.1250 · 0/0/0 · 0.8680` | `0.0000 · 0/0/0 · 0.5642` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.2895` |
+| Flask / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.1250 · 0/2/2 · 0.8753` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5369` | `0.2500 · 2/2/2 · 0.5368` | `0.2500 · 2/2/2 · 0.3551` |
 
 `focus-v1` and `directed-from-seed` have the same RecallNew and AllRequired result
 in all nine repository/budget aggregates above. Directed context spends a smaller
@@ -212,9 +215,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2726.33 / 2779.00` | `963.22 / 1047.16` | `+83.94 ms (8.71%)` | `286.54 / 288.83` | `299.23 / 302.76` | `1.18%` |
-| Repomix | `807.94 / 809.41` | `404.52 / 412.87` | `+8.35 ms (2.06%)` | `109.84 / 109.79` | `107.02 / 107.32` | `0.28%` |
-| Flask | `541.79 / 561.06` | `276.24 / 265.36` | `-10.88 ms (-3.94%)` | `83.75 / 84.09` | `87.28 / 87.23` | `0.40%` |
+| DevProjex | `2596.13 / 2655.83` | `2370.52 / 2386.56` | `+16.03 ms (0.68%)` | `290.17 / 289.87` | `362.32 / 363.30` | `0.27%` |
+| Repomix | `735.45 / 767.74` | `393.65 / 428.44` | `+34.79 ms (8.84%)` | `111.43 / 111.09` | `111.44 / 112.27` | `0.74%` |
+| Flask | `475.42 / 498.86` | `192.57 / 189.95` | `-2.61 ms (-1.36%)` | `83.66 / 83.86` | `85.58 / 86.50` | `1.07%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -208,40 +208,57 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			return new PackageMapDescriptor(
 				directory,
 				null,
-				new Dictionary<string, string?>(),
-				new Dictionary<string, string?>(),
+				new Dictionary<string, PackageTargetDescriptor>(),
+				new Dictionary<string, PackageTargetDescriptor>(),
 				null,
 				new HashSet<string>());
 		}
 	}
 
-	private static IReadOnlyDictionary<string, string?> FlattenMap(JsonElement root, string property)
+	private static IReadOnlyDictionary<string, PackageTargetDescriptor> FlattenMap(JsonElement root, string property)
 	{
-		var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+		var result = new Dictionary<string, PackageTargetDescriptor>(StringComparer.Ordinal);
 		if (!root.TryGetProperty(property, out var map)) return result;
-		if (map.ValueKind == JsonValueKind.String || map.ValueKind == JsonValueKind.Null)
+		if (map.ValueKind is JsonValueKind.String or JsonValueKind.Null)
 		{
-			result["."] = SelectConditional(map);
+			result["."] = ParsePackageTarget(map);
 			return result;
 		}
-		if (map.ValueKind != JsonValueKind.Object) return result;
+		if (map.ValueKind != JsonValueKind.Object)
+		{
+			result["."] = UnsupportedPackageTarget($"{property} must be a string, null, or object");
+			return result;
+		}
 		if (property == "exports" && !map.EnumerateObject().Any(static item => item.Name.StartsWith(".", StringComparison.Ordinal)))
 		{
-			result["."] = SelectConditional(map);
+			result["."] = ParsePackageTarget(map);
 			return result;
 		}
-		foreach (var item in map.EnumerateObject()) result[item.Name] = SelectConditional(item.Value);
+		foreach (var item in map.EnumerateObject()) result[item.Name] = ParsePackageTarget(item.Value);
 		return result;
 	}
 
-	private static string? SelectConditional(JsonElement value)
+	private static PackageTargetDescriptor ParsePackageTarget(JsonElement value)
 	{
-		if (value.ValueKind == JsonValueKind.String) return value.GetString();
-		if (value.ValueKind is JsonValueKind.Null or not JsonValueKind.Object) return null;
-		foreach (var condition in new[] { "types", "import", "require", "node", "default" })
-			if (value.TryGetProperty(condition, out var candidate)) return SelectConditional(candidate);
-		return null;
+		if (value.ValueKind == JsonValueKind.String)
+			return new PackageTargetDescriptor(PackageTargetKind.Path, value.GetString(), [], null);
+		if (value.ValueKind == JsonValueKind.Null)
+			return new PackageTargetDescriptor(PackageTargetKind.Blocked, null, [], null);
+		if (value.ValueKind != JsonValueKind.Object)
+			return UnsupportedPackageTarget($"package target kind {value.ValueKind} is not supported");
+		return new PackageTargetDescriptor(
+			PackageTargetKind.Conditions,
+			null,
+			value.EnumerateObject()
+				.Select(static condition => new PackageConditionDescriptor(
+					condition.Name,
+					ParsePackageTarget(condition.Value)))
+				.ToArray(),
+			null);
 	}
+
+	private static PackageTargetDescriptor UnsupportedPackageTarget(string reason) =>
+		new(PackageTargetKind.Unsupported, null, [], reason);
 
 	private static string? ReadPackageName(string content)
 	{

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -10,6 +10,19 @@ namespace DevProjex.Infrastructure.Dependencies;
 
 public sealed class FileDependencyConfigurationProvider : IDependencyConfigurationProvider
 {
+	internal const int MaximumConfigurationBytes = 4 * 1024 * 1024;
+	private readonly IDependencyControlFileReader _reader;
+
+	public FileDependencyConfigurationProvider()
+		: this(new BoundedDependencyControlFileReader())
+	{
+	}
+
+	internal FileDependencyConfigurationProvider(IDependencyControlFileReader reader)
+	{
+		_reader = reader ?? throw new ArgumentNullException(nameof(reader));
+	}
+
 	public async Task<DependencyResolverConfiguration> ReadAsync(
 		string sourceRoot,
 		IReadOnlyList<string> manifestFiles,
@@ -20,14 +33,61 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var scopes = new List<DependencyScopeDescriptor>();
 		var fingerprintParts = new List<string>();
 		var csharpProjects = new Dictionary<string, (string Scope, string[] References)>(PathComparer);
+		var snapshots = new Dictionary<string, Task<DependencyControlFileSnapshot>>(PathComparer);
+		var packageProjections = new Dictionary<string, Task<ConfigurationParseResult<PackageMapDescriptor>>>(PathComparer);
+		var diagnostics = new List<DependencyConfigurationDiagnostic>();
+
+		Task<DependencyControlFileSnapshot> ReadSnapshotAsync(string path)
+		{
+			if (snapshots.TryGetValue(path, out var existing)) return existing;
+			var created = _reader.ReadAsync(path, MaximumConfigurationBytes, cancellationToken).AsTask();
+			snapshots[path] = created;
+			return created;
+		}
+
+		Task<ConfigurationParseResult<PackageMapDescriptor>> ReadPackageAsync(string path)
+		{
+			if (packageProjections.TryGetValue(path, out var existing)) return existing;
+			var created = ReadPackageCoreAsync(path);
+			packageProjections[path] = created;
+			return created;
+		}
+
+		async Task<ConfigurationParseResult<PackageMapDescriptor>> ReadPackageCoreAsync(string path)
+		{
+			var snapshot = await ReadSnapshotAsync(path).ConfigureAwait(false);
+			fingerprintParts.Add(Fingerprint(root, path, snapshot.FingerprintValue));
+			return snapshot.State == DependencyConfigurationState.Valid
+				? ParsePackageMap(Path.GetDirectoryName(path)!, snapshot.Content)
+				: ConfigurationParseResult<PackageMapDescriptor>.Failure(
+					UnavailablePackageMap(Path.GetDirectoryName(path)!, snapshot.State, snapshot.Reason),
+					snapshot.State,
+					snapshot.Reason);
+		}
+
+		void AddDiagnostic(string path, DependencyConfigurationState state, string? reason, params string[] scopeIds)
+		{
+			if (state == DependencyConfigurationState.Valid ||
+			    state == DependencyConfigurationState.Missing && !manifest.Contains(path))
+				return;
+			diagnostics.Add(new DependencyConfigurationDiagnostic(
+				PortableRelative(root, path),
+				state,
+				reason ?? "configuration is unavailable",
+				scopeIds.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray()));
+		}
 
 		foreach (var project in manifest.Where(static path => path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)).Order(StringComparer.Ordinal))
 		{
-			var content = await ReadTextAsync(project, cancellationToken).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, project, content));
+			var snapshot = await ReadSnapshotAsync(project).ConfigureAwait(false);
+			fingerprintParts.Add(Fingerprint(root, project, snapshot.FingerprintValue));
 			var scope = "csharp:" + PortableRelative(root, project);
-			var references = ParseProjectReferences(project, content);
+			var parsed = snapshot.State == DependencyConfigurationState.Valid
+				? ParseProjectReferences(project, snapshot.Content)
+				: ConfigurationParseResult<string[]>.Failure([], snapshot.State, snapshot.Reason);
+			var references = parsed.Value;
 			csharpProjects[project] = (scope, references);
+			AddDiagnostic(project, parsed.State, parsed.Reason, scope);
 		}
 		foreach (var pair in csharpProjects.OrderBy(static pair => pair.Key, StringComparer.Ordinal))
 		{
@@ -35,6 +95,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				.Where(csharpProjects.ContainsKey)
 				.Select(path => csharpProjects[path].Scope)
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+			var diagnostic = diagnostics.FirstOrDefault(item => item.ScopeIds.Contains(pair.Value.Scope, StringComparer.Ordinal));
 			scopes.Add(new DependencyScopeDescriptor(
 				pair.Value.Scope,
 				Path.GetDirectoryName(pair.Key)!,
@@ -46,47 +107,68 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				null,
 				new HashSet<string>(),
 				[],
-				true));
+				true)
+			{
+				ConfigurationState = diagnostic?.State ?? DependencyConfigurationState.Valid,
+				ConfigurationDiagnostic = diagnostic?.Reason
+			});
 		}
 
 		foreach (var configPath in manifest.Where(IsTypeScriptConfig).Order(StringComparer.Ordinal))
 		{
-			var content = await ReadTextAsync(configPath, cancellationToken).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, configPath, content));
-			var parsed = ParseTypeScriptConfig(content);
+			var snapshot = await ReadSnapshotAsync(configPath).ConfigureAwait(false);
+			fingerprintParts.Add(Fingerprint(root, configPath, snapshot.FingerprintValue));
+			var parsed = snapshot.State == DependencyConfigurationState.Valid
+				? ParseTypeScriptConfig(snapshot.Content)
+				: ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+					TypeScriptConfiguration.Default, snapshot.State, snapshot.Reason);
 			var directory = Path.GetDirectoryName(configPath)!;
 			var package = FindNearestManifestFile(directory, root, "package.json", manifest);
-			var packageName = package is null ? null : ReadPackageName(await ReadTextAsync(package, cancellationToken).ConfigureAwait(false));
+			var packageName = package is null ? null : (await ReadPackageAsync(package).ConfigureAwait(false)).Value.PackageName;
+			var scopeId = "typescript:" + PortableRelative(root, configPath);
+			AddDiagnostic(configPath, parsed.State, parsed.Reason, scopeId);
 			scopes.Add(new DependencyScopeDescriptor(
-				"typescript:" + PortableRelative(root, configPath),
+				scopeId,
 				directory,
 				LanguageId.TypeScript,
 				[],
-				parsed.ModuleResolution,
-				parsed.Legacy,
-				parsed.Paths,
+				parsed.Value.ModuleResolution,
+				parsed.Value.Legacy,
+				parsed.Value.Paths,
 				packageName,
 				new HashSet<string>(),
 				[],
 				true,
-				AllowJavaScript: parsed.AllowJavaScript));
+				AllowJavaScript: parsed.Value.AllowJavaScript)
+			{
+				ConfigurationState = parsed.State,
+				ConfigurationDiagnostic = parsed.Reason
+			});
 		}
 
 		foreach (var configPath in manifest.Where(IsPythonConfig).Order(StringComparer.Ordinal))
 		{
-			var content = await ReadTextAsync(configPath, cancellationToken).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, configPath, content));
+			var snapshot = await ReadSnapshotAsync(configPath).ConfigureAwait(false);
+			fingerprintParts.Add(Fingerprint(root, configPath, snapshot.FingerprintValue));
 			var directory = Path.GetDirectoryName(configPath)!;
+			var scopeId = "python:" + PortableRelative(root, configPath);
+			AddDiagnostic(configPath, snapshot.State, snapshot.Reason, scopeId);
 			scopes.Add(new DependencyScopeDescriptor(
-				"python:" + PortableRelative(root, configPath),
+				scopeId,
 				directory,
 				LanguageId.Python,
 				[], null, false,
 				new Dictionary<string, IReadOnlyList<string>>(), null,
-				ParsePythonDependencies(configPath, content),
+				snapshot.State == DependencyConfigurationState.Valid
+					? ParsePythonDependencies(configPath, snapshot.Content)
+					: new HashSet<string>(),
 				new[] { directory, Path.Combine(directory, "src") },
 				true,
-				ParsePythonVersion(content)));
+				snapshot.State == DependencyConfigurationState.Valid ? ParsePythonVersion(snapshot.Content) : null)
+			{
+				ConfigurationState = snapshot.State,
+				ConfigurationDiagnostic = snapshot.Reason
+			});
 		}
 
 		AddFallbackScope(scopes, root, LanguageId.CSharp);
@@ -95,11 +177,10 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var packageMaps = new Dictionary<string, PackageMapDescriptor>(StringComparer.Ordinal);
 		foreach (var packagePath in manifest.Where(static path => Path.GetFileName(path).Equals("package.json", StringComparison.OrdinalIgnoreCase)).Order(StringComparer.Ordinal))
 		{
-			var content = await ReadTextAsync(packagePath, cancellationToken).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, packagePath, content));
-			var directory = Path.GetDirectoryName(packagePath)!;
-			var descriptor = ParsePackageMap(directory, content);
-			packageMaps[PortableRelative(root, directory)] = descriptor;
+			var parsed = await ReadPackageAsync(packagePath).ConfigureAwait(false);
+			packageMaps[PortableRelative(root, parsed.Value.Directory)] = parsed.Value;
+			AddDiagnostic(packagePath, parsed.State, parsed.Reason,
+				scopes.Where(scope => IsWithin(parsed.Value.Directory, scope.Root)).Select(static scope => scope.ScopeId).ToArray());
 		}
 
 		return new DependencyResolverConfiguration(
@@ -108,53 +189,54 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			packageMaps,
 			DotNetCatalog.Value,
 			PythonCatalogs.Value,
-			NodeCatalog.Value);
+			NodeCatalog.Value)
+		{
+			ConfigurationDiagnostics = diagnostics
+				.GroupBy(static item => (item.Path, item.State, item.Reason))
+				.Select(static group => group.First() with
+				{
+					ScopeIds = group.SelectMany(static item => item.ScopeIds)
+						.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray()
+				})
+				.OrderBy(static item => item.Path, StringComparer.Ordinal)
+				.ToArray()
+		};
 	}
 
-	private static IReadOnlySet<string> ParseNodeDependencies(string content)
+	private static IReadOnlySet<string> ParseNodeDependencies(JsonElement root)
 	{
 		var result = new HashSet<string>(StringComparer.Ordinal);
-		try
+		foreach (var property in new[] { "dependencies", "devDependencies", "peerDependencies", "optionalDependencies" })
 		{
-			using var document = JsonDocument.Parse(content, new JsonDocumentOptions
-			{
-				AllowTrailingCommas = true,
-				CommentHandling = JsonCommentHandling.Skip
-			});
-			foreach (var property in new[] { "dependencies", "devDependencies", "peerDependencies", "optionalDependencies" })
-			{
-				if (!document.RootElement.TryGetProperty(property, out var dependencies) ||
-				    dependencies.ValueKind != JsonValueKind.Object)
-					continue;
-				foreach (var dependency in dependencies.EnumerateObject())
-					result.Add(dependency.Name);
-			}
-		}
-		catch (JsonException)
-		{
+			if (!root.TryGetProperty(property, out var dependencies) ||
+			    dependencies.ValueKind != JsonValueKind.Object)
+				continue;
+			foreach (var dependency in dependencies.EnumerateObject())
+				result.Add(dependency.Name);
 		}
 		return result;
 	}
 
-	private static string[] ParseProjectReferences(string projectPath, string content)
+	private static ConfigurationParseResult<string[]> ParseProjectReferences(string projectPath, string content)
 	{
 		try
 		{
 			var directory = Path.GetDirectoryName(projectPath)!;
-			return XDocument.Parse(content).Descendants()
+			return ConfigurationParseResult<string[]>.Valid(XDocument.Parse(content).Descendants()
 				.Where(static element => element.Name.LocalName == "ProjectReference")
 				.Select(element => element.Attribute("Include")?.Value)
 				.Where(static value => !string.IsNullOrWhiteSpace(value))
 				.Select(value => Path.GetFullPath(Path.Combine(directory, value!)))
-				.Distinct(PathComparer).Order(StringComparer.Ordinal).ToArray();
+				.Distinct(PathComparer).Order(StringComparer.Ordinal).ToArray());
 		}
-		catch (System.Xml.XmlException)
+		catch (System.Xml.XmlException exception)
 		{
-			return [];
+			return ConfigurationParseResult<string[]>.Failure(
+				[], DependencyConfigurationState.Corrupt, OneLine(exception.Message));
 		}
 	}
 
-	private static TypeScriptConfiguration ParseTypeScriptConfig(string content)
+	private static ConfigurationParseResult<TypeScriptConfiguration> ParseTypeScriptConfig(string content)
 	{
 		try
 		{
@@ -163,9 +245,24 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				AllowTrailingCommas = true,
 				CommentHandling = JsonCommentHandling.Skip
 			});
+			if (document.RootElement.ValueKind != JsonValueKind.Object)
+				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+					TypeScriptConfiguration.Default,
+					DependencyConfigurationState.UnsupportedSemantics,
+					"tsconfig root must be an object");
 			if (!document.RootElement.TryGetProperty("compilerOptions", out var options))
-				return TypeScriptConfiguration.Default;
-			var moduleResolution = options.TryGetProperty("moduleResolution", out var mode)
+				return ConfigurationParseResult<TypeScriptConfiguration>.Valid(TypeScriptConfiguration.Default);
+			if (options.ValueKind != JsonValueKind.Object)
+				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+					TypeScriptConfiguration.Default,
+					DependencyConfigurationState.Corrupt,
+					"tsconfig compilerOptions must be an object");
+			if (options.TryGetProperty("moduleResolution", out var mode) && mode.ValueKind != JsonValueKind.String)
+				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+					TypeScriptConfiguration.Default,
+					DependencyConfigurationState.UnsupportedSemantics,
+					"tsconfig compilerOptions.moduleResolution must be a string");
+			var moduleResolution = options.TryGetProperty("moduleResolution", out mode)
 				? mode.GetString() ?? "bundler"
 				: "bundler";
 			var legacy = moduleResolution.Equals("node10", StringComparison.OrdinalIgnoreCase) ||
@@ -174,46 +271,83 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			var allowJavaScript = options.TryGetProperty("allowJs", out var allowJs) &&
 			                      allowJs.ValueKind is JsonValueKind.True;
 			var paths = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
-			if (options.TryGetProperty("paths", out var mappings) && mappings.ValueKind == JsonValueKind.Object)
+			if (options.TryGetProperty("paths", out var mappings) && mappings.ValueKind != JsonValueKind.Object)
+				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+					TypeScriptConfiguration.Default,
+					DependencyConfigurationState.UnsupportedSemantics,
+					"tsconfig compilerOptions.paths must be an object");
+			if (mappings.ValueKind == JsonValueKind.Object)
 			{
 				foreach (var mapping in mappings.EnumerateObject())
-					paths[mapping.Name] = mapping.Value.ValueKind == JsonValueKind.Array
-						? mapping.Value.EnumerateArray().Where(static item => item.ValueKind == JsonValueKind.String)
-							.Select(static item => item.GetString()!).ToArray()
-						: [];
+				{
+					if (mapping.Value.ValueKind != JsonValueKind.Array ||
+					    mapping.Value.EnumerateArray().Any(static item => item.ValueKind != JsonValueKind.String))
+						return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+							TypeScriptConfiguration.Default,
+							DependencyConfigurationState.UnsupportedSemantics,
+							$"tsconfig path mapping '{mapping.Name}' must be an array of strings");
+					paths[mapping.Name] = mapping.Value.EnumerateArray()
+						.Select(static item => item.GetString()!).ToArray();
+				}
 			}
-			return new TypeScriptConfiguration(moduleResolution, legacy, paths, allowJavaScript);
+			return ConfigurationParseResult<TypeScriptConfiguration>.Valid(
+				new TypeScriptConfiguration(moduleResolution, legacy, paths, allowJavaScript));
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
-			return TypeScriptConfiguration.Default;
+			return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+				TypeScriptConfiguration.Default,
+				DependencyConfigurationState.Corrupt,
+				"invalid tsconfig JSON: " + OneLine(exception.Message));
 		}
 	}
 
-	private static PackageMapDescriptor ParsePackageMap(string directory, string content)
+	private static ConfigurationParseResult<PackageMapDescriptor> ParsePackageMap(string directory, string content)
 	{
 		try
 		{
 			using var document = JsonDocument.Parse(content);
-			return new PackageMapDescriptor(
+			if (document.RootElement.ValueKind != JsonValueKind.Object)
+				return ConfigurationParseResult<PackageMapDescriptor>.Failure(
+					UnavailablePackageMap(
+						directory,
+						DependencyConfigurationState.UnsupportedSemantics,
+						"package.json root must be an object"),
+					DependencyConfigurationState.UnsupportedSemantics,
+					"package.json root must be an object");
+			return ConfigurationParseResult<PackageMapDescriptor>.Valid(new PackageMapDescriptor(
 				directory,
 				document.RootElement.TryGetProperty("name", out var name) ? name.GetString() : null,
 				FlattenMap(document.RootElement, "imports"),
 				FlattenMap(document.RootElement, "exports"),
 				document.RootElement.TryGetProperty("type", out var type) ? type.GetString() : null,
-				ParseNodeDependencies(content));
+				ParseNodeDependencies(document.RootElement)));
 		}
-		catch (JsonException)
+		catch (Exception exception) when (exception is JsonException or InvalidOperationException)
 		{
-			return new PackageMapDescriptor(
-				directory,
-				null,
-				new Dictionary<string, PackageTargetDescriptor>(),
-				new Dictionary<string, PackageTargetDescriptor>(),
-				null,
-				new HashSet<string>());
+			return ConfigurationParseResult<PackageMapDescriptor>.Failure(
+				UnavailablePackageMap(directory, DependencyConfigurationState.Corrupt, OneLine(exception.Message)),
+				DependencyConfigurationState.Corrupt,
+				OneLine(exception.Message));
 		}
 	}
+
+	private static PackageMapDescriptor EmptyPackageMap(string directory) => new(
+		directory,
+		null,
+		new Dictionary<string, PackageTargetDescriptor>(),
+		new Dictionary<string, PackageTargetDescriptor>(),
+		null,
+		new HashSet<string>());
+
+	private static PackageMapDescriptor UnavailablePackageMap(
+		string directory,
+		DependencyConfigurationState state,
+		string? reason) => EmptyPackageMap(directory) with
+		{
+			ConfigurationState = state,
+			ConfigurationDiagnostic = reason ?? "package.json configuration is unavailable"
+		};
 
 	private static IReadOnlyDictionary<string, PackageTargetDescriptor> FlattenMap(JsonElement root, string property)
 	{
@@ -259,16 +393,6 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 
 	private static PackageTargetDescriptor UnsupportedPackageTarget(string reason) =>
 		new(PackageTargetKind.Unsupported, null, [], reason);
-
-	private static string? ReadPackageName(string content)
-	{
-		try
-		{
-			using var document = JsonDocument.Parse(content);
-			return document.RootElement.TryGetProperty("name", out var name) ? name.GetString() : null;
-		}
-		catch (JsonException) { return null; }
-	}
 
 	private static string? ParsePythonVersion(string content)
 	{
@@ -399,8 +523,6 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		() => LoadCatalog("node-24.json"),
 		LazyThreadSafetyMode.ExecutionAndPublication);
 
-	private static async Task<string> ReadTextAsync(string path, CancellationToken cancellationToken) =>
-		await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
 	private static bool IsTypeScriptConfig(string path) => Path.GetFileName(path) is "tsconfig.json" or "jsconfig.json";
 	private static bool IsPythonConfig(string path) => Path.GetFileName(path) is "pyproject.toml" or "setup.cfg";
 	private static string? FindNearestManifestFile(string directory, string root, string name, IReadOnlySet<string> manifest)
@@ -422,7 +544,11 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			language == LanguageId.TypeScript ? "bundler" : null, false,
 			new Dictionary<string, IReadOnlyList<string>>(), null, new HashSet<string>(),
 			language == LanguageId.Python ? new[] { root, Path.Combine(root, "src") } : [],
-			false));
+			false)
+		{
+			ConfigurationState = DependencyConfigurationState.Missing,
+			ConfigurationDiagnostic = "no owning configuration file in the manifest"
+		});
 	}
 	private static string Fingerprint(string root, string path, string content) => $"{PortableRelative(root, path)}\0{Hash([content])}";
 	private static string Hash(IEnumerable<string> values) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(string.Join('\n', values)))).ToLowerInvariant();
@@ -433,6 +559,20 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		return relative != ".." && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) && !Path.IsPathRooted(relative);
 	}
 	private static StringComparer PathComparer => OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+	private static string OneLine(string value) => value.Replace('\r', ' ').Replace('\n', ' ').Trim();
+	private sealed record ConfigurationParseResult<T>(
+		T Value,
+		DependencyConfigurationState State,
+		string? Reason)
+	{
+		public static ConfigurationParseResult<T> Valid(T value) =>
+			new(value, DependencyConfigurationState.Valid, null);
+
+		public static ConfigurationParseResult<T> Failure(
+			T value,
+			DependencyConfigurationState state,
+			string? reason) => new(value, state, reason ?? "configuration is unavailable");
+	}
 	private sealed record TypeScriptConfiguration(
 		string ModuleResolution,
 		bool Legacy,
@@ -445,4 +585,107 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			new Dictionary<string, IReadOnlyList<string>>(),
 			false);
 	}
+}
+
+internal interface IDependencyControlFileReader
+{
+	ValueTask<DependencyControlFileSnapshot> ReadAsync(
+		string path,
+		int maximumBytes,
+		CancellationToken cancellationToken);
+}
+
+internal sealed record DependencyControlFileSnapshot(
+	DependencyConfigurationState State,
+	string Content,
+	string? Reason,
+	string FingerprintValue);
+
+internal sealed class BoundedDependencyControlFileReader : IDependencyControlFileReader
+{
+	private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+
+	public async ValueTask<DependencyControlFileSnapshot> ReadAsync(
+		string path,
+		int maximumBytes,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			await using var stream = new FileStream(
+				path,
+				FileMode.Open,
+				FileAccess.Read,
+				FileShare.Read | FileShare.Delete,
+				64 * 1024,
+				FileOptions.Asynchronous | FileOptions.SequentialScan);
+			var length = stream.Length;
+			var lastWrite = File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks;
+			if (length > maximumBytes || length > int.MaxValue)
+			{
+				return Failure(
+					DependencyConfigurationState.UnsupportedSemantics,
+					$"configuration exceeds the {maximumBytes} byte limit",
+					length,
+					lastWrite);
+			}
+
+			var bytes = new byte[checked((int)length)];
+			var written = 0;
+			while (written < bytes.Length)
+			{
+				var read = await stream.ReadAsync(bytes.AsMemory(written), cancellationToken).ConfigureAwait(false);
+				if (read == 0) break;
+				written += read;
+			}
+			var currentLength = stream.Length;
+			var currentLastWrite = File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks;
+			if (written != bytes.Length || currentLength != length || currentLastWrite != lastWrite)
+			{
+				return Failure(
+					DependencyConfigurationState.Corrupt,
+					"configuration changed while it was being read",
+					currentLength,
+					currentLastWrite);
+			}
+			var offset = bytes.AsSpan().StartsWith(StrictUtf8.Preamble) ? StrictUtf8.Preamble.Length : 0;
+			var content = StrictUtf8.GetString(bytes.AsSpan(offset));
+			return new DependencyControlFileSnapshot(
+				DependencyConfigurationState.Valid,
+				content,
+				null,
+				$"valid:{length}:{lastWrite}:{Hash(bytes)}");
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (FileNotFoundException exception)
+		{
+			return Failure(DependencyConfigurationState.Missing, OneLine(exception.Message), 0, 0);
+		}
+		catch (DirectoryNotFoundException exception)
+		{
+			return Failure(DependencyConfigurationState.Missing, OneLine(exception.Message), 0, 0);
+		}
+		catch (DecoderFallbackException exception)
+		{
+			return Failure(DependencyConfigurationState.Corrupt, OneLine(exception.Message), 0, 0);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+		{
+			return Failure(DependencyConfigurationState.Corrupt, OneLine(exception.Message), 0, 0);
+		}
+	}
+
+	private static DependencyControlFileSnapshot Failure(
+		DependencyConfigurationState state,
+		string reason,
+		long length,
+		long lastWrite) => new(state, string.Empty, reason, $"{state}:{length}:{lastWrite}:{reason}");
+
+	private static string Hash(ReadOnlySpan<byte> bytes) =>
+		Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+	private static string OneLine(string value) => value.Replace('\r', ' ').Replace('\n', ' ').Trim();
 }

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -19,6 +19,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	private const string DiagnosticErrorQuery = "(ERROR) @diagnostic.error";
 	private readonly IGrammarLibraryLocator _locator;
 	private readonly IFileContentAnalyzer _contentAnalyzer;
+	private readonly BoundedDependencySourceReader? _boundedSourceReader;
 	private readonly IReadOnlyDictionary<LanguageId, LanguageDefinition> _definitions;
 	private readonly ConcurrentDictionary<LanguageId, Lazy<LanguageRuntime>> _runtimes = [];
 	private readonly ConcurrentDictionary<LanguageId, string> _extractorIdentities = [];
@@ -38,16 +39,25 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	}
 
 	internal TreeSitterDependencyFactExtractor(IGrammarLibraryLocator locator)
-		: this(locator, new FileContentAnalyzer())
+		: this(locator, new FileContentAnalyzer(), new BoundedDependencySourceReader())
 	{
 	}
 
 	internal TreeSitterDependencyFactExtractor(
 		IGrammarLibraryLocator locator,
 		IFileContentAnalyzer contentAnalyzer)
+		: this(locator, contentAnalyzer, null)
+	{
+	}
+
+	internal TreeSitterDependencyFactExtractor(
+		IGrammarLibraryLocator locator,
+		IFileContentAnalyzer contentAnalyzer,
+		BoundedDependencySourceReader? boundedSourceReader)
 	{
 		_locator = locator ?? throw new ArgumentNullException(nameof(locator));
 		_contentAnalyzer = contentAnalyzer ?? throw new ArgumentNullException(nameof(contentAnalyzer));
+		_boundedSourceReader = boundedSourceReader;
 		_definitions = LanguageDefinition.CreateAll();
 	}
 
@@ -205,6 +215,19 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		int maximumCharacters,
 		CancellationToken cancellationToken)
 	{
+		if (_boundedSourceReader is not null)
+		{
+			var read = await _boundedSourceReader
+				.ReadAsync(fullPath, maximumCharacters, cancellationToken)
+				.ConfigureAwait(false);
+			return new PreparedSourceContent(
+				read.Fingerprint,
+				GetExtractorIdentity(language),
+				read.Source,
+				read.Status,
+				read.StatusReason,
+				read.CanCache);
+		}
 		await using var snapshot = await _contentAnalyzer
 			.OpenCompleteSnapshotAsync(fullPath, cancellationToken)
 			.ConfigureAwait(false);
@@ -572,6 +595,158 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		int Entries,
 		int EvictionEntries,
 		long RetainedBytes);
+
+	internal sealed class BoundedDependencySourceReader
+	{
+		private const int BufferSize = 64 * 1024;
+		private static readonly Encoding StrictUtf8 = new UTF8Encoding(false, true);
+		private static readonly Encoding StrictUtf16Le = new UnicodeEncoding(false, true, true);
+		private static readonly Encoding StrictUtf16Be = new UnicodeEncoding(true, true, true);
+		private static readonly Encoding StrictUtf32Le = new UTF32Encoding(false, true, true);
+		private static readonly Encoding StrictUtf32Be = new UTF32Encoding(true, true, true);
+		private long _lastBytesRead;
+
+		internal long LastBytesRead => Interlocked.Read(ref _lastBytesRead);
+
+		internal async Task<BoundedDependencySourceRead> ReadAsync(
+			string path,
+			int maximumCharacters,
+			CancellationToken cancellationToken)
+		{
+			var byteBuffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+			var characterBuffer = ArrayPool<char>.Shared.Rent(checked(maximumCharacters + 1));
+			var bytesReadTotal = 0L;
+			var charactersWritten = 0;
+			try
+			{
+				await using var stream = new FileStream(
+					path,
+					FileMode.Open,
+					FileAccess.Read,
+					FileShare.Read | FileShare.Delete,
+					BufferSize,
+					FileOptions.Asynchronous | FileOptions.SequentialScan);
+				var length = stream.Length;
+				var lastWrite = File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks;
+				Decoder? decoder = null;
+				while (true)
+				{
+					cancellationToken.ThrowIfCancellationRequested();
+					var bytesRead = await stream.ReadAsync(
+						byteBuffer.AsMemory(0, BufferSize),
+						cancellationToken).ConfigureAwait(false);
+					if (bytesRead == 0)
+						break;
+					bytesReadTotal += bytesRead;
+					var input = byteBuffer.AsSpan(0, bytesRead);
+					if (decoder is null)
+					{
+						var (encoding, preambleLength) = DetectEncoding(input);
+						decoder = encoding.GetDecoder();
+						input = input[preambleLength..];
+					}
+					while (!input.IsEmpty)
+					{
+						decoder.Convert(
+							input,
+							characterBuffer.AsSpan(charactersWritten),
+							flush: false,
+							out var bytesUsed,
+							out var charactersUsed,
+							out _);
+						input = input[bytesUsed..];
+						charactersWritten += charactersUsed;
+						if (charactersWritten > maximumCharacters)
+							return TooLarge(length, lastWrite, maximumCharacters);
+						if (bytesUsed == 0 && charactersUsed == 0)
+							throw new IOException("The bounded dependency source decoder made no progress.");
+					}
+				}
+
+				decoder ??= StrictUtf8.GetDecoder();
+				decoder.Convert(
+					ReadOnlySpan<byte>.Empty,
+					characterBuffer.AsSpan(charactersWritten),
+					flush: true,
+					out _,
+					out var finalCharacters,
+					out var completed);
+				charactersWritten += finalCharacters;
+				if (charactersWritten > maximumCharacters)
+					return TooLarge(length, lastWrite, maximumCharacters);
+				if (!completed)
+					throw new IOException("The bounded dependency source decoder did not complete.");
+				if (stream.Length != length || File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks != lastWrite)
+					throw new IOException("The dependency source changed while it was being read.");
+				var source = new string(characterBuffer, 0, charactersWritten);
+				if (source.AsSpan().Contains('\0'))
+				{
+					return new BoundedDependencySourceRead(
+						MetadataFingerprint("binary", length, lastWrite),
+						string.Empty,
+						DependencyFileStatus.ExtractionFailed,
+						"source is binary");
+				}
+				return new BoundedDependencySourceRead(
+					ContentFingerprint.Compute(source.AsSpan()).ToHexString().ToLowerInvariant(),
+					source,
+					DependencyFileStatus.Supported,
+					null);
+			}
+			catch (DecoderFallbackException exception)
+			{
+				return new BoundedDependencySourceRead(
+					MetadataFingerprint("unsupported-encoding", 0, 0),
+					string.Empty,
+					DependencyFileStatus.ExtractionFailed,
+					$"source uses an unsupported encoding: {OneLine(exception.Message)}");
+			}
+			finally
+			{
+				Interlocked.Exchange(ref _lastBytesRead, bytesReadTotal);
+				CryptographicOperations.ZeroMemory(byteBuffer.AsSpan());
+				CryptographicOperations.ZeroMemory(MemoryMarshal.AsBytes(
+					characterBuffer.AsSpan(0, charactersWritten)));
+				ArrayPool<byte>.Shared.Return(byteBuffer);
+				ArrayPool<char>.Shared.Return(characterBuffer);
+			}
+		}
+
+		private static BoundedDependencySourceRead TooLarge(
+			long length,
+			long lastWrite,
+			int maximumCharacters) => new(
+			MetadataFingerprint("character-limit", length, lastWrite),
+			string.Empty,
+			DependencyFileStatus.ExtractionFailed,
+			$"file exceeds the {maximumCharacters} character parse limit");
+
+		private static (Encoding Encoding, int PreambleLength) DetectEncoding(ReadOnlySpan<byte> bytes)
+		{
+			if (bytes.Length >= 4 && bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF)
+				return (StrictUtf32Be, 4);
+			if (bytes.Length >= 4 && bytes[0] == 0xFF && bytes[1] == 0xFE && bytes[2] == 0x00 && bytes[3] == 0x00)
+				return (StrictUtf32Le, 4);
+			if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+				return (StrictUtf8, 3);
+			if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+				return (StrictUtf16Be, 2);
+			if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+				return (StrictUtf16Le, 2);
+			return (StrictUtf8, 0);
+		}
+
+		private static string MetadataFingerprint(string state, long length, long lastWrite) =>
+			Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"{state}:{length}:{lastWrite}")))
+				.ToLowerInvariant();
+	}
+
+	internal sealed record BoundedDependencySourceRead(
+		string Fingerprint,
+		string Source,
+		DependencyFileStatus Status,
+		string? StatusReason,
+		bool CanCache = true);
 
 	private sealed record PreparedSourceContent(
 		string Fingerprint,

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text;
 using DevProjex.Application.Dependencies;
 using DevProjex.Infrastructure.Compression;
@@ -476,6 +477,82 @@ public sealed class DependencyFactsEngineIntegrationTests
 
 		Assert.Contains(result.Edges, edge => edge.Reference == "react" && edge.Status == ResolutionStatus.External);
 		Assert.Contains(result.Edges, edge => edge.Reference == "not-declared" && edge.Status == ResolutionStatus.Unresolved);
+	}
+
+	[Theory]
+	[InlineData("{\"compilerOptions\":null}", DependencyConfigurationState.Corrupt, "compilerOptions must be an object")]
+	[InlineData("{\"compilerOptions\":{", DependencyConfigurationState.Corrupt, "JSON")]
+	[InlineData("[]", DependencyConfigurationState.UnsupportedSemantics, "root must be an object")]
+	public async Task TypeScriptConfigurationFailures_AreDiagnosedAndLeaveReferencesUnresolved(
+		string configurationContent,
+		DependencyConfigurationState expectedState,
+		string expectedReason)
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", configurationContent);
+		var source = fixture.CreateFile("main.ts", "import value from './target.js';");
+		var target = fixture.CreateFile("target.ts", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "main.ts");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Contains(expectedReason, Assert.Single(edge.Reasons), StringComparison.OrdinalIgnoreCase);
+		var diagnostic = Assert.Single(result.Coverage.ConfigurationDiagnostics);
+		Assert.Equal("tsconfig.json", diagnostic.Path);
+		Assert.Equal(expectedState, diagnostic.State);
+	}
+
+	[Fact]
+	public async Task DependencyConfigurationRead_IsBoundedAndMissingConfigurationRemainsExplicit()
+	{
+		using var fixture = new TemporaryDirectory();
+		var oversized = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"padding\":\"" + new string('x', FileDependencyConfigurationProvider.MaximumConfigurationBytes) + "\"}");
+		var source = fixture.CreateFile("main.ts", "import value from './target.js';");
+		var target = fixture.CreateFile("target.ts", "export default 1;");
+		var provider = new FileDependencyConfigurationProvider();
+
+		var oversizedConfiguration = await provider.ReadAsync(
+			fixture.Path,
+			[oversized, source, target],
+			TestContext.Current.CancellationToken);
+		var oversizedScope = Assert.Single(oversizedConfiguration.Scopes,
+			scope => scope.LanguageId == LanguageId.TypeScript && scope.HasConfiguration);
+		Assert.Equal(DependencyConfigurationState.UnsupportedSemantics, oversizedScope.ConfigurationState);
+		Assert.Contains("byte limit", oversizedScope.ConfigurationDiagnostic, StringComparison.Ordinal);
+
+		var missingConfiguration = await provider.ReadAsync(
+			fixture.Path,
+			[source, target],
+			TestContext.Current.CancellationToken);
+		var fallback = Assert.Single(missingConfiguration.Scopes, scope => scope.LanguageId == LanguageId.TypeScript);
+		Assert.False(fallback.HasConfiguration);
+		Assert.Equal(DependencyConfigurationState.Missing, fallback.ConfigurationState);
+		Assert.Empty(missingConfiguration.ConfigurationDiagnostics);
+	}
+
+	[Fact]
+	public async Task ConfigurationProvider_ReadsEachControlFileOncePerOperation()
+	{
+		using var fixture = new TemporaryDirectory();
+		var package = fixture.CreateFile("package.json", "{\"name\":\"fixture\",\"type\":\"module\"}");
+		var rootConfig = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var nestedConfig = fixture.CreateFile("nested/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var reader = new CountingControlFileReader();
+		var provider = new FileDependencyConfigurationProvider(reader);
+
+		_ = await provider.ReadAsync(
+			fixture.Path,
+			[package, rootConfig, nestedConfig],
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(1, reader.CountFor(package));
+		Assert.Equal(1, reader.CountFor(rootConfig));
+		Assert.Equal(1, reader.CountFor(nestedConfig));
 	}
 
 	[Fact]
@@ -1530,6 +1607,23 @@ public sealed class DependencyFactsEngineIntegrationTests
 		{
 			ReadCount++;
 			return _inner.ReadAsync(sourceRoot, manifestFiles, cancellationToken);
+		}
+	}
+
+	private sealed class CountingControlFileReader : IDependencyControlFileReader
+	{
+		private readonly BoundedDependencyControlFileReader _inner = new();
+		private readonly ConcurrentDictionary<string, int> _counts = new(PathComparer.Default);
+
+		public int CountFor(string path) => _counts.GetValueOrDefault(Path.GetFullPath(path));
+
+		public ValueTask<DependencyControlFileSnapshot> ReadAsync(
+			string path,
+			int maximumBytes,
+			CancellationToken cancellationToken)
+		{
+			_counts.AddOrUpdate(Path.GetFullPath(path), 1, static (_, count) => count + 1);
+			return _inner.ReadAsync(path, maximumBytes, cancellationToken);
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -1326,6 +1326,56 @@ public sealed class DependencyFactsEngineIntegrationTests
 		Assert.Equal(0, extractor.ParseCount);
 	}
 
+	[Theory]
+	[InlineData("utf8")]
+	[InlineData("utf16-le")]
+	[InlineData("utf16-be")]
+	public async Task BoundedDependencySourceRead_StopsAfterTheDecodedCharacterLimit(string encodingName)
+	{
+		const int maximumCharacters = 100_000;
+		using var fixture = new TemporaryDirectory();
+		Encoding encoding = encodingName switch
+		{
+			"utf8" => new UTF8Encoding(true, true),
+			"utf16-le" => new UnicodeEncoding(false, true, true),
+			"utf16-be" => new UnicodeEncoding(true, true, true),
+			_ => throw new ArgumentOutOfRangeException(nameof(encodingName))
+		};
+		var bytes = encoding.GetPreamble()
+			.Concat(encoding.GetBytes(new string('x', maximumCharacters * 3)))
+			.ToArray();
+		var path = fixture.CreateFile("Large.cs", string.Empty);
+		File.WriteAllBytes(path, bytes);
+		var reader = new TreeSitterDependencyFactExtractor.BoundedDependencySourceReader();
+
+		var result = await reader.ReadAsync(path, maximumCharacters, TestContext.Current.CancellationToken);
+
+		Assert.Equal(DependencyFileStatus.ExtractionFailed, result.Status);
+		Assert.Contains("character parse limit", result.StatusReason, StringComparison.Ordinal);
+		Assert.InRange(reader.LastBytesRead, 1, bytes.Length - 1L);
+	}
+
+	[Fact]
+	public async Task BoundedDependencySourceRead_PreservesBomTextAndRejectsAnIncompleteSequence()
+	{
+		using var fixture = new TemporaryDirectory();
+		var unicode = new UnicodeEncoding(false, true, true);
+		var validBytes = unicode.GetPreamble().Concat(unicode.GetBytes("class Valid { }")).ToArray();
+		var valid = fixture.CreateFile("Valid.cs", string.Empty);
+		File.WriteAllBytes(valid, validBytes);
+		var incomplete = fixture.CreateFile("Incomplete.cs", string.Empty);
+		File.WriteAllBytes(incomplete, [0x63, 0x6c, 0x61, 0x73, 0x73, 0x20, 0xE2, 0x82]);
+		var reader = new TreeSitterDependencyFactExtractor.BoundedDependencySourceReader();
+
+		var validResult = await reader.ReadAsync(valid, 100, TestContext.Current.CancellationToken);
+		var incompleteResult = await reader.ReadAsync(incomplete, 100, TestContext.Current.CancellationToken);
+
+		Assert.Equal(DependencyFileStatus.Supported, validResult.Status);
+		Assert.Equal("class Valid { }", validResult.Source);
+		Assert.Equal(DependencyFileStatus.ExtractionFailed, incompleteResult.Status);
+		Assert.Contains("unsupported encoding", incompleteResult.StatusReason, StringComparison.Ordinal);
+	}
+
 	[Fact]
 	public async Task WarmRelatedQuery_ReusesTheCanonicalFileLookupFromTheResolvedSnapshot()
 	{

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -40,6 +40,7 @@ public sealed class DependencyFactsEngineIntegrationTests
 		var userEdge = Assert.Single(index.Edges, edge =>
 			edge.Source == "Consumer.cs" && edge.Reference == "User");
 		Assert.Equal(ResolutionStatus.Resolved, userEdge.Status);
+		Assert.Equal(["First.cs", "Second.cs"], userEdge.DeclarationFiles);
 		Assert.Contains("First.cs", userEdge.Candidates);
 		var resolvedReference = Assert.Single(index.Files.Single(file => file.Path == "Consumer.cs").References,
 			reference => reference.Name == "User");
@@ -50,6 +51,31 @@ public sealed class DependencyFactsEngineIntegrationTests
 		var localEdge = Assert.Single(index.Edges, edge =>
 			edge.Source == "Second.cs" && edge.Reference == "Helper");
 		Assert.Equal(ResolutionStatus.Unresolved, localEdge.Status);
+
+		var dependencies = await engine.FindRelatedAsync(
+			fixture.Path,
+			[project, first, second, ambiguous, global, marker, consumer],
+			["Consumer.cs"],
+			DependencyDirection.Dependencies,
+			cancellationToken: TestContext.Current.CancellationToken);
+		var partialDependencies = Assert.Single(dependencies.Seeds).Dependencies
+			.Where(item => item.Path is "First.cs" or "Second.cs")
+			.ToArray();
+		Assert.Equal(["First.cs", "Second.cs"], partialDependencies.Select(static item => item.Path));
+		Assert.All(partialDependencies, item =>
+		{
+			Assert.Equal(ResolutionStatus.Resolved, item.Status);
+			Assert.Contains(item.Reasons, reason => reason.Contains("one resolved symbol with 2 files", StringComparison.Ordinal));
+		});
+
+		var dependents = await engine.FindRelatedAsync(
+			fixture.Path,
+			[project, first, second, ambiguous, global, marker, consumer],
+			["Second.cs"],
+			DependencyDirection.Dependents,
+			cancellationToken: TestContext.Current.CancellationToken);
+		var caller = Assert.Single(Assert.Single(dependents.Seeds).Dependents, item => item.Path == "Consumer.cs");
+		Assert.Contains(caller.Reasons, reason => reason.Contains("one resolved symbol with 2 files", StringComparison.Ordinal));
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -385,6 +385,84 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task TypeScriptConditionalExports_SelectRequireForCommonJsSourceInObjectOrder()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var package = fixture.CreateFile("package.json", "{\"name\":\"self\",\"exports\":{\"import\":\"./import.mjs\",\"require\":\"./require.cjs\"}}");
+		var source = fixture.CreateFile("main.cts", "import value from 'self';");
+		var importTarget = fixture.CreateFile("import.mjs", "export default 1;");
+		var requireTarget = fixture.CreateFile("require.cjs", "module.exports = 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, package, source, importTarget, requireTarget],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Reference == "self");
+		Assert.Equal("require.cjs", edge.Target);
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+	}
+
+	[Fact]
+	public async Task TypeScriptConditionalExports_NullBlocksOnlyTheApplicableCondition()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var package = fixture.CreateFile("package.json", "{\"name\":\"self\",\"exports\":{\"import\":null,\"require\":\"./require.cjs\"}}");
+		var source = fixture.CreateFile("main.cts", "import value from 'self';");
+		var requireTarget = fixture.CreateFile("require.cjs", "module.exports = 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, package, source, requireTarget],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal("require.cjs", Assert.Single(result.Edges, item => item.Reference == "self").Target);
+	}
+
+	[Fact]
+	public async Task TypeScriptConditionalExports_DefaultBeforeImportWinsByDeclarationOrder()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var package = fixture.CreateFile("package.json", "{\"name\":\"self\",\"type\":\"module\",\"exports\":{\"default\":\"./default.js\",\"import\":\"./import.mjs\"}}");
+		var source = fixture.CreateFile("main.mts", "import value from 'self';");
+		var defaultTarget = fixture.CreateFile("default.js", "export default 1;");
+		var importTarget = fixture.CreateFile("import.mjs", "export default 2;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, package, source, defaultTarget, importTarget],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal("default.js", Assert.Single(result.Edges, item => item.Reference == "self").Target);
+	}
+
+	[Fact]
+	public async Task TypeScriptConditionalExports_ResolveNestedEsmConditionsAndFailClosedOnUnknownConditions()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var validPackage = fixture.CreateFile("valid/package.json", "{\"name\":\"valid\",\"type\":\"module\",\"exports\":{\"node\":{\"import\":\"./entry.mjs\",\"require\":\"./entry.cjs\"}}}");
+		var validSource = fixture.CreateFile("valid/main.mts", "import value from 'valid';");
+		var esmTarget = fixture.CreateFile("valid/entry.mjs", "export default 1;");
+		var cjsTarget = fixture.CreateFile("valid/entry.cjs", "module.exports = 1;");
+		var unknownPackage = fixture.CreateFile("unknown/package.json", "{\"name\":\"unknown\",\"type\":\"module\",\"exports\":{\"browser\":\"./browser.js\",\"default\":\"./default.js\"}}");
+		var unknownSource = fixture.CreateFile("unknown/main.mts", "import value from 'unknown';");
+		var browserTarget = fixture.CreateFile("unknown/browser.js", "export default 1;");
+		var fallbackTarget = fixture.CreateFile("unknown/default.js", "export default 2;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, validPackage, validSource, esmTarget, cjsTarget, unknownPackage, unknownSource, browserTarget, fallbackTarget],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal("valid/entry.mjs", Assert.Single(result.Edges, item => item.Reference == "valid").Target);
+		var unsupported = Assert.Single(result.Edges, item => item.Reference == "unknown");
+		Assert.Equal(ResolutionStatus.Unresolved, unsupported.Status);
+		Assert.Contains("condition 'browser' is not supported", Assert.Single(unsupported.Reasons), StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public async Task TypeScriptBareImports_RequireDeclaredExternalEvidence()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -571,6 +571,64 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task PythonImport_PrefersARegularPackageOverTheSameNamedModule()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var module = fixture.CreateFile("pkg.py", "value = 'module'");
+		var initializer = fixture.CreateFile("pkg/__init__.py", "value = 'package'");
+		var consumer = fixture.CreateFile("consumer.py", "import pkg");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, module, initializer, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py" && item.Reference == "pkg");
+		Assert.Equal("pkg/__init__.py", edge.Target);
+		Assert.DoesNotContain("pkg.py", edge.Candidates);
+	}
+
+	[Fact]
+	public async Task PythonFromImport_PrefersAStaticPackageBindingOverAChildModule()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var initializer = fixture.CreateFile("pkg/__init__.py", "from .impl import Service");
+		var implementation = fixture.CreateFile("pkg/impl.py", "class Service: pass");
+		var child = fixture.CreateFile("pkg/Service.py", "class Wrong: pass");
+		var consumer = fixture.CreateFile("consumer.py", "from pkg import Service");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, initializer, implementation, child, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py" && item.Reference == "pkg");
+		Assert.Equal("pkg/impl.py", edge.Target);
+		Assert.DoesNotContain("pkg/Service.py", edge.Candidates);
+	}
+
+	[Fact]
+	public async Task PythonRelativeImport_RejectsTraversalBeyondTheTopLevelPackage()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var initializer = fixture.CreateFile("pkg/__init__.py", string.Empty);
+		var consumer = fixture.CreateFile("pkg/consumer.py", "from .. import target");
+		var target = fixture.CreateFile("target.py", "value = 1");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, initializer, consumer, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "pkg/consumer.py");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
+		Assert.Contains("beyond the top-level package", Assert.Single(edge.Reasons), StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public async Task PythonPlatformCatalog_UsesDeclaredTargetVersionAndAConservativeUnknownVersion()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/DependencyFactsCacheBoundsTests.cs
+++ b/Tests/DevProjex.Tests.Unit/DependencyFactsCacheBoundsTests.cs
@@ -1,0 +1,132 @@
+using DevProjex.Application.Dependencies;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class DependencyFactsCacheBoundsTests
+{
+	[Fact]
+	public async Task ManifestSnapshotEviction_RemainsBoundedAcrossRepeatedGenerations()
+	{
+		using var fixture = new TemporaryDirectory();
+		var files = Enumerable.Range(0, 17)
+			.Select(index => fixture.CreateFile($"File{index:D2}.cs", $"file-{index}"))
+			.ToArray();
+		using var engine = new DependencyFactsEngine(
+			new SyntheticFactExtractor(),
+			new EmptyConfigurationProvider(),
+			new DependencyFactsLimits(MaximumCachedIndexes: 16));
+
+		for (var iteration = 0; iteration < 10_000; iteration++)
+		{
+			await engine.IndexAsync(
+				fixture.Path,
+				[files[iteration % files.Length]],
+				cancellationToken: TestContext.Current.CancellationToken);
+		}
+
+		Assert.InRange(engine.CacheState.ManifestSnapshots, 0, 16);
+		Assert.Equal(engine.CacheState.ManifestSnapshots, engine.CacheState.ManifestEvictionEntries);
+	}
+
+	[Fact]
+	public async Task ResolvedIndexEstimate_IncludesDeclarationsAndTheirSites()
+	{
+		using var fixture = new TemporaryDirectory();
+		var source = fixture.CreateFile("Declarations.cs", "declarations");
+		using var engine = new DependencyFactsEngine(
+			new SyntheticFactExtractor(declarationsPerFile: 200),
+			new EmptyConfigurationProvider(),
+			new DependencyFactsLimits(MaximumIndexCacheBytes: 4 * 1024));
+
+		_ = await engine.IndexAsync(
+			fixture.Path,
+			[source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var repeated = await engine.IndexAsync(
+			fixture.Path,
+			[source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.False(repeated.Metrics.ResolutionCacheHit);
+		Assert.Equal(0, engine.CacheState.ResolvedIndexes);
+		Assert.Equal(0, engine.CacheState.ResolvedIndexBytes);
+	}
+
+	private sealed class SyntheticFactExtractor(int declarationsPerFile = 0) : IDependencyFactExtractor
+	{
+		private int _parseCount;
+		public int ParseCount => Volatile.Read(ref _parseCount);
+		public int CompiledQuerySetCount => 0;
+
+		public ValueTask<PreparedDependencySource> PrepareAsync(
+			string sourceRoot,
+			string fullPath,
+			DependencyResolverConfiguration configuration,
+			DependencyFactsLimits limits,
+			CancellationToken cancellationToken,
+			string? contentIdentity = null)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var relative = Path.GetRelativePath(sourceRoot, fullPath).Replace('\\', '/');
+			return ValueTask.FromResult(new PreparedDependencySource(
+				fullPath,
+				relative,
+				"fixture",
+				LanguageId.CSharp,
+				relative,
+				"synthetic:v1",
+				string.Empty));
+		}
+
+		public FileFacts Extract(PreparedDependencySource source, DependencyFactsLimits limits)
+		{
+			Interlocked.Increment(ref _parseCount);
+			var declarations = Enumerable.Range(0, declarationsPerFile)
+				.Select(index => new DeclarationFact(
+					new SymbolIdentity(
+						source.ScopeId,
+						source.LanguageId,
+						SymbolKind.Class,
+						$"Fixture.Type{index:D4}",
+						0),
+					[new SourceSite(source.RelativePath, index + 1, $"Type{index:D4}")]))
+				.ToArray();
+			return new FileFacts(
+				source.RelativePath,
+				source.ScopeId,
+				source.LanguageId,
+				source.ContentFingerprint,
+				0,
+				DependencyFileStatus.Supported,
+				null,
+				false,
+				new Dictionary<string, int>(),
+				declarations,
+				[],
+				[],
+				[],
+				new Dictionary<string, string>(),
+				[],
+				new Dictionary<string, string>(),
+				[]);
+		}
+
+		public void Dispose()
+		{
+		}
+	}
+
+	private sealed class EmptyConfigurationProvider : IDependencyConfigurationProvider
+	{
+		public Task<DependencyResolverConfiguration> ReadAsync(
+			string sourceRoot,
+			IReadOnlyList<string> manifestFiles,
+			CancellationToken cancellationToken) => Task.FromResult(new DependencyResolverConfiguration(
+			"fixture",
+			[],
+			new Dictionary<string, PackageMapDescriptor>(),
+			new HashSet<string>(),
+			new Dictionary<string, IReadOnlySet<string>>(),
+			new HashSet<string>()));
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/FocusRankingEngineTests.cs
+++ b/Tests/DevProjex.Tests.Unit/FocusRankingEngineTests.cs
@@ -154,6 +154,23 @@ public sealed class FocusRankingEngineTests
 	}
 
 	[Fact]
+	public void Focus_VisitsEveryDeclarationFileOfOneResolvedSymbolAtHopOne()
+	{
+		var edge = Edge("caller.cs", "part-a.cs") with
+		{
+			DeclarationFiles = ["part-a.cs", "part-b.cs"]
+		};
+		var fixture = CreateFixture(
+			["caller.cs", "part-a.cs", "part-b.cs"],
+			[edge]);
+
+		var result = Apply(fixture, [Seed(fixture, "caller.cs")]);
+
+		Assert.Equal(1, Assert.Single(result.Entries, item => item.Path == "part-a.cs").Hop);
+		Assert.Equal(1, Assert.Single(result.Entries, item => item.Path == "part-b.cs").Hop);
+	}
+
+	[Fact]
 	public void Apply_ReportsBidirectionalEdgesAndHonorsCancellation()
 	{
 		var fixture = CreateFixture(

--- a/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ImportanceRankingServiceTests.cs
@@ -177,6 +177,35 @@ public sealed class ImportanceRankingServiceTests
 	}
 
 	[Fact]
+	public void BuildGraph_SplitsOneResolvedSymbolWeightAcrossAllDeclarationFiles()
+	{
+		var partial = Edge("caller.cs", "part-a.cs") with
+		{
+			DeclarationFiles = ["part-a.cs", "part-b.cs"]
+		};
+		var direct = Edge("caller.cs", "single.cs");
+		var files = new[] { "caller.cs", "part-a.cs", "part-b.cs", "single.cs" };
+		var snapshot = Snapshot([partial, direct]) with
+		{
+			Files = files.Select(path => CreateFacts(path, null)).ToArray()
+		};
+		var candidates = files.Select(path => new ImportanceRankingService.Candidate(path, path)).ToArray();
+
+		var graph = ImportanceRankingService.BuildGraph(
+			candidates,
+			snapshot,
+			TestContext.Current.CancellationToken);
+
+		var source = graph.NodeByPath["caller.cs"];
+		var weightedTargets = graph.Outgoing[source]
+			.Select((target, index) => (Path: graph.Paths[target], Weight: graph.OutgoingWeights[source][index]))
+			.ToDictionary(static item => item.Path, static item => item.Weight, StringComparer.Ordinal);
+		Assert.Equal(0.5, weightedTargets["part-a.cs"]);
+		Assert.Equal(0.5, weightedTargets["part-b.cs"]);
+		Assert.Equal(1, weightedTargets["single.cs"]);
+	}
+
+	[Fact]
 	public void CalculatePageRank_IsDeterministicAcrossInputOrderAndOmitsUnsupportedFiles()
 	{
 		var edges = new[] { Edge("a.cs", "b.cs"), Edge("c.cs", "b.cs"), Edge("b.cs", "a.cs") };

--- a/Tests/Fixtures/DependencyFacts/python/expected.json
+++ b/Tests/Fixtures/DependencyFacts/python/expected.json
@@ -2,7 +2,7 @@
   "name": "python",
   "edges": [
     { "source": "src/pkg/consumer.py", "reference": "", "status": "Resolved", "target": "src/pkg/sibling.py" },
-    { "source": "src/pkg/consumer.py", "reference": "pkg", "status": "Resolved", "target": "src/pkg/__init__.py" },
+    { "source": "src/pkg/consumer.py", "reference": "pkg", "status": "Resolved", "target": "src/pkg/public.py" },
     { "source": "src/pkg/consumer.py", "reference": "pkg.*", "status": "Unresolved", "reasonContains": "dynamic __all__" },
     { "source": "src/pkg/namespaces.py", "reference": "ns", "status": "Resolved", "target": "namespace:ns" },
     { "source": "src/pkg/namespaces.py", "reference": "ns.alpha", "status": "Resolved", "target": "ns/alpha.py" },

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
-  "runDate": "2026-09-07",
-  "productSha": "25b4acb6283913afe989374be60883694cb090a9",
-  "evaluatorSha": "25b4acb6283913afe989374be60883694cb090a9",
+  "runDate": "2026-09-08",
+  "productSha": "63fcc291a1379c6e9d03bc1d815aa51f986426c4",
+  "evaluatorSha": "63fcc291a1379c6e9d03bc1d815aa51f986426c4",
   "repositories": [
     {
       "id": "devprojex",
@@ -33,7 +33,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7883941970985493,
+              "irrelevantTokenShare": 0.7885,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -95,7 +95,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.857625,
+              "irrelevantTokenShare": 0.8576072009001126,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -103,7 +103,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.857625,
+              "irrelevantTokenShare": 0.8576072009001126,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -141,7 +141,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.947125,
+              "irrelevantTokenShare": 0.9471216951059441,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -157,7 +157,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9288125,
+              "irrelevantTokenShare": 0.9288036004500563,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -195,7 +195,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.8864716179044762,
+              "irrelevantTokenShare": 0.8864432216108054,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -249,7 +249,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9432429053631703,
+              "irrelevantTokenShare": 0.943235808952238,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -257,7 +257,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.68575,
+              "irrelevantTokenShare": 0.6857107138392299,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -303,7 +303,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.971625,
+              "irrelevantTokenShare": 0.9716232264516532,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -311,7 +311,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.971625,
+              "irrelevantTokenShare": 0.9716232264516532,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -319,7 +319,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9716214526815852,
+              "irrelevantTokenShare": 0.971625,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -365,7 +365,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.639,
+              "irrelevantTokenShare": 0.6388194097048524,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -373,7 +373,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.6388194097048524,
+              "irrelevantTokenShare": 0.6389097274318579,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -465,7 +465,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9097387173396675,
+              "irrelevantTokenShare": 0.90975,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -473,7 +473,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.90975,
+              "irrelevantTokenShare": 0.9097443590224389,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -573,7 +573,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.34158539634908724,
+              "irrelevantTokenShare": 0.34175,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -635,7 +635,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.670875,
+              "irrelevantTokenShare": 0.6708544284017751,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -805,7 +805,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.30614413400837553,
+              "irrelevantTokenShare": 0.3061875,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2726.3282,
-          "medianPeakWorkingSetBytes": 300453888,
+          "medianElapsedMilliseconds": 2596.1262,
+          "medianPeakWorkingSetBytes": 304263168,
           "elapsedMilliseconds": [
-            2717.9614,
-            2726.3282,
-            2698.6197,
-            2737.7128,
-            2696.9874,
-            2890.9551,
-            2762.2087
+            3020.15,
+            2613.2415,
+            2596.1262,
+            2592.749,
+            2629.6301,
+            2586.9825,
+            2591.674
           ],
           "peakWorkingSetBytes": [
-            301821952,
-            300449792,
-            301756416,
-            300204032,
-            301486080,
-            300007424,
-            300453888
+            304521216,
+            303935488,
+            304263168,
+            303763456,
+            303464448,
+            306647040,
+            304279552
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2778.9973,
-          "medianPeakWorkingSetBytes": 302862336,
+          "medianElapsedMilliseconds": 2655.8346,
+          "medianPeakWorkingSetBytes": 303951872,
           "elapsedMilliseconds": [
-            2767.7627,
-            2753.9851,
-            2844.6242,
-            2778.9973,
-            2762.3726,
-            2814.7969,
-            2791.7261
+            2688.049,
+            2615.0937,
+            2669.8165,
+            2656.2968,
+            2548.037,
+            2655.8346,
+            2547.3124
           ],
           "peakWorkingSetBytes": [
-            305172480,
-            301531136,
-            302862336,
-            302284800,
-            304816128,
-            302735360,
-            303968256
+            304242688,
+            303292416,
+            303792128,
+            305012736,
+            304541696,
+            303951872,
+            303378432
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 963.2234,
-          "medianPeakWorkingSetBytes": 313761792,
+          "medianElapsedMilliseconds": 2370.5226,
+          "medianPeakWorkingSetBytes": 379920384,
           "elapsedMilliseconds": [
-            956.5843,
-            999.0454,
-            963.2234,
-            1083.6795,
-            901.2034,
-            961.8287,
-            983.3566
+            2370.5226,
+            2359.9898,
+            2251.8089,
+            2253.025,
+            2390.4163,
+            2537.8765,
+            2505.0276
           ],
           "peakWorkingSetBytes": [
-            313761792,
-            321998848,
-            316080128,
-            317079552,
-            310820864,
-            305303552,
-            310005760
+            379789312,
+            379846656,
+            378404864,
+            380440576,
+            379957248,
+            379920384,
+            381562880
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 1047.1624,
-          "medianPeakWorkingSetBytes": 317468672,
+          "medianElapsedMilliseconds": 2386.5551,
+          "medianPeakWorkingSetBytes": 380944384,
           "elapsedMilliseconds": [
-            931.4746,
-            966.4111,
-            1223.7262,
-            1398.1819,
-            1565.1181,
-            1047.1624,
-            901.116
+            2551.3588,
+            2608.1176,
+            2839.8019,
+            2195.9694,
+            2386.5551,
+            2187.2311,
+            2144.8493
           ],
           "peakWorkingSetBytes": [
-            316710912,
-            308109312,
-            319959040,
-            317468672,
-            325844992,
-            322748416,
-            307859456
+            382279680,
+            380944384,
+            381575168,
+            377806848,
+            380944384,
+            378834944,
+            378568704
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 807.9358,
-          "medianPeakWorkingSetBytes": 115171328,
+          "medianElapsedMilliseconds": 735.4462,
+          "medianPeakWorkingSetBytes": 116846592,
           "elapsedMilliseconds": [
-            822.7609,
-            822.0804,
-            799.3832,
-            804.1743,
-            800.7245,
-            819.1301,
-            807.9358
+            716.9566,
+            732.1489,
+            750.4801,
+            729.276,
+            735.4462,
+            739.1756,
+            777.382
           ],
           "peakWorkingSetBytes": [
-            113483776,
-            115171328,
-            115089408,
-            115265536,
-            115363840,
-            115073024,
-            115875840
+            117661696,
+            117002240,
+            116068352,
+            116846592,
+            118169600,
+            115400704,
+            115802112
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 809.4142,
-          "medianPeakWorkingSetBytes": 115118080,
+          "medianElapsedMilliseconds": 767.7423,
+          "medianPeakWorkingSetBytes": 116482048,
           "elapsedMilliseconds": [
-            863.4567,
-            855.5966,
-            817.3058,
-            806.9406,
-            807.3073,
-            799.7565,
-            809.4142
+            802.1455,
+            794.2094,
+            814.2577,
+            731.1579,
+            767.7423,
+            749.9931,
+            746.4546
           ],
           "peakWorkingSetBytes": [
-            115281920,
-            115224576,
-            115724288,
-            115089408,
-            114823168,
-            115118080,
-            114868224
+            116154368,
+            117051392,
+            116617216,
+            114176000,
+            116482048,
+            118571008,
+            116072448
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 404.5227,
-          "medianPeakWorkingSetBytes": 112218112,
+          "medianElapsedMilliseconds": 393.6513,
+          "medianPeakWorkingSetBytes": 116854784,
           "elapsedMilliseconds": [
-            414.3616,
-            400.5229,
-            403.9158,
-            410.2114,
-            405.5427,
-            404.5227,
-            400.8836
+            366.9047,
+            404.1117,
+            514.3201,
+            380.3471,
+            384.2012,
+            393.6513,
+            395.1191
           ],
           "peakWorkingSetBytes": [
-            112283648,
-            111759360,
-            112091136,
-            112218112,
-            112128000,
-            112218112,
-            112308224
+            117424128,
+            116375552,
+            117100544,
+            116514816,
+            116854784,
+            116867072,
+            116719616
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 412.8746,
-          "medianPeakWorkingSetBytes": 112537600,
+          "medianElapsedMilliseconds": 428.4383,
+          "medianPeakWorkingSetBytes": 117723136,
           "elapsedMilliseconds": [
-            421.067,
-            415.5048,
-            403.0993,
-            410.5365,
-            420.8001,
-            412.8746,
-            403.8871
+            421.7354,
+            440.6707,
+            423.3542,
+            428.4383,
+            471.6773,
+            411.2595,
+            464.856
           ],
           "peakWorkingSetBytes": [
-            111996928,
-            112574464,
-            112300032,
-            112340992,
-            112865280,
-            113086464,
-            112537600
+            116736000,
+            117760000,
+            117563392,
+            120389632,
+            117305344,
+            117723136,
+            118829056
           ]
         }
       ]
@@ -1925,7 +1925,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.13378344586146537,
+              "irrelevantTokenShare": 0.134,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -1933,7 +1933,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.134,
+              "irrelevantTokenShare": 0.13389173646705838,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -1941,7 +1941,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.134,
+              "irrelevantTokenShare": 0.13389173646705838,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2003,7 +2003,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.5555555555555556,
+              "irrelevantTokenShare": 0.22131055411936607,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2025,7 +2025,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0.040010002500625155,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2079,7 +2079,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0.5200650081260157,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2087,7 +2087,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.520125,
+              "irrelevantTokenShare": 0.5200650081260157,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2095,7 +2095,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.520125,
+              "irrelevantTokenShare": 0.5200650081260157,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2103,7 +2103,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.520125,
+              "irrelevantTokenShare": 0.5200650081260157,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2111,7 +2111,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.45784493715576896,
+              "irrelevantTokenShare": 0.3862509992006395,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2133,7 +2133,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0.7600475029689355,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2141,7 +2141,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7600625,
+              "irrelevantTokenShare": 0.7600475029689355,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2157,7 +2157,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7600625,
+              "irrelevantTokenShare": 0.7600475029689355,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2165,7 +2165,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7589173574478775,
+              "irrelevantTokenShare": 0.7169713948687703,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2219,7 +2219,7 @@
               "available": true,
               "recallNew": null,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2273,7 +2273,7 @@
               "available": true,
               "recallNew": null,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2311,7 +2311,7 @@
               "available": true,
               "recallNew": null,
               "allRequired": true,
-              "irrelevantTokenShare": 0.4067383422927866,
+              "irrelevantTokenShare": 0.4068125,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -2327,7 +2327,7 @@
               "available": true,
               "recallNew": null,
               "allRequired": true,
-              "irrelevantTokenShare": 0.40036643922163256,
+              "irrelevantTokenShare": 0,
               "oracle": true,
               "oracleAfterSeeds": true
             }
@@ -2419,7 +2419,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.4122280570142536,
+              "irrelevantTokenShare": 0.4123015376922115,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2427,7 +2427,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.4122280570142536,
+              "irrelevantTokenShare": 0.4123015376922115,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2435,7 +2435,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.407262640272349,
+              "irrelevantTokenShare": 0.4062894670371306,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2457,7 +2457,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7061507688461057,
+              "irrelevantTokenShare": 0.7061691355709732,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2465,7 +2465,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7061507688461057,
+              "irrelevantTokenShare": 0.7061691355709732,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2489,7 +2489,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.6984412085444865,
+              "irrelevantTokenShare": 0.6704983528422234,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2527,7 +2527,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.5086271567891973,
+              "irrelevantTokenShare": 0.508504252126063,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2535,7 +2535,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.5086271567891973,
+              "irrelevantTokenShare": 0.508504252126063,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2543,7 +2543,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.422737955346651,
+              "irrelevantTokenShare": 0,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2563,9 +2563,9 @@
             },
             "importance-v1": {
               "available": true,
-              "recallNew": 0,
+              "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0.8201025128141017,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2581,7 +2581,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7543442930366295,
+              "irrelevantTokenShare": 0.754375,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2589,7 +2589,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7543135783945987,
+              "irrelevantTokenShare": 0.754375,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2597,7 +2597,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.6623711340206185,
+              "irrelevantTokenShare": 0.5514722666057977,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2617,9 +2617,9 @@
             },
             "importance-v1": {
               "available": true,
-              "recallNew": 0,
+              "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 1,
+              "irrelevantTokenShare": 0.9100568785549097,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -2641,9 +2641,9 @@
             },
             "focus-ppr": {
               "available": true,
-              "recallNew": 0,
-              "allRequired": false,
-              "irrelevantTokenShare": 0.8771875,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.24420276267266705,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -2651,7 +2651,7 @@
               "available": true,
               "recallNew": 1,
               "allRequired": true,
-              "irrelevantTokenShare": 0.24173825797955728,
+              "irrelevantTokenShare": 0.166528811690102,
               "oracle": true,
               "oracleAfterSeeds": true
             }
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 541.7877,
-          "medianPeakWorkingSetBytes": 87822336,
+          "medianElapsedMilliseconds": 475.4177,
+          "medianPeakWorkingSetBytes": 87724032,
           "elapsedMilliseconds": [
-            562.9431,
-            541.7877,
-            536.6992,
-            554.1312,
-            540.8867,
-            526.8387,
-            544.967
+            482.5856,
+            475.9827,
+            473.8478,
+            502.1508,
+            471.8771,
+            462.8321,
+            475.4177
           ],
           "peakWorkingSetBytes": [
-            87547904,
-            87662592,
-            88039424,
-            87822336,
-            87867392,
-            87490560,
-            88285184
+            88010752,
+            87293952,
+            87646208,
+            87302144,
+            88227840,
+            87724032,
+            87945216
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 561.0574,
-          "medianPeakWorkingSetBytes": 88170496,
+          "medianElapsedMilliseconds": 498.8584,
+          "medianPeakWorkingSetBytes": 87932928,
           "elapsedMilliseconds": [
-            560.808,
-            548.2033,
-            561.0574,
-            547.7078,
-            576.9564,
-            621.6922,
-            657.5556
+            482.1816,
+            500.9469,
+            482.6469,
+            504.2011,
+            491.3198,
+            519.865,
+            498.8584
           ],
           "peakWorkingSetBytes": [
-            87793664,
-            88170496,
-            88346624,
-            88211456,
-            88326144,
-            87674880,
-            87744512
+            88666112,
+            87101440,
+            88506368,
+            87932928,
+            87519232,
+            87756800,
+            88158208
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 276.2381,
-          "medianPeakWorkingSetBytes": 91521024,
+          "medianElapsedMilliseconds": 192.5677,
+          "medianPeakWorkingSetBytes": 89735168,
           "elapsedMilliseconds": [
-            293.1194,
-            311.9157,
-            286.4159,
-            266.6004,
-            266.8981,
-            268.6043,
-            276.2381
+            193.4068,
+            186.5403,
+            192.5677,
+            186.0851,
+            186.9024,
+            194.1904,
+            195.4589
           ],
           "peakWorkingSetBytes": [
-            91693056,
-            90583040,
-            91983872,
-            91521024,
-            91381760,
-            91439104,
-            91594752
+            90365952,
+            89534464,
+            89460736,
+            90189824,
+            89915392,
+            89735168,
+            89505792
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 265.3574,
-          "medianPeakWorkingSetBytes": 91471872,
+          "medianElapsedMilliseconds": 189.9542,
+          "medianPeakWorkingSetBytes": 90697728,
           "elapsedMilliseconds": [
-            274.8634,
-            265.3574,
-            265.181,
-            270.3878,
-            262.1114,
-            261.917,
-            265.67
+            192.0389,
+            188.0606,
+            185.7661,
+            183.7238,
+            189.9542,
+            190.0647,
+            233.9212
           ],
           "peakWorkingSetBytes": [
-            91471872,
-            92033024,
-            91635712,
-            91525120,
-            91107328,
-            91103232,
-            91369472
+            90697728,
+            91152384,
+            90669056,
+            90136576,
+            90914816,
+            90013696,
+            90701824
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": 83.93899999999996,
-      "repomix": 8.3519,
-      "flask": -10.88069999999999
+      "devprojex": 16.032500000000255,
+      "repomix": 34.787000000000035,
+      "flask": -2.613500000000016
     },
     "warmIncrementalPercent": {
-      "devprojex": 8.714385468625448,
-      "repomix": 2.0646307364209724,
-      "flask": -3.938884607155925
+      "devprojex": 0.6763276587196535,
+      "repomix": 8.837008794331439,
+      "flask": -1.3571850315499516
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 1.181431294222083,
-      "repomix": 0.2847027046756944,
-      "flask": 0.3964367333613171
+      "devprojex": 0.26953015503374517,
+      "repomix": 0.743103508710435,
+      "flask": 1.0726675187146248
     },
     "recallPassed": true,
     "allRequiredPassed": true,

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-08",
-  "productSha": "63fcc291a1379c6e9d03bc1d815aa51f986426c4",
-  "evaluatorSha": "63fcc291a1379c6e9d03bc1d815aa51f986426c4",
+  "productSha": "efe8b7083ccd523202bcc517255c71b1399fd9b4",
+  "evaluatorSha": "efe8b7083ccd523202bcc517255c71b1399fd9b4",
   "repositories": [
     {
       "id": "devprojex",
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2596.1262,
-          "medianPeakWorkingSetBytes": 304263168,
+          "medianElapsedMilliseconds": 2446.5994,
+          "medianPeakWorkingSetBytes": 315916288,
           "elapsedMilliseconds": [
-            3020.15,
-            2613.2415,
-            2596.1262,
-            2592.749,
-            2629.6301,
-            2586.9825,
-            2591.674
+            2468.18,
+            2437.378,
+            2529.9551,
+            2387.022,
+            2482.9199,
+            2443.4637,
+            2446.5994
           ],
           "peakWorkingSetBytes": [
-            304521216,
-            303935488,
-            304263168,
-            303763456,
-            303464448,
-            306647040,
-            304279552
+            314802176,
+            315916288,
+            314003456,
+            316018688,
+            315932672,
+            317300736,
+            315572224
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2655.8346,
-          "medianPeakWorkingSetBytes": 303951872,
+          "medianElapsedMilliseconds": 2563.0794,
+          "medianPeakWorkingSetBytes": 315580416,
           "elapsedMilliseconds": [
-            2688.049,
-            2615.0937,
-            2669.8165,
-            2656.2968,
-            2548.037,
-            2655.8346,
-            2547.3124
+            2534.0708,
+            2602.5267,
+            2563.0794,
+            2853.575,
+            2569.4044,
+            2523.4734,
+            2458.5597
           ],
           "peakWorkingSetBytes": [
-            304242688,
-            303292416,
-            303792128,
-            305012736,
-            304541696,
-            303951872,
-            303378432
+            314761216,
+            314826752,
+            315580416,
+            316350464,
+            315260928,
+            315748352,
+            317571072
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2370.5226,
-          "medianPeakWorkingSetBytes": 379920384,
+          "medianElapsedMilliseconds": 884.7422,
+          "medianPeakWorkingSetBytes": 320950272,
           "elapsedMilliseconds": [
-            2370.5226,
-            2359.9898,
-            2251.8089,
-            2253.025,
-            2390.4163,
-            2537.8765,
-            2505.0276
+            885.0604,
+            837.4633,
+            889.9375,
+            842.3548,
+            825.0265,
+            884.7422,
+            925.8167
           ],
           "peakWorkingSetBytes": [
-            379789312,
-            379846656,
-            378404864,
-            380440576,
-            379957248,
-            379920384,
-            381562880
+            317571072,
+            320950272,
+            319406080,
+            321916928,
+            319041536,
+            321032192,
+            321798144
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2386.5551,
-          "medianPeakWorkingSetBytes": 380944384,
+          "medianElapsedMilliseconds": 878.6411,
+          "medianPeakWorkingSetBytes": 323235840,
           "elapsedMilliseconds": [
-            2551.3588,
-            2608.1176,
-            2839.8019,
-            2195.9694,
-            2386.5551,
-            2187.2311,
-            2144.8493
+            904.3165,
+            889.3062,
+            843.5885,
+            891.9314,
+            878.6411,
+            877.7811,
+            865.3265
           ],
           "peakWorkingSetBytes": [
-            382279680,
-            380944384,
-            381575168,
-            377806848,
-            380944384,
-            378834944,
-            378568704
+            330821632,
+            321331200,
+            316698624,
+            324931584,
+            322375680,
+            323694592,
+            323235840
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 735.4462,
-          "medianPeakWorkingSetBytes": 116846592,
+          "medianElapsedMilliseconds": 712.3366,
+          "medianPeakWorkingSetBytes": 116559872,
           "elapsedMilliseconds": [
-            716.9566,
-            732.1489,
-            750.4801,
-            729.276,
-            735.4462,
-            739.1756,
-            777.382
+            727.5936,
+            709.8105,
+            736.4194,
+            712.3366,
+            729.725,
+            710.3753,
+            700.6331
           ],
           "peakWorkingSetBytes": [
-            117661696,
-            117002240,
-            116068352,
-            116846592,
-            118169600,
-            115400704,
-            115802112
+            116559872,
+            116326400,
+            116563968,
+            116723712,
+            114733056,
+            116703232,
+            115716096
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 767.7423,
-          "medianPeakWorkingSetBytes": 116482048,
+          "medianElapsedMilliseconds": 726.2491,
+          "medianPeakWorkingSetBytes": 116371456,
           "elapsedMilliseconds": [
-            802.1455,
-            794.2094,
-            814.2577,
-            731.1579,
-            767.7423,
-            749.9931,
-            746.4546
+            729.4131,
+            731.7984,
+            707.9188,
+            729.9012,
+            710.4836,
+            714.7981,
+            726.2491
           ],
           "peakWorkingSetBytes": [
-            116154368,
-            117051392,
-            116617216,
-            114176000,
-            116482048,
-            118571008,
-            116072448
+            114819072,
+            116498432,
+            116842496,
+            116465664,
+            114552832,
+            116371456,
+            114286592
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 393.6513,
-          "medianPeakWorkingSetBytes": 116854784,
+          "medianElapsedMilliseconds": 355.371,
+          "medianPeakWorkingSetBytes": 117329920,
           "elapsedMilliseconds": [
-            366.9047,
-            404.1117,
-            514.3201,
-            380.3471,
-            384.2012,
-            393.6513,
-            395.1191
+            365.6334,
+            355.371,
+            353.1041,
+            352.658,
+            362.7924,
+            349.5526,
+            374.0879
           ],
           "peakWorkingSetBytes": [
-            117424128,
-            116375552,
-            117100544,
-            116514816,
-            116854784,
-            116867072,
-            116719616
+            118079488,
+            117882880,
+            117329920,
+            113823744,
+            117993472,
+            116367360,
+            116539392
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 428.4383,
-          "medianPeakWorkingSetBytes": 117723136,
+          "medianElapsedMilliseconds": 354.1019,
+          "medianPeakWorkingSetBytes": 117678080,
           "elapsedMilliseconds": [
-            421.7354,
-            440.6707,
-            423.3542,
-            428.4383,
-            471.6773,
-            411.2595,
-            464.856
+            354.1019,
+            374.1333,
+            364.5468,
+            351.3647,
+            362.0659,
+            352.4192,
+            345.9806
           ],
           "peakWorkingSetBytes": [
-            116736000,
-            117760000,
-            117563392,
-            120389632,
-            117305344,
-            117723136,
-            118829056
+            118022144,
+            117440512,
+            117678080,
+            116355072,
+            116080640,
+            117977088,
+            118460416
           ]
         }
       ]
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 475.4177,
-          "medianPeakWorkingSetBytes": 87724032,
+          "medianElapsedMilliseconds": 414.6447,
+          "medianPeakWorkingSetBytes": 87166976,
           "elapsedMilliseconds": [
-            482.5856,
-            475.9827,
-            473.8478,
-            502.1508,
-            471.8771,
-            462.8321,
-            475.4177
+            468.8255,
+            406.9876,
+            414.6447,
+            409.9796,
+            410.3649,
+            414.7842,
+            415.1457
           ],
           "peakWorkingSetBytes": [
-            88010752,
-            87293952,
-            87646208,
-            87302144,
-            88227840,
-            87724032,
-            87945216
+            87519232,
+            88379392,
+            87097344,
+            87166976,
+            87126016,
+            87556096,
+            86888448
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 498.8584,
-          "medianPeakWorkingSetBytes": 87932928,
+          "medianElapsedMilliseconds": 420.7916,
+          "medianPeakWorkingSetBytes": 87568384,
           "elapsedMilliseconds": [
-            482.1816,
-            500.9469,
-            482.6469,
-            504.2011,
-            491.3198,
-            519.865,
-            498.8584
+            421.4418,
+            418.4912,
+            420.7916,
+            415.5701,
+            422.0637,
+            423.0728,
+            416.5586
           ],
           "peakWorkingSetBytes": [
-            88666112,
-            87101440,
-            88506368,
-            87932928,
-            87519232,
-            87756800,
-            88158208
+            87576576,
+            87605248,
+            87121920,
+            87568384,
+            87056384,
+            87060480,
+            88195072
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 192.5677,
-          "medianPeakWorkingSetBytes": 89735168,
+          "medianElapsedMilliseconds": 162.7996,
+          "medianPeakWorkingSetBytes": 90804224,
           "elapsedMilliseconds": [
-            193.4068,
-            186.5403,
-            192.5677,
-            186.0851,
-            186.9024,
-            194.1904,
-            195.4589
+            174.635,
+            151.8294,
+            155.5774,
+            162.7996,
+            152.7791,
+            173.0812,
+            180.9568
           ],
           "peakWorkingSetBytes": [
-            90365952,
-            89534464,
-            89460736,
-            90189824,
-            89915392,
-            89735168,
-            89505792
+            90480640,
+            90808320,
+            90804224,
+            90910720,
+            90517504,
+            91201536,
+            90763264
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 189.9542,
-          "medianPeakWorkingSetBytes": 90697728,
+          "medianElapsedMilliseconds": 173.2918,
+          "medianPeakWorkingSetBytes": 91058176,
           "elapsedMilliseconds": [
-            192.0389,
-            188.0606,
-            185.7661,
-            183.7238,
-            189.9542,
-            190.0647,
-            233.9212
+            191.6381,
+            186.2093,
+            170.882,
+            171.2815,
+            178.2944,
+            173.2918,
+            172.4393
           ],
           "peakWorkingSetBytes": [
-            90697728,
-            91152384,
-            90669056,
-            90136576,
-            90914816,
-            90013696,
-            90701824
+            91058176,
+            91058176,
+            90632192,
+            91209728,
+            91254784,
+            90378240,
+            91312128
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": 16.032500000000255,
-      "repomix": 34.787000000000035,
-      "flask": -2.613500000000016
+      "devprojex": -6.101099999999974,
+      "repomix": -1.2690999999999804,
+      "flask": 10.492199999999997
     },
     "warmIncrementalPercent": {
-      "devprojex": 0.6763276587196535,
-      "repomix": 8.837008794331439,
-      "flask": -1.3571850315499516
+      "devprojex": -0.6895907078920813,
+      "repomix": -0.35711974246631845,
+      "flask": 6.444856129867639
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 0.26953015503374517,
-      "repomix": 0.743103508710435,
-      "flask": 1.0726675187146248
+      "devprojex": 0.712125272789923,
+      "repomix": 0.2967359050445104,
+      "flask": 0.4605046755321649
     },
     "recallPassed": true,
     "allRequiredPassed": true,


### PR DESCRIPTION
## What

- project resolved symbols to every declaration file while preserving one canonical target
- resolve TypeScript conditional exports in import/require context and preserve ordered nested conditions
- match CPython package, static re-export, and relative-import precedence
- fail closed on corrupt, unsupported, and oversized dependency control files
- reuse one verified snapshot per control file in an indexing operation
- bind manifest-snapshot eviction bookkeeping to live entries and account for retained facts in index limits
- refresh the registered focus evaluation after the graph corrections

## Why

The dependency graph could disagree across related, reverse-related, and focus consumers; package configuration was flattened before the reference context was known; Python imports could select the wrong file; and cache bookkeeping or retained facts could exceed their documented bounds.

## Behavior and safety

Statuses keep their existing meanings. Invalid configuration now produces incomplete-resolution diagnostics and unresolved references instead of implicit defaults or command failure. All targets remain gated by the effective manifest. No product process, new option, ranking weight, or parallelism was added.

## Verification

- dependency/TypeScript/Python/CSharp/Related integration filters: 71 passed, 1 platform skip
- dependency cache/ranking/focus unit filters: 30 passed
- real related/focus process filters: 3 passed
- documentation and ranking output contracts: 29 passed
- registered three-corpus RankingEval: PASS, 15 eligible cells, +0.3000 RecallNew delta
- TerminalHost Release build: 0 warnings