### PR TITLE
fix(dependencies): preserve reference semantics

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -40,6 +40,7 @@ public sealed record DependencyResolverConfiguration(
 {
 	public IReadOnlyList<DependencyConfigurationDiagnostic> ConfigurationDiagnostics { get; init; } = [];
 	public bool CanCache { get; init; } = true;
+	public IReadOnlyList<string> AbsentControlFiles { get; init; } = [];
 
 	public DependencyScopeDescriptor? FindScope(string scopeId) =>
 		Scopes.FirstOrDefault(scope => string.Equals(scope.ScopeId, scopeId, StringComparison.Ordinal));

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1549,7 +1549,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			}
 			if (scope is not null && ConfigurationFailure(scope) is { } configurationFailure)
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, configurationFailure, []);
-			var isQualified = reference.Name.Contains('.');
+			var isQualified = reference.IsGlobalQualified || reference.Name.Contains('.');
 			var typeParameterShadowsReference = !isQualified && (source.TypeParameterScopes.Count > 0
 				? source.TypeParameterScopes.Any(parameter =>
 					parameter.Name == simpleName &&
@@ -1558,8 +1558,10 @@ public sealed class DependencyFactsEngine : IDisposable
 				: source.TypeParameters.Contains(simpleName, StringComparer.Ordinal));
 			if (typeParameterShadowsReference)
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, "type parameter shadows declarations", []);
-			var expandedName = ExpandQualifiedAlias(source, reference.Name);
-			var candidates = reference.Name.Contains('.')
+			var expandedName = reference.IsGlobalQualified
+				? reference.Name
+				: ExpandQualifiedAlias(source, reference.Name);
+			var candidates = isQualified
 				? LookupQualified(source, expandedName, reference.GenericArity)
 				: LookupSimple(source, simpleName, reference.GenericArity);
 			var attributeName = reference.SyntaxKind == "attribute"
@@ -1577,9 +1579,9 @@ public sealed class DependencyFactsEngine : IDisposable
 				if (source.Aliases.TryGetValue(simpleName, out var alias) ||
 				    globalAliases?.TryGetValue(simpleName, out alias) == true)
 					candidates = LookupQualified(source, alias, reference.GenericArity);
-				else if (reference.Name.Contains('.') && candidates.Length == 0)
+				else if (!reference.IsGlobalQualified && reference.Name.Contains('.') && candidates.Length == 0)
 					candidates = LookupContextualCSharpQualified(source, reference, expandedName);
-				else if (!reference.Name.Contains('.'))
+				else if (!isQualified)
 					candidates = SelectVisibleCSharpCandidates(source, reference, candidates);
 			}
 			if (candidates.Length == 0)

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1064,9 +1064,9 @@ public sealed class DependencyFactsEngine : IDisposable
 
 		private DependencyEdge ResolveTypeScriptImport(FileFacts source, ImportFact import)
 		{
-			if (!import.HasLiteralSpecifier)
+			if (!string.Equals(import.Reason, "not resolved yet", StringComparison.Ordinal))
 				return Edge(source, import, ResolutionStatus.Unresolved, null,
-					"module specifier is not a string literal", []);
+					import.Reason, []);
 			var scope = FindScope(source.ScopeId);
 			if (scope is null || !scope.HasConfiguration)
 				return Edge(source, import, ResolutionStatus.Unresolved, null,

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -78,6 +78,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		    _manifestSnapshots.TryGetValue(manifestRequestKey, out var cachedSnapshot) &&
 		    cachedSnapshot.ManifestPaths.SequenceEqual(manifestRelativePaths, StringComparer.Ordinal) &&
 		    cachedSnapshot.Stamps.SequenceEqual(initialStamps) &&
+		    AreControlFilesStillAbsent(cachedSnapshot.AbsentControlFiles) &&
 		    ContentIdentitiesMatch(cachedSnapshot.ContentIdentities, alignedContentIdentities) &&
 		    _indexCache.ContainsKey(cachedSnapshot.IndexCacheKey))
 		{
@@ -226,7 +227,8 @@ public sealed class DependencyFactsEngine : IDisposable
 			FileByPath = resolved.FileByPath
 		};
 		var finalStamps = TryCaptureFileStamps(manifest);
-		if (canCacheIndex && initialStamps is not null && finalStamps is not null && initialStamps.SequenceEqual(finalStamps))
+		if (canCacheIndex && initialStamps is not null && finalStamps is not null && initialStamps.SequenceEqual(finalStamps) &&
+		    AreControlFilesStillAbsent(configuration.AbsentControlFiles))
 		{
 			if (_indexCache.ContainsKey(cacheKey))
 				StoreManifestSnapshot(
@@ -234,6 +236,7 @@ public sealed class DependencyFactsEngine : IDisposable
 					manifestRelativePaths,
 					initialStamps,
 					alignedContentIdentities,
+					configuration.AbsentControlFiles,
 					cacheKey,
 					result);
 		}
@@ -358,7 +361,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			path,
 			status,
 			edges.SelectMany(static edge => edge.Reasons.Concat(edge.Evidence.Select(site =>
-				$"{EvidenceLabel(edge.Layer)} {edge.Reference} at line {site.Line}")))
+				$"{EvidenceLabel(edge.Layer)} at line {site.Line}")))
 				.Concat(declarationPartReasons)
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
 			edges.SelectMany(static edge => edge.Candidates).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
@@ -511,6 +514,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		IReadOnlyList<string> manifestPaths,
 		IReadOnlyList<FileStamp> stamps,
 		IReadOnlyList<string>? contentIdentities,
+		IReadOnlyList<string> absentControlFiles,
 		IndexCacheKey indexCacheKey,
 		DependencyIndexSnapshot snapshot)
 	{
@@ -519,7 +523,8 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (!_indexCache.ContainsKey(indexCacheKey)) return;
 			if (_manifestSnapshots.TryGetValue(key, out var previous))
 				RemoveManifestSnapshotUnderLock(key, previous);
-			var entry = new ManifestSnapshotCacheEntry(key, manifestPaths, stamps, contentIdentities, indexCacheKey, snapshot);
+			var entry = new ManifestSnapshotCacheEntry(
+				key, manifestPaths, stamps, contentIdentities, absentControlFiles, indexCacheKey, snapshot);
 			_manifestSnapshots[key] = entry;
 			entry.OrderNode = _manifestSnapshotOrder.AddLast(entry);
 			while (_manifestSnapshots.Count > _limits.MaximumCachedIndexes &&
@@ -633,6 +638,9 @@ public sealed class DependencyFactsEngine : IDisposable
 			edge.Candidates.Sum(strings.Add) + edge.DeclarationFiles.Sum(strings.Add)) +
 			index.Files.Sum(file => EstimateFileFactsBytes(file, strings));
 	}
+
+	private static bool AreControlFilesStillAbsent(IEnumerable<string> paths) =>
+		paths.All(static path => !File.Exists(path));
 
 	private static long SiteBytes(SourceSite site, RetainedStringEstimator strings) =>
 		64 + strings.Add(site.File) + strings.Add(site.Evidence);
@@ -789,6 +797,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		IReadOnlyList<string> ManifestPaths,
 		IReadOnlyList<FileStamp> Stamps,
 		IReadOnlyList<string>? ContentIdentities,
+		IReadOnlyList<string> AbsentControlFiles,
 		IndexCacheKey IndexCacheKey,
 		DependencyIndexSnapshot Snapshot)
 	{
@@ -1107,7 +1116,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				var mapped = ResolvePaths(scope, source, import.Specifier).ToArray();
 				if (mapped.Length > 0)
 					return FinishImport(source, import, mapped,
-						$"one module target under {scope.ModuleResolution} in {scope.ScopeId}");
+						"one module target under configured module resolution");
 				var packageName = BarePackageName(import.Specifier);
 				return FindNearestPackageMap(source)?.ExternalPackages.Contains(packageName) == true
 					? Edge(source, import, ResolutionStatus.External, null,
@@ -1116,7 +1125,7 @@ public sealed class DependencyFactsEngine : IDisposable
 						"bare package has no target or external-package evidence", []);
 			}
 			return FinishImport(source, import, candidates,
-				$"one module target under {scope.ModuleResolution} in {scope.ScopeId}");
+				"one module target under configured module resolution");
 		}
 
 		private bool SupportsCommonJs(FileFacts source, DependencyScopeDescriptor scope)
@@ -1206,7 +1215,9 @@ public sealed class DependencyFactsEngine : IDisposable
 						return new PackageMapProbe([], null);
 					var selected = SelectPackageTarget(target!, PackageCondition(source, import));
 					if (selected.Kind == PackageTargetSelectionKind.Blocked)
-						return new PackageMapProbe([], $"package {(exports ? "exports" : "imports")} target is null-blocked");
+						return new PackageMapProbe([], exports
+							? "package exports target is null-blocked"
+							: "package imports target is null-blocked");
 					if (selected.Kind == PackageTargetSelectionKind.Unsupported)
 						return new PackageMapProbe([], selected.Reason);
 					if (selected.Kind != PackageTargetSelectionKind.Path || selected.Path is null)
@@ -1302,7 +1313,7 @@ public sealed class DependencyFactsEngine : IDisposable
 					return new PackageTargetSelection(
 						PackageTargetSelectionKind.Unsupported,
 						null,
-						$"package condition '{branch.Name}' is not supported");
+						"package condition is not supported");
 				if (!IsActivePackageCondition(branch.Name, moduleCondition))
 					continue;
 				var selected = SelectPackageTarget(branch.Target, moduleCondition);
@@ -1609,7 +1620,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
 			return candidates.Length == 1
 				? Edge(source, reference, ResolutionStatus.Resolved, files[0],
-					$"one visible declaration identity in {source.ScopeId}", files) with
+						"one visible declaration identity", files) with
 					{
 						DeclarationFiles = files
 					}
@@ -1764,7 +1775,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			{
 				0 => Edge(source, import, ResolutionStatus.Unresolved, null, "no target in the manifest for this module", []),
 				1 => Edge(source, import, ResolutionStatus.Resolved, candidates[0],
-					resolvedReason ?? $"one module target in {source.ScopeId}", candidates),
+					resolvedReason ?? "one module target", candidates),
 				_ => Edge(source, import, ResolutionStatus.Ambiguous, null, "multiple module targets", candidates)
 			};
 		}

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1055,6 +1055,9 @@ public sealed class DependencyFactsEngine : IDisposable
 
 		private DependencyEdge ResolveTypeScriptImport(FileFacts source, ImportFact import)
 		{
+			if (!import.HasLiteralSpecifier)
+				return Edge(source, import, ResolutionStatus.Unresolved, null,
+					"module specifier is not a string literal", []);
 			var scope = FindScope(source.ScopeId);
 			if (scope is null || !scope.HasConfiguration)
 				return Edge(source, import, ResolutionStatus.Unresolved, null,
@@ -1414,13 +1417,23 @@ public sealed class DependencyFactsEngine : IDisposable
 				}
 				else
 					candidates.Clear();
+				if (candidates.Count == 0 && !moduleEntityExists)
+				{
+					var child = module.Length == 0 ? import.ImportedName : module + "." + import.ImportedName;
+					candidates = ProbePythonModule(source, child).ToList();
+					if (candidates.Count > 0)
+						return FinishImport(source, import, candidates);
+				}
+				if (candidates.Count == 0 && moduleEntityExists)
+					return Edge(source, import, ResolutionStatus.Unresolved, null,
+						"name not found in module", []);
 			}
 			if (candidates.Count == 0 && !moduleEntityExists)
 			{
-				var portions = ProbePythonNamespace(source, module).ToArray();
-				if (portions.Length > 0)
+				var portionCount = CountPythonNamespacePortions(source, module);
+				if (portionCount > 0)
 					return Edge(source, import, ResolutionStatus.Resolved, "namespace:" + module,
-						$"one namespace-package entity with {portions.Length} portion(s)", portions);
+						"one namespace-package entity", []);
 			}
 			if (candidates.Count == 0 && import.RelativeLevel == 0 && DependencyPlatformCatalog.IsPythonExternal(_configuration, source.ScopeId, import.Specifier))
 				return Edge(source, import, ResolutionStatus.External, null, "known Python standard-library module", []);
