### PR TITLE
Fix red CI and prepare v5.2 release

### DIFF
--- a/Apps/Avalonia/Coordinators/MetricsPipeline.cs
+++ b/Apps/Avalonia/Coordinators/MetricsPipeline.cs
@@ -63,17 +63,30 @@ internal sealed class MetricsPipeline(
         FileMetricsData Metrics,
         bool HasMetrics);
 
+	private readonly record struct FileMetricsSourceVersion(
+		long Length,
+		long LastWriteTimeUtcTicks,
+		bool IsMissing)
+	{
+		public bool IsCurrent(string path) =>
+			TryCaptureCurrentSourceVersion(path) == this;
+	}
+
     private readonly record struct FileMetricsScanResult(
         FileMetricsVariant Raw,
         FileMetricsVariant Effective,
         string TransformIdentity,
+		FileMetricsSourceVersion? SourceVersion,
         bool WasInspected);
 
-    private sealed class FileMetricsCacheEntry(FileMetricsVariant raw)
+    private sealed class FileMetricsCacheEntry(
+		FileMetricsVariant raw,
+		FileMetricsSourceVersion sourceVersion)
     {
         private readonly Dictionary<string, FileMetricsVariant> _transformed = new(StringComparer.Ordinal);
 
         public FileMetricsVariant Raw { get; set; } = raw;
+		public FileMetricsSourceVersion SourceVersion { get; } = sourceVersion;
 
         public void SetTransformed(string identity, FileMetricsVariant metrics) =>
             _transformed[identity] = metrics;
@@ -280,36 +293,11 @@ internal sealed class MetricsPipeline(
 
         var selectedPaths = selectedPathsProvider();
         var hasAnyChecked = selectedPaths.Count > 0;
-        var hasCompleteMetricsBaseline = _hasCompleteMetricsBaseline;
         var treeFormat = treeFormatProvider();
         var currentTree = currentTreeProvider();
         var currentPath = currentPathProvider();
 
-        if (!hasCompleteMetricsBaseline)
-        {
-            _backgroundTasks.Register(RecalculateIncompleteBaselineMetricsAsync(
-                recalcCts,
-                token,
-                recalcVersion,
-                hasAnyChecked,
-                selectedPaths,
-                treeFormat,
-                currentTree,
-                currentPath,
-                cleanupAfterCompletion),
-			nameof(RecalculateIncompleteBaselineMetricsAsync));
-            return;
-        }
-
-        if (!MetricsCalculationPolicy.ShouldProceedWithMetricsCalculation(hasAnyChecked, hasCompleteMetricsBaseline))
-        {
-            UpdateStatusBarMetrics(0, 0, 0, 0, 0, 0);
-            DisposeIfCurrent(ref _recalculateMetricsCts, recalcCts);
-            ScheduleMemoryCleanup(cleanupAfterCompletion);
-            return;
-        }
-
-        _backgroundTasks.Register(RecalculateMetricsCoreAsync(
+        _backgroundTasks.Register(RecalculateIncompleteBaselineMetricsAsync(
             recalcCts,
             token,
             recalcVersion,
@@ -319,7 +307,7 @@ internal sealed class MetricsPipeline(
             currentTree,
             currentPath,
             cleanupAfterCompletion),
-			nameof(RecalculateMetricsCoreAsync));
+			nameof(RecalculateIncompleteBaselineMetricsAsync));
     }
 
     public async Task InitializeFileMetricsCacheSoonAfterFirstPaintAsync(
@@ -419,6 +407,17 @@ internal sealed class MetricsPipeline(
         CancelBackgroundCalculation();
         ClearFileMetricsCache(trimCapacity: true);
     }
+
+	/// <summary>
+	/// Invalidates the selected-tree projection and aggregate totals without changing the
+	/// generation of source-versioned per-file facts or transformation variants.
+	/// </summary>
+	public void InvalidateSelectionProjection()
+	{
+		_recalculateMetricsCts?.Cancel();
+		Interlocked.Increment(ref _metricsRecalcVersion);
+		InvalidateComputedCaches();
+	}
 
     public void CancelByUser()
     {
@@ -964,14 +963,15 @@ internal sealed class MetricsPipeline(
             for (var index = 0; index < count; index++)
             {
                 var result = results[index];
-                if (!result.WasInspected)
+                if (!result.WasInspected || result.SourceVersion is not { } sourceVersion)
                     continue;
 
                 var filePath = filePaths[index];
-                if (!_fileMetricsCache.TryGetValue(filePath, out var entry))
+                if (!_fileMetricsCache.TryGetValue(filePath, out var entry) ||
+					entry.SourceVersion != sourceVersion)
                 {
-                    entry = new FileMetricsCacheEntry(result.Raw);
-                    _fileMetricsCache.Add(filePath, entry);
+					entry = new FileMetricsCacheEntry(result.Raw, sourceVersion);
+					_fileMetricsCache[filePath] = entry;
                 }
                 else
                 {
@@ -1024,34 +1024,52 @@ internal sealed class MetricsPipeline(
             ? string.Empty
             : _appliedTransformIdentity;
 
-        await Parallel.ForAsync(0, filePaths.Count, parallelOptions, async (index, ct) =>
+		await Parallel.ForAsync(0, filePaths.Count, parallelOptions, async (index, ct) =>
         {
             var filePath = filePaths[index];
             try
             {
+				var sourceVersionBeforeRead = TryCaptureCurrentSourceVersion(filePath);
                 if (fileContentAnalyzer.ClassifyWithoutReading(filePath) ==
                     FileContentClassification.Binary)
                 {
+					var binarySourceVersion = TryCaptureStableSourceVersion(
+						filePath,
+						sourceVersionBeforeRead);
+					if (binarySourceVersion is null)
+					{
+						Interlocked.Exchange(ref hadReadFailures, 1);
+						return;
+					}
+
                     stagedResults[index] = new FileMetricsScanResult(
                         Raw: new FileMetricsVariant(default, HasMetrics: false),
                         Effective: new FileMetricsVariant(default, HasMetrics: false),
                         TransformIdentity: transformIdentity,
+						SourceVersion: binarySourceVersion,
                         WasInspected: true);
                     return;
                 }
 
                 TextFileMetrics? rawMetrics;
                 TextFileMetrics? effectiveMetrics;
+				FileMetricsSourceVersion? sourceVersion = null;
 				ContentReadFact? retainedFact = null;
 				if (readFacts is not null && readFacts.TryGet(filePath, out var retained))
 					retainedFact = retained;
                 if (transformationScope is not null && IsCompressible(filePath))
                 {
-					var fact = retainedFact is { IsMaterializedText: true }
-						? retainedFact
-						: await fileContentAnalyzer
+					ContentReadFact fact;
+					if (retainedFact is { IsMaterializedText: true })
+					{
+						fact = retainedFact;
+					}
+					else
+					{
+						fact = await fileContentAnalyzer
 							.ReadFactAsync(filePath, MaximumMetricsMaterializationBytes, ct)
 							.ConfigureAwait(false);
+					}
 					rawMetrics = fact.RawMetrics;
 					effectiveMetrics = rawMetrics is { IsEstimated: false } && fact.IsMaterializedText
 						? MeasureTransformed(
@@ -1080,10 +1098,20 @@ internal sealed class MetricsPipeline(
                     effectiveMetrics = rawMetrics;
                 }
 
+				sourceVersion ??= TryCaptureStableSourceVersion(
+					filePath,
+					sourceVersionBeforeRead);
+				if (sourceVersion is null || !sourceVersion.Value.IsCurrent(filePath))
+				{
+					Interlocked.Exchange(ref hadReadFailures, 1);
+					return;
+				}
+
                 stagedResults[index] = new FileMetricsScanResult(
                     Raw: ToVariant(rawMetrics),
                     Effective: ToVariant(effectiveMetrics),
                     TransformIdentity: transformIdentity,
+					SourceVersion: sourceVersion,
                     WasInspected: true);
             }
             catch (OperationCanceledException)
@@ -1113,6 +1141,45 @@ internal sealed class MetricsPipeline(
 
         return Volatile.Read(ref hadReadFailures) != 0;
     }
+
+	private static FileMetricsSourceVersion? TryCaptureCurrentSourceVersion(string path)
+	{
+		try
+		{
+			using var stream = new FileStream(
+				path,
+				FileMode.Open,
+				FileAccess.Read,
+				FileShare.Read | FileShare.Delete,
+				bufferSize: 1,
+				FileOptions.RandomAccess);
+			return new FileMetricsSourceVersion(
+				RandomAccess.GetLength(stream.SafeFileHandle),
+				File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks,
+				IsMissing: false);
+		}
+		catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
+		{
+			return new FileMetricsSourceVersion(
+				Length: 0,
+				LastWriteTimeUtcTicks: 0,
+				IsMissing: true);
+		}
+		catch (Exception exception) when (IsExpectedMetricsReadFailure(exception))
+		{
+			return null;
+		}
+	}
+
+	private static FileMetricsSourceVersion? TryCaptureStableSourceVersion(
+		string path,
+		FileMetricsSourceVersion? versionBeforeRead)
+	{
+		var versionAfterRead = TryCaptureCurrentSourceVersion(path);
+		return versionBeforeRead is { } before && versionAfterRead == before
+			? versionAfterRead
+			: null;
+	}
 
     private static bool IsExpectedMetricsReadFailure(Exception exception) =>
         exception is IOException or UnauthorizedAccessException or SecurityException;
@@ -1215,11 +1282,15 @@ internal sealed class MetricsPipeline(
 
             if (targetFilePaths.Count == 0)
             {
-                await PublishTreeMetricsWhileContentPendingAsync(
-                    token,
-                    recalcVersion,
-                    treeFormat,
-                    selection);
+				await PublishMetricsAsync(
+					token,
+					recalcVersion,
+					hasAnyChecked,
+					selectedPaths,
+					treeFormat,
+					currentTree,
+					currentPath,
+					selection);
                 completed = true;
                 return;
             }
@@ -1332,46 +1403,6 @@ internal sealed class MetricsPipeline(
         });
     }
 
-    private async Task RecalculateMetricsCoreAsync(
-        CancellationTokenSource recalcCts,
-        CancellationToken token,
-        int recalcVersion,
-        bool hasAnyChecked,
-        IReadOnlySet<string> selectedPaths,
-        TreeTextFormat treeFormat,
-        BuildTreeResult? currentTree,
-        string? currentPath,
-        MemoryCleanupReason? cleanupAfterCompletion)
-    {
-        var completed = false;
-        try
-        {
-            await PublishMetricsAsync(
-                token,
-                recalcVersion,
-                hasAnyChecked,
-                selectedPaths,
-                treeFormat,
-                currentTree,
-                currentPath);
-            completed = true;
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected when a newer recalculation supersedes the current one.
-        }
-        finally
-        {
-            if (completed &&
-                recalcVersion == Volatile.Read(ref _metricsRecalcVersion))
-            {
-                ScheduleMemoryCleanup(cleanupAfterCompletion);
-            }
-
-            DisposeIfCurrent(ref _recalculateMetricsCts, recalcCts);
-        }
-    }
-
     private void ScheduleMemoryCleanup(
         MemoryCleanupReason? cleanupReason)
     {
@@ -1441,6 +1472,7 @@ internal sealed class MetricsPipeline(
     {
 		cancellationToken.ThrowIfCancellationRequested();
         var missingPaths = new List<string>();
+		var removedStaleEntry = false;
         lock (_metricsLock)
         {
             for (var index = 0; index < orderedPaths.Count; index++)
@@ -1449,9 +1481,21 @@ internal sealed class MetricsPipeline(
                 var path = orderedPaths[index];
                 if (!_fileMetricsCache.TryGetValue(path, out var entry) ||
                     !entry.TryGet(_appliedTransformIdentity, out _))
+				{
                     missingPaths.Add(path);
+					continue;
+				}
+
+				if (!entry.SourceVersion.IsCurrent(path))
+				{
+					_fileMetricsCache.Remove(path);
+					missingPaths.Add(path);
+					removedStaleEntry = true;
+				}
             }
         }
+		if (removedStaleEntry)
+			InvalidateContentMetricsCache();
 
         return missingPaths;
     }

--- a/Apps/Avalonia/MainWindow.RefreshTreeHost.cs
+++ b/Apps/Avalonia/MainWindow.RefreshTreeHost.cs
@@ -69,9 +69,9 @@ public partial class MainWindow : IRefreshTreePipelineHost
 
     void IRefreshTreePipelineHost.BeforeInteractiveFilterRefresh()
     {
-        // A filter projects a new graph from the in-memory baseline. Stop metrics that still
-        // reference the previous full graph before that graph becomes eligible for collection.
-        _metrics.CancelAndDiscardBackgroundCalculation();
+        // A name filter changes only the tree projection and its aggregate totals. Per-file facts
+        // remain reusable because each entry is independently guarded by its source identity.
+        _metrics.InvalidateSelectionProjection();
     }
 
     BuildTreeSnapshotResult IRefreshTreePipelineHost.BuildTree(TreeRefreshInput input, CancellationToken cancellationToken) =>

--- a/Apps/Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/Apps/Avalonia/ViewModels/MainWindowViewModel.cs
@@ -32,7 +32,7 @@ public enum PreviewWorkspaceMode
 
 public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
 {
-    public const string TitleVersion = "5.1";
+    public const string TitleVersion = "5.2";
     public const string BaseTitle = "DevProjex v" + TitleVersion;
     public const double DefaultTreeFontSize = 15;
     public const double DefaultPreviewFontSize = 15;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <DevProjexVersion Condition="'$(DevProjexVersion)'==''">5.1</DevProjexVersion>
-    <DevProjexAssemblyVersion Condition="'$(DevProjexAssemblyVersion)'==''">5.1.0.0</DevProjexAssemblyVersion>
+    <DevProjexVersion Condition="'$(DevProjexVersion)'==''">5.2</DevProjexVersion>
+    <DevProjexAssemblyVersion Condition="'$(DevProjexAssemblyVersion)'==''">5.2.0.0</DevProjexAssemblyVersion>
     <DevProjexFileVersion Condition="'$(DevProjexFileVersion)'==''">$(DevProjexAssemblyVersion)</DevProjexFileVersion>
     <DevProjexInformationalVersion Condition="'$(DevProjexInformationalVersion)'==''">$(DevProjexVersion)</DevProjexInformationalVersion>
-    <DevProjexStorePackageVersion Condition="'$(DevProjexStorePackageVersion)'==''">5.1.0.0</DevProjexStorePackageVersion>
+    <DevProjexStorePackageVersion Condition="'$(DevProjexStorePackageVersion)'==''">5.2.0.0</DevProjexStorePackageVersion>
     <Version>$(DevProjexVersion)</Version>
     <AssemblyVersion>$(DevProjexAssemblyVersion)</AssemblyVersion>
     <FileVersion>$(DevProjexFileVersion)</FileVersion>

--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -121,15 +121,15 @@ dotnet tool install --global devprojex
 
 Release automation prepares one headless archive for each supported RID. Choose
 `DevProjex-headless.v<version>.<rid>.zip` on Windows or
-`DevProjex-headless.v<version>.<rid>.tar.gz` on Linux and macOS. For example:
+`DevProjex-headless.v<version>.<rid>.tar.gz` on Linux and macOS. For the v5.2 release:
 
 ```powershell
-Expand-Archive DevProjex-headless.v<version>.win-x64.zip
+Expand-Archive DevProjex-headless.v5.2.win-x64.zip
 ./devprojex.exe --version
 ```
 
 ```bash
-tar xzf DevProjex-headless.v<version>.linux-x64.tar.gz
+tar xzf DevProjex-headless.v5.2.linux-x64.tar.gz
 ./devprojex --version
 ```
 

--- a/Docs/Release-Process.md
+++ b/Docs/Release-Process.md
@@ -118,7 +118,7 @@ is not release-ready:
 `-GitHubArtifactsOnly` remains an alias for `-Channels github`:
 
 ```powershell
-./Scripts/release-all.ps1 -Version 5.1 -GitHubArtifactsOnly
+./Scripts/release-all.ps1 -Version 5.2 -GitHubArtifactsOnly
 ```
 
 Build Store without WACK from a non-elevated console, then validate the existing
@@ -146,8 +146,8 @@ gate explicitly:
 
 ```powershell
 ./Scripts/release-all.ps1 -Channels github -Rids win-x64,linux-x64 -SkipWack -NonInteractive
-./Scripts/Test-ReleaseArtifacts.ps1 -PublishRoot publish -Version 5.1 -Channels github -Rids win-x64,linux-x64
-./Scripts/Test-ReleaseArtifactGateMutation.ps1 -PublishRoot publish -Version 5.1 -Channels github -Rids win-x64,linux-x64
+./Scripts/Test-ReleaseArtifacts.ps1 -PublishRoot publish -Version 5.2 -Channels github -Rids win-x64,linux-x64
+./Scripts/Test-ReleaseArtifactGateMutation.ps1 -PublishRoot publish -Version 5.2 -Channels github -Rids win-x64,linux-x64
 ```
 
 When `-NonInteractive` is set, `Read-Host` is never called. An invalid explicit

--- a/Packaging/Linux/README.md
+++ b/Packaging/Linux/README.md
@@ -73,7 +73,7 @@ sudo apt-get update
 sudo apt-get install -y appstream desktop-file-utils file jq libfile-mimeinfo-perl xvfb
 appstreamcli --version # 0.16.4 or newer
 
-VERSION=5.1
+VERSION=5.2
 RID=linux-x64
 APPIMAGE_ARCH=x86_64
 APP_ID=io.github.Avazbek22.DevProjex

--- a/Packaging/Linux/io.github.Avazbek22.DevProjex.metainfo.xml
+++ b/Packaging/Linux/io.github.Avazbek22.DevProjex.metainfo.xml
@@ -55,6 +55,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.2" date="2026-09-08" />
     <release version="5.1" date="2026-09-02" />
   </releases>
   <content_rating type="oars-1.1" />

--- a/Packaging/MacOS/README.md
+++ b/Packaging/MacOS/README.md
@@ -12,7 +12,7 @@ Icon PNGs are located in `Assets/AppIcon/MacOS/AppIconSet/`:
 `Scripts/release-all.ps1` builds the official unsigned macOS artifacts:
 
 ```powershell
-./Scripts/release-all.ps1 -Version 5.1 -GitHubArtifactsOnly
+./Scripts/release-all.ps1 -Version 5.2 -GitHubArtifactsOnly
 ```
 
 The equivalent channel form is `-Channels github`. Use `-Rids osx-x64` or

--- a/Packaging/Windows/DevProjex.Store/Package.appxmanifest
+++ b/Packaging/Windows/DevProjex.Store/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap uap3 desktop rescap">
-  <Identity Name="StarkIndustriesDev.DevProjex" Publisher="CN=1BD76FFF-E0E6-4C9D-AD30-0248861C72C8" Version="5.1.0.0" />
+  <Identity Name="StarkIndustriesDev.DevProjex" Publisher="CN=1BD76FFF-E0E6-4C9D-AD30-0248861C72C8" Version="5.2.0.0" />
   <Properties>
     <DisplayName>ms-resource:AppDisplayName</DisplayName>
     <PublisherDisplayName>Stark Industries Dev</PublisherDisplayName>

--- a/Tests/DevProjex.Tests.Terminal/DocumentationExecutionRegressionTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationExecutionRegressionTests.cs
@@ -14,9 +14,11 @@ public sealed class DocumentationExecutionRegressionTests
 		var project = workspace.CreateDirectory("source-project");
 		workspace.WriteFile("source-project/src/App.cs", "internal sealed class App {}\n");
 		workspace.WriteFile("source-project/README.md", "# Sample\n");
-		InitializeGitIndex(project);
+		var repositoryRoot = FindRepositoryRoot();
+		Assert.False(PathUtility.IsPathInside(workspace.Path, repositoryRoot));
+		InitializeGitIndex(project, workspace.CreateDirectory("source-project.git"));
 		var examples = await ExtractPublishedDirectExamplesAsync(
-			FindRepositoryRoot(),
+			repositoryRoot,
 			TestContext.Current.CancellationToken);
 		var uniqueCommands = examples
 			.Distinct(StringComparer.Ordinal)
@@ -32,16 +34,25 @@ public sealed class DocumentationExecutionRegressionTests
 				workspace.Path,
 				index);
 			var environment = new TestTerminalEnvironment();
+			var serviceFactory = new TerminalServiceFactory(
+				() => workspace.CreateDirectory($"app-data-{index}"));
 			var exitCode = await new TerminalApplication(
 					environment,
-					new TerminalServiceFactory(() => workspace.CreateDirectory($"app-data-{index}")))
+					serviceFactory)
 				.RunAsync(arguments, TestContext.Current.CancellationToken);
 
 			Assert.True(
 				exitCode == CommandLineExitCodes.Success,
 				$"Documented command failed with exit code {exitCode}: " +
 				$"{uniqueCommands[index]}{Environment.NewLine}{environment.StandardError}");
-			Assert.Empty(environment.StandardError);
+			Assert.True(
+				string.IsNullOrEmpty(environment.StandardError),
+				BuildUnexpectedStandardErrorDiagnostic(
+					uniqueCommands[index],
+					arguments,
+					environment.StandardError,
+					serviceFactory,
+					project));
 			Assert.NotEmpty(environment.StandardOutput);
 			Assert.Equal(before, ComputeTreeFingerprint(project));
 			AssertObservableResult(
@@ -274,9 +285,46 @@ public sealed class DocumentationExecutionRegressionTests
 		return Convert.ToHexString(hash.GetHashAndReset());
 	}
 
-	private static void InitializeGitIndex(string project)
+	private static string BuildUnexpectedStandardErrorDiagnostic(
+		string documentedCommand,
+		IReadOnlyList<string> arguments,
+		string standardError,
+		TerminalServiceFactory serviceFactory,
+		string project)
 	{
-		RunGit(project, "init", "--quiet");
+		using var services = serviceFactory.Create(AppLanguage.En);
+		var loaded = services.AnalysisService.Load(new ProjectAnalysisRequest(project));
+		var unavailablePaths = EnumerateAccessDeniedPaths(loaded.Tree.Root).ToArray();
+		return
+			$"Documented command wrote stderr.\n" +
+			$"Documented: {documentedCommand}\n" +
+			$"Executed: devprojex {string.Join(' ', arguments.Select(QuoteArgument))}\n" +
+			$"Full stderr:\n{standardError}\n" +
+			$"Access-denied paths from a diagnostic rescan ({unavailablePaths.Length}):\n" +
+			(unavailablePaths.Length == 0
+				? "<none observed during diagnostic rescan>"
+				: string.Join(Environment.NewLine, unavailablePaths));
+	}
+
+	private static IEnumerable<string> EnumerateAccessDeniedPaths(TreeNodeDescriptor node)
+	{
+		if (node.IsAccessDenied)
+			yield return node.FullPath;
+		foreach (var child in node.Children)
+		{
+			foreach (var path in EnumerateAccessDeniedPaths(child))
+				yield return path;
+		}
+	}
+
+	private static string QuoteArgument(string argument) =>
+		argument.Any(char.IsWhiteSpace)
+			? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+			: argument;
+
+	private static void InitializeGitIndex(string project, string gitDirectory)
+	{
+		RunGit(project, "init", "--quiet", $"--separate-git-dir={gitDirectory}");
 		RunGit(project, "add", "--all");
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/GeneratedCompletionNativeShellIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/GeneratedCompletionNativeShellIntegrationTests.cs
@@ -224,14 +224,30 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 			generated.StandardOutput);
 		const string line =
 			"devprojex analyze \".\\Program Files\" --format ";
-
-		var completed = await RunPowerShellCandidateCompletionAsync(
+		var coldStart = await MeasureWindowsPowerShellColdStartAsync(
 			shellExecutable,
-			integrationRoot,
-			completionScript,
-			workingDirectory,
-			line,
 			TestContext.Current.CancellationToken);
+
+		ShellProcessResult completed;
+		try
+		{
+			completed = await RunPowerShellCandidateCompletionAsync(
+				shellExecutable,
+				integrationRoot,
+				completionScript,
+				workingDirectory,
+				line,
+				TestContext.Current.CancellationToken);
+		}
+		catch (TimeoutException exception)
+		{
+			throw new TimeoutException(
+				$"Windows PowerShell 5.1 cold start: {coldStart.TotalMilliseconds:F0} ms; " +
+				$"completion timeout: {WindowsPowerShellProcessTimeout.TotalMilliseconds:F0} ms; " +
+				$"cold-start/timeout ratio: {coldStart.TotalMilliseconds / WindowsPowerShellProcessTimeout.TotalMilliseconds:P1}. " +
+				exception.Message,
+				exception);
+		}
 
 		Assert.True(
 			completed.ExitCode == 0,
@@ -249,6 +265,29 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 					StringSplitOptions.RemoveEmptyEntries |
 					StringSplitOptions.TrimEntries)
 				.Order(StringComparer.Ordinal));
+	}
+
+	private static async Task<TimeSpan> MeasureWindowsPowerShellColdStartAsync(
+		string shellExecutable,
+		CancellationToken cancellationToken)
+	{
+		var startInfo = CreateShellStartInfo("powershell", shellExecutable);
+		startInfo.ArgumentList.Add("-Command");
+		startInfo.ArgumentList.Add("exit 0");
+		var stopwatch = Stopwatch.StartNew();
+		var result = await RunProcessAsync(
+			startInfo,
+			cancellationToken,
+			WindowsPowerShellProcessTimeout);
+		stopwatch.Stop();
+		Assert.True(
+			result.ExitCode == 0 &&
+			string.IsNullOrWhiteSpace(result.StandardOutput) &&
+			string.IsNullOrWhiteSpace(result.StandardError),
+			$"Windows PowerShell 5.1 cold-start probe took {stopwatch.Elapsed.TotalMilliseconds:F0} ms " +
+			$"and exited with {result.ExitCode}. stdout=[{result.StandardOutput}] " +
+			$"stderr=[{result.StandardError}]");
+		return stopwatch.Elapsed;
 	}
 
 	private static async Task<ShellProcessResult> RunCompletionAsync(

--- a/Tests/DevProjex.Tests.Terminal/TerminalRecentRepositoriesPtyTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalRecentRepositoriesPtyTests.cs
@@ -57,10 +57,9 @@ public sealed partial class TerminalRecentRepositoriesPtyTests
 			welcomeDirectory.Path);
 
 		await terminal.SendEnterAsync(TestContext.Current.CancellationToken);
-		var workspace = await terminal.WaitForStableScreenAsync(
-			required: "RepositoryMarker.cs",
-			timeout: TimeSpan.FromSeconds(30),
-			cancellationToken: TestContext.Current.CancellationToken);
+		var workspace = await WaitForWorkspaceTreeRenderedAsync(
+			terminal,
+			TestContext.Current.CancellationToken);
 
 		Assert.Contains("DevProjex Terminal · DevProjex", workspace, StringComparison.Ordinal);
 		Assert.Contains(RepositoryUrl, workspace, StringComparison.Ordinal);
@@ -110,6 +109,47 @@ public sealed partial class TerminalRecentRepositoriesPtyTests
 			CommandLineExitCodes.Success,
 			await terminal.WaitForExitAsync(
 				cancellationToken: TestContext.Current.CancellationToken));
+	}
+
+	private static async Task<string> WaitForWorkspaceTreeRenderedAsync(
+		TerminalPtyHarness terminal,
+		CancellationToken cancellationToken)
+	{
+		var stopwatch = Stopwatch.StartNew();
+		var timeline = new List<string>();
+		var previous = string.Empty;
+		var stableSamples = 0;
+		while (stopwatch.Elapsed < TimeSpan.FromSeconds(30))
+		{
+			var screen = terminal.CaptureScreen();
+			var tree = screen.Contains("PROJECT TREE", StringComparison.Ordinal);
+			var parameters = screen.Contains("PARAMETERS", StringComparison.Ordinal);
+			var marker = screen.Contains("RepositoryMarker.cs", StringComparison.Ordinal);
+			if (!string.Equals(previous, screen, StringComparison.Ordinal))
+			{
+				timeline.Add(
+					$"{stopwatch.Elapsed.TotalMilliseconds,7:F0} ms " +
+					$"tree={tree} parameters={parameters} marker={marker} " +
+					$"chars={screen.Length}");
+				previous = screen;
+				stableSamples = 0;
+			}
+			else if (tree && parameters && marker && ++stableSamples >= 3)
+			{
+				return screen;
+			}
+
+			if (terminal.HasExited)
+				break;
+			await Task.Delay(80, cancellationToken);
+		}
+
+		var finalScreen = terminal.CaptureScreen();
+		throw new Xunit.Sdk.XunitException(
+			"Workspace tree did not reach its rendered signal " +
+			"(PROJECT TREE + PARAMETERS + RepositoryMarker.cs).\n" +
+			$"Timeline:\n{string.Join(Environment.NewLine, timeline)}\n" +
+			$"Full screen:\n{finalScreen}");
 	}
 
 	[Fact(Timeout = 90_000)]

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
@@ -114,6 +114,77 @@ public sealed class MetricsPipelineWarmupTests
 		Assert.Equal(1, selectedPaths.EnumerationCount);
 	}
 
+	[AvaloniaFact]
+	public async Task NameFilter_ReusesUnchangedFactsAndRereadsOnlyChangedFile()
+	{
+		using var temp = new TemporaryDirectory();
+		var matchingFile = temp.CreateFile("Matching.cs", "internal class Matching { }");
+		var otherFile = temp.CreateFile("Other.cs", "internal class Other { }");
+		var fullRoot = CreateTree(temp.Path, [matchingFile, otherFile]);
+		var filteredRoot = CreateTree(temp.Path, [matchingFile]);
+		var fullTree = new BuildTreeResult(
+			fullRoot,
+			RootAccessDenied: false,
+			HadAccessDenied: false,
+			[matchingFile, otherFile]);
+		var filteredTree = new BuildTreeResult(
+			filteredRoot,
+			RootAccessDenied: false,
+			HadAccessDenied: false,
+			[matchingFile]);
+		var currentTree = fullTree;
+		var viewModel = CreateViewModel();
+		viewModel.IsProjectLoaded = true;
+		viewModel.TreeNodes.Add(new TreeNodeViewModel(fullRoot, parent: null, icon: null));
+		var analyzer = new CountingFileContentAnalyzer(new FileContentAnalyzer());
+		var completedRecalculations = 0;
+		using var pipeline = new MetricsPipeline(
+			viewModel,
+			CreateLocalization(),
+			analyzer,
+			new TreeExportService(),
+			new StatusOperationCoordinator(
+				viewModel,
+				isBackgroundMetricsActive: () => false,
+				metricsOperationTextProvider: () => viewModel.StatusOperationCalculatingData),
+			currentTreeProvider: () => currentTree,
+			currentPathProvider: () => temp.Path,
+			selectedPathsProvider: () => new HashSet<string>(PathComparer.Default),
+			treeFormatProvider: () => TreeTextFormat.Ascii,
+			exportPathPresentationProvider: () => null,
+			boundsWidthProvider: () => 1400,
+			scheduleMemoryCleanup: _ => Interlocked.Increment(ref completedRecalculations));
+
+		await pipeline.InitializeFileMetricsCacheSoonAfterFirstPaintAsync(
+			fullTree,
+			TestContext.Current.CancellationToken);
+		Assert.True(pipeline.HasCompleteBaseline);
+		Assert.Equal(1, analyzer.GetMetricsCallCount(matchingFile));
+		Assert.Equal(1, analyzer.GetMetricsCallCount(otherFile));
+
+		currentTree = filteredTree;
+		pipeline.InvalidateSelectionProjection();
+		pipeline.Recalculate(MemoryCleanupReason.FilterApplied);
+		await WaitUntilAsync(
+			() => Volatile.Read(ref completedRecalculations) == 1,
+			TimeSpan.FromSeconds(5));
+
+		Assert.Equal(1, analyzer.GetMetricsCallCount(matchingFile));
+		Assert.Equal(1, analyzer.GetMetricsCallCount(otherFile));
+
+		File.WriteAllText(matchingFile, "internal class Matching { int Changed; }");
+		File.SetLastWriteTimeUtc(matchingFile, DateTime.UtcNow.AddMinutes(1));
+		currentTree = fullTree;
+		pipeline.InvalidateSelectionProjection();
+		pipeline.Recalculate(MemoryCleanupReason.FilterApplied);
+		await WaitUntilAsync(
+			() => Volatile.Read(ref completedRecalculations) == 2,
+			TimeSpan.FromSeconds(5));
+
+		Assert.Equal(2, analyzer.GetMetricsCallCount(matchingFile));
+		Assert.Equal(1, analyzer.GetMetricsCallCount(otherFile));
+	}
+
     [AvaloniaFact]
     public async Task InitializeFileMetricsCacheAsync_PendingVisualGate_DefersAllFileIoUntilReveal()
     {


### PR DESCRIPTION
## Summary
- stabilize the three cross-platform CI regressions with actionable diagnostics
- align repository, desktop, Store, AppImage, packaging, and documentation versions on 5.2
- retain source-versioned GUI file metrics across name-filter projections

## Targeted validation
- three previously failing terminal tests (Release): 3 passed
- MetricsPipelineWarmupTests (Release): 26 passed
- release/version and packaging contract filters: passed
- Test-ReleaseVersion.ps1 for v5.2: passed
- TerminalHost and Avalonia Release builds: 0 warnings
- built win-x64 devprojex --version: 5.2

No tags or artifacts were published.