### PR TITLE
Keep GUI metrics I/O responsive and strengthen CI evidence

### DIFF
--- a/Apps/Avalonia/Coordinators/MetricsPipeline.cs
+++ b/Apps/Avalonia/Coordinators/MetricsPipeline.cs
@@ -4,6 +4,87 @@ using DevProjex.Avalonia.Services;
 
 namespace DevProjex.Avalonia.Coordinators;
 
+internal readonly record struct MetricsFileSourceVersion(
+	long Length,
+	long LastWriteTimeUtcTicks,
+	bool IsMissing);
+
+internal interface IMetricsFileSourceVersionProvider
+{
+	MetricsFileSourceVersion? Capture(string path);
+}
+
+internal readonly record struct MetricsPipelineIoSnapshot(
+	long FileVersionOpenCount,
+	long MetricsLockAttemptCount,
+	long MetricsLockAcquisitionCount,
+	TimeSpan MetricsLockWait);
+
+internal sealed class MetricsPipelineIoTestPoint
+{
+	private long _fileVersionOpenCount;
+	private long _metricsLockAttemptCount;
+	private long _metricsLockAcquisitionCount;
+	private long _metricsLockWaitTicks;
+
+	public MetricsPipelineIoSnapshot Snapshot => new(
+		Volatile.Read(ref _fileVersionOpenCount),
+		Volatile.Read(ref _metricsLockAttemptCount),
+		Volatile.Read(ref _metricsLockAcquisitionCount),
+		TimeSpan.FromTicks(Volatile.Read(ref _metricsLockWaitTicks)));
+
+	internal void RecordFileVersionOpen() =>
+		Interlocked.Increment(ref _fileVersionOpenCount);
+
+	internal void RecordMetricsLockAttempt() =>
+		Interlocked.Increment(ref _metricsLockAttemptCount);
+
+	internal void RecordMetricsLockWait(TimeSpan elapsed)
+	{
+		Interlocked.Increment(ref _metricsLockAcquisitionCount);
+		Interlocked.Add(ref _metricsLockWaitTicks, elapsed.Ticks);
+	}
+}
+
+internal sealed class PhysicalMetricsFileSourceVersionProvider : IMetricsFileSourceVersionProvider
+{
+	public static PhysicalMetricsFileSourceVersionProvider Instance { get; } = new();
+
+	private PhysicalMetricsFileSourceVersionProvider()
+	{
+	}
+
+	public MetricsFileSourceVersion? Capture(string path)
+	{
+		try
+		{
+			using var stream = new FileStream(
+				path,
+				FileMode.Open,
+				FileAccess.Read,
+				FileShare.Read | FileShare.Delete,
+				bufferSize: 1,
+				FileOptions.RandomAccess);
+			return new MetricsFileSourceVersion(
+				RandomAccess.GetLength(stream.SafeFileHandle),
+				File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks,
+				IsMissing: false);
+		}
+		catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
+		{
+			return new MetricsFileSourceVersion(
+				Length: 0,
+				LastWriteTimeUtcTicks: 0,
+				IsMissing: true);
+		}
+		catch (Exception exception) when (
+			exception is IOException or UnauthorizedAccessException or SecurityException)
+		{
+			return null;
+		}
+	}
+}
+
 internal sealed class MetricsPipeline(
     MainWindowViewModel viewModel,
     LocalizationService localization,
@@ -18,7 +99,9 @@ internal sealed class MetricsPipeline(
     Func<double> boundsWidthProvider,
     Action<MemoryCleanupReason>? scheduleMemoryCleanup = null,
     Func<ContentTransformationContext?>? transformationContextProvider = null,
-    BackgroundTaskRegistry? backgroundTasks = null) : IDisposable
+    BackgroundTaskRegistry? backgroundTasks = null,
+	IMetricsFileSourceVersionProvider? fileSourceVersionProvider = null,
+	MetricsPipelineIoTestPoint? ioTestPoint = null) : IDisposable
 {
     private readonly record struct TreeMetricsCacheKey(
         int TreeIdentity,
@@ -63,30 +146,26 @@ internal sealed class MetricsPipeline(
         FileMetricsData Metrics,
         bool HasMetrics);
 
-	private readonly record struct FileMetricsSourceVersion(
-		long Length,
-		long LastWriteTimeUtcTicks,
-		bool IsMissing)
-	{
-		public bool IsCurrent(string path) =>
-			TryCaptureCurrentSourceVersion(path) == this;
-	}
-
     private readonly record struct FileMetricsScanResult(
         FileMetricsVariant Raw,
         FileMetricsVariant Effective,
         string TransformIdentity,
-		FileMetricsSourceVersion? SourceVersion,
+		MetricsFileSourceVersion? SourceVersion,
         bool WasInspected);
+
+	private readonly record struct FileMetricsVersionCandidate(
+		string Path,
+		FileMetricsCacheEntry Entry,
+		MetricsFileSourceVersion SourceVersion);
 
     private sealed class FileMetricsCacheEntry(
 		FileMetricsVariant raw,
-		FileMetricsSourceVersion sourceVersion)
+		MetricsFileSourceVersion sourceVersion)
     {
         private readonly Dictionary<string, FileMetricsVariant> _transformed = new(StringComparer.Ordinal);
 
         public FileMetricsVariant Raw { get; set; } = raw;
-		public FileMetricsSourceVersion SourceVersion { get; } = sourceVersion;
+		public MetricsFileSourceVersion SourceVersion { get; } = sourceVersion;
 
         public void SetTransformed(string identity, FileMetricsVariant metrics) =>
             _transformed[identity] = metrics;
@@ -116,6 +195,8 @@ internal sealed class MetricsPipeline(
     private readonly CodeCompressionPrewarmer _compressionPrewarmer = new(fileContentAnalyzer);
 	private readonly BackgroundTaskRegistry _backgroundTasks = backgroundTasks ?? new();
 	private readonly bool _ownsBackgroundTasks = backgroundTasks is null;
+	private readonly IMetricsFileSourceVersionProvider _fileSourceVersionProvider =
+		fileSourceVersionProvider ?? PhysicalMetricsFileSourceVersionProvider.Instance;
 
     private CancellationTokenSource? _metricsCalculationCts;
     private CancellationTokenSource? _compressionPrewarmCts;
@@ -950,39 +1031,39 @@ internal sealed class MetricsPipeline(
         if (filePaths.Count == 0 || results.Count == 0)
             return;
 
-        var mergedAny = false;
-        lock (_metricsLock)
-        {
-            if (expectedCacheGeneration !=
-                Volatile.Read(ref _metricsCacheGeneration))
-            {
-                return;
-            }
+		var mergedAny = false;
+		lock (_metricsLock)
+		{
+			if (expectedCacheGeneration !=
+			    Volatile.Read(ref _metricsCacheGeneration))
+			{
+				return;
+			}
 
-            var count = Math.Min(filePaths.Count, results.Count);
-            for (var index = 0; index < count; index++)
-            {
-                var result = results[index];
-                if (!result.WasInspected || result.SourceVersion is not { } sourceVersion)
-                    continue;
+			var count = Math.Min(filePaths.Count, results.Count);
+			for (var index = 0; index < count; index++)
+			{
+				var result = results[index];
+				if (!result.WasInspected || result.SourceVersion is not { } sourceVersion)
+					continue;
 
-                var filePath = filePaths[index];
-                if (!_fileMetricsCache.TryGetValue(filePath, out var entry) ||
+				var filePath = filePaths[index];
+				if (!_fileMetricsCache.TryGetValue(filePath, out var entry) ||
 					entry.SourceVersion != sourceVersion)
-                {
+				{
 					entry = new FileMetricsCacheEntry(result.Raw, sourceVersion);
 					_fileMetricsCache[filePath] = entry;
-                }
-                else
-                {
-                    entry.Raw = result.Raw;
-                }
+				}
+				else
+				{
+					entry.Raw = result.Raw;
+				}
 
-                if (result.TransformIdentity.Length > 0)
-                    entry.SetTransformed(result.TransformIdentity, result.Effective);
-                mergedAny = true;
-            }
-        }
+				if (result.TransformIdentity.Length > 0)
+					entry.SetTransformed(result.TransformIdentity, result.Effective);
+				mergedAny = true;
+			}
+		}
 
 		if (mergedAny)
 			InvalidateContentMetricsCache();
@@ -1053,7 +1134,7 @@ internal sealed class MetricsPipeline(
 
                 TextFileMetrics? rawMetrics;
                 TextFileMetrics? effectiveMetrics;
-				FileMetricsSourceVersion? sourceVersion = null;
+				MetricsFileSourceVersion? sourceVersion = null;
 				ContentReadFact? retainedFact = null;
 				if (readFacts is not null && readFacts.TryGet(filePath, out var retained))
 					retainedFact = retained;
@@ -1101,7 +1182,8 @@ internal sealed class MetricsPipeline(
 				sourceVersion ??= TryCaptureStableSourceVersion(
 					filePath,
 					sourceVersionBeforeRead);
-				if (sourceVersion is null || !sourceVersion.Value.IsCurrent(filePath))
+				if (sourceVersion is null ||
+					TryCaptureCurrentSourceVersion(filePath) != sourceVersion.Value)
 				{
 					Interlocked.Exchange(ref hadReadFailures, 1);
 					return;
@@ -1142,38 +1224,15 @@ internal sealed class MetricsPipeline(
         return Volatile.Read(ref hadReadFailures) != 0;
     }
 
-	private static FileMetricsSourceVersion? TryCaptureCurrentSourceVersion(string path)
+	private MetricsFileSourceVersion? TryCaptureCurrentSourceVersion(string path)
 	{
-		try
-		{
-			using var stream = new FileStream(
-				path,
-				FileMode.Open,
-				FileAccess.Read,
-				FileShare.Read | FileShare.Delete,
-				bufferSize: 1,
-				FileOptions.RandomAccess);
-			return new FileMetricsSourceVersion(
-				RandomAccess.GetLength(stream.SafeFileHandle),
-				File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks,
-				IsMissing: false);
-		}
-		catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
-		{
-			return new FileMetricsSourceVersion(
-				Length: 0,
-				LastWriteTimeUtcTicks: 0,
-				IsMissing: true);
-		}
-		catch (Exception exception) when (IsExpectedMetricsReadFailure(exception))
-		{
-			return null;
-		}
+		ioTestPoint?.RecordFileVersionOpen();
+		return _fileSourceVersionProvider.Capture(path);
 	}
 
-	private static FileMetricsSourceVersion? TryCaptureStableSourceVersion(
+	private MetricsFileSourceVersion? TryCaptureStableSourceVersion(
 		string path,
-		FileMetricsSourceVersion? versionBeforeRead)
+		MetricsFileSourceVersion? versionBeforeRead)
 	{
 		var versionAfterRead = TryCaptureCurrentSourceVersion(path);
 		return versionBeforeRead is { } before && versionAfterRead == before
@@ -1321,8 +1380,8 @@ internal sealed class MetricsPipeline(
                         selection);
 
                     var hadReadFailures = await EnsureSelectedFileMetricsAsync(missingPaths, token);
-                    if (!hasAnyChecked &&
-                        !hadReadFailures &&
+					if (!selection.HasEffectiveSelection &&
+						!hadReadFailures &&
 						CollectMissingMetricsFilePaths(targetFilePaths, token).Count == 0)
                     {
                         _hasCompleteMetricsBaseline = true;
@@ -1430,6 +1489,19 @@ internal sealed class MetricsPipeline(
             return;
         }
 
+		if (!hasAnyChecked)
+		{
+			await Dispatcher.UIThread.InvokeAsync(() =>
+			{
+				if (!token.IsCancellationRequested &&
+				    recalcVersion == Volatile.Read(ref _metricsRecalcVersion))
+				{
+					UpdateStatusBarMetrics(0, 0, 0, 0, 0, 0);
+				}
+			});
+			return;
+		}
+
         var selection = preparedSelection ?? await Task.Run(
             () => BuildMetricsSelectionProjection(
                 currentTree,
@@ -1471,34 +1543,96 @@ internal sealed class MetricsPipeline(
 		CancellationToken cancellationToken)
     {
 		cancellationToken.ThrowIfCancellationRequested();
-        var missingPaths = new List<string>();
-		var removedStaleEntry = false;
-        lock (_metricsLock)
+		var cacheGeneration = Volatile.Read(ref _metricsCacheGeneration);
+		var transformIdentity = _appliedTransformIdentity;
+		var candidates = new List<FileMetricsVersionCandidate>(orderedPaths.Count);
+
+		EnterMetricsLock();
+		try
         {
             for (var index = 0; index < orderedPaths.Count; index++)
             {
 				cancellationToken.ThrowIfCancellationRequested();
                 var path = orderedPaths[index];
-                if (!_fileMetricsCache.TryGetValue(path, out var entry) ||
-                    !entry.TryGet(_appliedTransformIdentity, out _))
-				{
-                    missingPaths.Add(path);
+				if (!_fileMetricsCache.TryGetValue(path, out var entry) ||
+				    !entry.TryGet(transformIdentity, out _))
 					continue;
-				}
 
-				if (!entry.SourceVersion.IsCurrent(path))
-				{
-					_fileMetricsCache.Remove(path);
-					missingPaths.Add(path);
-					removedStaleEntry = true;
-				}
+				candidates.Add(new FileMetricsVersionCandidate(path, entry, entry.SourceVersion));
             }
         }
+		finally
+		{
+			Monitor.Exit(_metricsLock);
+		}
+
+		var staleCandidates = new List<FileMetricsVersionCandidate>();
+		for (var index = 0; index < candidates.Count; index++)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var candidate = candidates[index];
+			if (TryCaptureCurrentSourceVersion(candidate.Path) != candidate.SourceVersion)
+				staleCandidates.Add(candidate);
+		}
+
+		cancellationToken.ThrowIfCancellationRequested();
+		var missingPaths = new List<string>();
+		var removedStaleEntry = false;
+		EnterMetricsLock();
+		try
+		{
+			if (cacheGeneration != Volatile.Read(ref _metricsCacheGeneration) ||
+			    !string.Equals(transformIdentity, _appliedTransformIdentity, StringComparison.Ordinal))
+			{
+				throw new OperationCanceledException(cancellationToken);
+			}
+
+			for (var index = 0; index < staleCandidates.Count; index++)
+			{
+				var candidate = staleCandidates[index];
+				if (_fileMetricsCache.TryGetValue(candidate.Path, out var current) &&
+				    ReferenceEquals(current, candidate.Entry) &&
+				    current.SourceVersion == candidate.SourceVersion)
+				{
+					_fileMetricsCache.Remove(candidate.Path);
+					removedStaleEntry = true;
+				}
+			}
+
+			for (var index = 0; index < orderedPaths.Count; index++)
+			{
+				var path = orderedPaths[index];
+				if (!_fileMetricsCache.TryGetValue(path, out var entry) ||
+				    !entry.TryGet(transformIdentity, out _))
+				{
+					missingPaths.Add(path);
+				}
+			}
+		}
+		finally
+		{
+			Monitor.Exit(_metricsLock);
+		}
+
 		if (removedStaleEntry)
 			InvalidateContentMetricsCache();
 
         return missingPaths;
     }
+
+	private void EnterMetricsLock()
+	{
+		if (ioTestPoint is null)
+		{
+			Monitor.Enter(_metricsLock);
+			return;
+		}
+
+		var waitStarted = Stopwatch.GetTimestamp();
+		ioTestPoint.RecordMetricsLockAttempt();
+		Monitor.Enter(_metricsLock);
+		ioTestPoint.RecordMetricsLockWait(Stopwatch.GetElapsedTime(waitStarted));
+	}
 
     private async Task<bool> EnsureSelectedFileMetricsAsync(
         IReadOnlyList<string> missingPaths,

--- a/Apps/Avalonia/Coordinators/MetricsPipeline.cs
+++ b/Apps/Avalonia/Coordinators/MetricsPipeline.cs
@@ -1489,7 +1489,7 @@ internal sealed class MetricsPipeline(
             return;
         }
 
-		if (!hasAnyChecked)
+		if (!hasAnyChecked && currentTree.OrderedFilePaths is { Count: 0 })
 		{
 			await Dispatcher.UIThread.InvokeAsync(() =>
 			{

--- a/Apps/Avalonia/Services/PreviewPolicies.cs
+++ b/Apps/Avalonia/Services/PreviewPolicies.cs
@@ -1021,9 +1021,6 @@ internal static class MetricsCalculationPolicy
         }
     }
 
-    public static bool ShouldProceedWithMetricsCalculation(bool hasAnyCheckedNodes, bool hasCompleteMetricsBaseline) =>
-        hasAnyCheckedNodes || hasCompleteMetricsBaseline;
-
     public static int GetBaselineWarmupParallelism(int processorCount)
     {
         if (processorCount <= 1)

--- a/Tests/DevProjex.Tests.Terminal/DocumentationExecutionRegressionTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationExecutionRegressionTests.cs
@@ -7,8 +7,11 @@ namespace DevProjex.Tests.Terminal;
 
 public sealed class DocumentationExecutionRegressionTests
 {
-	[Fact]
-	public async Task PublishedDirectCommandExamplesExecuteWithoutMutatingSource()
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task PublishedDirectCommandExamplesExecuteWithoutMutatingSource(
+		bool useSeparateGitDirectory)
 	{
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("source-project");
@@ -16,7 +19,11 @@ public sealed class DocumentationExecutionRegressionTests
 		workspace.WriteFile("source-project/README.md", "# Sample\n");
 		var repositoryRoot = FindRepositoryRoot();
 		Assert.False(PathUtility.IsPathInside(workspace.Path, repositoryRoot));
-		InitializeGitIndex(project, workspace.CreateDirectory("source-project.git"));
+		InitializeGitIndex(
+			project,
+			useSeparateGitDirectory
+				? workspace.CreateDirectory("source-project.git")
+				: null);
 		var examples = await ExtractPublishedDirectExamplesAsync(
 			repositoryRoot,
 			TestContext.Current.CancellationToken);
@@ -40,19 +47,25 @@ public sealed class DocumentationExecutionRegressionTests
 					environment,
 					serviceFactory)
 				.RunAsync(arguments, TestContext.Current.CancellationToken);
+			var failureDiagnostic =
+				exitCode != CommandLineExitCodes.Success ||
+				!string.IsNullOrEmpty(environment.StandardError)
+					? BuildCommandFailureDiagnostic(
+						uniqueCommands[index],
+						arguments,
+						environment.StandardError,
+						serviceFactory,
+						project,
+						before,
+						useSeparateGitDirectory)
+					: string.Empty;
 
 			Assert.True(
 				exitCode == CommandLineExitCodes.Success,
-				$"Documented command failed with exit code {exitCode}: " +
-				$"{uniqueCommands[index]}{Environment.NewLine}{environment.StandardError}");
+				$"Documented command failed with exit code {exitCode}.\n{failureDiagnostic}");
 			Assert.True(
 				string.IsNullOrEmpty(environment.StandardError),
-				BuildUnexpectedStandardErrorDiagnostic(
-					uniqueCommands[index],
-					arguments,
-					environment.StandardError,
-					serviceFactory,
-					project));
+				failureDiagnostic);
 			Assert.NotEmpty(environment.StandardOutput);
 			Assert.Equal(before, ComputeTreeFingerprint(project));
 			AssertObservableResult(
@@ -285,20 +298,25 @@ public sealed class DocumentationExecutionRegressionTests
 		return Convert.ToHexString(hash.GetHashAndReset());
 	}
 
-	private static string BuildUnexpectedStandardErrorDiagnostic(
+	private static string BuildCommandFailureDiagnostic(
 		string documentedCommand,
 		IReadOnlyList<string> arguments,
 		string standardError,
 		TerminalServiceFactory serviceFactory,
-		string project)
+		string project,
+		string sourceFingerprintBeforeCommand,
+		bool useSeparateGitDirectory)
 	{
 		using var services = serviceFactory.Create(AppLanguage.En);
 		var loaded = services.AnalysisService.Load(new ProjectAnalysisRequest(project));
 		var unavailablePaths = EnumerateAccessDeniedPaths(loaded.Tree.Root).ToArray();
 		return
-			$"Documented command wrote stderr.\n" +
+			$"Documented command failed or wrote stderr.\n" +
+			$"Git layout: {(useSeparateGitDirectory ? "separate git dir" : "in-tree .git")}\n" +
 			$"Documented: {documentedCommand}\n" +
 			$"Executed: devprojex {string.Join(' ', arguments.Select(QuoteArgument))}\n" +
+			$"Source fingerprint before command: {sourceFingerprintBeforeCommand}\n" +
+			$"Source fingerprint at diagnostic rescan: {ComputeTreeFingerprint(project)}\n" +
 			$"Full stderr:\n{standardError}\n" +
 			$"Access-denied paths from a diagnostic rescan ({unavailablePaths.Length}):\n" +
 			(unavailablePaths.Length == 0
@@ -322,9 +340,12 @@ public sealed class DocumentationExecutionRegressionTests
 			? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
 			: argument;
 
-	private static void InitializeGitIndex(string project, string gitDirectory)
+	private static void InitializeGitIndex(string project, string? gitDirectory)
 	{
-		RunGit(project, "init", "--quiet", $"--separate-git-dir={gitDirectory}");
+		if (gitDirectory is null)
+			RunGit(project, "init", "--quiet");
+		else
+			RunGit(project, "init", "--quiet", $"--separate-git-dir={gitDirectory}");
 		RunGit(project, "add", "--all");
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/GeneratedCompletionNativeShellIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/GeneratedCompletionNativeShellIntegrationTests.cs
@@ -1,16 +1,33 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace DevProjex.Tests.Terminal;
 
 [Collection(TerminalProcessCollection.Name)]
-public sealed class GeneratedCompletionNativeShellIntegrationTests
+public sealed class GeneratedCompletionNativeShellIntegrationTests(ITestOutputHelper output)
 {
 	private const string CompletionLine = "devprojex analyze . --format ";
 	private const string CompletionShellsVariable =
 		"DEVPROJEX_COMPLETION_SHELLS";
+	private const uint SnapshotProcesses = 0x00000002;
 	private static readonly TimeSpan WindowsPowerShellProcessTimeout = TimeSpan.FromSeconds(60);
 	private static readonly TimeSpan ProcessCleanupTimeout = TimeSpan.FromSeconds(5);
 	private static readonly UTF8Encoding Utf8WithoutBom = new(encoderShouldEmitUTF8Identifier: false);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	private static extern IntPtr CreateToolhelp32Snapshot(uint flags, uint processId);
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool Process32First(IntPtr snapshot, ref ProcessEntry32 entry);
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool Process32Next(IntPtr snapshot, ref ProcessEntry32 entry);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool CloseHandle(IntPtr handle);
 
 	[Theory]
 	[InlineData("bash")]
@@ -186,6 +203,25 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 	[Fact(Timeout = 120_000)]
 	public async Task WindowsPowerShell51CompletesAfterClosedQuotedWhitespacePath()
 	{
+		var measurement = await RunWindowsPowerShell51CompletionScenarioAsync(warmUp: true);
+		output.WriteLine(
+			"DPX_PS51_WARMUP_MS={0:F0}; DPX_PS51_WARM_COMPLETION_MS={1:F0}",
+			measurement.WarmupDuration!.Value.TotalMilliseconds,
+			measurement.CompletionDuration.TotalMilliseconds);
+	}
+
+	[Fact(Timeout = 120_000)]
+	public async Task WindowsPowerShell51ColdCompletionRecordsDurationAndDiagnostics()
+	{
+		var measurement = await RunWindowsPowerShell51CompletionScenarioAsync(warmUp: false);
+		output.WriteLine(
+			"DPX_PS51_COLD_COMPLETION_MS={0:F0}",
+			measurement.CompletionDuration.TotalMilliseconds);
+	}
+
+	[Fact(Timeout = 15_000)]
+	public async Task WindowsPowerShell51TimeoutReportsStagePidInputsStreamsAndChildren()
+	{
 		if (!OperatingSystem.IsWindows())
 		{
 			Assert.Skip("Windows PowerShell 5.1 is available only on Windows.");
@@ -202,6 +238,48 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 		{
 			Assert.Skip("Windows PowerShell 5.1 is not installed on this Windows host.");
 			return;
+		}
+
+		var startInfo = CreateShellStartInfo("powershell", shellExecutable);
+		startInfo.Environment["DPX_DIAGNOSTIC_INPUT"] = "cold-completion";
+		startInfo.ArgumentList.Add("-Command");
+		startInfo.ArgumentList.Add("Write-Output ready; Start-Sleep -Seconds 30");
+		var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+			RunProcessAsync(
+				startInfo,
+				TestContext.Current.CancellationToken,
+				TimeSpan.FromMilliseconds(300),
+				diagnosticStage: "diagnostic-contract"));
+
+		Assert.Contains("Stage=[diagnostic-contract]", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("PID=", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("inputs=[", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("DPX_DIAGNOSTIC_INPUT=[cold-completion]", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("stdout=[", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("stderr=[", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("children-before-termination=[", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("children-after-termination=[", exception.Message, StringComparison.Ordinal);
+	}
+
+	private static async Task<WindowsPowerShellCompletionMeasurement>
+		RunWindowsPowerShell51CompletionScenarioAsync(bool warmUp)
+	{
+		if (!OperatingSystem.IsWindows())
+		{
+			Assert.Skip("Windows PowerShell 5.1 is available only on Windows.");
+			throw new UnreachableException();
+		}
+
+		var shellExecutable = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+			"System32",
+			"WindowsPowerShell",
+			"v1.0",
+			"powershell.exe");
+		if (!File.Exists(shellExecutable))
+		{
+			Assert.Skip("Windows PowerShell 5.1 is not installed on this Windows host.");
+			throw new UnreachableException();
 		}
 
 		var unifiedHost = PublishedApplicationLocator.FindExecutable();
@@ -224,30 +302,23 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 			generated.StandardOutput);
 		const string line =
 			"devprojex analyze \".\\Program Files\" --format ";
-		var coldStart = await MeasureWindowsPowerShellColdStartAsync(
-			shellExecutable,
-			TestContext.Current.CancellationToken);
-
-		ShellProcessResult completed;
-		try
+		TimeSpan? warmupDuration = null;
+		if (warmUp)
 		{
-			completed = await RunPowerShellCandidateCompletionAsync(
+			warmupDuration = await MeasureWindowsPowerShellColdStartAsync(
 				shellExecutable,
-				integrationRoot,
-				completionScript,
-				workingDirectory,
-				line,
 				TestContext.Current.CancellationToken);
 		}
-		catch (TimeoutException exception)
-		{
-			throw new TimeoutException(
-				$"Windows PowerShell 5.1 cold start: {coldStart.TotalMilliseconds:F0} ms; " +
-				$"completion timeout: {WindowsPowerShellProcessTimeout.TotalMilliseconds:F0} ms; " +
-				$"cold-start/timeout ratio: {coldStart.TotalMilliseconds / WindowsPowerShellProcessTimeout.TotalMilliseconds:P1}. " +
-				exception.Message,
-				exception);
-		}
+
+		var completionStopwatch = Stopwatch.StartNew();
+		var completed = await RunPowerShellCandidateCompletionAsync(
+			shellExecutable,
+			integrationRoot,
+			completionScript,
+			workingDirectory,
+			line,
+			TestContext.Current.CancellationToken);
+		completionStopwatch.Stop();
 
 		Assert.True(
 			completed.ExitCode == 0,
@@ -265,6 +336,9 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 					StringSplitOptions.RemoveEmptyEntries |
 					StringSplitOptions.TrimEntries)
 				.Order(StringComparer.Ordinal));
+		return new WindowsPowerShellCompletionMeasurement(
+			warmupDuration,
+			completionStopwatch.Elapsed);
 	}
 
 	private static async Task<TimeSpan> MeasureWindowsPowerShellColdStartAsync(
@@ -278,7 +352,8 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 		var result = await RunProcessAsync(
 			startInfo,
 			cancellationToken,
-			WindowsPowerShellProcessTimeout);
+			WindowsPowerShellProcessTimeout,
+			diagnosticStage: "Windows PowerShell 5.1 warmup");
 		stopwatch.Stop();
 		Assert.True(
 			result.ExitCode == 0 &&
@@ -455,7 +530,8 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 		return await RunProcessAsync(
 			startInfo,
 			cancellationToken,
-			WindowsPowerShellProcessTimeout);
+			WindowsPowerShellProcessTimeout,
+			diagnosticStage: "Windows PowerShell 5.1 completion");
 	}
 
 	private static ProcessStartInfo CreateShellStartInfo(
@@ -813,7 +889,8 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 	private static async Task<ShellProcessResult> RunProcessAsync(
 		ProcessStartInfo startInfo,
 		CancellationToken cancellationToken,
-		TimeSpan? processTimeout = null)
+		TimeSpan? processTimeout = null,
+		string diagnosticStage = "native shell process")
 	{
 		using var processTimeoutCancellation = new CancellationTokenSource(
 			processTimeout ?? TimeSpan.FromSeconds(20));
@@ -823,6 +900,8 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 		using var outputCancellation = new CancellationTokenSource();
 		using var process = new Process { StartInfo = startInfo };
 		Assert.True(process.Start(), $"Could not start {startInfo.FileName}.");
+		var processId = process.Id;
+		var processInputs = FormatProcessInputs(startInfo);
 		var standardOutput = process.StandardOutput.ReadToEndAsync(outputCancellation.Token);
 		var standardError = process.StandardError.ReadToEndAsync(outputCancellation.Token);
 		process.StandardInput.Close();
@@ -834,16 +913,22 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 			}
 			catch (OperationCanceledException) when (processCancellation.IsCancellationRequested)
 			{
+				var descendantsBeforeTermination = CaptureDescendantProcesses(processId);
 				await TerminateProcessTreeAsync(process);
+				var descendantsAfterTermination = CaptureDescendantProcesses(processId);
 				var cancelledOutput = await DrainProcessOutputAsync(
 					standardOutput,
 					standardError,
 					outputCancellation);
 				cancellationToken.ThrowIfCancellationRequested();
 				throw new TimeoutException(
-					$"{startInfo.FileName} completion integration timed out. " +
-					$"stdout=[{cancelledOutput.StandardOutput}] " +
-					$"stderr=[{cancelledOutput.StandardError}]");
+					$"Stage=[{diagnosticStage}] timed out after " +
+					$"{(processTimeout ?? TimeSpan.FromSeconds(20)).TotalMilliseconds:F0} ms. " +
+					$"PID={processId}; inputs=[{processInputs}]; " +
+					$"stdout=[{cancelledOutput.StandardOutput}]; " +
+					$"stderr=[{cancelledOutput.StandardError}]; " +
+					$"children-before-termination=[{descendantsBeforeTermination}]; " +
+					$"children-after-termination=[{descendantsAfterTermination}]");
 			}
 
 			var output = await DrainProcessOutputAsync(
@@ -853,8 +938,10 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 			if (!output.Completed)
 			{
 				throw new TimeoutException(
-					$"{startInfo.FileName} completion integration output did not close. " +
-					$"stdout=[{output.StandardOutput}] stderr=[{output.StandardError}]");
+					$"Stage=[{diagnosticStage}: output drain] did not close. " +
+					$"PID={processId}; inputs=[{processInputs}]; " +
+					$"stdout=[{output.StandardOutput}]; stderr=[{output.StandardError}]; " +
+					$"children=[{CaptureDescendantProcesses(processId)}]");
 			}
 
 			return new ShellProcessResult(
@@ -870,6 +957,81 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 				outputCancellation.Cancel();
 				await ObserveReadersAsync(standardOutput, standardError);
 			}
+		}
+	}
+
+	private static string FormatProcessInputs(ProcessStartInfo startInfo)
+	{
+		var arguments = string.Join(
+			' ',
+			startInfo.ArgumentList.Select(static argument => $"[{argument}]"));
+		var environment = startInfo.Environment
+			.Where(static item => item.Key.StartsWith("DPX_", StringComparison.Ordinal))
+			.OrderBy(static item => item.Key, StringComparer.Ordinal)
+			.Select(static item => $"{item.Key}=[{item.Value}]");
+		return
+			$"file=[{startInfo.FileName}]; arguments={arguments}; " +
+			$"working-directory=[{startInfo.WorkingDirectory}]; " +
+			$"environment={string.Join(';', environment)}";
+	}
+
+	private static string CaptureDescendantProcesses(int rootProcessId)
+	{
+		if (!OperatingSystem.IsWindows())
+			return "not available on this platform";
+
+		var snapshot = CreateToolhelp32Snapshot(SnapshotProcesses, 0);
+		if (snapshot == new IntPtr(-1))
+			return $"snapshot-error={Marshal.GetLastWin32Error()}";
+
+		try
+		{
+			var entries = new List<ProcessSnapshotEntry>();
+			var entry = new ProcessEntry32
+			{
+				Size = checked((uint)Marshal.SizeOf<ProcessEntry32>())
+			};
+			if (Process32First(snapshot, ref entry))
+			{
+				do
+				{
+					entries.Add(new ProcessSnapshotEntry(
+						checked((int)entry.ProcessId),
+						checked((int)entry.ParentProcessId),
+						entry.ExecutableFile));
+					entry.Size = checked((uint)Marshal.SizeOf<ProcessEntry32>());
+				}
+				while (Process32Next(snapshot, ref entry));
+			}
+
+			var descendantIds = new HashSet<int> { rootProcessId };
+			var descendants = new List<ProcessSnapshotEntry>();
+			var added = true;
+			while (added)
+			{
+				added = false;
+				foreach (var candidate in entries)
+				{
+					if (!descendantIds.Contains(candidate.ParentProcessId) ||
+					    !descendantIds.Add(candidate.ProcessId))
+					{
+						continue;
+					}
+					descendants.Add(candidate);
+					added = true;
+				}
+			}
+
+			return descendants.Count == 0
+				? "none"
+				: string.Join(
+					", ",
+					descendants.Select(static child =>
+						$"pid={child.ProcessId}/ppid={child.ParentProcessId}/name={child.Name}"));
+		}
+		finally
+		{
+			CloseHandle(snapshot);
 		}
 	}
 
@@ -1069,4 +1231,30 @@ public sealed class GeneratedCompletionNativeShellIntegrationTests
 		int ExitCode,
 		string StandardOutput,
 		string StandardError);
+
+	private sealed record WindowsPowerShellCompletionMeasurement(
+		TimeSpan? WarmupDuration,
+		TimeSpan CompletionDuration);
+
+	private sealed record ProcessSnapshotEntry(
+		int ProcessId,
+		int ParentProcessId,
+		string Name);
+
+	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+	private struct ProcessEntry32
+	{
+		public uint Size;
+		public uint Usage;
+		public uint ProcessId;
+		public IntPtr DefaultHeapId;
+		public uint ModuleId;
+		public uint ThreadCount;
+		public uint ParentProcessId;
+		public int BasePriority;
+		public uint Flags;
+
+		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+		public string ExecutableFile;
+	}
 }

--- a/Tests/DevProjex.Tests.Terminal/TerminalPtyHarness.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalPtyHarness.cs
@@ -756,30 +756,58 @@ internal sealed class TerminalPtyHarness : IAsyncDisposable
 			$"Terminal responses: {CaptureTerminalResponseLog()}");
 	}
 
-	public async Task<string> WaitForStableScreenAsync(
+	public Task<string> WaitForStableScreenAsync(
 		string required,
 		string? forbidden = null,
 		TimeSpan? timeout = null,
+		CancellationToken cancellationToken = default) =>
+		WaitForStableScreenAsync(
+			screen =>
+				screen.Contains(required, StringComparison.Ordinal) &&
+				(forbidden is null || !screen.Contains(forbidden, StringComparison.Ordinal)),
+			forbidden is null
+				? $"containing '{required}'"
+				: $"containing '{required}' without '{forbidden}'",
+			screen =>
+				$"required={screen.Contains(required, StringComparison.Ordinal)} " +
+				$"forbidden={forbidden is not null && screen.Contains(forbidden, StringComparison.Ordinal)}",
+			timeout,
+			cancellationToken);
+
+	public async Task<string> WaitForStableScreenAsync(
+		Func<string, bool> readiness,
+		string readinessDescription,
+		Func<string, string>? timelineState = null,
+		TimeSpan? timeout = null,
 		CancellationToken cancellationToken = default)
 	{
+		ArgumentNullException.ThrowIfNull(readiness);
+		ArgumentException.ThrowIfNullOrWhiteSpace(readinessDescription);
 		var stopwatch = Stopwatch.StartNew();
 		var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(15);
 		var previous = string.Empty;
 		var stableSamples = 0;
+		var timeline = new List<string>();
 		while (stopwatch.Elapsed < effectiveTimeout)
 		{
 			var screen = CaptureScreen();
+			var matches = readiness(screen);
+			if (!string.Equals(previous, screen, StringComparison.Ordinal))
+			{
+				timeline.Add(
+					$"{stopwatch.Elapsed.TotalMilliseconds,7:F0} ms " +
+					$"ready={matches} {timelineState?.Invoke(screen) ?? string.Empty} " +
+					$"chars={screen.Length}");
+			}
 			if (HasExited)
 			{
 				throw new Xunit.Sdk.XunitException(
 					$"Terminal process exited with code {_process.ExitCode} before the screen " +
-					$"stabilized for '{required}'.\nScreen:\n{screen}\nRaw output:\n{CaptureRawOutput()}");
+					$"stabilized while {readinessDescription}.\n" +
+					$"Timeline:\n{string.Join(Environment.NewLine, timeline)}\n" +
+					$"Full screen:\n{screen}\nRaw output:\n{CaptureRawOutput()}");
 			}
 
-			var matches =
-				screen.Contains(required, StringComparison.Ordinal) &&
-				(forbidden is null ||
-				 !screen.Contains(forbidden, StringComparison.Ordinal));
 			if (matches &&
 			    string.Equals(previous, screen, StringComparison.Ordinal))
 			{
@@ -796,12 +824,10 @@ internal sealed class TerminalPtyHarness : IAsyncDisposable
 			await Task.Delay(80, cancellationToken).ConfigureAwait(false);
 		}
 
-		var forbiddenCondition = forbidden is null
-			? string.Empty
-			: $" without '{forbidden}'";
 		throw new TimeoutException(
-			$"Timed out waiting for a stable screen containing '{required}'" +
-			$"{forbiddenCondition}.\n{CaptureScreen()}\n" +
+			$"Timed out waiting for a stable screen while {readinessDescription}.\n" +
+			$"Timeline:\n{string.Join(Environment.NewLine, timeline)}\n" +
+			$"Full screen:\n{CaptureScreen()}\n" +
 			$"Raw output tail:\n{CaptureRawOutputTail()}\n" +
 			$"Terminal responses: {CaptureTerminalResponseLog()}");
 	}

--- a/Tests/DevProjex.Tests.Terminal/TerminalRecentRepositoriesPtyTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalRecentRepositoriesPtyTests.cs
@@ -57,9 +57,19 @@ public sealed partial class TerminalRecentRepositoriesPtyTests
 			welcomeDirectory.Path);
 
 		await terminal.SendEnterAsync(TestContext.Current.CancellationToken);
-		var workspace = await WaitForWorkspaceTreeRenderedAsync(
-			terminal,
-			TestContext.Current.CancellationToken);
+		var workspace = await terminal.WaitForStableScreenAsync(
+			readiness: static screen =>
+				screen.Contains("PROJECT TREE", StringComparison.Ordinal) &&
+				screen.Contains("PARAMETERS", StringComparison.Ordinal) &&
+				screen.Contains("RepositoryMarker.cs", StringComparison.Ordinal),
+			readinessDescription:
+				"waiting for PROJECT TREE + PARAMETERS + RepositoryMarker.cs",
+			timelineState: static screen =>
+				$"tree={screen.Contains("PROJECT TREE", StringComparison.Ordinal)} " +
+				$"parameters={screen.Contains("PARAMETERS", StringComparison.Ordinal)} " +
+				$"marker={screen.Contains("RepositoryMarker.cs", StringComparison.Ordinal)}",
+			timeout: TimeSpan.FromSeconds(30),
+			cancellationToken: TestContext.Current.CancellationToken);
 
 		Assert.Contains("DevProjex Terminal · DevProjex", workspace, StringComparison.Ordinal);
 		Assert.Contains(RepositoryUrl, workspace, StringComparison.Ordinal);
@@ -109,47 +119,6 @@ public sealed partial class TerminalRecentRepositoriesPtyTests
 			CommandLineExitCodes.Success,
 			await terminal.WaitForExitAsync(
 				cancellationToken: TestContext.Current.CancellationToken));
-	}
-
-	private static async Task<string> WaitForWorkspaceTreeRenderedAsync(
-		TerminalPtyHarness terminal,
-		CancellationToken cancellationToken)
-	{
-		var stopwatch = Stopwatch.StartNew();
-		var timeline = new List<string>();
-		var previous = string.Empty;
-		var stableSamples = 0;
-		while (stopwatch.Elapsed < TimeSpan.FromSeconds(30))
-		{
-			var screen = terminal.CaptureScreen();
-			var tree = screen.Contains("PROJECT TREE", StringComparison.Ordinal);
-			var parameters = screen.Contains("PARAMETERS", StringComparison.Ordinal);
-			var marker = screen.Contains("RepositoryMarker.cs", StringComparison.Ordinal);
-			if (!string.Equals(previous, screen, StringComparison.Ordinal))
-			{
-				timeline.Add(
-					$"{stopwatch.Elapsed.TotalMilliseconds,7:F0} ms " +
-					$"tree={tree} parameters={parameters} marker={marker} " +
-					$"chars={screen.Length}");
-				previous = screen;
-				stableSamples = 0;
-			}
-			else if (tree && parameters && marker && ++stableSamples >= 3)
-			{
-				return screen;
-			}
-
-			if (terminal.HasExited)
-				break;
-			await Task.Delay(80, cancellationToken);
-		}
-
-		var finalScreen = terminal.CaptureScreen();
-		throw new Xunit.Sdk.XunitException(
-			"Workspace tree did not reach its rendered signal " +
-			"(PROJECT TREE + PARAMETERS + RepositoryMarker.cs).\n" +
-			$"Timeline:\n{string.Join(Environment.NewLine, timeline)}\n" +
-			$"Full screen:\n{finalScreen}");
 	}
 
 	[Fact(Timeout = 90_000)]

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MainWindowMetricsPolicyTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MainWindowMetricsPolicyTests.cs
@@ -24,31 +24,6 @@ public sealed class MainWindowMetricsPolicyTests
     }
 
     [Theory]
-    [InlineData(false, false, false)]
-    [InlineData(false, true, true)]
-    [InlineData(true, false, true)]
-    [InlineData(true, true, true)]
-    public void ShouldProceedWithMetricsCalculation_ReturnsExpectedDecision(
-        bool hasAnyCheckedNodes,
-        bool hasCompleteMetricsBaseline,
-        bool expected)
-    {
-        var result = MetricsCalculationPolicy.ShouldProceedWithMetricsCalculation(
-            hasAnyCheckedNodes,
-            hasCompleteMetricsBaseline);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Fact]
-    public void ZeroCheckedPathsKeepPublishingTheCompleteWholeTreeBaseline()
-    {
-        Assert.True(MetricsCalculationPolicy.ShouldProceedWithMetricsCalculation(
-            hasAnyCheckedNodes: false,
-            hasCompleteMetricsBaseline: true));
-    }
-
-    [Theory]
     [InlineData(1, 1)]
     [InlineData(2, 4)]
     [InlineData(4, 4)]

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineIoMeasurementTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineIoMeasurementTests.cs
@@ -1,0 +1,365 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using DevProjex.Avalonia.Services;
+
+namespace DevProjex.Tests.Unit.Avalonia;
+
+[Collection("AvaloniaUI")]
+public sealed class MetricsPipelineIoMeasurementTests(ITestOutputHelper output)
+{
+	[AvaloniaFact]
+	public async Task ConcurrentMergeDuringFreshnessProbe_PreservesLatestFileMetrics()
+	{
+		var rootPath = Path.Combine(Path.GetTempPath(), "DevProjex-Metrics-Concurrent");
+		var filePath = Path.Combine(rootPath, "Changed.cs");
+		var root = new TreeNodeDescriptor(
+			"root",
+			rootPath,
+			true,
+			false,
+			"folder",
+			[new TreeNodeDescriptor("Changed.cs", filePath, false, false, "csharp", [])]);
+		var currentTree = new BuildTreeResult(root, false, false, [filePath]);
+		var viewModel = CreateViewModel();
+		viewModel.IsProjectLoaded = true;
+		viewModel.TreeNodes.Add(new TreeNodeViewModel(root, parent: null, icon: null));
+		var versions = new ControlledMetricsFileSourceVersionProvider([filePath]);
+		var analyzer = new SyntheticMetricsAnalyzer(versions);
+		var completedRecalculations = 0;
+		using var pipeline = new MetricsPipeline(
+			viewModel,
+			CreateLocalization(),
+			analyzer,
+			new TreeExportService(),
+			new StatusOperationCoordinator(
+				viewModel,
+				isBackgroundMetricsActive: () => false,
+				metricsOperationTextProvider: () => viewModel.StatusOperationCalculatingData),
+			currentTreeProvider: () => currentTree,
+			currentPathProvider: () => rootPath,
+			selectedPathsProvider: () => new HashSet<string>([rootPath], PathComparer.Default),
+			treeFormatProvider: () => TreeTextFormat.Ascii,
+			exportPathPresentationProvider: () => null,
+			boundsWidthProvider: () => 1400,
+			scheduleMemoryCleanup: _ => Interlocked.Increment(ref completedRecalculations),
+			fileSourceVersionProvider: versions);
+
+		await pipeline.InitializeFileMetricsCacheSoonAfterFirstPaintAsync(
+			currentTree,
+			TestContext.Current.CancellationToken);
+		await WaitUntilAsync(
+			() => pipeline.HasCompleteBaseline && pipeline.HasStatusMetricsSnapshot,
+			TimeSpan.FromSeconds(5));
+		var publishedContentCharsBefore = ReadPublishedContentChars(pipeline);
+
+		versions.Change(filePath);
+		versions.ArmOneSlowOpen();
+		var staleSweep = Task.Run(
+			() => InvokeMissingPathSweep(pipeline, [filePath]),
+			TestContext.Current.CancellationToken);
+		await versions.WaitForSlowOpenAsync(TestContext.Current.CancellationToken);
+
+		pipeline.Recalculate(MemoryCleanupReason.FilterApplied);
+		var latestPublication = WaitUntilAsync(
+			() => Volatile.Read(ref completedRecalculations) == 1,
+			TimeSpan.FromSeconds(5));
+		var publishedBeforeRelease = ReferenceEquals(
+			await Task.WhenAny(
+				latestPublication,
+				Task.Delay(100, TestContext.Current.CancellationToken)),
+			latestPublication);
+		versions.ReleaseSlowOpen();
+		await latestPublication;
+		var missingAfterConcurrentMerge = await staleSweep;
+
+		Assert.True(publishedBeforeRelease);
+		Assert.Empty(missingAfterConcurrentMerge);
+		Assert.Equal(2, analyzer.MetricsCallCount);
+		Assert.Equal(1, ReadPublishedContentChars(pipeline) - publishedContentCharsBefore);
+	}
+
+	[AvaloniaTheory(Timeout = 60_000)]
+	[InlineData(100, false)]
+	[InlineData(100, true)]
+	[InlineData(20_000, false)]
+	[InlineData(20_000, true)]
+	public async Task FilterRefresh_MeasuresVersionIoLockWaitAndPublicationLatency(
+		int fileCount,
+		bool changeOneFile)
+	{
+		var measurement = await MeasureFilterRefreshAsync(fileCount, changeOneFile);
+
+		output.WriteLine(
+			"files={0}; changed={1}; opens={2}; content-rereads={3}; lock-wait-ms={4:F3}; publication-ms={5:F3}",
+			fileCount,
+			changeOneFile ? 1 : 0,
+			measurement.FileVersionOpens,
+			measurement.RepeatedContentReads,
+			measurement.MetricsLockWait.TotalMilliseconds,
+			measurement.PublicationLatency.TotalMilliseconds);
+		Assert.True(measurement.FileVersionOpens >= fileCount);
+		Assert.Equal(changeOneFile ? 1 : 0, measurement.RepeatedContentReads);
+		Assert.Equal(changeOneFile ? 1 : 0, measurement.PublishedContentCharsDelta);
+		Assert.True(measurement.MetricsLockWait >= TimeSpan.Zero);
+		Assert.True(measurement.PublicationLatency > TimeSpan.Zero);
+		Assert.True(
+			measurement.PublishedBeforeSlowOpenReleased,
+			"A newer filter refresh was blocked by an older freshness probe.");
+	}
+
+	private static async Task<FilterRefreshMeasurement> MeasureFilterRefreshAsync(
+		int fileCount,
+		bool changeOneFile)
+	{
+		var rootPath = Path.Combine(Path.GetTempPath(), "DevProjex-Metrics-Synthetic");
+		var filePaths = Enumerable.Range(0, fileCount)
+			.Select(index => Path.Combine(rootPath, $"File-{index:D5}.cs"))
+			.ToArray();
+		var root = new TreeNodeDescriptor(
+			"root",
+			rootPath,
+			true,
+			false,
+			"folder",
+			filePaths.Select(path => new TreeNodeDescriptor(
+				Path.GetFileName(path),
+				path,
+				false,
+				false,
+				"csharp",
+				[])).ToArray());
+		var currentTree = new BuildTreeResult(root, false, false, filePaths);
+		var viewModel = CreateViewModel();
+		viewModel.IsProjectLoaded = true;
+		viewModel.TreeNodes.Add(new TreeNodeViewModel(root, parent: null, icon: null));
+		var versions = new ControlledMetricsFileSourceVersionProvider(filePaths);
+		var analyzer = new SyntheticMetricsAnalyzer(versions);
+		var io = new MetricsPipelineIoTestPoint();
+		var completedRecalculations = 0;
+		using var pipeline = new MetricsPipeline(
+			viewModel,
+			CreateLocalization(),
+			analyzer,
+			new TreeExportService(),
+			new StatusOperationCoordinator(
+				viewModel,
+				isBackgroundMetricsActive: () => false,
+				metricsOperationTextProvider: () => viewModel.StatusOperationCalculatingData),
+			currentTreeProvider: () => currentTree,
+			currentPathProvider: () => rootPath,
+			selectedPathsProvider: () => new HashSet<string>([rootPath], PathComparer.Default),
+			treeFormatProvider: () => TreeTextFormat.Ascii,
+			exportPathPresentationProvider: () => null,
+			boundsWidthProvider: () => 1400,
+			scheduleMemoryCleanup: _ => Interlocked.Increment(ref completedRecalculations),
+			fileSourceVersionProvider: versions,
+			ioTestPoint: io);
+
+		await pipeline.InitializeFileMetricsCacheSoonAfterFirstPaintAsync(
+			currentTree,
+			TestContext.Current.CancellationToken);
+		await WaitUntilAsync(
+			() => pipeline.HasCompleteBaseline && pipeline.HasStatusMetricsSnapshot,
+			TimeSpan.FromSeconds(10));
+		var before = io.Snapshot;
+		var contentReadsBefore = analyzer.MetricsCallCount;
+		var publishedContentCharsBefore = ReadPublishedContentChars(pipeline);
+		if (changeOneFile)
+			versions.Change(filePaths[0]);
+
+		versions.ArmOneSlowOpen();
+		var stopwatch = Stopwatch.StartNew();
+		var publishedBeforeSlowOpenReleased = false;
+		try
+		{
+			pipeline.InvalidateSelectionProjection();
+			pipeline.Recalculate(MemoryCleanupReason.FilterApplied);
+			await versions.WaitForSlowOpenAsync(TestContext.Current.CancellationToken);
+
+			pipeline.InvalidateSelectionProjection();
+			pipeline.Recalculate(MemoryCleanupReason.FilterApplied);
+			await WaitUntilAsync(
+				() => io.Snapshot.MetricsLockAttemptCount >= before.MetricsLockAttemptCount + 2,
+				TimeSpan.FromSeconds(5));
+
+			var publication = WaitUntilAsync(
+				() => Volatile.Read(ref completedRecalculations) >= 1,
+				TimeSpan.FromSeconds(10));
+			var controlledDelay = Task.Delay(
+				TimeSpan.FromMilliseconds(100),
+				TestContext.Current.CancellationToken);
+			publishedBeforeSlowOpenReleased =
+				ReferenceEquals(await Task.WhenAny(publication, controlledDelay), publication);
+			versions.ReleaseSlowOpen();
+			await publication;
+		}
+		finally
+		{
+			versions.ReleaseSlowOpen();
+		}
+		stopwatch.Stop();
+
+		var after = io.Snapshot;
+		return new FilterRefreshMeasurement(
+			after.FileVersionOpenCount - before.FileVersionOpenCount,
+			analyzer.MetricsCallCount - contentReadsBefore,
+			after.MetricsLockWait - before.MetricsLockWait,
+			stopwatch.Elapsed,
+			publishedBeforeSlowOpenReleased,
+			ReadPublishedContentChars(pipeline) - publishedContentCharsBefore);
+	}
+
+	private static long ReadPublishedContentChars(MetricsPipeline pipeline) =>
+		(long)(typeof(MetricsPipeline).GetField(
+			"_lastStatusContentChars",
+			BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(pipeline) ?? -1L);
+
+	private static IReadOnlyList<string> InvokeMissingPathSweep(
+		MetricsPipeline pipeline,
+		IReadOnlyList<string> paths)
+	{
+		var method = typeof(MetricsPipeline).GetMethod(
+			"CollectMissingMetricsFilePaths",
+			BindingFlags.Instance | BindingFlags.NonPublic)
+			?? throw new MissingMethodException(nameof(MetricsPipeline), "CollectMissingMetricsFilePaths");
+		return (IReadOnlyList<string>)(method.Invoke(
+			pipeline,
+			[paths, CancellationToken.None])
+			?? throw new InvalidOperationException("The freshness sweep returned no result."));
+	}
+
+	private static MainWindowViewModel CreateViewModel() =>
+		new(CreateLocalization(), new HelpContentProvider());
+
+	private static LocalizationService CreateLocalization()
+	{
+		IReadOnlyDictionary<string, string> english = new Dictionary<string, string>
+		{
+			["Status.Operation.CalculatingData"] = "Calculating data",
+			["Status.Metric.Lines"] = "{0} lines",
+			["Status.Metric.Chars"] = "{0} chars",
+			["Status.Metric.Tokens"] = "{0} tokens"
+		};
+		return new LocalizationService(
+			new StubLocalizationCatalog(
+				new Dictionary<AppLanguage, IReadOnlyDictionary<string, string>>
+				{
+					[AppLanguage.En] = english
+				}),
+			AppLanguage.En);
+	}
+
+	private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+	{
+		var stopwatch = Stopwatch.StartNew();
+		while (!condition())
+		{
+			if (stopwatch.Elapsed >= timeout)
+				throw new TimeoutException("Metrics pipeline did not reach the measured state in time.");
+			await Task.Delay(10, TestContext.Current.CancellationToken);
+		}
+	}
+
+	private readonly record struct FilterRefreshMeasurement(
+		long FileVersionOpens,
+		int RepeatedContentReads,
+		TimeSpan MetricsLockWait,
+		TimeSpan PublicationLatency,
+		bool PublishedBeforeSlowOpenReleased,
+		long PublishedContentCharsDelta);
+
+	private sealed class ControlledMetricsFileSourceVersionProvider : IMetricsFileSourceVersionProvider
+	{
+		private readonly ConcurrentDictionary<string, MetricsFileSourceVersion> _versions;
+		private TaskCompletionSource _slowOpenEntered = NewSignal();
+		private TaskCompletionSource _slowOpenRelease = NewSignal();
+		private int _slowOpenArmed;
+
+		public ControlledMetricsFileSourceVersionProvider(IEnumerable<string> paths)
+		{
+			_versions = new ConcurrentDictionary<string, MetricsFileSourceVersion>(
+				paths.Select((path, index) => new KeyValuePair<string, MetricsFileSourceVersion>(
+					path,
+					new MetricsFileSourceVersion(Length: 1, index + 1, IsMissing: false))),
+				PathComparer.Default);
+		}
+
+		public MetricsFileSourceVersion? Capture(string path)
+		{
+			if (Interlocked.Exchange(ref _slowOpenArmed, 0) == 1)
+			{
+				_slowOpenEntered.TrySetResult();
+				_slowOpenRelease.Task
+					.WaitAsync(TimeSpan.FromSeconds(5))
+					.GetAwaiter()
+					.GetResult();
+			}
+			return _versions[path];
+		}
+
+		public void Change(string path) =>
+			_versions.AddOrUpdate(
+				path,
+				static _ => throw new InvalidOperationException("The synthetic path was not initialized."),
+				static (_, current) => current with
+				{
+					Length = current.Length + 1,
+					LastWriteTimeUtcTicks = current.LastWriteTimeUtcTicks + 1
+				});
+
+		public long ReadLength(string path) => _versions[path].Length;
+
+		public void ArmOneSlowOpen()
+		{
+			_slowOpenEntered = NewSignal();
+			_slowOpenRelease = NewSignal();
+			Volatile.Write(ref _slowOpenArmed, 1);
+		}
+
+		public Task WaitForSlowOpenAsync(CancellationToken cancellationToken) =>
+			_slowOpenEntered.Task.WaitAsync(cancellationToken);
+
+		public void ReleaseSlowOpen() => _slowOpenRelease.TrySetResult();
+
+		private static TaskCompletionSource NewSignal() =>
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+	}
+
+	private sealed class SyntheticMetricsAnalyzer(
+		ControlledMetricsFileSourceVersionProvider versions) : IFileContentAnalyzer
+	{
+		private int _metricsCallCount;
+
+		public int MetricsCallCount => Volatile.Read(ref _metricsCallCount);
+
+		public ValueTask<bool> IsTextFileAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			ValueTask.FromResult(true);
+
+		public ValueTask<TextFileMetrics?> GetTextFileMetricsAsync(
+			string path,
+			CancellationToken cancellationToken = default)
+		{
+			Interlocked.Increment(ref _metricsCallCount);
+			var length = versions.ReadLength(path);
+			return ValueTask.FromResult<TextFileMetrics?>(new TextFileMetrics(
+				SizeBytes: length,
+				LineCount: 1,
+				CharCount: checked((int)length),
+				IsEmpty: false,
+				IsWhitespaceOnly: false));
+		}
+
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			CancellationToken cancellationToken = default) =>
+			ValueTask.FromResult<TextFileContent?>(null);
+
+		public ValueTask<TextFileContent?> TryReadAsTextAsync(
+			string path,
+			long maxSizeForFullRead,
+			CancellationToken cancellationToken = default) =>
+			ValueTask.FromResult<TextFileContent?>(null);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
@@ -10,6 +10,44 @@ namespace DevProjex.Tests.Unit.Avalonia;
 public sealed class MetricsPipelineWarmupTests
 {
 	[AvaloniaFact]
+	public async Task PublishMetricsAsync_NoCheckedNodesAndNoFilesClearsContentTotals()
+	{
+		using var temp = new TemporaryDirectory();
+		var root = new TreeNodeDescriptor("root", temp.Path, true, false, "folder", []);
+		var currentTree = new BuildTreeResult(root, false, false, []);
+		var viewModel = CreateViewModel();
+		viewModel.IsProjectLoaded = true;
+		viewModel.TreeNodes.Add(new TreeNodeViewModel(root, parent: null, icon: null));
+		var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var pipeline = new MetricsPipeline(
+			viewModel,
+			CreateLocalization(),
+			new FileContentAnalyzer(),
+			new TreeExportService(),
+			new StatusOperationCoordinator(
+				viewModel,
+				isBackgroundMetricsActive: () => false,
+				metricsOperationTextProvider: () => viewModel.StatusOperationCalculatingData),
+			currentTreeProvider: () => currentTree,
+			currentPathProvider: () => temp.Path,
+			selectedPathsProvider: () => new HashSet<string>(PathComparer.Default),
+			treeFormatProvider: () => TreeTextFormat.Ascii,
+			exportPathPresentationProvider: () => null,
+			boundsWidthProvider: () => 1400,
+			scheduleMemoryCleanup: _ => completed.TrySetResult());
+
+		pipeline.UpdateStatusBarMetrics(9, 9, 9, 9, 9, 9);
+		pipeline.Recalculate(MemoryCleanupReason.FilterApplied);
+		await completed.Task.WaitAsync(
+			TimeSpan.FromSeconds(5),
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(0L, ReadPrivateLong(pipeline, "_lastStatusContentLines"));
+		Assert.Equal(0L, ReadPrivateLong(pipeline, "_lastStatusContentChars"));
+		Assert.Equal(0L, ReadPrivateLong(pipeline, "_lastStatusContentTokens"));
+	}
+
+	[AvaloniaFact]
 	public async Task EmptyContentSelectionMetricsMatchRootOnlyDocument()
 	{
 		using var temp = new TemporaryDirectory();
@@ -715,7 +753,7 @@ public sealed class MetricsPipelineWarmupTests
 			status,
 			currentTreeProvider: () => currentTree,
 			currentPathProvider: () => temp.Path,
-			selectedPathsProvider: () => new HashSet<string>(PathComparer.Default),
+			selectedPathsProvider: () => new HashSet<string>([temp.Path], PathComparer.Default),
 			treeFormatProvider: () => TreeTextFormat.Ascii,
 			exportPathPresentationProvider: () => null,
 			boundsWidthProvider: () => 1400,
@@ -1184,7 +1222,7 @@ public sealed class MetricsPipelineWarmupTests
             status,
             currentTreeProvider: () => currentTree,
             currentPathProvider: () => temp.Path,
-            selectedPathsProvider: () => new HashSet<string>(PathComparer.Default),
+            selectedPathsProvider: () => new HashSet<string>([temp.Path], PathComparer.Default),
             treeFormatProvider: () => TreeTextFormat.Ascii,
             exportPathPresentationProvider: () => null,
             boundsWidthProvider: () => 1400);
@@ -1626,11 +1664,16 @@ public sealed class MetricsPipelineWarmupTests
             status,
             currentTreeProvider: () => currentTree,
             currentPathProvider: () => currentPath,
-            selectedPathsProvider: () => new HashSet<string>(PathComparer.Default),
+            selectedPathsProvider: () => new HashSet<string>([currentPath], PathComparer.Default),
             treeFormatProvider: () => TreeTextFormat.Ascii,
             exportPathPresentationProvider: () => null,
             boundsWidthProvider: () => 1400);
     }
+
+	private static long ReadPrivateLong(MetricsPipeline pipeline, string fieldName) =>
+		(long)(typeof(MetricsPipeline).GetField(
+			fieldName,
+			BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(pipeline) ?? -1L);
 
     private static MainWindowViewModel CreateViewModel() =>
         new(CreateLocalization(), new HelpContentProvider());


### PR DESCRIPTION
## Summary
- move source-version probes outside the GUI metrics cache lock and protect the apply phase by cache generation, transform identity, and entry identity
- keep zero content rereads for unchanged name filters and reread only the changed file; cover cancellation and a concurrent cache merge with a controlled version provider
- remove the unused metrics calculation policy; explicitly clear status metrics for an empty file tree while preserving the GUI contract that an empty normalized path set means the whole tree
- run documentation commands with both an in-tree `.git` and a separate git directory, retaining command/stderr/access-denied/fingerprint diagnostics
- split Windows PowerShell 5.1 cold completion measurement from the warmed release gate and add bounded timeout process-tree diagnostics
- reuse a predicate-based PTY readiness wait with cancellation, a full-screen failure capture, and a state timeline

Base: `7ceaae0be58dffefca12e657fe0825812a9d510e`

## Targeted validation
- `MetricsPipelineWarmupTests`, `MetricsPipelineIoMeasurementTests`, `MainWindowMetricsPolicyTests`: 53 passed (Release)
- affected UI classes after preserving normalized whole-tree selection: 61 passed (Release)
- documentation layouts, PowerShell 5.1 cold/warm/timeout diagnostics, PTY harness contracts, cached-repository PTY: 17 passed (Release)
- local Windows PowerShell 5.1: cold completion 530 ms; warmup 150 ms; warm completion 471 ms
- CI Windows PowerShell 5.1 on the final head: cold completion 758 ms; warmup 2279 ms; warm completion 1293 ms
- Linux CI: in-tree `.git` passed in 2.298 s; separate git directory passed in 1.144 s; the historical access-denied warning was not reproduced

## CI
- [.NET CI](https://github.com/Avazbek22/DevProjex/actions/runs/34258221675): passed (attempt 2)
- [Release Validation](https://github.com/Avazbek22/DevProjex/actions/runs/34258221684): passed
- macOS x64 published PTY filter: 27 passed, 0 skipped

No timeout or assertion threshold was relaxed. No tags or artifacts were published.