@@ -1441,7 +1454,8 @@ public sealed class DependencyFactsEngine : IDisposable
 			ISet<string> visited)
 		{
 			if (depth >= 8 || !visited.Add(candidate) || !_files.TryGetValue(candidate, out var facts)) return [];
-			if (facts.Declarations.Any(declaration => SimpleName(declaration.Identity.QualifiedName) == name))
+			if (facts.Declarations.Any(declaration => declaration.ContainingType is null &&
+				SimpleName(declaration.Identity.QualifiedName) == name))
 				return [candidate];
 			foreach (var import in facts.Imports.Where(import =>
 				string.Equals(import.Alias ?? import.ImportedName ?? import.Specifier.Split('.').Last(), name, StringComparison.Ordinal)))
@@ -1474,7 +1488,6 @@ public sealed class DependencyFactsEngine : IDisposable
 						.Order(StringComparer.Ordinal)
 						.ToArray();
 					if (nested.Length > 0) return nested;
-					if (moduleTargets.Length > 0) return moduleTargets;
 					var childTargets = ProbePythonModule(facts, child).ToArray();
 					if (childTargets.Length > 0) return childTargets;
 				}
@@ -1487,19 +1500,19 @@ public sealed class DependencyFactsEngine : IDisposable
 			return [];
 		}
 
-		private IEnumerable<string> ProbePythonNamespace(FileFacts source, string module)
+		private int CountPythonNamespacePortions(FileFacts source, string module)
 		{
-			if (module.Length == 0) return [];
+			if (module.Length == 0) return 0;
 			var relative = module.Replace('.', '/').Trim('/') + '/';
-			var portions = new List<string>();
+			var portions = 0;
 			foreach (var root in PythonRootPrefixes(source))
 			{
 				var prefix = string.Join('/', new[] { root, relative }.Where(static value => value.Length > 0));
 				var init = prefix + "__init__.py";
-				if (!_files.ContainsKey(init))
-					portions.AddRange(_files.Keys.Where(path => path.StartsWith(prefix, StringComparison.Ordinal)).Take(1));
+				if (!_files.ContainsKey(init) && _files.Keys.Any(path => path.StartsWith(prefix, StringComparison.Ordinal)))
+					portions++;
 			}
-			return portions.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal);
+			return portions;
 		}
 
 		private IEnumerable<string> ProbePythonModule(FileFacts source, string module)

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -80,7 +80,10 @@ public sealed record ImportFact(
 	ResolutionStatus Status = ResolutionStatus.Unresolved,
 	string Reason = "not resolved yet",
 	IReadOnlyList<string>? Candidates = null,
-	string? Target = null);
+	string? Target = null)
+{
+	public bool HasLiteralSpecifier { get; init; } = true;
+}
 
 public sealed record ReferenceFact(
 	EvidenceLayer Layer,

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -96,6 +96,7 @@ public sealed record ReferenceFact(
 	public string ContainingNamespace { get; init; } = string.Empty;
 	public string? ContainingType { get; init; }
 	public int SourceStartIndex { get; init; } = -1;
+	public bool IsGlobalQualified { get; init; }
 }
 
 public sealed record FileFacts(

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -80,10 +80,7 @@ public sealed record ImportFact(
 	ResolutionStatus Status = ResolutionStatus.Unresolved,
 	string Reason = "not resolved yet",
 	IReadOnlyList<string>? Candidates = null,
-	string? Target = null)
-{
-	public bool HasLiteralSpecifier { get; init; } = true;
-}
+	string? Target = null);
 
 public sealed record ReferenceFact(
 	EvidenceLayer Layer,

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -27,8 +27,9 @@ an optional file scope. Partial C# declarations share one identity with multiple
 file-local types remain distinct even when their names match. A resolved edge to such a partial
 identity keeps one canonical target and the complete declaration-file list. Related-file projections
 show every declaration file as a resolved part of the same symbol, in both directions; ambiguous
-candidates remain a separate concept. Each reference retains its source line and a compact source
-excerpt. Results use four statuses:
+candidates remain a separate concept. Each reference retains its exact source occurrence, lexical
+owner, source line, and a compact source excerpt; two same-name references on one line are not
+deduplicated before resolution. Results use four statuses:
 
 - **Resolved** — exactly one declaration or module in the allowed manifest is supported by the
   resolver evidence;
@@ -50,7 +51,9 @@ C# compilation scopes come from `.csproj` ownership and `ProjectReference` entri
 Both `/` and `\` in an MSBuild `Include` are normalized as project-reference separators on every OS;
 this normalization never applies to ordinary Unix filenames. Global usings and aliases are shared
 within the owning scope; type parameters shadow global symbols only inside the lexical span of their
-declaring type or method, while a qualified name is never suppressed by its final component;
+declaring type or method, while a qualified name is never suppressed by its final component.
+The `global::` qualifier is retained as absolute-lookup evidence: it bypasses type-parameter
+shadowing and never falls back through the source namespace or imported namespaces;
 nested generic names preserve the arity of every containing type. `InternalsVisibleTo` does not create
 an edge, target-typed `new()` stays unresolved, and source-generator output is unavailable. A simple
 type name can resolve only to a declaration in the current or an enclosing namespace, an exactly

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -165,9 +165,11 @@ fact, including declarations and all declaration sites, even when the graph has 
 Manifest-snapshot eviction entries are generation-bound and removed together with their live
 snapshot, so repeated rebuilds of the same cache keys cannot grow bookkeeping outside the limit.
 
-Access failures, missing files, and other transient I/O failures in either source or control files are
-not retained in the prepared-source, resolved-index, or manifest-snapshot caches. A later request
-retries extraction and configuration reading even when file stamps are unchanged. Stable outcomes such
+Access failures and other transient I/O failures in either source or control files are not retained in
+the prepared-source, resolved-index, or manifest-snapshot caches. A later request retries extraction
+and configuration reading even when file stamps are unchanged. An expected control file observed as
+absent is cacheable: its canonical path is part of the snapshot, and the snapshot is rejected as soon
+as that path appears. Stable outcomes such
 as invalid configuration syntax, an unsupported language, a content parse failure, or a safety limit
 remain cacheable.
 
@@ -197,6 +199,9 @@ change serialized results.
 contains a portable relative path, aggregated evidence reasons, resolution status, estimated tokens,
 and a cross-scope marker when applicable. Ambiguous references remain one group with their candidate
 list. Coverage reports manifest files, supported and unsupported languages, and extraction failures.
+Reason and configuration-diagnostic text uses a fixed vocabulary; project-controlled symbol names,
+module specifiers, mapping keys, and paths remain in their dedicated structured fields rather than
+being interpolated into trusted explanatory text.
 An unsupported seed is a successful empty result with an explicit diagnostic; a supported seed with
 no edges reports that no related files exist in the effective selection. At most eight configuration
 diagnostic lines are rendered in CLI text output; JSON retains the complete safe array.

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -68,6 +68,9 @@ owning `.csproj` inside the effective manifest, cross-file C# type references st
 TypeScript and JavaScript use the nearest `tsconfig.json` or `jsconfig.json`. The resolver distinguishes
 relative, bare, package-self, and `#imports` specifiers and follows ordered substitution: the first
 existing probe wins, so multiple files found later in the same probe sequence are not ambiguity.
+Module specifiers are read from parsed `import`, `export`, dynamic `import(...)`, and supported
+literal `require(...)` syntax, including side-effect imports. A variable or template expression in
+place of a string literal remains `Unresolved`; it is never treated as a guessed path.
 `.js`, `.mjs`, and `.cjs` specifiers probe their TypeScript and declaration counterparts before the
 literal JavaScript file. Extensionless imports and directory indexes always probe `.js` and `.jsx`
 after `.ts`, `.tsx`, and `.d.ts`; `allowJs` controls compilation membership, not resolution of files
@@ -98,11 +101,17 @@ accepted with or without a BOM; malformed byte sequences remain corrupt.
 
 Python relative imports start at the source package. `from module import Name` first checks classes,
 functions, and static import aliases provided by either an ordinary module or a package initializer.
+Only module-level class and function declarations provide importable names; a method or nested class
+cannot satisfy `from module import Name`. Import syntax is read from parsed nodes, so parenthesized
+multiline lists, comments, aliases, relative forms, and wildcard imports have the same semantics as
+their single-line forms.
 Only a package may then fall back to a child module of that name. Regular and namespace-package portions are
-combined, and a package initializer takes precedence over a same-named module file. Within a package,
+combined as package entities rather than being represented by an arbitrary file under the namespace;
+a requested child is resolved to that child. A package initializer takes precedence over a same-named module file. Within a package,
 a statically provided or re-exported name is resolved before a same-named child module. `.py` is
 preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and `__all__` affects
-wildcard imports only. Relative imports that would escape the top-level package remain unresolved.
+wildcard imports only. A missing imported name remains `Unresolved` with a constant reason instead of
+turning the existence of the module into evidence for that name. Relative imports that would escape the top-level package remain unresolved.
 Dynamic `__all__`, `setup.py`, and import hooks are not executed and remain unresolved. Separate
 complete `sys.stdlib_module_names` snapshots cover Python
 3.12 and 3.13. A decisive `requires-python`/`python_requires` constraint selects its snapshot;

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-2026-09-08 reference-semantics rerun are both `7e8a1c9bc6229e2d61cc8a4e538cbf817f91f3a5`.
+2026-09-08 reference-semantics rerun are both `798ce9bef2622fda1eb6320ef98009428388c6c7`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -215,9 +215,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2733.31 / 2832.46` | `942.99 / 1002.12` | `+59.14 ms (6.27%)` | `303.42 / 300.89` | `307.43 / 309.50` | `0.67%` |
-| Repomix | `800.65 / 900.88` | `440.35 / 464.77` | `+24.42 ms (5.55%)` | `110.12 / 110.57` | `111.21 / 111.44` | `0.41%` |
-| Flask | `507.96 / 505.33` | `223.14 / 239.32` | `+16.18 ms (7.25%)` | `86.45 / 86.32` | `87.75 / 88.10` | `0.40%` |
+| DevProjex | `2727.88 / 2812.78` | `982.39 / 910.07` | `-72.33 ms (-7.36%)` | `304.45 / 302.29` | `307.70 / 310.05` | `0.76%` |
+| Repomix | `763.28 / 768.28` | `401.38 / 427.63` | `+26.25 ms (6.54%)` | `109.69 / 109.98` | `110.84 / 110.85` | `0.26%` |
+| Flask | `478.99 / 503.83` | `223.32 / 235.30` | `+11.99 ms (5.37%)` | `86.34 / 86.53` | `87.61 / 88.17` | `0.64%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-2026-09-08 engine-contract rerun are both `1c913520abde175dd13c1cb1a393c0d985581b9e`.
+2026-09-08 reference-semantics rerun are both `7e8a1c9bc6229e2d61cc8a4e538cbf817f91f3a5`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -190,11 +190,11 @@ oracles are counts over the five tasks at that repository and budget.
 | DevProjex / 8,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.7997` | `0.2000 · 0/2/2 · 0.7409` | `0.1000 · 0/2/2 · 0.7924` | `0.2000 · 0/2/2 · 0.5611` |
 | DevProjex / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.8999` | `0.1000 · 0/2/2 · 0.8962` | `0.2000 · 0/2/2 · 0.7574` | `0.1000 · 0/2/2 · 0.7375` |
 | Repomix / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.4111` | `0.0000 · 0/1/1 · 0.4110` | `0.0000 · 0/1/1 · 0.4109` | `0.0000 · 0/1/1 · 0.3883` |
-| Repomix / 8,000 | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 0.7055` | `0.2000 · 1/3/3 · 0.6202` | `0.3000 · 1/3/3 · 0.5349` | `0.2000 · 1/3/3 · 0.5965` |
+| Repomix / 8,000 | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 0.7055` | `0.3000 · 1/3/3 · 0.5930` | `0.3000 · 1/3/3 · 0.5349` | `0.3000 · 1/3/3 · 0.5710` |
 | Repomix / 16,000 | `0.0000 · 0/5/5 · 1.0000` | `0.0000 · 0/5/5 · 1.0000` | `0.0000 · 0/5/5 · 0.8528` | `0.4000 · 2/5/5 · 0.7538` | `0.3000 · 1/5/5 · 0.7675` | `0.4000 · 2/5/5 · 0.7013` |
 | Flask / 4,000 | `0.0000 · 0/0/0 · 1.0000` | `0.1250 · 0/0/0 · 0.9280` | `0.0000 · 0/0/0 · 0.7098` | `0.0000 · 0/0/0 · 0.7097` | `0.0000 · 0/0/0 · 0.7097` | `0.0000 · 0/0/0 · 0.6845` |
-| Flask / 8,000 | `0.0000 · 0/0/0 · 1.0000` | `0.1250 · 0/0/0 · 0.9640` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5260` |
-| Flask / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.9754` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5368` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5322` |
+| Flask / 8,000 | `0.0000 · 0/0/0 · 1.0000` | `0.1250 · 0/0/0 · 0.9640` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5641` | `0.0000 · 0/0/0 · 0.5384` |
+| Flask / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.9754` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5368` | `0.0000 · 1/2/2 · 0.6634` | `0.2500 · 2/2/2 · 0.5304` |
 
 `focus-v1` and `directed-from-seed` have the same RecallNew and AllRequired result
 in all nine repository/budget aggregates above. Directed context spends a smaller
@@ -215,13 +215,13 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2741.14 / 2723.38` | `917.76 / 910.68` | `-7.08 ms (-0.77%)` | `308.18 / 308.62` | `311.57 / 311.99` | `0.14%` |
-| Repomix | `750.76 / 779.09` | `464.81 / 398.05` | `-66.76 ms (-14.36%)` | `111.86 / 112.75` | `112.02 / 112.03` | `0.80%` |
-| Flask | `451.80 / 505.19` | `189.24 / 205.98` | `+16.75 ms (8.85%)` | `85.87 / 86.39` | `87.60 / 87.67` | `0.61%` |
+| DevProjex | `2733.31 / 2832.46` | `942.99 / 1002.12` | `+59.14 ms (6.27%)` | `303.42 / 300.89` | `307.43 / 309.50` | `0.67%` |
+| Repomix | `800.65 / 900.88` | `440.35 / 464.77` | `+24.42 ms (5.55%)` | `110.12 / 110.57` | `111.21 / 111.44` | `0.41%` |
+| Flask | `507.96 / 505.33` | `223.14 / 239.32` | `+16.18 ms (7.25%)` | `86.45 / 86.32` | `87.75 / 88.10` | `0.40%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was
-`+0.3000`; the repository deltas were DevProjex `+0.1000`, Repomix `+0.3333`, and Flask
+`+0.3333`; the repository deltas were DevProjex `+0.1000`, Repomix `+0.3889`, and Flask
 `+1.0000`. There were zero cells where focus regressed a seed-first `AllRequired` success.
 Every warm increment was below `max(5% of importance time, 100 ms)`, and maximum median RSS
 growth was below 10% on every corpus. All three pre-registered gates therefore pass, so the

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -61,7 +61,8 @@ internal abstract partial class DependencyLanguageAdapter : IDependencyLanguageA
 
 	protected static IReadOnlyList<ReferenceFact> Distinct(IEnumerable<ReferenceFact> references) =>
 		references.GroupBy(static fact =>
-				(fact.Layer, fact.Name, fact.GenericArity, fact.Site.Line, fact.SyntaxKind))
+			(fact.Layer, fact.Name, fact.GenericArity, fact.Site.Line, fact.SyntaxKind,
+				fact.SourceStartIndex, fact.ContainingNamespace, fact.ContainingType, fact.IsGlobalQualified))
 			.Select(static group => group.First())
 			.OrderBy(static fact => fact.Site.Line)
 			.ThenBy(static fact => fact.Name, StringComparer.Ordinal)
@@ -206,17 +207,19 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		var typeText = capture.Text;
 		foreach (Match match in TypeNameRegex().Matches(typeText))
 		{
+			var isGlobalQualified = match.Value.StartsWith("global::", StringComparison.Ordinal);
 			var name = match.Value.Replace("global::", string.Empty, StringComparison.Ordinal)
 				.Replace("::", ".", StringComparison.Ordinal);
 			var simpleName = name.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? name;
 			if (!Keywords.Contains(simpleName))
-				yield return NewReference(
+					yield return NewReference(
 					context,
 					capture,
 					name,
 					GenericArityAt(typeText, match.Index + match.Length),
 					containingNamespace,
-					containingType);
+					containingType,
+					isGlobalQualified);
 		}
 	}
 
@@ -293,7 +296,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		string name,
 		int arity,
 		string containingNamespace,
-		string? containingType) =>
+		string? containingType,
+		bool isGlobalQualified = false) =>
 		new(EvidenceLayer.TypeReference, name, arity,
 			capture.Name.StartsWith("reference.", StringComparison.Ordinal)
 				? capture.Name["reference.".Length..]
@@ -302,7 +306,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		{
 			ContainingNamespace = containingNamespace,
 			ContainingType = containingType,
-			SourceStartIndex = capture.StartIndex
+			SourceStartIndex = capture.StartIndex,
+			IsGlobalQualified = isGlobalQualified
 		};
 
 	private static FileFacts Failure(DependencyExtractionContext context, string reason) => new(

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -420,10 +420,9 @@ internal sealed partial class TypeScriptDependencyLanguageAdapter : DependencyLa
 		{
 			if (!syntax.HasLiteralSpecifier)
 			{
-				yield return new ImportFact(string.Empty, null, null, false, 0, Site(context, capture))
-				{
-					HasLiteralSpecifier = false
-				};
+				yield return new ImportFact(
+					string.Empty, null, null, false, 0, Site(context, capture),
+					Reason: "module specifier is not a string literal");
 				yield break;
 			}
 			if (syntax.Bindings.Count == 0)

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -14,7 +14,8 @@ internal sealed record DependencySyntaxCapture(
 	int GenericArity = 0,
 	bool IsFileLocal = false,
 	string? ContainingDeclaration = null,
-	DependencyImportSyntax? ImportSyntax = null);
+	DependencyImportSyntax? ImportSyntax = null,
+	int CapturedNameStartIndex = -1);
 
 internal sealed record DependencyImportSyntax(
 	string Specifier,
@@ -171,10 +172,11 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 			.Where(static capture => capture.Name.StartsWith("reference.", StringComparison.Ordinal))
 			.ToArray();
 		var referenceScopes = BuildReferenceScopes(referenceCaptures, declarationScopes.Ordered);
-		var declarationSites = declarations
-			.Select(static declaration => (
-				declaration.DeclarationSites[0].Line,
-				Name: SimpleName(declaration.Identity.QualifiedName)))
+		var declarationOccurrences = declarationCaptures
+			.Where(static capture => capture.CapturedNameStartIndex >= 0)
+			.Select(static capture => (
+				capture.CapturedNameStartIndex,
+				Name: capture.CapturedName!))
 			.ToHashSet();
 		var references = referenceCaptures
 			.SelectMany(capture => ExtractReferences(
@@ -182,7 +184,7 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 				capture,
 				referenceScopes.GetValueOrDefault(capture),
 				namespaces))
-			.Where(reference => !declarationSites.Contains((reference.Site.Line, reference.Name)))
+			.Where(reference => !declarationOccurrences.Contains((reference.SourceStartIndex, reference.Name)))
 			.Take(limits.MaximumFactsPerFile + 1).ToArray();
 		if (declarations.Count + references.Length > limits.MaximumFactsPerFile)
 			return Failure(context, "fact limit exceeded");

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -12,7 +12,17 @@ internal sealed record DependencySyntaxCapture(
 	int EndIndex,
 	string? CapturedName = null,
 	int GenericArity = 0,
-	bool IsFileLocal = false);
+	bool IsFileLocal = false,
+	string? ContainingDeclaration = null,
+	DependencyImportSyntax? ImportSyntax = null);
+
+internal sealed record DependencyImportSyntax(
+	string Specifier,
+	int RelativeLevel,
+	IReadOnlyList<DependencyImportBinding> Bindings,
+	bool HasLiteralSpecifier = true);
+
+internal sealed record DependencyImportBinding(string Name, string? Alias, bool IsWildcard = false);
 
 internal sealed record DependencyExtractionContext(
 	string RelativePath,
@@ -406,27 +416,25 @@ internal sealed partial class TypeScriptDependencyLanguageAdapter : DependencyLa
 
 	private static IEnumerable<ImportFact> ExtractImports(DependencyExtractionContext context, DependencySyntaxCapture capture)
 	{
-		if (capture.Name == "import.call")
+		if (capture.ImportSyntax is { } syntax)
 		{
-			var require = RequireRegex().Match(capture.Text);
-			if (require.Success)
-				yield return new ImportFact(require.Groups["path"].Value, null, null, false, 0, Site(context, capture));
+			if (!syntax.HasLiteralSpecifier)
+			{
+				yield return new ImportFact(string.Empty, null, null, false, 0, Site(context, capture))
+				{
+					HasLiteralSpecifier = false
+				};
+				yield break;
+			}
+			if (syntax.Bindings.Count == 0)
+			{
+				yield return new ImportFact(syntax.Specifier, null, null, false, 0, Site(context, capture));
+				yield break;
+			}
+			foreach (var binding in syntax.Bindings)
+				yield return new ImportFact(syntax.Specifier, binding.Name, binding.Alias,
+					binding.IsWildcard, 0, Site(context, capture));
 			yield break;
-		}
-		var match = ModuleRegex().Match(capture.Text);
-		if (!match.Success) yield break;
-		var specifier = match.Groups["path"].Value;
-		var names = NamedImportsRegex().Match(capture.Text);
-		if (!names.Success)
-		{
-			yield return new ImportFact(specifier, null, null, capture.Text.Contains('*'), 0, Site(context, capture));
-			yield break;
-		}
-		foreach (var item in names.Groups["names"].Value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-		{
-			var parts = Regex.Split(item, @"\s+as\s+", RegexOptions.CultureInvariant);
-			yield return new ImportFact(specifier, parts[0].Trim(), parts.Length > 1 ? parts[1].Trim() : null,
-				false, 0, Site(context, capture));
 		}
 	}
 
@@ -448,9 +456,6 @@ internal sealed partial class TypeScriptDependencyLanguageAdapter : DependencyLa
 		[], [], [], [], new Dictionary<string, string>(), [], new Dictionary<string, string>(), []);
 	private static readonly HashSet<string> Keywords = new(
 		["string", "number", "boolean", "unknown", "never", "any", "void", "null", "undefined", "keyof", "typeof", "readonly", "new", "extends", "implements"], StringComparer.Ordinal);
-	[GeneratedRegex("(?:from\\s+|import\\s*\\(|require\\s*\\()\\s*['\"](?<path>[^'\"]+)['\"]", RegexOptions.CultureInvariant)] private static partial Regex ModuleRegex();
-	[GeneratedRegex("""require\s*\(\s*['"](?<path>[^'"]+)['"]\s*\)""", RegexOptions.CultureInvariant)] private static partial Regex RequireRegex();
-	[GeneratedRegex(@"\{(?<names>[^}]+)\}", RegexOptions.CultureInvariant)] private static partial Regex NamedImportsRegex();
 	[GeneratedRegex(@"[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*", RegexOptions.CultureInvariant)] private static partial Regex TypeRegex();
 	[GeneratedRegex(@"\bnew\s+(?<type>[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)", RegexOptions.CultureInvariant)] private static partial Regex NewTypeRegex();
 }
@@ -466,7 +471,10 @@ internal sealed partial class PythonDependencyLanguageAdapter : DependencyLangua
 			if (string.IsNullOrEmpty(capture.CapturedName)) return null;
 			var kind = capture.Name == "declaration.class" ? SymbolKind.Class : SymbolKind.Function;
 			return new DeclarationFact(new SymbolIdentity(context.ScopeId, context.LanguageId, kind,
-				$"{module}.{capture.CapturedName}", 0), [Site(context, capture)]);
+				$"{module}.{capture.CapturedName}", 0), [Site(context, capture)])
+			{
+				ContainingType = capture.ContainingDeclaration
+			};
 		}).Where(static item => item is not null).Cast<DeclarationFact>().ToArray();
 		var imports = context.References.Where(static capture => capture.Name.StartsWith("import.", StringComparison.Ordinal))
 			.SelectMany(capture => ExtractImports(context, capture)).ToArray();
@@ -485,26 +493,12 @@ internal sealed partial class PythonDependencyLanguageAdapter : DependencyLangua
 
 	private static IEnumerable<ImportFact> ExtractImports(DependencyExtractionContext context, DependencySyntaxCapture capture)
 	{
-		if (capture.Name == "import.direct")
-		{
-			foreach (var item in capture.Text["import".Length..].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-			{
-				var parts = Regex.Split(item, @"\s+as\s+", RegexOptions.CultureInvariant);
-				yield return new ImportFact(parts[0], null, parts.Length > 1 ? parts[1] : null, false, 0, Site(context, capture));
-			}
-			yield break;
-		}
-		var match = FromRegex().Match(capture.Text);
-		if (!match.Success) yield break;
-		var dotted = match.Groups["module"].Value;
-		var relativeLevel = dotted.TakeWhile(static value => value == '.').Count();
-		var module = dotted[relativeLevel..];
-		foreach (var item in match.Groups["names"].Value.Trim('(', ')', ' ').Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-		{
-			var parts = Regex.Split(item, @"\s+as\s+", RegexOptions.CultureInvariant);
-			yield return new ImportFact(module, parts[0], parts.Length > 1 ? parts[1] : null,
-				parts[0] == "*", relativeLevel, Site(context, capture));
-		}
+		if (capture.ImportSyntax is not { } syntax) yield break;
+		foreach (var binding in syntax.Bindings)
+			yield return capture.Name == "import.direct"
+				? new ImportFact(binding.Name, null, binding.Alias, false, 0, Site(context, capture))
+				: new ImportFact(syntax.Specifier, binding.Name, binding.Alias,
+					binding.IsWildcard, syntax.RelativeLevel, Site(context, capture));
 	}
 
 	private static FileFacts Failed(DependencyExtractionContext context) => new(
@@ -513,7 +507,6 @@ internal sealed partial class PythonDependencyLanguageAdapter : DependencyLangua
 		[], [], [], [], new Dictionary<string, string>(), [], new Dictionary<string, string>(), []);
 	private static readonly HashSet<string> Keywords = new(
 		["def", "class", "None", "True", "False", "str", "int", "float", "bool", "bytes", "list", "dict", "tuple", "set", "object", "typing", "self", "cls"], StringComparer.Ordinal);
-	[GeneratedRegex(@"^from\s+(?<module>\.*(?:[A-Za-z_][\w.]*)?)\s+import\s+(?<names>.+)$", RegexOptions.CultureInvariant)] private static partial Regex FromRegex();
 	[GeneratedRegex(@"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*", RegexOptions.CultureInvariant)] private static partial Regex TypeRegex();
 	[GeneratedRegex(@"(?m)^\s*__all__\s*=\s*[A-Za-z_]", RegexOptions.CultureInvariant)] private static partial Regex DynamicAllRegex();
 }

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -36,6 +36,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var snapshots = new Dictionary<string, Task<DependencyControlFileSnapshot>>(PathComparer);
 		var packageProjections = new Dictionary<string, Task<ConfigurationParseResult<PackageMapDescriptor>>>(PathComparer);
 		var diagnostics = new List<DependencyConfigurationDiagnostic>();
+		var absentControlFiles = new HashSet<string>(PathComparer);
 		var transientReadFailure = 0;
 
 		Task<DependencyControlFileSnapshot> ReadSnapshotAsync(string path)
@@ -49,6 +50,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		async Task<DependencyControlFileSnapshot> ReadTrackedSnapshotAsync(string path)
 		{
 			var snapshot = await _reader.ReadAsync(path, MaximumConfigurationBytes, cancellationToken).ConfigureAwait(false);
+			if (snapshot.State == DependencyConfigurationState.Missing)
+				absentControlFiles.Add(Path.GetFullPath(path));
 			if (!snapshot.CanCache)
 				Interlocked.Exchange(ref transientReadFailure, 1);
 			return snapshot;
@@ -95,6 +98,13 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				? ParseProjectReferences(project, snapshot.Content)
 				: ConfigurationParseResult<string[]>.Failure([], snapshot.State, snapshot.Reason);
 			var references = parsed.Value;
+			foreach (var reference in references.Where(reference => !manifest.Contains(reference)))
+			{
+				var exists = File.Exists(reference);
+				fingerprintParts.Add(Fingerprint(root, reference, exists ? "present" : "missing"));
+				if (!exists)
+					absentControlFiles.Add(reference);
+			}
 			csharpProjects[project] = (scope, references);
 			AddDiagnostic(project, parsed.State, parsed.Reason, scope);
 		}
@@ -209,7 +219,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				})
 				.OrderBy(static item => item.Path, StringComparer.Ordinal)
 				.ToArray(),
-			CanCache = Volatile.Read(ref transientReadFailure) == 0
+			CanCache = Volatile.Read(ref transientReadFailure) == 0,
+			AbsentControlFiles = absentControlFiles.Order(StringComparer.Ordinal).ToArray()
 		};
 	}
 
@@ -298,7 +309,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 						return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
 							TypeScriptConfiguration.Default,
 							DependencyConfigurationState.UnsupportedSemantics,
-							$"tsconfig path mapping '{mapping.Name}' must be an array of strings");
+							"tsconfig path mapping must be an array of strings");
 					paths[mapping.Name] = mapping.Value.EnumerateArray()
 						.Select(static item => item.GetString()!).ToArray();
 				}
@@ -373,7 +384,9 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		}
 		if (map.ValueKind != JsonValueKind.Object)
 		{
-			result["."] = UnsupportedPackageTarget($"{property} must be a string, null, or object");
+			result["."] = UnsupportedPackageTarget(property == "exports"
+				? "package exports must be a string, null, or object"
+				: "package imports must be a string, null, or object");
 			return result;
 		}
 		if (property == "exports" && !map.EnumerateObject().Any(static item => item.Name.StartsWith(".", StringComparison.Ordinal)))
@@ -392,7 +405,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		if (value.ValueKind == JsonValueKind.Null)
 			return new PackageTargetDescriptor(PackageTargetKind.Blocked, null, [], null);
 		if (value.ValueKind != JsonValueKind.Object)
-			return UnsupportedPackageTarget($"package target kind {value.ValueKind} is not supported");
+			return UnsupportedPackageTarget("package target kind is not supported");
 		return new PackageTargetDescriptor(
 			PackageTargetKind.Conditions,
 			null,
@@ -678,11 +691,11 @@ internal sealed class BoundedDependencyControlFileReader : IDependencyControlFil
 		}
 		catch (FileNotFoundException)
 		{
-			return Failure(DependencyConfigurationState.Missing, "configuration file is unavailable", 0, 0, canCache: false);
+			return Failure(DependencyConfigurationState.Missing, "configuration file is unavailable", 0, 0);
 		}
 		catch (DirectoryNotFoundException)
 		{
-			return Failure(DependencyConfigurationState.Missing, "configuration file is unavailable", 0, 0, canCache: false);
+			return Failure(DependencyConfigurationState.Missing, "configuration file is unavailable", 0, 0);
 		}
 		catch (DecoderFallbackException)
 		{

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -96,7 +96,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			return new PreparedDependencySource(fullPath, relative, scope, language,
 				Hash(Encoding.UTF8.GetBytes(identity)), "unsupported:v1", string.Empty,
 				DependencyFileStatus.Unsupported,
-				$"{Path.GetExtension(fullPath).TrimStart('.')} is not supported by the dependency engine yet");
+				"file language is not supported by the dependency engine yet");
 		}
 
 		try
@@ -148,7 +148,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			return new PreparedDependencySource(fullPath, relative, scope, language,
 				Hash(Encoding.UTF8.GetBytes(exception.GetType().Name)), GetExtractorIdentity(language),
 				string.Empty, DependencyFileStatus.ExtractionFailed,
-				$"{exception.GetType().Name}: {OneLine(exception.Message)}",
+				"source file could not be read",
 				CanCache: false);
 		}
 	}
@@ -380,14 +380,14 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		       IOException or UnauthorizedAccessException or System.Security.SecurityException)
 		{
 			return StatusOnly(source, DependencyFileStatus.ExtractionFailed,
-				$"{exception.GetType().Name}: {OneLine(exception.Message)}") with { CanCache = false };
+				"dependency grammar could not be loaded") with { CanCache = false };
 		}
 		catch (Exception exception) when (exception is
 		       DllNotFoundException or BadImageFormatException or
 		       EntryPointNotFoundException or InvalidOperationException)
 		{
 			return StatusOnly(source, DependencyFileStatus.ExtractionFailed,
-				$"{exception.GetType().Name}: {OneLine(exception.Message)}");
+				"dependency grammar could not be loaded");
 		}
 	}
 
@@ -805,13 +805,13 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 					DependencyFileStatus.Supported,
 					null);
 			}
-			catch (DecoderFallbackException exception)
+			catch (DecoderFallbackException)
 			{
 				return new BoundedDependencySourceRead(
 					MetadataFingerprint("unsupported-encoding", 0, 0),
 					string.Empty,
 					DependencyFileStatus.ExtractionFailed,
-					$"source uses an unsupported encoding: {OneLine(exception.Message)}");
+					"source uses an unsupported encoding");
 			}
 			finally
 			{

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -479,7 +479,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		var isCompact = captureName.StartsWith("declaration.", StringComparison.Ordinal) ||
 			captureName == "context.namespace";
 		if (!isCompact)
-			return CreateCapture(captureName, node, node.Text, null, 0, false);
+			return CreateCapture(captureName, node, node.Text, null, 0, false,
+				importSyntax: CreateImportSyntax(captureName, node));
 
 		var capturedName = node.GetChildForField("name")?.Text;
 		var typeParameters = node.Children.FirstOrDefault(static child =>
@@ -490,7 +491,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			: capturedName + (genericArity == 0 ? string.Empty : $"`{genericArity}");
 		var isFileLocal = captureName.StartsWith("declaration.", StringComparison.Ordinal) &&
 			node.Children.Any(static child => child.Type == "modifier" && child.Text == "file");
-		return CreateCapture(captureName, node, evidence, capturedName, genericArity, isFileLocal);
+		return CreateCapture(captureName, node, evidence, capturedName, genericArity, isFileLocal,
+			FindContainingDeclaration(node));
 	}
 
 	private static DependencySyntaxCapture CreateCapture(
@@ -499,7 +501,9 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		string text,
 		string? capturedName,
 		int genericArity,
-		bool isFileLocal) =>
+		bool isFileLocal,
+		string? containingDeclaration = null,
+		DependencyImportSyntax? importSyntax = null) =>
 		new(
 			captureName,
 			node.Type,
@@ -509,7 +513,70 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			checked((int)node.EndIndex),
 			capturedName,
 			genericArity,
-			isFileLocal);
+			isFileLocal,
+			containingDeclaration,
+			importSyntax);
+
+	private static string? FindContainingDeclaration(Node node)
+	{
+		for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+		{
+			if (parent.Type is not ("class_definition" or "function_definition")) continue;
+			var name = parent.GetChildForField("name")?.Text;
+			if (!string.IsNullOrWhiteSpace(name)) return name;
+		}
+		return null;
+	}
+
+	private static DependencyImportSyntax? CreateImportSyntax(string captureName, Node node)
+	{
+		if (captureName is "import.esm" or "import.export")
+		{
+			var source = node.GetChildForField("source");
+			return source is null
+				? null
+				: new DependencyImportSyntax(ReadQuotedLiteral(source.Text) ?? string.Empty, 0, [],
+					ReadQuotedLiteral(source.Text) is not null);
+		}
+		if (captureName == "import.call")
+		{
+			var function = node.GetChildForField("function")?.Text;
+			if (function is not ("require" or "import")) return null;
+			var argument = node.GetChildForField("arguments")?.NamedChildren.FirstOrDefault();
+			var specifier = argument is null ? null : ReadQuotedLiteral(argument.Text);
+			return new DependencyImportSyntax(specifier ?? string.Empty, 0, [], specifier is not null);
+		}
+		if (captureName == "import.direct")
+		{
+			var bindings = ReadPythonBindings(node.GetChildrenForField("name"));
+			return new DependencyImportSyntax(string.Empty, 0, bindings);
+		}
+		if (captureName == "import.from")
+		{
+			var moduleText = node.GetChildForField("module_name")?.Text ?? string.Empty;
+			var relativeLevel = moduleText.TakeWhile(static character => character == '.').Count();
+			var bindings = ReadPythonBindings(node.GetChildrenForField("name"));
+			if (node.NamedChildren.Any(static child => child.Type == "wildcard_import"))
+				bindings = [new DependencyImportBinding("*", null, true)];
+			return new DependencyImportSyntax(moduleText[relativeLevel..], relativeLevel, bindings);
+		}
+		return null;
+	}
+
+	private static IReadOnlyList<DependencyImportBinding> ReadPythonBindings(IEnumerable<Node> nodes) =>
+		nodes.Select(node =>
+		{
+			if (node.Type != "aliased_import")
+				return new DependencyImportBinding(node.Text, null, node.Type == "wildcard_import");
+			return new DependencyImportBinding(
+				node.GetChildForField("name")?.Text ?? string.Empty,
+				node.GetChildForField("alias")?.Text);
+		}).Where(static binding => binding.Name.Length > 0).ToArray();
+
+	private static string? ReadQuotedLiteral(string text) =>
+		text.Length >= 2 && text[0] is '\'' or '"' && text[^1] == text[0]
+			? text[1..^1]
+			: null;
 
 	private static int CountGenericArity(string text)
 	{

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -482,7 +482,9 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			return CreateCapture(captureName, node, node.Text, null, 0, false,
 				importSyntax: CreateImportSyntax(captureName, node));
 
-		var capturedName = node.GetChildForField("name")?.Text;
+		var nameNode = node.GetChildForField("name");
+		var capturedName = nameNode?.Text;
+		var capturedNameStartIndex = nameNode is null ? -1 : checked((int)nameNode.StartIndex);
 		var typeParameters = node.Children.FirstOrDefault(static child =>
 			child.Type is "type_parameter_list" or "type_parameters");
 		var genericArity = typeParameters is null ? 0 : CountGenericArity(typeParameters.Text);
@@ -492,7 +494,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		var isFileLocal = captureName.StartsWith("declaration.", StringComparison.Ordinal) &&
 			node.Children.Any(static child => child.Type == "modifier" && child.Text == "file");
 		return CreateCapture(captureName, node, evidence, capturedName, genericArity, isFileLocal,
-			FindContainingDeclaration(node));
+			FindContainingDeclaration(node), capturedNameStartIndex: capturedNameStartIndex);
 	}
 
 	private static DependencySyntaxCapture CreateCapture(
@@ -503,7 +505,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		int genericArity,
 		bool isFileLocal,
 		string? containingDeclaration = null,
-		DependencyImportSyntax? importSyntax = null) =>
+		DependencyImportSyntax? importSyntax = null,
+		int capturedNameStartIndex = -1) =>
 		new(
 			captureName,
 			node.Type,
@@ -515,7 +518,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			genericArity,
 			isFileLocal,
 			containingDeclaration,
-			importSyntax);
+			importSyntax,
+			capturedNameStartIndex);
 
 	private static string? FindContainingDeclaration(Node node)
 	{

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -578,7 +578,8 @@ public sealed class DependencyFactsEngineIntegrationTests
 		Assert.Equal("valid/entry.mjs", Assert.Single(result.Edges, item => item.Reference == "valid").Target);
 		var unsupported = Assert.Single(result.Edges, item => item.Reference == "unknown");
 		Assert.Equal(ResolutionStatus.Unresolved, unsupported.Status);
-		Assert.Contains("condition 'browser' is not supported", Assert.Single(unsupported.Reasons), StringComparison.Ordinal);
+		// Project-controlled condition names stay out of trusted resolution reasons.
+		Assert.Equal("package condition is not supported", Assert.Single(unsupported.Reasons));
 	}
 
 	[Fact]
@@ -1820,7 +1821,8 @@ public sealed class DependencyFactsEngineIntegrationTests
 
 		var failed = Assert.Single(result.Files, file => file.Path == "Source.cs");
 		Assert.Equal(DependencyFileStatus.ExtractionFailed, failed.Status);
-		Assert.Contains(nameof(FileNotFoundException), failed.StatusReason, StringComparison.Ordinal);
+		// Exception messages and resource names stay out of trusted diagnostics.
+		Assert.Equal("dependency grammar could not be loaded", failed.StatusReason);
 		Assert.Equal(1, result.Coverage.ExtractionFailed);
 	}
 

--- a/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
@@ -1,0 +1,74 @@
+using DevProjex.Application.Dependencies;
+using DevProjex.Infrastructure.Dependencies;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class DependencyReferenceSemanticsIntegrationTests
+{
+	[Fact]
+	public async Task CSharpReferences_OnOneLineRemainDistinctOccurrencesAcrossLexicalOwners()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var model = fixture.CreateFile("Models/User.cs", "namespace Models; public sealed class User { }");
+		var source = fixture.CreateFile("Consumers.cs",
+			"using Models; class Box<User> { User a; } class Consumer { User b; }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[project, model, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var references = result.Files.Single(file => file.Path == "Consumers.cs").References
+			.Where(reference => reference.Name == "User")
+			.ToArray();
+		Assert.Equal(2, references.Length);
+		Assert.Contains(references, reference => reference.Status == ResolutionStatus.Unresolved);
+		Assert.Contains(references, reference =>
+			reference.Status == ResolutionStatus.Resolved && reference.Target == "Models/User.cs");
+	}
+
+	[Fact]
+	public async Task CSharpGlobalQualification_BypassesTypeParameterShadowingAndContextualFallback()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var global = fixture.CreateFile("User.cs", "public sealed class User { }");
+		var model = fixture.CreateFile("Models/User.cs", "namespace Models; public sealed class User { }");
+		var source = fixture.CreateFile("Consumers.cs", """
+			namespace Consumers;
+			class Box<User>
+			{
+				global::User AbsoluteGlobal;
+				global::Models.User AbsoluteQualified;
+				User Shadowed;
+			}
+			class Neighbor { global::User Absolute; User Ordinary; }
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[project, global, model, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var facts = result.Files.Single(file => file.Path == "Consumers.cs");
+		Assert.Contains(facts.References, reference => reference.Name == "User" &&
+			reference.IsGlobalQualified && reference.Site.Line == 4 && reference.Target == "User.cs");
+		Assert.Contains(facts.References, reference => reference.Name == "Models.User" &&
+			reference.IsGlobalQualified && reference.Site.Line == 5 && reference.Target == "Models/User.cs");
+		Assert.Contains(result.Edges, edge => edge.Source == "Consumers.cs" &&
+			edge.Reference == "Models.User" && edge.Target == "Models/User.cs" &&
+			edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(result.Edges, edge => edge.Source == "Consumers.cs" &&
+			edge.Reference == "User" && edge.Status == ResolutionStatus.Unresolved);
+		Assert.Contains(result.Edges, edge => edge.Source == "Consumers.cs" &&
+			edge.Reference == "User" && edge.Target == "User.cs" &&
+			edge.Status == ResolutionStatus.Resolved);
+	}
+
+	private static DependencyFactsEngine CreateEngine() => new(
+		new TreeSitterDependencyFactExtractor(),
+		new FileDependencyConfigurationProvider());
+}

--- a/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
@@ -181,6 +181,59 @@ public sealed class DependencyReferenceSemanticsIntegrationTests
 		Assert.DoesNotContain("ns/aaa.py", edge.Candidates);
 	}
 
+	[Fact]
+	public async Task DependencyReasons_DoNotEchoProjectControlledNamesSpecifiersOrPaths()
+	{
+		const string sentinel = "PROJECT_SENTINEL_DO_NOT_ECHO";
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"paths\":{\"" + sentinel + "\":42}}}");
+		var source = fixture.CreateFile("main.ts", "import \"" + sentinel + "\";");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var reasons = result.Edges.SelectMany(static edge => edge.Reasons)
+			.Concat(result.Files.SelectMany(static file => file.Imports.Select(import => import.Reason)))
+			.Concat(result.Files.SelectMany(static file => file.References.Select(reference => reference.Reason)))
+			.Concat(result.Files.Select(static file => file.StatusReason ?? string.Empty))
+			.Concat(result.Coverage.ConfigurationDiagnostics.Select(static diagnostic => diagnostic.Reason));
+		Assert.DoesNotContain(reasons, reason => reason.Contains(sentinel, StringComparison.Ordinal));
+		Assert.Contains(result.Coverage.ConfigurationDiagnostics,
+			diagnostic => diagnostic.Reason == "tsconfig path mapping must be an array of strings");
+	}
+
+	[Fact]
+	public async Task MissingReferencedControlFile_IsCacheableUntilTheFileAppears()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("App/App.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <ItemGroup><ProjectReference Include="../Missing/Missing.csproj" /></ItemGroup>
+			</Project>
+			""");
+		var source = fixture.CreateFile("App/Consumer.cs", "public sealed class Consumer { }");
+		var configuration = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path, [project, source], TestContext.Current.CancellationToken);
+		Assert.Contains(Path.GetFullPath(Path.Combine(fixture.Path, "Missing/Missing.csproj")),
+			configuration.AbsentControlFiles);
+		using var engine = CreateEngine();
+
+		var first = await engine.IndexAsync(fixture.Path, [project, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var warm = await engine.IndexAsync(fixture.Path, [project, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var appeared = fixture.CreateFile("Missing/Missing.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var invalidated = await engine.IndexAsync(fixture.Path, [project, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.False(first.Metrics.ResolutionCacheHit);
+		Assert.True(warm.Metrics.ResolutionCacheHit);
+		Assert.False(invalidated.Metrics.ResolutionCacheHit);
+		Assert.True(File.Exists(appeared));
+	}
+
 	private static DependencyFactsEngine CreateEngine() => new(
 		new TreeSitterDependencyFactExtractor(),
 		new FileDependencyConfigurationProvider());

--- a/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
@@ -152,9 +152,13 @@ public sealed class DependencyReferenceSemanticsIntegrationTests
 		var result = await engine.IndexAsync(fixture.Path, [config, target, source],
 			cancellationToken: TestContext.Current.CancellationToken);
 
+		var imports = result.Files.Single(file => file.Path == "main.ts").Imports;
+		Assert.Equal(8, imports.Count(import => import.Specifier == "./register.js"));
+		Assert.Equal(2, imports.Count(import => import.Reason == "module specifier is not a string literal"));
 		var edges = result.Edges.Where(edge => edge.Source == "main.ts").ToArray();
-		Assert.Contains(edges, edge => edge.Reference == "./register.js" &&
+		var resolved = Assert.Single(edges, edge => edge.Reference == "./register.js" &&
 			edge.Status == ResolutionStatus.Resolved && edge.Target == "register.ts");
+		Assert.Equal(8, resolved.Evidence.Count);
 		var unsupported = edges.Where(edge => edge.Status == ResolutionStatus.Unresolved &&
 			edge.Reasons.Contains("module specifier is not a string literal")).ToArray();
 		var unsupportedEdge = Assert.Single(unsupported);

--- a/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
@@ -68,6 +68,119 @@ public sealed class DependencyReferenceSemanticsIntegrationTests
 			edge.Status == ResolutionStatus.Resolved);
 	}
 
+	[Fact]
+	public async Task PythonFromImport_RejectsNestedDeclarationsAndMissingNamesButKeepsTopLevelBindings()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var model = fixture.CreateFile("model.py", "class Container:\n    def helper(self): pass\n\nclass Item: pass\ndef create(): pass");
+		var nestedConsumer = fixture.CreateFile("nested_consumer.py", "from model import helper");
+		var missingConsumer = fixture.CreateFile("missing_consumer.py", "from model import Missing");
+		var consumer = fixture.CreateFile("consumer.py", "from model import Item\nfrom model import create");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, model, nestedConsumer, missingConsumer, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var imports = result.Files.Single(file => file.Path == "consumer.py").Imports;
+		Assert.Equal(2, imports.Count);
+		var resolved = Assert.Single(result.Edges, edge => edge.Source == "consumer.py" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "model.py");
+		Assert.Equal(2, resolved.Evidence.Count);
+		var unresolved = result.Edges.Where(edge => edge.Source is "nested_consumer.py" or "missing_consumer.py" &&
+			edge.Status == ResolutionStatus.Unresolved).ToArray();
+		Assert.Equal(2, unresolved.Length);
+		Assert.All(unresolved, edge => Assert.Contains("name not found in module", edge.Reasons));
+		var nested = result.Files.Single(file => file.Path == "model.py").Declarations
+			.Single(declaration => declaration.Identity.QualifiedName.EndsWith(".helper", StringComparison.Ordinal));
+		Assert.Equal("Container", nested.ContainingType);
+	}
+
+	[Fact]
+	public async Task PythonImports_UseParsedNodesForMultilineAliasesRelativeAndWildcardForms()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var init = fixture.CreateFile("pkg/__init__.py", "from .model import Item");
+		var model = fixture.CreateFile("pkg/model.py", "class Item: pass\nclass Other: pass");
+		var consumer = fixture.CreateFile("pkg/consumer.py", """
+			from .model import (
+			    Item as Renamed,
+			    # retained syntax comment
+			    Other,
+			)
+			from .model import *
+			from . import model
+			import pkg.model as direct
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, init, model, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var facts = result.Files.Single(file => file.Path == "pkg/consumer.py");
+		Assert.Contains(facts.Imports, fact => fact.Specifier == "model" && fact.ImportedName == "Item" && fact.Alias == "Renamed");
+		Assert.Contains(facts.Imports, fact => fact.Specifier == "model" && fact.ImportedName == "Other");
+		Assert.Contains(facts.Imports, fact => fact.Specifier == "model" && fact.IsWildcard);
+		Assert.Contains(facts.Imports, fact => fact.Specifier.Length == 0 && fact.ImportedName == "model" && fact.RelativeLevel == 1);
+		Assert.Contains(facts.Imports, fact => fact.Specifier == "pkg.model" && fact.Alias == "direct");
+		Assert.All(result.Edges.Where(edge => edge.Source == "pkg/consumer.py"),
+			edge => Assert.Equal(ResolutionStatus.Resolved, edge.Status));
+	}
+
+	[Fact]
+	public async Task TypeScriptImports_UseSyntaxSourceAndRejectNonLiteralCalls()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var target = fixture.CreateFile("register.ts", "export const x = 1;");
+		var source = fixture.CreateFile("main.ts", """
+			import "./register.js";
+			import value from "./register.js";
+			import * as ns from "./register.js";
+			import type { x } from "./register.js";
+			export * from "./register.js";
+			export { x } from "./register.js";
+			require("./register.js");
+			import("./register.js");
+			const path = "./register.js";
+			require(path);
+			import(`./register.js`);
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edges = result.Edges.Where(edge => edge.Source == "main.ts").ToArray();
+		Assert.Contains(edges, edge => edge.Reference == "./register.js" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "register.ts");
+		var unsupported = edges.Where(edge => edge.Status == ResolutionStatus.Unresolved &&
+			edge.Reasons.Contains("module specifier is not a string literal")).ToArray();
+		var unsupportedEdge = Assert.Single(unsupported);
+		Assert.Equal(2, unsupportedEdge.Evidence.Count);
+		Assert.DoesNotContain(unsupported, edge => edge.Target is not null);
+	}
+
+	[Fact]
+	public async Task PythonNamespaceImport_ResolvesTheRequestedChildInsteadOfAnArbitraryPortionFile()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var unrelated = fixture.CreateFile("ns/aaa.py", "value = 1");
+		var child = fixture.CreateFile("ns/child.py", "value = 2");
+		var consumer = fixture.CreateFile("consumer.py", "from ns import child");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, unrelated, child, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("ns/child.py", edge.Target);
+		Assert.DoesNotContain("ns/aaa.py", edge.Candidates);
+	}
+
 	private static DependencyFactsEngine CreateEngine() => new(
 		new TreeSitterDependencyFactExtractor(),
 		new FileDependencyConfigurationProvider());

--- a/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
@@ -30,6 +30,24 @@ public sealed class DependencyReferenceSemanticsIntegrationTests
 	}
 
 	[Fact]
+	public async Task CSharpDeclarationFiltering_UsesTheNameOccurrenceInsteadOfTheWholeLine()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var source = fixture.CreateFile("User.cs", "public sealed class User { public User Value { get; } }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [project, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var facts = result.Files.Single(file => file.Path == "User.cs");
+		Assert.Single(facts.Declarations, declaration => declaration.Identity.QualifiedName == "User");
+		Assert.Single(facts.References, reference => reference.Name == "User");
+		Assert.Contains(result.Edges, edge => edge.Source == "User.cs" && edge.Target == "User.cs" &&
+			edge.Status == ResolutionStatus.Resolved);
+	}
+
+	[Fact]
 	public async Task CSharpGlobalQualification_BypassesTypeParameterShadowingAndContextualFallback()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
@@ -134,6 +134,43 @@ public sealed class RelatedCommandProcessTests
 		Assert.DoesNotContain("[Dependency configuration]", valid.StandardOutput, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public void RealPublishedCommandPreservesParsedImportAndCSharpOccurrenceSemantics()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />\n");
+		workspace.WriteFile("project/Models.cs", "namespace Models; public sealed class User { }\n");
+		workspace.WriteFile("project/Consumers.cs",
+			"using Models; class Box<User> { User a; } class Consumer { User b; }\n");
+		workspace.WriteFile("project/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}\n");
+		workspace.WriteFile("project/register.ts", "export const ready = true;\n");
+		workspace.WriteFile("project/main.ts", "import \"./register.js\";\n");
+		workspace.WriteFile("project/pyproject.toml", "[project]\nname = \"fixture\"\n");
+		workspace.WriteFile("project/model.py", "class Container:\n    def nested(self): pass\n\nclass Item: pass\n");
+		workspace.WriteFile("project/python_consumer.py", "from model import (\n    Item,\n)\n");
+
+		var csharp = Run(workspace, "related", "Consumers.cs", "--project", project,
+			"--format", "json", "--git-mode", "none", "--exclude", "none");
+		var typeScript = Run(workspace, "related", "main.ts", "--project", project,
+			"--format", "json", "--git-mode", "none", "--exclude", "none");
+		var python = Run(workspace, "related", "python_consumer.py", "--project", project,
+			"--format", "json", "--git-mode", "none", "--exclude", "none");
+
+		Assert.Equal(0, csharp.ExitCode);
+		using (var document = JsonDocument.Parse(csharp.StandardOutput))
+		{
+			var dependencies = Assert.Single(document.RootElement.GetProperty("seeds").EnumerateArray())
+				.GetProperty("dependencies").EnumerateArray().ToArray();
+			Assert.Contains(dependencies, item => item.GetProperty("path").GetString() == "Models.cs");
+		}
+		Assert.Equal(0, typeScript.ExitCode);
+		Assert.Contains("register.ts", typeScript.StandardOutput, StringComparison.Ordinal);
+		Assert.Equal(0, python.ExitCode);
+		Assert.Contains("model.py", python.StandardOutput, StringComparison.Ordinal);
+		Assert.DoesNotContain("nested", python.StandardOutput, StringComparison.Ordinal);
+	}
+
 	private static TerminalTestProcessResult Run(TemporaryDirectory workspace, params string[] arguments)
 	{
 		var startInfo = new ProcessStartInfo("dotnet")

--- a/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
@@ -9,6 +9,61 @@ namespace DevProjex.Tests.Terminal;
 public sealed partial class McpServerProcessTests
 {
 	[Fact]
+	public async Task RealProcessRelatedFilesPreservesParsedImportSemantics()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}\n");
+		workspace.WriteFile("project/register.ts", "export const ready = true;\n");
+		workspace.WriteFile("project/main.ts", "import \"./register.js\";\n");
+		workspace.WriteFile("project/pyproject.toml", "[project]\nname = \"fixture\"\n");
+		workspace.WriteFile("project/model.py", "class Container:\n    def nested(self): pass\n\nclass Item: pass\n");
+		workspace.WriteFile("project/consumer.py", "from model import (\n    Item,\n)\n");
+		var startInfo = new ProcessStartInfo("dotnet")
+		{
+			UseShellExecute = false,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			CreateNoWindow = true,
+			WorkingDirectory = project
+		};
+		startInfo.ArgumentList.Add(PublishedApplicationLocator.FindApplicationAssembly());
+		startInfo.ArgumentList.Add("mcp");
+		startInfo.ArgumentList.Add("--root");
+		startInfo.ArgumentList.Add(project);
+		startInfo.ArgumentList.Add("--git-mode");
+		startInfo.ArgumentList.Add("none");
+		startInfo.ArgumentList.Add("--exclude");
+		startInfo.ArgumentList.Add("none");
+		startInfo.Environment["DEVPROJEX_INTERNAL_DATA_ROOT"] = workspace.CreateDirectory("data");
+
+		using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("MCP process did not start.");
+		var errorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+		await using (var client = await McpClient.CreateAsync(
+			new StreamClientTransport(process.StandardInput.BaseStream, process.StandardOutput.BaseStream),
+			clientOptions: null, loggerFactory: null, TestContext.Current.CancellationToken))
+		{
+			var typeScript = await client.CallToolAsync("related_files",
+				new Dictionary<string, object?> { ["path"] = "main.ts", ["direction"] = "dependencies" },
+				progress: null, options: null, TestContext.Current.CancellationToken);
+			var python = await client.CallToolAsync("related_files",
+				new Dictionary<string, object?> { ["path"] = "consumer.py", ["direction"] = "dependencies" },
+				progress: null, options: null, TestContext.Current.CancellationToken);
+			Assert.Contains("register.ts", Assert.IsType<TextContentBlock>(Assert.Single(typeScript.Content)).Text,
+				StringComparison.Ordinal);
+			var pythonText = Assert.IsType<TextContentBlock>(Assert.Single(python.Content)).Text;
+			Assert.Contains("model.py", pythonText, StringComparison.Ordinal);
+			Assert.DoesNotContain("nested", pythonText, StringComparison.Ordinal);
+		}
+		process.StandardInput.Close();
+		await process.WaitForExitAsync(TestContext.Current.CancellationToken)
+			.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+		Assert.Equal(0, process.ExitCode);
+		Assert.True(string.IsNullOrWhiteSpace(await errorTask), await errorTask);
+	}
+
+	[Fact]
 	public async Task RealProcessRelatedFilesReportsBothDirectionsAmbiguityCoverageAndProgress()
 	{
 		if (!await IsGitAvailableAsync())

--- a/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
@@ -227,7 +227,11 @@ public sealed partial class McpServerProcessTests
 				TestContext.Current.CancellationToken);
 			var unsupportedText = Assert.IsType<TextContentBlock>(Assert.Single(unsupported.Content)).Text;
 			var closingBoundary = unsupportedText.LastIndexOf("</untrusted-data-", StringComparison.Ordinal);
-			var noFacts = unsupportedText.IndexOf("[No facts] md is not supported", StringComparison.Ordinal);
+			// Dependency diagnostics intentionally use constant trusted reasons so project-controlled
+			// extensions cannot be echoed outside the untrusted-data boundary.
+			var noFacts = unsupportedText.IndexOf(
+				"[No facts] file language is not supported by the dependency engine yet",
+				StringComparison.Ordinal);
 			Assert.True(closingBoundary >= 0 && noFacts > closingBoundary, unsupportedText);
 		}
 

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-08",
-  "productSha": "7e8a1c9bc6229e2d61cc8a4e538cbf817f91f3a5",
-  "evaluatorSha": "7e8a1c9bc6229e2d61cc8a4e538cbf817f91f3a5",
+  "productSha": "798ce9bef2622fda1eb6320ef98009428388c6c7",
+  "evaluatorSha": "798ce9bef2622fda1eb6320ef98009428388c6c7",
   "repositories": [
     {
       "id": "devprojex",
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2733.3089,
-          "medianPeakWorkingSetBytes": 318156800,
+          "medianElapsedMilliseconds": 2727.879,
+          "medianPeakWorkingSetBytes": 319238144,
           "elapsedMilliseconds": [
-            2549.9843,
-            3094.0315,
-            3365.2011,
-            2585.4247,
-            2667.3333,
-            2733.3089,
-            2822.1437
+            2860.1653,
+            2810.255,
+            2877.0395,
+            2727.879,
+            2670.9112,
+            2716.9539,
+            2701.9038
           ],
           "peakWorkingSetBytes": [
-            319369216,
-            318058496,
-            318156800,
-            319119360,
-            315265024,
-            318902272,
-            314691584
+            315703296,
+            320544768,
+            320876544,
+            318865408,
+            319238144,
+            319578112,
+            314736640
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2832.4569,
-          "medianPeakWorkingSetBytes": 315506688,
+          "medianElapsedMilliseconds": 2812.7785,
+          "medianPeakWorkingSetBytes": 316973056,
           "elapsedMilliseconds": [
-            2741.2238,
-            2580.4833,
-            2742.0051,
-            2862.7813,
-            3597.899,
-            2832.4569,
-            3291.5232
+            2732.9258,
+            2835.4789,
+            2834.1718,
+            2937.7606,
+            2802.022,
+            2751.5557,
+            2812.7785
           ],
           "peakWorkingSetBytes": [
-            319488000,
-            314474496,
-            314888192,
-            314421248,
-            320614400,
-            315506688,
-            316981248
+            318996480,
+            316833792,
+            316006400,
+            317825024,
+            316973056,
+            316104704,
+            318865408
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 942.9868,
-          "medianPeakWorkingSetBytes": 322359296,
+          "medianElapsedMilliseconds": 982.3944,
+          "medianPeakWorkingSetBytes": 322650112,
           "elapsedMilliseconds": [
-            942.9868,
-            880.5622,
-            925.1331,
-            932.2042,
-            954.0765,
-            973.0601,
-            1139.5225
+            949.4206,
+            1073.7196,
+            963.0919,
+            993.9284,
+            1075.0218,
+            982.3944,
+            918.3786
           ],
           "peakWorkingSetBytes": [
-            313016320,
-            324460544,
-            324857856,
-            319463424,
-            329125888,
-            322359296,
-            320462848
+            323256320,
+            319688704,
+            328351744,
+            322650112,
+            322461696,
+            329375744,
+            311386112
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 1002.1232,
-          "medianPeakWorkingSetBytes": 324530176,
+          "medianElapsedMilliseconds": 910.0667,
+          "medianPeakWorkingSetBytes": 325115904,
           "elapsedMilliseconds": [
-            915.7391,
-            1017.7031,
-            883.2161,
-            1361.1209,
-            1368.838,
-            1002.1232,
-            936.7692
+            935.5388,
+            884.0064,
+            910.0667,
+            1174.4562,
+            1018.4942,
+            900.539,
+            898.7582
           ],
           "peakWorkingSetBytes": [
-            320458752,
-            320995328,
-            324530176,
-            328613888,
-            320708608,
-            327811072,
-            324567040
+            321806336,
+            329084928,
+            324386816,
+            329129984,
+            325115904,
+            326430720,
+            321871872
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 800.6517,
-          "medianPeakWorkingSetBytes": 115470336,
+          "medianElapsedMilliseconds": 763.2784,
+          "medianPeakWorkingSetBytes": 115019776,
           "elapsedMilliseconds": [
-            775.9437,
-            800.6517,
-            838.0931,
-            781.1414,
-            793.9339,
-            811.7573,
-            849.0115
+            748.3874,
+            749.9452,
+            780.1337,
+            748.7846,
+            767.3463,
+            763.2784,
+            766.5077
           ],
           "peakWorkingSetBytes": [
-            115240960,
-            115699712,
-            115957760,
-            116506624,
-            115134464,
-            115036160,
-            115470336
+            114327552,
+            115089408,
+            114987008,
+            112275456,
+            115400704,
+            116707328,
+            115019776
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 900.8799,
-          "medianPeakWorkingSetBytes": 115945472,
+          "medianElapsedMilliseconds": 768.2812,
+          "medianPeakWorkingSetBytes": 115318784,
           "elapsedMilliseconds": [
-            876.1415,
-            1193.117,
-            960.1144,
-            900.8799,
-            918.7424,
-            816.776,
-            845.394
+            762.8923,
+            768.2812,
+            768.1074,
+            781.7544,
+            838.1749,
+            806.0313,
+            763.2394
           ],
           "peakWorkingSetBytes": [
-            117526528,
-            117309440,
-            117841920,
-            115945472,
-            115343360,
-            113848320,
-            115630080
+            114356224,
+            115810304,
+            115646464,
+            115023872,
+            115318784,
+            112898048,
+            115580928
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 440.3532,
-          "medianPeakWorkingSetBytes": 116613120,
+          "medianElapsedMilliseconds": 401.381,
+          "medianPeakWorkingSetBytes": 116224000,
           "elapsedMilliseconds": [
-            465.2768,
-            445.9437,
-            436.2875,
-            427.6049,
-            440.3532,
-            432.1774,
-            457.5
+            396.3881,
+            406.5513,
+            403.6066,
+            398.9629,
+            401.381,
+            416.1997,
+            386.7873
           ],
           "peakWorkingSetBytes": [
-            116686848,
-            116539392,
-            117456896,
-            116613120,
-            116523008,
-            117125120,
-            116064256
+            116224000,
+            116355072,
+            116629504,
+            116080640,
+            116072448,
+            116903936,
+            116166656
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 464.7749,
-          "medianPeakWorkingSetBytes": 116850688,
+          "medianElapsedMilliseconds": 427.6332,
+          "medianPeakWorkingSetBytes": 116236288,
           "elapsedMilliseconds": [
-            618.1429,
-            497.314,
-            529.6741,
-            451.9957,
-            447.0087,
-            464.7749,
-            448.1639
+            398.3431,
+            393.4496,
+            395.0501,
+            434.2664,
+            471.7958,
+            427.6332,
+            437.0509
           ],
           "peakWorkingSetBytes": [
-            116101120,
-            116850688,
-            116600832,
-            117424128,
-            116383744,
-            116862976,
-            117030912
+            116981760,
+            115900416,
+            114274304,
+            116236288,
+            117903360,
+            117198848,
+            115142656
           ]
         }
       ]
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 507.9554,
-          "medianPeakWorkingSetBytes": 90652672,
+          "medianElapsedMilliseconds": 478.9858,
+          "medianPeakWorkingSetBytes": 90533888,
           "elapsedMilliseconds": [
-            501.6264,
-            507.9554,
-            502.04,
-            517.4479,
-            510.406,
-            508.5774,
-            490.9107
+            464.4867,
+            475.0383,
+            490.9836,
+            490.9514,
+            504.6387,
+            467.1542,
+            478.9858
           ],
           "peakWorkingSetBytes": [
-            90390528,
-            90652672,
-            90673152,
-            91009024,
-            90480640,
-            90337280,
-            90673152
+            90533888,
+            89976832,
+            90124288,
+            91070464,
+            90660864,
+            90415104,
+            90693632
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 505.3338,
-          "medianPeakWorkingSetBytes": 90513408,
+          "medianElapsedMilliseconds": 503.8273,
+          "medianPeakWorkingSetBytes": 90730496,
           "elapsedMilliseconds": [
-            505.3338,
-            491.1484,
-            491.4166,
-            496.842,
-            519.8096,
-            576.3478,
-            513.1269
+            515.9594,
+            502.0043,
+            476.5579,
+            503.8273,
+            483.2454,
+            551.9325,
+            589.6398
           ],
           "peakWorkingSetBytes": [
-            90677248,
-            90513408,
-            90185728,
-            90374144,
-            90644480,
-            91185152,
-            90394624
+            90841088,
+            90267648,
+            90873856,
+            90537984,
+            90066944,
+            91017216,
+            90730496
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 223.1351,
-          "medianPeakWorkingSetBytes": 92016640,
+          "medianElapsedMilliseconds": 223.3175,
+          "medianPeakWorkingSetBytes": 91860992,
           "elapsedMilliseconds": [
-            211.8346,
-            219.5629,
-            232.0163,
-            214.1253,
-            236.5995,
-            291.6448,
-            223.1351
+            237.3139,
+            223.3175,
+            213.8131,
+            200.3682,
+            222.783,
+            225.2083,
+            236.0111
           ],
           "peakWorkingSetBytes": [
-            92303360,
-            91496448,
-            91734016,
-            92131328,
-            92196864,
-            91942912,
-            92016640
+            91643904,
+            92221440,
+            91746304,
+            91656192,
+            91860992,
+            92475392,
+            92479488
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 239.3187,
-          "medianPeakWorkingSetBytes": 92381184,
+          "medianElapsedMilliseconds": 235.3027,
+          "medianPeakWorkingSetBytes": 92450816,
           "elapsedMilliseconds": [
-            239.3187,
-            225.6252,
-            290.1383,
-            226.738,
-            248.3143,
-            240.1974,
-            230.3727
+            235.3027,
+            261.0536,
+            216.4641,
+            221.286,
+            230.6797,
+            244.2924,
+            241.2528
           ],
           "peakWorkingSetBytes": [
-            92319744,
-            92479488,
-            92512256,
-            92205056,
-            92536832,
-            92381184,
-            92073984
+            92356608,
+            93184000,
+            92450816,
+            91930624,
+            92680192,
+            93835264,
+            91885568
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": 59.13639999999998,
-      "repomix": 24.421699999999987,
-      "flask": 16.183600000000013
+      "devprojex": -72.32770000000005,
+      "repomix": 26.252200000000016,
+      "flask": 11.985199999999992
     },
     "warmIncrementalPercent": {
-      "devprojex": 6.271180041968771,
-      "repomix": 5.545934490767862,
-      "flask": 7.252825754442045
+      "devprojex": -7.36238928072066,
+      "repomix": 6.540469030671611,
+      "flask": 5.366887951011448
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 0.6734348991753599,
-      "repomix": 0.4114788407647831,
-      "flask": 0.396171822835522
+      "devprojex": 0.7642309450058397,
+      "repomix": 0.25996225205655066,
+      "flask": 0.6420832032817586
     },
     "recallPassed": true,
     "allRequiredPassed": true,

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-08",
-  "productSha": "1c913520abde175dd13c1cb1a393c0d985581b9e",
-  "evaluatorSha": "1c913520abde175dd13c1cb1a393c0d985581b9e",
+  "productSha": "7e8a1c9bc6229e2d61cc8a4e538cbf817f91f3a5",
+  "evaluatorSha": "7e8a1c9bc6229e2d61cc8a4e538cbf817f91f3a5",
   "repositories": [
     {
       "id": "devprojex",
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2741.1446,
-          "medianPeakWorkingSetBytes": 323145728,
+          "medianElapsedMilliseconds": 2733.3089,
+          "medianPeakWorkingSetBytes": 318156800,
           "elapsedMilliseconds": [
-            2827.371,
-            2877.6425,
-            2823.8446,
-            2741.1446,
-            2725.7522,
-            2676.9313,
-            2664.7149
+            2549.9843,
+            3094.0315,
+            3365.2011,
+            2585.4247,
+            2667.3333,
+            2733.3089,
+            2822.1437
           ],
           "peakWorkingSetBytes": [
-            322871296,
-            322797568,
-            323203072,
-            323002368,
-            323510272,
-            323571712,
-            323145728
+            319369216,
+            318058496,
+            318156800,
+            319119360,
+            315265024,
+            318902272,
+            314691584
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2723.3807,
-          "medianPeakWorkingSetBytes": 323612672,
+          "medianElapsedMilliseconds": 2832.4569,
+          "medianPeakWorkingSetBytes": 315506688,
           "elapsedMilliseconds": [
-            2771.9397,
-            2761.6991,
-            2721.0678,
-            2696.1333,
-            2704.9493,
-            2723.3807,
-            2756.9543
+            2741.2238,
+            2580.4833,
+            2742.0051,
+            2862.7813,
+            3597.899,
+            2832.4569,
+            3291.5232
           ],
           "peakWorkingSetBytes": [
-            324055040,
-            323612672,
-            323420160,
-            323964928,
-            323469312,
-            323809280,
-            323252224
+            319488000,
+            314474496,
+            314888192,
+            314421248,
+            320614400,
+            315506688,
+            316981248
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 917.7578,
-          "medianPeakWorkingSetBytes": 326709248,
+          "medianElapsedMilliseconds": 942.9868,
+          "medianPeakWorkingSetBytes": 322359296,
           "elapsedMilliseconds": [
-            1006.9337,
-            887.8236,
-            898.8276,
-            916.7459,
-            981.7166,
-            922.8804,
-            917.7578
+            942.9868,
+            880.5622,
+            925.1331,
+            932.2042,
+            954.0765,
+            973.0601,
+            1139.5225
           ],
           "peakWorkingSetBytes": [
-            331177984,
-            329039872,
-            323678208,
-            326709248,
-            323280896,
-            323354624,
-            327106560
+            313016320,
+            324460544,
+            324857856,
+            319463424,
+            329125888,
+            322359296,
+            320462848
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 910.6792,
-          "medianPeakWorkingSetBytes": 327147520,
+          "medianElapsedMilliseconds": 1002.1232,
+          "medianPeakWorkingSetBytes": 324530176,
           "elapsedMilliseconds": [
-            930.2544,
-            896.9205,
-            902.3565,
-            931.4153,
-            910.6792,
-            901.6079,
-            928.9197
+            915.7391,
+            1017.7031,
+            883.2161,
+            1361.1209,
+            1368.838,
+            1002.1232,
+            936.7692
           ],
           "peakWorkingSetBytes": [
-            329351168,
-            332767232,
-            327147520,
-            325980160,
-            326864896,
-            326238208,
-            328966144
+            320458752,
+            320995328,
+            324530176,
+            328613888,
+            320708608,
+            327811072,
+            324567040
           ]
         }
       ]
@@ -1330,7 +1330,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.5753219152394049,
+              "irrelevantTokenShare": 0.575375,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -1492,7 +1492,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.5465116279069767,
+              "irrelevantTokenShare": 0.54656832104013,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -1546,7 +1546,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.773284160520065,
+              "irrelevantTokenShare": 0.7733125,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -1608,7 +1608,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.3506753376688344,
+              "irrelevantTokenShare": 0.3508377094273568,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -1660,9 +1660,9 @@
             },
             "focus-v1": {
               "available": true,
-              "recallNew": 0,
+              "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.6754594324290536,
+              "irrelevantTokenShare": 0.539125,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -1676,9 +1676,9 @@
             },
             "directed-from-seed": {
               "available": true,
-              "recallNew": 0,
+              "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.6665382145150931,
+              "irrelevantTokenShare": 0.538779084313235,
               "oracle": true,
               "oracleAfterSeeds": true
             }
@@ -1708,7 +1708,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.83775,
+              "irrelevantTokenShare": 0.8377297162145269,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -1716,7 +1716,7 @@
               "available": true,
               "recallNew": 1,
               "allRequired": true,
-              "irrelevantTokenShare": 0.5562015503875969,
+              "irrelevantTokenShare": 0.5563125,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 750.7588,
-          "medianPeakWorkingSetBytes": 117288960,
+          "medianElapsedMilliseconds": 800.6517,
+          "medianPeakWorkingSetBytes": 115470336,
           "elapsedMilliseconds": [
-            769.6079,
-            750.7588,
-            750.1261,
-            762.6834,
-            750.7034,
-            755.6056,
-            748.9306
+            775.9437,
+            800.6517,
+            838.0931,
+            781.1414,
+            793.9339,
+            811.7573,
+            849.0115
           ],
           "peakWorkingSetBytes": [
-            115965952,
-            118222848,
-            118575104,
-            117288960,
-            116518912,
-            118411264,
-            116379648
+            115240960,
+            115699712,
+            115957760,
+            116506624,
+            115134464,
+            115036160,
+            115470336
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 779.0895,
-          "medianPeakWorkingSetBytes": 118222848,
+          "medianElapsedMilliseconds": 900.8799,
+          "medianPeakWorkingSetBytes": 115945472,
           "elapsedMilliseconds": [
-            753.8733,
-            761.1051,
-            760.9724,
-            779.0895,
-            859.8602,
-            849.6652,
-            838.3452
+            876.1415,
+            1193.117,
+            960.1144,
+            900.8799,
+            918.7424,
+            816.776,
+            845.394
           ],
           "peakWorkingSetBytes": [
-            116269056,
-            118263808,
-            118263808,
-            116543488,
-            118222848,
-            116285440,
-            118403072
+            117526528,
+            117309440,
+            117841920,
+            115945472,
+            115343360,
+            113848320,
+            115630080
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 464.8097,
-          "medianPeakWorkingSetBytes": 117465088,
+          "medianElapsedMilliseconds": 440.3532,
+          "medianPeakWorkingSetBytes": 116613120,
           "elapsedMilliseconds": [
-            409.445,
-            423.1344,
-            466.436,
-            464.8097,
-            469.4289,
-            489.0083,
-            376.082
+            465.2768,
+            445.9437,
+            436.2875,
+            427.6049,
+            440.3532,
+            432.1774,
+            457.5
           ],
           "peakWorkingSetBytes": [
-            117829632,
-            118177792,
-            117465088,
-            117227520,
-            116641792,
-            118714368,
-            117231616
+            116686848,
+            116539392,
+            117456896,
+            116613120,
+            116523008,
+            117125120,
+            116064256
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 398.0476,
-          "medianPeakWorkingSetBytes": 117469184,
+          "medianElapsedMilliseconds": 464.7749,
+          "medianPeakWorkingSetBytes": 116850688,
           "elapsedMilliseconds": [
-            383.9215,
-            395.7667,
-            388.8526,
-            559.7703,
-            486.529,
-            398.0476,
-            410.2502
+            618.1429,
+            497.314,
+            529.6741,
+            451.9957,
+            447.0087,
+            464.7749,
+            448.1639
           ],
           "peakWorkingSetBytes": [
-            117702656,
-            117075968,
-            117133312,
-            119263232,
-            117469184,
-            119234560,
-            117035008
+            116101120,
+            116850688,
+            116600832,
+            117424128,
+            116383744,
+            116862976,
+            117030912
           ]
         }
       ]
@@ -2103,7 +2103,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.5200650081260157,
+              "irrelevantTokenShare": 0.520125,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2111,7 +2111,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.45784493715576896,
+              "irrelevantTokenShare": 0.5196446446446447,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2473,7 +2473,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.7061875,
+              "irrelevantTokenShare": 0.7061691355709732,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -2489,7 +2489,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.70359394703657,
+              "irrelevantTokenShare": 0.6946807819705137,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -2619,7 +2619,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.8771875,
+              "irrelevantTokenShare": 0.8771721465183148,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -2627,7 +2627,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.8771875,
+              "irrelevantTokenShare": 0.8771721465183148,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 451.7971,
-          "medianPeakWorkingSetBytes": 90042368,
+          "medianElapsedMilliseconds": 507.9554,
+          "medianPeakWorkingSetBytes": 90652672,
           "elapsedMilliseconds": [
-            452.3961,
-            447.61,
-            448.9972,
-            451.4263,
-            475.7568,
-            527.1567,
-            451.7971
+            501.6264,
+            507.9554,
+            502.04,
+            517.4479,
+            510.406,
+            508.5774,
+            490.9107
           ],
           "peakWorkingSetBytes": [
-            89972736,
-            89837568,
-            90275840,
-            90206208,
-            90320896,
-            90042368,
-            89763840
+            90390528,
+            90652672,
+            90673152,
+            91009024,
+            90480640,
+            90337280,
+            90673152
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 505.1934,
-          "medianPeakWorkingSetBytes": 90591232,
+          "medianElapsedMilliseconds": 505.3338,
+          "medianPeakWorkingSetBytes": 90513408,
           "elapsedMilliseconds": [
-            466.2204,
-            602.2492,
-            505.1934,
-            473.1098,
-            564.0658,
-            623.5853,
-            472.0967
+            505.3338,
+            491.1484,
+            491.4166,
+            496.842,
+            519.8096,
+            576.3478,
+            513.1269
           ],
           "peakWorkingSetBytes": [
-            90071040,
-            91029504,
-            90132480,
-            89903104,
-            90591232,
-            90849280,
-            90669056
+            90677248,
+            90513408,
+            90185728,
+            90374144,
+            90644480,
+            91185152,
+            90394624
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 189.2351,
-          "medianPeakWorkingSetBytes": 91856896,
+          "medianElapsedMilliseconds": 223.1351,
+          "medianPeakWorkingSetBytes": 92016640,
           "elapsedMilliseconds": [
-            189.0975,
-            189.2351,
-            180.6813,
-            192.1943,
-            181.4632,
-            194.3405,
-            198.1856
+            211.8346,
+            219.5629,
+            232.0163,
+            214.1253,
+            236.5995,
+            291.6448,
+            223.1351
           ],
           "peakWorkingSetBytes": [
-            92065792,
-            92078080,
-            91856896,
-            91406336,
-            91906048,
-            91443200,
-            91725824
+            92303360,
+            91496448,
+            91734016,
+            92131328,
+            92196864,
+            91942912,
+            92016640
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 205.9846,
-          "medianPeakWorkingSetBytes": 91926528,
+          "medianElapsedMilliseconds": 239.3187,
+          "medianPeakWorkingSetBytes": 92381184,
           "elapsedMilliseconds": [
-            198.3767,
-            196.2042,
-            232.3974,
-            215.1112,
-            219.1971,
-            196.3093,
-            205.9846
+            239.3187,
+            225.6252,
+            290.1383,
+            226.738,
+            248.3143,
+            240.1974,
+            230.3727
           ],
           "peakWorkingSetBytes": [
-            91340800,
-            91926528,
-            92352512,
-            92577792,
-            92377088,
-            91885568,
-            91746304
+            92319744,
+            92479488,
+            92512256,
+            92205056,
+            92536832,
+            92381184,
+            92073984
           ]
         }
       ]
@@ -2764,27 +2764,27 @@
   ],
   "criterion": {
     "eligibleCells": 15,
-    "overallRecallNewDelta": 0.3,
+    "overallRecallNewDelta": 0.3333333333333333,
     "repositoryRecallNewDelta": {
       "devprojex": 0.1,
-      "repomix": 0.3333333333333333,
+      "repomix": 0.3888888888888889,
       "flask": 1
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": -7.078599999999938,
-      "repomix": -66.76210000000003,
-      "flask": 16.749500000000012
+      "devprojex": 59.13639999999998,
+      "repomix": 24.421699999999987,
+      "flask": 16.183600000000013
     },
     "warmIncrementalPercent": {
-      "devprojex": -0.7712928182141233,
-      "repomix": -14.363319009908793,
-      "flask": 8.851159219404863
+      "devprojex": 6.271180041968771,
+      "repomix": 5.545934490767862,
+      "flask": 7.252825754442045
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 0.1444995119972621,
-      "repomix": 0.7962283918281823,
-      "flask": 0.6095619342218987
+      "devprojex": 0.6734348991753599,
+      "repomix": 0.4114788407647831,
+      "flask": 0.396171822835522
     },
     "recallPassed": true,
     "allRequiredPassed": true,


### PR DESCRIPTION
## What changed

- preserve distinct C# reference occurrences and absolute global qualification
- derive Python and TypeScript/JavaScript imports from parsed syntax nodes
- reject nested Python declarations as module bindings and keep missing names unresolved
- represent namespace-package imports without arbitrary file selection
- keep trusted dependency reasons constant and invalidate cached negative control-file observations when files appear
- add published CLI and real MCP process coverage

## Behavior corrections

Side-effect and multiline imports now produce the same dependency facts as their single-line forms. Non-literal JavaScript module specifiers stay unresolved. Project-controlled names, paths, specifiers, condition keys, and exception text no longer enter trusted reason strings.

## Validation

- targeted dependency integration tests
- published CLI and real MCP process tests
- RankingEval on all three frozen corpora: PASS, 15 eligible cells, +0.3333 RecallNew delta
- Release build of TerminalHost with zero warnings