### PR TITLE
fix(dependencies): preserve extraction and binding semantics

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -166,12 +166,14 @@ jobs:
       - name: Run ${{ matrix.suite_name }} Tests
         if: ${{ matrix.os_id != 'linux' && matrix.suite_id != 'ui' }}
         shell: pwsh
+        env:
+          TEST_FILTER: ${{ matrix.suite_id == 'integration' && '(Category!=TerminalCommand)&(Category!=LocalPerformance)&(Category!=Performance)' || '(Category!=LocalPerformance)&(Category!=Performance)' }}
         run: >
           dotnet test ${{ matrix.project_path }}
           -c Release
           --no-build
           --verbosity minimal
-          ${{ matrix.test_filter_args }}
+          --filter "$env:TEST_FILTER"
           --logger "trx;LogFileName=${{ matrix.trx_name }}"
           --results-directory "TestResults/${{ matrix.suite_id }}"
           --blame-hang
@@ -195,12 +197,14 @@ jobs:
       - name: Run ${{ matrix.suite_name }} Tests (Linux headless)
         if: ${{ matrix.os_id == 'linux' && matrix.suite_id != 'ui' }}
         shell: bash
+        env:
+          TEST_FILTER: ${{ matrix.suite_id == 'integration' && '(Category!=TerminalCommand)&(Category!=LocalPerformance)&(Category!=Performance)' || '(Category!=LocalPerformance)&(Category!=Performance)' }}
         run: >
           xvfb-run -a dotnet test ${{ matrix.project_path }}
           -c Release
           --no-build
           --verbosity minimal
-          ${{ matrix.test_filter_args }}
+          --filter "$TEST_FILTER"
           --logger "trx;LogFileName=${{ matrix.trx_name }}"
           --results-directory "TestResults/${{ matrix.suite_id }}"
           --blame-hang

--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -119,6 +119,15 @@ public interface IDependencyFactExtractor : IDisposable
 
 	FileFacts Extract(PreparedDependencySource source, DependencyFactsLimits limits);
 
+	FileFacts Extract(
+		PreparedDependencySource source,
+		DependencyFactsLimits limits,
+		CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		return Extract(source, limits);
+	}
+
 	int ParseCount { get; }
 	int CompiledQuerySetCount { get; }
 }
@@ -134,6 +143,7 @@ public interface IDependencyConfigurationProvider
 public sealed record DependencyFactsLimits(
 	int MaximumCharactersPerFile = 2 * 1024 * 1024,
 	int MaximumFactsPerFile = 50_000,
+	int MaximumRawCapturesPerFile = 1_000_000,
 	int MaximumEdgesPerFile = 20_000,
 	int MaximumWorkPerIndex = 5_000_000,
 	int MaximumCachedFiles = 8_192,

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -122,7 +122,7 @@ public sealed class DependencyFactsEngine : IDisposable
 					source.LanguageId);
 				if (source.PreparedStatus != DependencyFileStatus.Supported)
 				{
-					var extracted = _extractor.Extract(source, _limits);
+					var extracted = _extractor.Extract(source, _limits, token);
 					facts[index] = extracted;
 					cacheable[index] = source.CanCache && extracted.CanCache;
 					progress?.Report(new DependencyIndexProgress(
@@ -132,7 +132,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				}
 				var key = CreateFileCacheKey(source);
 				var created = new Lazy<Task<FileFacts>>(
-					() => Task.Run(() => _extractor.Extract(source, _limits), token),
+					() => Task.Run(() => _extractor.Extract(source, _limits, token), token),
 					LazyThreadSafetyMode.ExecutionAndPublication);
 				var lazy = _fileCache.GetOrAdd(key, created);
 				if (ReferenceEquals(lazy, created))
@@ -361,7 +361,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			path,
 			status,
 			edges.SelectMany(static edge => edge.Reasons.Concat(edge.Evidence.Select(site =>
-				$"{EvidenceLabel(edge.Layer)} at line {site.Line}")))
+				$"{EvidenceLabel(edge.Layer)} {edge.Reference} at line {site.Line}")))
 				.Concat(declarationPartReasons)
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
 			edges.SelectMany(static edge => edge.Candidates).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
@@ -616,7 +616,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			strings.Add(declaration.ContainingNamespace) +
 			declaration.DeclarationSites.Sum(site => SiteBytes(site, strings))) +
 		facts.Imports.Sum(import => 128 + strings.Add(import.Specifier) + strings.Add(import.ImportedName) +
-			strings.Add(import.Alias) + SiteBytes(import.Site, strings)) +
+			strings.Add(import.Alias) + strings.Add(import.ContainingDeclaration) + SiteBytes(import.Site, strings)) +
 		facts.References.Sum(reference => 160 + strings.Add(reference.Name) + strings.Add(reference.SyntaxKind) +
 			strings.Add(reference.Reason) + strings.Add(reference.Target) +
 			(reference.Candidates?.Sum(strings.Add) ?? 0) +
@@ -627,7 +627,8 @@ public sealed class DependencyFactsEngine : IDisposable
 		facts.GlobalContextNamespaces.Sum(strings.Add) +
 		facts.GlobalAliases.Sum(pair => strings.Add(pair.Key) + strings.Add(pair.Value)) +
 		facts.TypeParameters.Sum(strings.Add) +
-		facts.TypeParameterScopes.Sum(scope => 40 + strings.Add(scope.Name));
+		facts.TypeParameterScopes.Sum(scope => 40 + strings.Add(scope.Name)) +
+		facts.CSharpUsingDirectives.Sum(directive => 64 + strings.Add(directive.Target) + strings.Add(directive.Alias));
 
 	private static long EstimateResolvedIndexBytes(ResolvedIndex index)
 	{
@@ -1141,8 +1142,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			return true;
 		}
 
-		private static bool IsRequire(ImportFact import) =>
-			import.Site.Evidence.TrimStart().StartsWith("require", StringComparison.Ordinal);
+		private static bool IsRequire(ImportFact import) => import.ImportKind == ModuleImportKind.Require;
 
 		private bool RequiresExplicitRelativeExtension(FileFacts source, DependencyScopeDescriptor scope)
 		{
@@ -1255,6 +1255,8 @@ public sealed class DependencyFactsEngine : IDisposable
 		{
 			if (IsRequire(import))
 				return "require";
+			if (import.ImportKind == ModuleImportKind.DynamicImport)
+				return "import";
 			var scope = FindScope(source.ScopeId);
 			var mode = scope?.ModuleResolution ?? "bundler";
 			return scope is not null &&
@@ -1468,7 +1470,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (facts.Declarations.Any(declaration => declaration.ContainingType is null &&
 				SimpleName(declaration.Identity.QualifiedName) == name))
 				return [candidate];
-			foreach (var import in facts.Imports.Where(import =>
+			foreach (var import in facts.Imports.Where(import => import.ContainingDeclaration is null &&
 				string.Equals(import.Alias ?? import.ImportedName ?? import.Specifier.Split('.').Last(), name, StringComparison.Ordinal)))
 			{
 				var sourceModule = PythonModule(facts);
@@ -1573,8 +1575,8 @@ public sealed class DependencyFactsEngine : IDisposable
 			}
 			if (scope is not null && ConfigurationFailure(scope) is { } configurationFailure)
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, configurationFailure, []);
-			var isQualified = reference.IsGlobalQualified || reference.Name.Contains('.');
-			var typeParameterShadowsReference = !isQualified && (source.TypeParameterScopes.Count > 0
+			var isSyntacticallyQualified = reference.IsGlobalQualified || reference.Name.Contains('.');
+			var typeParameterShadowsReference = !isSyntacticallyQualified && (source.TypeParameterScopes.Count > 0
 				? source.TypeParameterScopes.Any(parameter =>
 					parameter.Name == simpleName &&
 					parameter.StartIndex <= reference.SourceStartIndex &&
@@ -1582,30 +1584,29 @@ public sealed class DependencyFactsEngine : IDisposable
 				: source.TypeParameters.Contains(simpleName, StringComparer.Ordinal));
 			if (typeParameterShadowsReference)
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, "type parameter shadows declarations", []);
-			var expandedName = reference.IsGlobalQualified
-				? reference.Name
-				: ExpandQualifiedAlias(source, reference.Name);
-			var candidates = isQualified
+			string? expandedAlias = null;
+			var aliasExpanded = source.LanguageId == LanguageId.CSharp &&
+			                    !reference.IsGlobalQualified &&
+			                    TryExpandCSharpAlias(source, reference, out expandedAlias);
+			var expandedName = aliasExpanded ? expandedAlias! : reference.Name;
+			var requiresQualifiedLookup = isSyntacticallyQualified || aliasExpanded;
+			var candidates = requiresQualifiedLookup
 				? LookupQualified(source, expandedName, reference.GenericArity)
 				: LookupSimple(source, simpleName, reference.GenericArity);
 			var attributeName = reference.SyntaxKind == "attribute"
-				? reference.Name + "Attribute"
+				? expandedName + "Attribute"
 				: null;
 			if (candidates.Length == 0 && attributeName is not null)
 			{
 				candidates = attributeName.Contains('.')
-					? LookupQualified(source, ExpandQualifiedAlias(source, attributeName), reference.GenericArity)
+					? LookupQualified(source, attributeName, reference.GenericArity)
 					: LookupSimple(source, attributeName, reference.GenericArity);
 			}
 			if (source.LanguageId == LanguageId.CSharp)
 			{
-				var globalAliases = _globalAliases.GetValueOrDefault(source.ScopeId);
-				if (source.Aliases.TryGetValue(simpleName, out var alias) ||
-				    globalAliases?.TryGetValue(simpleName, out alias) == true)
-					candidates = LookupQualified(source, alias, reference.GenericArity);
-				else if (!reference.IsGlobalQualified && reference.Name.Contains('.') && candidates.Length == 0)
+				if (!reference.IsGlobalQualified && reference.Name.Contains('.') && !aliasExpanded && candidates.Length == 0)
 					candidates = LookupContextualCSharpQualified(source, reference, expandedName);
-				else if (!isQualified)
+				else if (!requiresQualifiedLookup)
 					candidates = SelectVisibleCSharpCandidates(source, reference, candidates);
 			}
 			if (candidates.Length == 0)
@@ -1690,7 +1691,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				namespaceName = separator < 0 ? string.Empty : namespaceName[..separator];
 			}
 
-			var importedNamespaces = _contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [];
+			var importedNamespaces = ActiveCSharpNamespaces(source, reference);
 			var imported = candidates.Where(candidate =>
 				candidate.ContainingType is null &&
 				importedNamespaces.Contains(candidate.ContainingNamespace, StringComparer.Ordinal)).ToArray();
@@ -1716,7 +1717,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				namespaceName = separator < 0 ? string.Empty : namespaceName[..separator];
 			}
 
-			return (_contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [])
+			return ActiveCSharpNamespaces(source, reference)
 				.SelectMany(namespaceValue => LookupQualified(
 					source,
 					namespaceValue + "." + qualifiedName,
@@ -1760,8 +1761,8 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (declaration.Identity.ScopeId == source.ScopeId)
 				return true;
 			return source.LanguageId == LanguageId.CSharp &&
-			       FindScope(source.ScopeId)?.ProjectReferences.Contains(
-			       declaration.Identity.ScopeId, StringComparer.Ordinal) == true;
+			       VisibleScopeIds(source.ScopeId).Contains(
+			       declaration.Identity.ScopeId, StringComparer.Ordinal);
 		}
 
 		private DependencyEdge FinishImport(
@@ -1802,17 +1803,45 @@ public sealed class DependencyFactsEngine : IDisposable
 			DependencyPlatformCatalog.IsDotNetAlias(reference) ||
 			_configuration.DotNetExternalSymbols.Contains(reference) ||
 			_dotNetExternalSimpleNames.Contains(SimpleName(reference));
-		private string ExpandQualifiedAlias(FileFacts source, string name)
+		private bool TryExpandCSharpAlias(
+			FileFacts source,
+			ReferenceFact reference,
+			out string? expanded)
 		{
-			var separator = name.IndexOf('.');
-			if (separator <= 0) return name;
-			var prefix = name[..separator];
+			var separator = reference.Name.IndexOf('.');
+			var prefix = separator < 0 ? reference.Name : reference.Name[..separator];
+			var suffix = separator < 0 ? string.Empty : reference.Name[separator..];
+			var local = source.CSharpUsingDirectives
+				.Where(directive => directive.Alias == prefix && IsActive(directive, reference.SourceStartIndex))
+				.OrderBy(directive => directive.ScopeEndIndex - directive.ScopeStartIndex)
+				.ThenBy(static directive => directive.Target, StringComparer.Ordinal)
+				.FirstOrDefault();
+			if (local is not null)
+			{
+				expanded = local.Target + suffix;
+				return true;
+			}
 			var globalAliases = _globalAliases.GetValueOrDefault(source.ScopeId);
-			return source.Aliases.TryGetValue(prefix, out var target) ||
-			       globalAliases?.TryGetValue(prefix, out target) == true
-				? target + name[separator..]
-				: name;
+			if (globalAliases?.TryGetValue(prefix, out var target) == true)
+			{
+				expanded = target + suffix;
+				return true;
+			}
+			expanded = null;
+			return false;
 		}
+
+		private IReadOnlyList<string> ActiveCSharpNamespaces(FileFacts source, ReferenceFact reference) =>
+			(_contextNamespacesByFile.GetValueOrDefault(source.Path) ?? [])
+			.Concat(source.CSharpUsingDirectives
+				.Where(directive => directive.Alias is null && IsActive(directive, reference.SourceStartIndex))
+				.Select(static directive => directive.Target))
+			.Distinct(StringComparer.Ordinal)
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+
+		private static bool IsActive(CSharpUsingDirective directive, int sourceStartIndex) =>
+			directive.ScopeStartIndex <= sourceStartIndex && directive.ScopeEndIndex >= sourceStartIndex;
 
 		private static string QualifiedLookupName(string qualified)
 		{

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -54,6 +54,12 @@ public sealed record SourceSite(string File, int Line, string Evidence);
 
 public sealed record TypeParameterScope(string Name, int StartIndex, int EndIndex);
 
+public sealed record CSharpUsingDirective(
+	string Target,
+	string? Alias,
+	int ScopeStartIndex,
+	int ScopeEndIndex);
+
 public sealed record SymbolIdentity(
 	string ScopeId,
 	LanguageId LanguageId,
@@ -70,6 +76,13 @@ public sealed record DeclarationFact(
 	public string? ContainingType { get; init; }
 }
 
+public enum ModuleImportKind
+{
+	StaticImport,
+	DynamicImport,
+	Require
+}
+
 public sealed record ImportFact(
 	string Specifier,
 	string? ImportedName,
@@ -80,7 +93,11 @@ public sealed record ImportFact(
 	ResolutionStatus Status = ResolutionStatus.Unresolved,
 	string Reason = "not resolved yet",
 	IReadOnlyList<string>? Candidates = null,
-	string? Target = null);
+	string? Target = null)
+{
+	public string? ContainingDeclaration { get; init; }
+	public ModuleImportKind ImportKind { get; init; }
+}
 
 public sealed record ReferenceFact(
 	EvidenceLayer Layer,
@@ -120,6 +137,7 @@ public sealed record FileFacts(
 {
 	public bool CanCache { get; init; } = true;
 	public IReadOnlyList<TypeParameterScope> TypeParameterScopes { get; init; } = [];
+	public IReadOnlyList<CSharpUsingDirective> CSharpUsingDirectives { get; init; } = [];
 }
 
 public sealed record DependencyEdge(

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -49,8 +49,15 @@ reason can cross the current manifest gate, and self-file relationships are supp
 
 C# compilation scopes come from `.csproj` ownership and `ProjectReference` entries read as XML.
 Both `/` and `\` in an MSBuild `Include` are normalized as project-reference separators on every OS;
-this normalization never applies to ordinary Unix filenames. Global usings and aliases are shared
-within the owning scope; type parameters shadow global symbols only inside the lexical span of their
+this normalization never applies to ordinary Unix filenames. Project-reference visibility is
+transitive, matching the SDK default: if A references B and B references C, source in A can resolve
+declarations from C. The configuration model does not yet expose
+`DisableTransitiveProjectReferences`; a project that opts out cannot currently narrow that visibility.
+Global usings and aliases are shared
+within the owning scope. Non-global usings and aliases apply only inside their compilation-unit or
+namespace-block lexical scope; repeated blocks for the same namespace do not leak aliases into one
+another. An alias is expanded only when it is the first component of the reference, and `global::`
+bypasses alias expansion. Type parameters shadow global symbols only inside the lexical span of their
 declaring type or method, while a qualified name is never suppressed by its final component.
 The `global::` qualifier is retained as absolute-lookup evidence: it bypasses type-parameter
 shadowing and never falls back through the source namespace or imported namespaces;
@@ -78,6 +85,9 @@ already present in the manifest. Exact `paths` entries precede wildcard entries;
 wildcards, the longest prefix before `*` wins. Only that pattern's targets are tried, in declaration
 order. A wildcard whose prefix and suffix overlap in the specifier is not a match; the same guard
 applies to package maps. `package.json` `exports`, conditions, and explicit `null` blocking remain authoritative.
+Conditional package targets distinguish syntax from the source module kind: runtime `import(...)`
+selects the `import` condition even in a `.cts` or `.cjs` file, while literal `require(...)` selects
+the `require` condition.
 Directory-index fallback is allowed by `node10` and `bundler`; under `node16`/`nodenext`, an ESM
 relative import needs an explicit extension while a supported CommonJS context can use extensionless
 and directory probes. `.mts`/`.mjs` are ESM, `.cts`/`.cjs` are CommonJS, and ordinary
@@ -102,7 +112,9 @@ accepted with or without a BOM; malformed byte sequences remain corrupt.
 Python relative imports start at the source package. `from module import Name` first checks classes,
 functions, and static import aliases provided by either an ordinary module or a package initializer.
 Only module-level class and function declarations provide importable names; a method or nested class
-cannot satisfy `from module import Name`. Import syntax is read from parsed nodes, so parenthesized
+cannot satisfy `from module import Name`. Imports inside a function or class still create a dependency
+from their file to the imported module, but they do not become names exported by the containing
+module. Import syntax is read from parsed nodes, so parenthesized
 multiline lists, comments, aliases, relative forms, and wildcard imports have the same semantics as
 their single-line forms.
 Only a package may then fall back to a child module of that name. Regular and namespace-package portions are
@@ -129,9 +141,16 @@ C#, TypeScript/TSX/JavaScript, and Python adapters use shipped Tree-sitter gramm
 content fingerprint; its syntax tree is disposed immediately and only compact facts remain. Files
 without an adapter are counted as unsupported instead of disappearing. Read, grammar, and query
 failures are counted separately as extraction failures.
+The same per-file handling applies before language dispatch: if an unsupported file disappears or its
+metadata cannot be read after selection, it is reported as a transient extraction failure and is not
+retained in the facts cache; it does not abort the rest of the index.
 
-The default safety limits are 2 Mi characters per source file, 50,000 facts per file, 20,000 edges
-per file, and 5,000,000 units of resolver work per index pass. A limit produces an explicit
+The default safety limits are 2 Mi characters per source file, 50,000 useful facts per file,
+1,000,000 raw query captures per file, 20,000 edges per file, and 5,000,000 units of resolver work
+per index pass. Query captures that do not describe a supported declaration, import, or reference do
+not consume the useful-fact budget. The separate raw-capture ceiling bounds traversal of noisy syntax;
+reaching either fact ceiling produces `ExtractionFailed` with `fact limit exceeded`, never a supported
+file with silently missing dependencies. Any limit produces an explicit
 `Unresolved` fact or extraction status with a reason; it is never reported as an empty successful
 analysis. Source decoding is bounded by decoded characters rather than bytes: UTF-8, UTF-16, and
 UTF-32 BOMs are honored, incomplete sequences fail closed, and reading stops as soon as the engine
@@ -199,9 +218,11 @@ change serialized results.
 contains a portable relative path, aggregated evidence reasons, resolution status, estimated tokens,
 and a cross-scope marker when applicable. Ambiguous references remain one group with their candidate
 list. Coverage reports manifest files, supported and unsupported languages, and extraction failures.
-Reason and configuration-diagnostic text uses a fixed vocabulary; project-controlled symbol names,
-module specifiers, mapping keys, and paths remain in their dedicated structured fields rather than
-being interpolated into trusted explanatory text.
+File-status reasons and configuration diagnostics use a fixed vocabulary; project-controlled mapping
+keys and paths remain in their dedicated structured fields rather than being interpolated into trusted
+diagnostic text. Edge evidence is project data: it deliberately includes the referenced symbol or
+module specifier together with its source line. MCP keeps that evidence inside the untrusted-data block,
+and CLI JSON returns it as result data.
 An unsupported seed is a successful empty result with an explicit diagnostic; a supported seed with
 no edges reports that no related files exist in the effective selection. At most eight configuration
 diagnostic lines are rendered in CLI text output; JSON retains the complete safe array.

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -168,7 +168,7 @@ greedy admission pass for every comparator. The one seed for each of the existin
 was selected from the task wording, not from its required-file set or ranked output. The
 complete machine-readable result is
 `tools/RankingEval/results/2026-09-07-focus-v1.json`; the product and evaluator SHA for the
-2026-09-08 reference-semantics rerun are both `798ce9bef2622fda1eb6320ef98009428388c6c7`.
+2026-09-08 extraction-and-binding rerun are both `0ce6eb3b03e724fcb3d4b54d21bf156dc468ab33`.
 
 The six frozen orders are current manifest order, `importance-v1`, seed first without graph
 traversal, `focus-v1` minimum undirected graph hop, evaluation-only personalized PageRank,
@@ -186,9 +186,9 @@ oracles are counts over the five tasks at that repository and budget.
 
 | Repository / budget | Current | Importance | Seed-first | Focus-v1 | Focus-PPR | Directed-from-seed |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.8628` | `0.1000 · 0/1/1 · 0.8482` | `0.1000 · 0/1/1 · 0.8481` | `0.1000 · 0/1/1 · 0.7511` |
-| DevProjex / 8,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.7997` | `0.2000 · 0/2/2 · 0.7409` | `0.1000 · 0/2/2 · 0.7924` | `0.2000 · 0/2/2 · 0.5611` |
-| DevProjex / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.8999` | `0.1000 · 0/2/2 · 0.8962` | `0.2000 · 0/2/2 · 0.7574` | `0.1000 · 0/2/2 · 0.7375` |
+| DevProjex / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.8627` | `0.1000 · 0/1/1 · 0.8481` | `0.1000 · 0/1/1 · 0.8481` | `0.1000 · 0/1/1 · 0.8057` |
+| DevProjex / 8,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.7997` | `0.2000 · 0/2/2 · 0.7409` | `0.1000 · 0/2/2 · 0.7924` | `0.2000 · 0/2/2 · 0.6157` |
+| DevProjex / 16,000 | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 1.0000` | `0.0000 · 0/2/2 · 0.8999` | `0.1000 · 0/2/2 · 0.8962` | `0.2000 · 0/2/2 · 0.7574` | `0.1000 · 0/2/2 · 0.7381` |
 | Repomix / 4,000 | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 1.0000` | `0.0000 · 0/1/1 · 0.4111` | `0.0000 · 0/1/1 · 0.4110` | `0.0000 · 0/1/1 · 0.4109` | `0.0000 · 0/1/1 · 0.3883` |
 | Repomix / 8,000 | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 1.0000` | `0.0000 · 0/3/3 · 0.7055` | `0.3000 · 1/3/3 · 0.5930` | `0.3000 · 1/3/3 · 0.5349` | `0.3000 · 1/3/3 · 0.5710` |
 | Repomix / 16,000 | `0.0000 · 0/5/5 · 1.0000` | `0.0000 · 0/5/5 · 1.0000` | `0.0000 · 0/5/5 · 0.8528` | `0.4000 · 2/5/5 · 0.7538` | `0.3000 · 1/5/5 · 0.7675` | `0.4000 · 2/5/5 · 0.7013` |
@@ -215,9 +215,9 @@ growth for the corpus.
 
 | Repository | Cold ms (importance / focus) | Warm ms (importance / focus) | Warm focus addition | Cold RSS MiB | Warm RSS MiB | Maximum RSS growth |
 |---|---:|---:|---:|---:|---:|---:|
-| DevProjex | `2727.88 / 2812.78` | `982.39 / 910.07` | `-72.33 ms (-7.36%)` | `304.45 / 302.29` | `307.70 / 310.05` | `0.76%` |
-| Repomix | `763.28 / 768.28` | `401.38 / 427.63` | `+26.25 ms (6.54%)` | `109.69 / 109.98` | `110.84 / 110.85` | `0.26%` |
-| Flask | `478.99 / 503.83` | `223.32 / 235.30` | `+11.99 ms (5.37%)` | `86.34 / 86.53` | `87.61 / 88.17` | `0.64%` |
+| DevProjex | `3014.91 / 2833.84` | `1011.30 / 974.44` | `-36.86 ms (-3.64%)` | `308.78 / 305.74` | `314.68 / 315.78` | `0.35%` |
+| Repomix | `856.22 / 796.92` | `405.56 / 411.88` | `+6.32 ms (1.56%)` | `112.01 / 111.31` | `107.11 / 107.40` | `0.27%` |
+| Flask | `465.98 / 472.38` | `206.65 / 253.86` | `+47.21 ms (22.85%)` | `86.64 / 86.48` | `87.73 / 88.72` | `1.13%` |
 
 Fifteen of the 45 task-budget cells had a feasible oracle after the real seed admission and
 a defined RecallNew. Across those cells, `focus-v1 - seed-first` mean RecallNew was

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -15,13 +15,15 @@ internal sealed record DependencySyntaxCapture(
 	bool IsFileLocal = false,
 	string? ContainingDeclaration = null,
 	DependencyImportSyntax? ImportSyntax = null,
-	int CapturedNameStartIndex = -1);
+	int CapturedNameStartIndex = -1,
+	string? Evidence = null);
 
 internal sealed record DependencyImportSyntax(
 	string Specifier,
 	int RelativeLevel,
 	IReadOnlyList<DependencyImportBinding> Bindings,
-	bool HasLiteralSpecifier = true);
+	bool HasLiteralSpecifier = true,
+	ModuleImportKind ImportKind = ModuleImportKind.StaticImport);
 
 internal sealed record DependencyImportBinding(string Name, string? Alias, bool IsWildcard = false);
 
@@ -34,7 +36,19 @@ internal sealed record DependencyExtractionContext(
 	bool HasSyntaxErrors,
 	IReadOnlyDictionary<string, int> ErrorNodeKinds,
 	IReadOnlyList<DependencySyntaxCapture> Declarations,
-	IReadOnlyList<DependencySyntaxCapture> References);
+	IReadOnlyList<DependencySyntaxCapture> References)
+{
+	public DependencyAdapterWorkCounter Work { get; } = new();
+}
+
+internal sealed class DependencyAdapterWorkCounter
+{
+	public long VisitedRanges { get; private set; }
+	public long Comparisons { get; private set; }
+
+	public void VisitRange() => VisitedRanges++;
+	public void Compare() => Comparisons++;
+}
 
 internal interface IDependencyLanguageAdapter
 {
@@ -44,7 +58,7 @@ internal interface IDependencyLanguageAdapter
 internal abstract partial class DependencyLanguageAdapter : IDependencyLanguageAdapter
 {
 	protected static SourceSite Site(DependencyExtractionContext context, DependencySyntaxCapture capture) =>
-		new(context.RelativePath, capture.Line, OneLine(capture.Text));
+		new(context.RelativePath, capture.Line, capture.Evidence ?? OneLine(capture.Text));
 
 	protected static string OneLine(string value)
 	{
@@ -76,6 +90,7 @@ internal abstract partial class DependencyLanguageAdapter : IDependencyLanguageA
 				fact.SourceStartIndex, fact.ContainingNamespace, fact.ContainingType, fact.IsGlobalQualified))
 			.Select(static group => group.First())
 			.OrderBy(static fact => fact.Site.Line)
+			.ThenBy(static fact => fact.SourceStartIndex)
 			.ThenBy(static fact => fact.Name, StringComparer.Ordinal)
 			.ToArray();
 
@@ -129,8 +144,11 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 	public override FileFacts Extract(DependencyExtractionContext context, DependencyFactsLimits limits)
 	{
 		var namespaces = ParseNamespaces(context.Declarations);
-		var aliases = ParseUsings(
+		var usingDirectives = ParseUsings(
 			context.Declarations,
+			namespaces,
+			context.Source.Length,
+			out var aliases,
 			out var usingNamespaces,
 			out var globalNamespaces,
 			out var globalAliases);
@@ -148,7 +166,7 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		var declarationCaptures = context.Declarations
 			.Where(capture => Kinds.ContainsKey(capture.Name) && !string.IsNullOrEmpty(capture.CapturedName))
 			.ToArray();
-		var declarationScopes = BuildDeclarationScopes(declarationCaptures, namespaces);
+		var declarationScopes = BuildDeclarationScopes(declarationCaptures, namespaces, context.Work);
 		var declarations = new List<DeclarationFact>(declarationCaptures.Length);
 		foreach (var capture in declarationCaptures)
 		{
@@ -171,7 +189,7 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		var referenceCaptures = context.References
 			.Where(static capture => capture.Name.StartsWith("reference.", StringComparison.Ordinal))
 			.ToArray();
-		var referenceScopes = BuildReferenceScopes(referenceCaptures, declarationScopes.Ordered);
+		var referenceScopes = BuildReferenceScopes(referenceCaptures, declarationScopes.Ordered, context.Work);
 		var declarationOccurrences = declarationCaptures
 			.Where(static capture => capture.CapturedNameStartIndex >= 0)
 			.Select(static capture => (
@@ -199,7 +217,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 			globalAliases,
 			typeParameters) with
 		{
-			TypeParameterScopes = typeParameterScopes
+			TypeParameterScopes = typeParameterScopes,
+			CSharpUsingDirectives = usingDirectives
 		};
 	}
 
@@ -209,7 +228,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		DeclarationScope? declarationScope,
 		IReadOnlyList<NamespaceSpan> namespaces)
 	{
-		var containingNamespace = declarationScope?.ContainingNamespace ?? FindContainingNamespace(capture, namespaces);
+		var containingNamespace = declarationScope?.ContainingNamespace ??
+			FindContainingNamespace(capture, namespaces, context.Work);
 		var containingType = declarationScope?.QualifiedName;
 		if (capture.Name == "reference.target_typed_object_creation")
 		{
@@ -237,7 +257,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 
 	private static DeclarationScopeIndex BuildDeclarationScopes(
 		IReadOnlyList<DependencySyntaxCapture> declarations,
-		IReadOnlyList<NamespaceSpan> namespaces)
+		IReadOnlyList<NamespaceSpan> namespaces,
+		DependencyAdapterWorkCounter work)
 	{
 		var byCapture = new Dictionary<DependencySyntaxCapture, DeclarationScope>(ReferenceEqualityComparer.Instance);
 		var orderedScopes = new List<DeclarationScope>(declarations.Count);
@@ -247,9 +268,10 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 			         .ThenByDescending(static item => item.EndIndex)
 			         .ThenBy(static item => item.CapturedName, StringComparer.Ordinal))
 		{
-			while (active.TryPeek(out var current) && !Contains(current.Capture, capture))
+			work.VisitRange();
+			while (active.TryPeek(out var current) && !Contains(current.Capture, capture, work))
 				active.Pop();
-			var containingNamespace = FindContainingNamespace(capture, namespaces);
+			var containingNamespace = FindContainingNamespace(capture, namespaces, work);
 			var containingType = active.TryPeek(out var parent) ? parent.QualifiedName : null;
 			var qualifiedName = string.Join('.', new[]
 				{
@@ -266,7 +288,8 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 
 	private static IReadOnlyDictionary<DependencySyntaxCapture, DeclarationScope?> BuildReferenceScopes(
 		IReadOnlyList<DependencySyntaxCapture> references,
-		IReadOnlyList<DeclarationScope> declarations)
+		IReadOnlyList<DeclarationScope> declarations,
+		DependencyAdapterWorkCounter work)
 	{
 		var result = new Dictionary<DependencySyntaxCapture, DeclarationScope?>(ReferenceEqualityComparer.Instance);
 		var active = new Stack<DeclarationScope>();
@@ -275,32 +298,46 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 			         .OrderBy(static item => item.StartIndex)
 			         .ThenBy(static item => item.EndIndex))
 		{
+			work.VisitRange();
 			while (declarationIndex < declarations.Count &&
 			       declarations[declarationIndex].Capture.StartIndex < reference.StartIndex)
 			{
 				var declaration = declarations[declarationIndex++];
-				while (active.TryPeek(out var current) && !Contains(current.Capture, declaration.Capture))
+				while (active.TryPeek(out var current) && !Contains(current.Capture, declaration.Capture, work))
 					active.Pop();
 				active.Push(declaration);
 			}
-			while (active.TryPeek(out var current) && !Contains(current.Capture, reference))
+			while (active.TryPeek(out var current) && !Contains(current.Capture, reference, work))
 				active.Pop();
 			result[reference] = active.TryPeek(out var containing) ? containing : null;
 		}
 		return result;
 	}
 
-	private static bool Contains(DependencySyntaxCapture container, DependencySyntaxCapture item) =>
-		container.StartIndex < item.StartIndex && container.EndIndex >= item.EndIndex;
+	private static bool Contains(
+		DependencySyntaxCapture container,
+		DependencySyntaxCapture item,
+		DependencyAdapterWorkCounter work)
+	{
+		work.Compare();
+		return container.StartIndex < item.StartIndex && container.EndIndex >= item.EndIndex;
+	}
 
 	private static string FindContainingNamespace(
 		DependencySyntaxCapture capture,
-		IReadOnlyList<NamespaceSpan> namespaces) =>
-		namespaces
-			.Where(item => item.Start <= capture.StartIndex && item.End >= capture.EndIndex)
-			.OrderBy(item => item.End - item.Start)
-			.Select(static item => item.Name)
-			.FirstOrDefault() ?? namespaces.FirstOrDefault(static item => item.FileScoped)?.Name ?? string.Empty;
+		IReadOnlyList<NamespaceSpan> namespaces,
+		DependencyAdapterWorkCounter work)
+	{
+		NamespaceSpan? closest = null;
+		foreach (var item in namespaces)
+		{
+			work.VisitRange();
+			work.Compare();
+			if (item.Start > capture.StartIndex || item.End < capture.EndIndex) continue;
+			if (closest is null || item.End - item.Start < closest.End - closest.Start) closest = item;
+		}
+		return closest?.Name ?? namespaces.FirstOrDefault(static item => item.FileScoped)?.Name ?? string.Empty;
+	}
 
 	private static ReferenceFact NewReference(
 		DependencyExtractionContext context,
@@ -333,8 +370,11 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 				capture.StartIndex, capture.EndIndex, capture.NodeType == "file_scoped_namespace_declaration"))
 			.Where(static item => item.Name.Length > 0).ToArray();
 
-	private static IReadOnlyDictionary<string, string> ParseUsings(
+	private static IReadOnlyList<CSharpUsingDirective> ParseUsings(
 		IEnumerable<DependencySyntaxCapture> captures,
+		IReadOnlyList<NamespaceSpan> namespaceSpans,
+		int sourceLength,
+		out IReadOnlyDictionary<string, string> fileAliases,
 		out HashSet<string> namespaces,
 		out HashSet<string> globalNamespaces,
 		out IReadOnlyDictionary<string, string> globalAliases)
@@ -343,6 +383,7 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 		globalNamespaces = new HashSet<string>(StringComparer.Ordinal);
 		var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
 		var globals = new Dictionary<string, string>(StringComparer.Ordinal);
+		var directives = new List<CSharpUsingDirective>();
 		foreach (var capture in captures.Where(static capture => capture.Name == "context.using"))
 		{
 			var match = UsingRegex().Match(capture.Text);
@@ -350,13 +391,31 @@ internal sealed partial class CSharpDependencyLanguageAdapter : DependencyLangua
 				continue;
 			var target = match.Groups["target"].Value.Replace("global::", string.Empty, StringComparison.Ordinal);
 			var isGlobal = capture.Text.TrimStart().StartsWith("global using ", StringComparison.Ordinal);
-			if (match.Groups["alias"].Success)
-				(isGlobal ? globals : aliases)[match.Groups["alias"].Value] = target;
-			else
-				(isGlobal ? globalNamespaces : namespaces).Add(target);
+			var alias = match.Groups["alias"].Success ? match.Groups["alias"].Value : null;
+			if (isGlobal)
+			{
+				if (alias is null) globalNamespaces.Add(target);
+				else globals[alias] = target;
+				continue;
+			}
+			var lexicalNamespace = namespaceSpans
+				.Where(item => item.Start <= capture.StartIndex && item.End >= capture.EndIndex)
+				.OrderBy(item => item.End - item.Start)
+				.FirstOrDefault();
+			var scopeStart = lexicalNamespace?.Start ?? 0;
+			var scopeEnd = lexicalNamespace?.End ?? sourceLength;
+			directives.Add(new CSharpUsingDirective(target, alias, scopeStart, scopeEnd));
+			if (lexicalNamespace is not null) continue;
+			if (alias is null) namespaces.Add(target);
+			else aliases[alias] = target;
 		}
+		fileAliases = aliases;
 		globalAliases = globals;
-		return aliases;
+		return directives.OrderBy(static item => item.ScopeStartIndex)
+			.ThenBy(static item => item.ScopeEndIndex)
+			.ThenBy(static item => item.Alias, StringComparer.Ordinal)
+			.ThenBy(static item => item.Target, StringComparer.Ordinal)
+			.ToArray();
 	}
 
 	private static string SimpleName(string qualified)
@@ -424,17 +483,26 @@ internal sealed partial class TypeScriptDependencyLanguageAdapter : DependencyLa
 			{
 				yield return new ImportFact(
 					string.Empty, null, null, false, 0, Site(context, capture),
-					Reason: "module specifier is not a string literal");
+					Reason: "module specifier is not a string literal")
+				{
+					ImportKind = syntax.ImportKind
+				};
 				yield break;
 			}
 			if (syntax.Bindings.Count == 0)
 			{
-				yield return new ImportFact(syntax.Specifier, null, null, false, 0, Site(context, capture));
+				yield return new ImportFact(syntax.Specifier, null, null, false, 0, Site(context, capture))
+				{
+					ImportKind = syntax.ImportKind
+				};
 				yield break;
 			}
 			foreach (var binding in syntax.Bindings)
 				yield return new ImportFact(syntax.Specifier, binding.Name, binding.Alias,
-					binding.IsWildcard, 0, Site(context, capture));
+					binding.IsWildcard, 0, Site(context, capture))
+				{
+					ImportKind = syntax.ImportKind
+				};
 			yield break;
 		}
 	}
@@ -496,10 +564,13 @@ internal sealed partial class PythonDependencyLanguageAdapter : DependencyLangua
 	{
 		if (capture.ImportSyntax is not { } syntax) yield break;
 		foreach (var binding in syntax.Bindings)
-			yield return capture.Name == "import.direct"
+			yield return (capture.Name == "import.direct"
 				? new ImportFact(binding.Name, null, binding.Alias, false, 0, Site(context, capture))
 				: new ImportFact(syntax.Specifier, binding.Name, binding.Alias,
-					binding.IsWildcard, syntax.RelativeLevel, Site(context, capture));
+					binding.IsWildcard, syntax.RelativeLevel, Site(context, capture))) with
+			{
+				ContainingDeclaration = capture.ContainingDeclaration
+			};
 	}
 
 	private static FileFacts Failed(DependencyExtractionContext context) => new(

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -31,6 +31,12 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	private long _preparedSourceGeneration;
 	private int _parseCount;
 	private int _compiledQuerySetCount;
+	private long _rawCapturesVisited;
+	private long _createdCaptures;
+	private long _materializedCharacters;
+	private long _adapterVisitedRanges;
+	private long _adapterComparisons;
+	private long _createdFacts;
 	private int _disposed;
 
 	public TreeSitterDependencyFactExtractor()
@@ -63,6 +69,14 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 
 	public int ParseCount => Volatile.Read(ref _parseCount);
 	public int CompiledQuerySetCount => Volatile.Read(ref _compiledQuerySetCount);
+	internal DependencyExtractionWorkState WorkState => new(
+		Interlocked.Read(ref _rawCapturesVisited),
+		Interlocked.Read(ref _createdCaptures),
+		Interlocked.Read(ref _materializedCharacters),
+		Interlocked.Read(ref _adapterVisitedRanges),
+		Interlocked.Read(ref _adapterComparisons),
+		Interlocked.Read(ref _createdFacts),
+		ParseCount);
 	internal PreparedSourceCacheState CacheState
 	{
 		get
@@ -89,18 +103,18 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			.OrderByDescending(static candidate => candidate.Root.Length)
 			.Select(static candidate => candidate.ScopeId)
 			.FirstOrDefault() ?? $"root:{LanguageFamily(language).ToString().ToLowerInvariant()}";
-		if (language == LanguageId.Unsupported)
-		{
-			var info = new FileInfo(fullPath);
-			var identity = $"{info.Length}:{info.LastWriteTimeUtc.Ticks}";
-			return new PreparedDependencySource(fullPath, relative, scope, language,
-				Hash(Encoding.UTF8.GetBytes(identity)), "unsupported:v1", string.Empty,
-				DependencyFileStatus.Unsupported,
-				"file language is not supported by the dependency engine yet");
-		}
-
 		try
 		{
+			if (language == LanguageId.Unsupported)
+			{
+				var unsupportedInfo = new FileInfo(fullPath);
+				var identity = $"{unsupportedInfo.Length}:{unsupportedInfo.LastWriteTimeUtc.Ticks}";
+				return new PreparedDependencySource(fullPath, relative, scope, language,
+					Hash(Encoding.UTF8.GetBytes(identity)), "unsupported:v1", string.Empty,
+					DependencyFileStatus.Unsupported,
+					"file language is not supported by the dependency engine yet");
+			}
+
 			var info = new FileInfo(fullPath);
 			var key = new PreparedSourceCacheKey(
 				Path.GetFullPath(fullPath),
@@ -146,7 +160,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Security.SecurityException)
 		{
 			return new PreparedDependencySource(fullPath, relative, scope, language,
-				Hash(Encoding.UTF8.GetBytes(exception.GetType().Name)), GetExtractorIdentity(language),
+				Hash(Encoding.UTF8.GetBytes(exception.GetType().Name)),
+				language == LanguageId.Unsupported ? "unsupported:v1" : GetExtractorIdentity(language),
 				string.Empty, DependencyFileStatus.ExtractionFailed,
 				"source file could not be read",
 				CanCache: false);
@@ -344,7 +359,13 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			return $"{definition.Library}:TreeSitter.DotNet-1.3.0:{queryHash}";
 		});
 
-	public FileFacts Extract(PreparedDependencySource source, DependencyFactsLimits limits)
+	public FileFacts Extract(PreparedDependencySource source, DependencyFactsLimits limits) =>
+		Extract(source, limits, CancellationToken.None);
+
+	public FileFacts Extract(
+		PreparedDependencySource source,
+		DependencyFactsLimits limits,
+		CancellationToken cancellationToken)
 	{
 		ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 		if (source.PreparedStatus != DependencyFileStatus.Supported)
@@ -355,15 +376,19 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 
 		try
 		{
+			cancellationToken.ThrowIfCancellationRequested();
 			var runtime = GetRuntime(source.LanguageId);
 			using var lease = runtime.Rent(_workerBudget);
 			using var tree = lease.Parser.Parse(source.Source) ??
 				throw new InvalidOperationException("Tree-sitter returned no syntax tree.");
 			Interlocked.Increment(ref _parseCount);
-			var (declarations, references, errorKinds) = CaptureFacts(
+			var (declarations, references, errorKinds, rawCaptureLimitExceeded) = CaptureFacts(
 				runtime.Facts,
 				tree.RootNode,
-				limits.MaximumFactsPerFile);
+				limits.MaximumRawCapturesPerFile,
+				cancellationToken);
+			if (rawCaptureLimitExceeded)
+				return StatusOnly(source, DependencyFileStatus.ExtractionFailed, "fact limit exceeded");
 			var context = new DependencyExtractionContext(
 				source.RelativePath,
 				source.ScopeId,
@@ -374,7 +399,12 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				errorKinds,
 				declarations,
 				references);
-			return runtime.Adapter.Extract(context, limits);
+			var result = runtime.Adapter.Extract(context, limits);
+			Interlocked.Add(ref _adapterVisitedRanges, context.Work.VisitedRanges);
+			Interlocked.Add(ref _adapterComparisons, context.Work.Comparisons);
+			Interlocked.Add(ref _createdFacts,
+				result.Declarations.Count + result.Imports.Count + result.References.Count);
+			return result;
 		}
 		catch (Exception exception) when (exception is
 		       IOException or UnauthorizedAccessException or System.Security.SecurityException)
@@ -425,77 +455,171 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		}
 	}
 
-	private static (
+	private (
 		IReadOnlyList<DependencySyntaxCapture> Declarations,
 		IReadOnlyList<DependencySyntaxCapture> References,
-		IReadOnlyDictionary<string, int> ErrorKinds) CaptureFacts(Query query, Node root, int limit)
+		IReadOnlyDictionary<string, int> ErrorKinds,
+		bool RawCaptureLimitExceeded) CaptureFacts(
+		Query query,
+		Node root,
+		int rawCaptureLimit,
+		CancellationToken cancellationToken)
 	{
 		using var cursor = query.Execute(root);
 		var declarations = new List<DependencySyntaxCapture>();
 		var references = new List<DependencySyntaxCapture>();
 		var errorKinds = new Dictionary<string, int>(StringComparer.Ordinal);
-		foreach (var capture in cursor.Captures)
+		var rawCapturesVisited = 0L;
+		var createdCaptures = 0L;
+		var materialization = new NodeTextMaterializationCounter();
+		var rawCaptureLimitExceeded = false;
+		try
 		{
-			if (capture.Name == "diagnostic.error")
+			foreach (var capture in cursor.Captures)
 			{
-				var kinds = capture.Node.Children.Where(static child => child.IsNamed)
-					.Select(static child => child.Type).Distinct().ToArray();
-				if (kinds.Length == 0) kinds = ["<token>"];
-				foreach (var kind in kinds)
-					errorKinds[kind] = errorKinds.GetValueOrDefault(kind) + 1;
-				continue;
+				if ((rawCapturesVisited & 255) == 0)
+					cancellationToken.ThrowIfCancellationRequested();
+				rawCapturesVisited++;
+				if (rawCapturesVisited > rawCaptureLimit)
+				{
+					rawCaptureLimitExceeded = true;
+					break;
+				}
+				if (capture.Name == "diagnostic.error")
+				{
+					var kinds = capture.Node.Children.Where(static child => child.IsNamed)
+						.Select(static child => child.Type).Distinct().ToArray();
+					if (kinds.Length == 0) kinds = ["<token>"];
+					foreach (var kind in kinds)
+						errorKinds[kind] = errorKinds.GetValueOrDefault(kind) + 1;
+					continue;
+				}
+				var created = TryCreateCapture(capture.Name, capture.Node, materialization);
+				if (created is null)
+					continue;
+				var target = IsDeclarationCapture(capture.Name) ? declarations : references;
+				target.Add(created);
+				createdCaptures++;
 			}
-			var target = IsDeclarationCapture(capture.Name) ? declarations : references;
-			if (target.Count <= limit)
-				target.Add(CreateCapture(capture.Name, capture.Node));
+		}
+		finally
+		{
+			Interlocked.Add(ref _rawCapturesVisited, rawCapturesVisited);
+			Interlocked.Add(ref _createdCaptures, createdCaptures);
+			Interlocked.Add(ref _materializedCharacters, materialization.Characters);
 		}
 		return (
 			declarations.OrderBy(static capture => capture.StartIndex)
 				.ThenBy(static capture => capture.Name, StringComparer.Ordinal).ToArray(),
 			references.OrderBy(static capture => capture.StartIndex)
 				.ThenBy(static capture => capture.Name, StringComparer.Ordinal).ToArray(),
-			errorKinds);
+			errorKinds,
+			rawCaptureLimitExceeded);
 	}
 
 	private static bool IsDeclarationCapture(string captureName) =>
 		captureName.StartsWith("declaration.", StringComparison.Ordinal) ||
 		captureName is "context.namespace" or "context.using";
 
-	private static DependencySyntaxCapture CreateCapture(string captureName, Node node)
+	private static DependencySyntaxCapture? TryCreateCapture(
+		string captureName,
+		Node node,
+		NodeTextMaterializationCounter materialization)
 	{
 		if (captureName == "context.type_parameters")
 		{
 			var owner = node.Parent;
 			while (owner is not null && !IsTypeParameterOwner(owner.Type))
 				owner = owner.Parent;
+			var text = materialization.Read(node);
 			return new DependencySyntaxCapture(
 				captureName,
 				node.Type,
-				node.Text,
+				text,
 				checked((int)node.StartPosition.Row + 1),
 				checked((int)(owner?.StartIndex ?? node.StartIndex)),
-				checked((int)(owner?.EndIndex ?? node.EndIndex)));
+				checked((int)(owner?.EndIndex ?? node.EndIndex)),
+				Evidence: OneLineEvidence(text));
 		}
+		string? moduleCallName = null;
+		if (captureName == "import.call" &&
+		    !TryReadSupportedModuleCall(node, materialization, out moduleCallName))
+			return null;
+
+		if (captureName.StartsWith("import.", StringComparison.Ordinal))
+		{
+			var importSyntax = CreateImportSyntax(captureName, node, materialization, moduleCallName);
+			var importEvidence = CreateCompactImportEvidence(captureName, importSyntax);
+			return CreateCapture(captureName, node, importEvidence, null, 0, false,
+				FindImportOwner(captureName, node, materialization), importSyntax, evidence: importEvidence);
+		}
+
 		var isCompact = captureName.StartsWith("declaration.", StringComparison.Ordinal) ||
 			captureName == "context.namespace";
 		if (!isCompact)
-			return CreateCapture(captureName, node, node.Text, null, 0, false,
-				importSyntax: CreateImportSyntax(captureName, node));
+		{
+			var text = materialization.Read(node);
+			return CreateCapture(captureName, node, text, null, 0, false,
+				evidence: OneLineEvidence(text));
+		}
 
 		var nameNode = node.GetChildForField("name");
-		var capturedName = nameNode?.Text;
+		var capturedName = nameNode is null ? null : materialization.Read(nameNode);
 		var capturedNameStartIndex = nameNode is null ? -1 : checked((int)nameNode.StartIndex);
 		var typeParameters = node.Children.FirstOrDefault(static child =>
 			child.Type is "type_parameter_list" or "type_parameters");
-		var genericArity = typeParameters is null ? 0 : CountGenericArity(typeParameters.Text);
+		var genericArity = typeParameters is null ? 0 : CountGenericArity(materialization.Read(typeParameters));
 		var evidence = string.IsNullOrEmpty(capturedName)
 			? string.Empty
 			: capturedName + (genericArity == 0 ? string.Empty : $"`{genericArity}");
 		var isFileLocal = captureName.StartsWith("declaration.", StringComparison.Ordinal) &&
-			node.Children.Any(static child => child.Type == "modifier" && child.Text == "file");
+			node.Children.Any(child => child.Type == "modifier" && materialization.Read(child) == "file");
 		return CreateCapture(captureName, node, evidence, capturedName, genericArity, isFileLocal,
-			FindContainingDeclaration(node), capturedNameStartIndex: capturedNameStartIndex);
+			FindContainingDeclaration(node, materialization), capturedNameStartIndex: capturedNameStartIndex, evidence: evidence);
 	}
+
+	private static bool TryReadSupportedModuleCall(
+		Node node,
+		NodeTextMaterializationCounter materialization,
+		out string? functionName)
+	{
+		var function = node.GetChildForField("function");
+		functionName = function is null ? null : materialization.Read(function);
+		return functionName is "require" or "import";
+	}
+
+	private static string CreateCompactImportEvidence(
+		string captureName,
+		DependencyImportSyntax? syntax)
+	{
+		if (captureName is "import.esm" or "import.export")
+			return OneLineEvidence($"{(captureName == "import.export" ? "export" : "import")} {syntax?.Specifier ?? string.Empty}");
+		if (captureName == "import.call")
+		{
+			var function = syntax?.ImportKind == ModuleImportKind.Require ? "require" : "import";
+			var argument = syntax?.HasLiteralSpecifier == true ? syntax.Specifier : "<non-literal>";
+			return OneLineEvidence($"{function}({argument})");
+		}
+		if (captureName == "import.direct")
+			return "import " + OneLineEvidence(string.Join(", ", syntax?.Bindings.Select(static binding => binding.Name) ?? []));
+		return "from " + OneLineEvidence(syntax?.Specifier ?? string.Empty) + " import";
+	}
+
+	private static string OneLineEvidence(string value)
+	{
+		var prefixLength = Math.Min(value.Length, 240);
+		var line = value.AsSpan(0, prefixLength).ToString().Replace('\r', ' ').Replace('\n', ' ').Trim();
+		if (value.Length <= prefixLength) return line;
+		return line.Length <= 237 ? line + "..." : line[..237] + "...";
+	}
+
+	private static string? FindImportOwner(
+		string captureName,
+		Node node,
+		NodeTextMaterializationCounter materialization) =>
+		captureName is "import.direct" or "import.from"
+			? FindContainingDeclaration(node, materialization)
+			: null;
 
 	private static DependencySyntaxCapture CreateCapture(
 		string captureName,
@@ -506,7 +630,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		bool isFileLocal,
 		string? containingDeclaration = null,
 		DependencyImportSyntax? importSyntax = null,
-		int capturedNameStartIndex = -1) =>
+		int capturedNameStartIndex = -1,
+		string? evidence = null) =>
 		new(
 			captureName,
 			node.Type,
@@ -519,47 +644,61 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			isFileLocal,
 			containingDeclaration,
 			importSyntax,
-			capturedNameStartIndex);
+			capturedNameStartIndex,
+			evidence);
 
-	private static string? FindContainingDeclaration(Node node)
+	private static string? FindContainingDeclaration(
+		Node node,
+		NodeTextMaterializationCounter materialization)
 	{
 		for (var parent = node.Parent; parent is not null; parent = parent.Parent)
 		{
 			if (parent.Type is not ("class_definition" or "function_definition")) continue;
-			var name = parent.GetChildForField("name")?.Text;
+			var nameNode = parent.GetChildForField("name");
+			var name = nameNode is null ? null : materialization.Read(nameNode);
 			if (!string.IsNullOrWhiteSpace(name)) return name;
 		}
 		return null;
 	}
 
-	private static DependencyImportSyntax? CreateImportSyntax(string captureName, Node node)
+	private static DependencyImportSyntax? CreateImportSyntax(
+		string captureName,
+		Node node,
+		NodeTextMaterializationCounter materialization,
+		string? moduleCallName)
 	{
 		if (captureName is "import.esm" or "import.export")
 		{
 			var source = node.GetChildForField("source");
+			var specifier = source is null ? null : ReadJavaScriptStringLiteral(source, materialization);
 			return source is null
 				? null
-				: new DependencyImportSyntax(ReadQuotedLiteral(source.Text) ?? string.Empty, 0, [],
-					ReadQuotedLiteral(source.Text) is not null);
+				: new DependencyImportSyntax(specifier ?? string.Empty, 0, [], specifier is not null);
 		}
 		if (captureName == "import.call")
 		{
-			var function = node.GetChildForField("function")?.Text;
-			if (function is not ("require" or "import")) return null;
-			var argument = node.GetChildForField("arguments")?.NamedChildren.FirstOrDefault();
-			var specifier = argument is null ? null : ReadQuotedLiteral(argument.Text);
-			return new DependencyImportSyntax(specifier ?? string.Empty, 0, [], specifier is not null);
+			var argument = node.GetChildForField("arguments")?.NamedChildren
+				.Where(static child => child.Type != "comment")
+				.SingleOrDefault();
+			var specifier = argument is null ? null : ReadJavaScriptStringLiteral(argument, materialization);
+			return new DependencyImportSyntax(
+				specifier ?? string.Empty,
+				0,
+				[],
+				specifier is not null,
+				moduleCallName == "require" ? ModuleImportKind.Require : ModuleImportKind.DynamicImport);
 		}
 		if (captureName == "import.direct")
 		{
-			var bindings = ReadPythonBindings(node.GetChildrenForField("name"));
+			var bindings = ReadPythonBindings(node.GetChildrenForField("name"), materialization);
 			return new DependencyImportSyntax(string.Empty, 0, bindings);
 		}
 		if (captureName == "import.from")
 		{
-			var moduleText = node.GetChildForField("module_name")?.Text ?? string.Empty;
+			var moduleNode = node.GetChildForField("module_name");
+			var moduleText = moduleNode is null ? string.Empty : materialization.Read(moduleNode);
 			var relativeLevel = moduleText.TakeWhile(static character => character == '.').Count();
-			var bindings = ReadPythonBindings(node.GetChildrenForField("name"));
+			var bindings = ReadPythonBindings(node.GetChildrenForField("name"), materialization);
 			if (node.NamedChildren.Any(static child => child.Type == "wildcard_import"))
 				bindings = [new DependencyImportBinding("*", null, true)];
 			return new DependencyImportSyntax(moduleText[relativeLevel..], relativeLevel, bindings);
@@ -567,20 +706,91 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		return null;
 	}
 
-	private static IReadOnlyList<DependencyImportBinding> ReadPythonBindings(IEnumerable<Node> nodes) =>
+	private static IReadOnlyList<DependencyImportBinding> ReadPythonBindings(
+		IEnumerable<Node> nodes,
+		NodeTextMaterializationCounter materialization) =>
 		nodes.Select(node =>
 		{
 			if (node.Type != "aliased_import")
-				return new DependencyImportBinding(node.Text, null, node.Type == "wildcard_import");
+				return new DependencyImportBinding(materialization.Read(node), null, node.Type == "wildcard_import");
+			var nameNode = node.GetChildForField("name");
+			var aliasNode = node.GetChildForField("alias");
 			return new DependencyImportBinding(
-				node.GetChildForField("name")?.Text ?? string.Empty,
-				node.GetChildForField("alias")?.Text);
+				nameNode is null ? string.Empty : materialization.Read(nameNode),
+				aliasNode is null ? null : materialization.Read(aliasNode));
 		}).Where(static binding => binding.Name.Length > 0).ToArray();
 
-	private static string? ReadQuotedLiteral(string text) =>
-		text.Length >= 2 && text[0] is '\'' or '"' && text[^1] == text[0]
-			? text[1..^1]
-			: null;
+	private static string? ReadJavaScriptStringLiteral(
+		Node node,
+		NodeTextMaterializationCounter materialization)
+	{
+		if (node.Type != "string") return null;
+		var text = materialization.Read(node);
+		if (text.Length < 2 || text[0] is not ('\'' or '"') || text[^1] != text[0]) return null;
+		var result = new StringBuilder(text.Length - 2);
+		for (var index = 1; index < text.Length - 1; index++)
+		{
+			var character = text[index];
+			if (character != '\\')
+			{
+				result.Append(character);
+				continue;
+			}
+			if (++index >= text.Length - 1) return null;
+			var escaped = text[index];
+			switch (escaped)
+			{
+				case '\\': result.Append('\\'); break;
+				case '\'': result.Append('\''); break;
+				case '"': result.Append('"'); break;
+				case 'n': result.Append('\n'); break;
+				case 'r': result.Append('\r'); break;
+				case 't': result.Append('\t'); break;
+				case 'b': result.Append('\b'); break;
+				case 'f': result.Append('\f'); break;
+				case 'v': result.Append('\v'); break;
+				case '0': result.Append('\0'); break;
+				case 'x':
+					if (!TryReadHexEscape(text, ref index, 2, out var hex)) return null;
+					result.Append((char)hex);
+					break;
+				case 'u':
+					if (!TryReadHexEscape(text, ref index, 4, out var unicode)) return null;
+					result.Append((char)unicode);
+					break;
+				case '\r':
+					if (index + 1 < text.Length - 1 && text[index + 1] == '\n') index++;
+					break;
+				case '\n':
+					break;
+				default:
+					result.Append(escaped);
+					break;
+			}
+		}
+		return result.ToString();
+	}
+
+	private static bool TryReadHexEscape(string text, ref int index, int digits, out int value)
+	{
+		value = 0;
+		if (index + digits >= text.Length) return false;
+		for (var offset = 1; offset <= digits; offset++)
+		{
+			var digit = text[index + offset];
+			var numeric = digit switch
+			{
+				>= '0' and <= '9' => digit - '0',
+				>= 'a' and <= 'f' => digit - 'a' + 10,
+				>= 'A' and <= 'F' => digit - 'A' + 10,
+				_ => -1
+			};
+			if (numeric < 0) return false;
+			value = (value << 4) | numeric;
+		}
+		index += digits;
+		return true;
+	}
 
 	private static int CountGenericArity(string text)
 	{
@@ -605,7 +815,10 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 
 	private static FileFacts StatusOnly(PreparedDependencySource source, DependencyFileStatus status, string? reason) => new(
 		source.RelativePath, source.ScopeId, source.LanguageId, source.ContentFingerprint, source.Source.Length,
-		status, reason, false, new Dictionary<string, int>(), [], [], [], [], new Dictionary<string, string>(), [], new Dictionary<string, string>(), []);
+		status, reason, false, new Dictionary<string, int>(), [], [], [], [], new Dictionary<string, string>(), [], new Dictionary<string, string>(), [])
+	{
+		CanCache = source.CanCache
+	};
 
 	private static string ReadQuery(string directory, string file)
 	{
@@ -882,6 +1095,27 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		DependencyFileStatus Status,
 		string? StatusReason,
 		bool CanCache = true);
+
+	internal readonly record struct DependencyExtractionWorkState(
+		long RawCapturesVisited,
+		long CreatedCaptures,
+		long MaterializedCharacters,
+		long AdapterVisitedRanges,
+		long AdapterComparisons,
+		long CreatedFacts,
+		int ParsedFiles);
+
+	private sealed class NodeTextMaterializationCounter
+	{
+		public long Characters { get; private set; }
+
+		public string Read(Node node)
+		{
+			var text = node.Text;
+			Characters += text.Length;
+			return text;
+		}
+	}
 
 	private sealed record PreparedSourceContent(
 		string Fingerprint,

--- a/Tests/DevProjex.Tests.Integration/DependencyExtractionAndBindingIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyExtractionAndBindingIntegrationTests.cs
@@ -1,0 +1,410 @@
+using DevProjex.Application.Dependencies;
+using DevProjex.Application.Ranking;
+using DevProjex.Infrastructure.Dependencies;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class DependencyExtractionAndBindingIntegrationTests(ITestOutputHelper output)
+{
+	[Fact]
+	public async Task CSharpReferences_OnOneLineRemainDistinctOccurrences()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var model = fixture.CreateFile("Models/User.cs", "namespace Models; public sealed class User { }");
+		var source = fixture.CreateFile("Consumers.cs", "using Models; class Box<User> { User a; } class Consumer { User b; }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [project, model, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "Consumers.cs" && item.Target == "Models/User.cs");
+		Assert.Single(edge.Evidence);
+		Assert.Contains(result.Files.Single(file => file.Path == "Consumers.cs").References,
+			reference => reference.Name == "User" && reference.ContainingType == "Consumer");
+		Assert.Contains(result.Files.Single(file => file.Path == "Consumers.cs").References,
+			reference => reference.Name == "User" && reference.ContainingType == "Box`1" && reference.Status == ResolutionStatus.Unresolved);
+	}
+
+	[Fact]
+	public async Task TypeScriptImportFacts_DoNotDependOnOrdinaryCallOrder()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var target = fixture.CreateFile("dep.ts", "export const value = 1;");
+		var calls = string.Join('\n', Enumerable.Repeat("noop();", 8));
+		var before = fixture.CreateFile("before.ts", $"import \"./dep.js\";\n{calls}");
+		var after = fixture.CreateFile("after.ts", $"{calls}\nimport \"./dep.js\";");
+		using var engine = CreateEngine(new DependencyFactsLimits(MaximumFactsPerFile: 2));
+
+		var result = await engine.IndexAsync(fixture.Path, [config, target, before, after],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.All(new[] { "before.ts", "after.ts" }, path =>
+		{
+			var edge = Assert.Single(result.Edges, item => item.Source == path);
+			Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+			Assert.Equal("dep.ts", edge.Target);
+		});
+	}
+
+	[Fact]
+	public async Task TypeScriptFactLimits_AreExplicitAndCancellationIsObserved()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var first = fixture.CreateFile("first.ts", "export const first = 1;");
+		var second = fixture.CreateFile("second.ts", "export const second = 2;");
+		var third = fixture.CreateFile("third.ts", "export const third = 3;");
+		var usefulOverflow = fixture.CreateFile("useful.ts", "import './first.js'; import './second.js'; import './third.js';");
+		var rawOverflow = fixture.CreateFile("raw.ts", "noop(); noop(); noop(); noop(); import './first.js';");
+
+		using (var usefulEngine = CreateEngine(new DependencyFactsLimits(MaximumFactsPerFile: 2)))
+		{
+			var index = await usefulEngine.IndexAsync(fixture.Path, [config, first, second, third, usefulOverflow],
+				cancellationToken: TestContext.Current.CancellationToken);
+			var file = Assert.Single(index.Files, item => item.Path == "useful.ts");
+			Assert.Equal(DependencyFileStatus.ExtractionFailed, file.Status);
+			Assert.Equal("fact limit exceeded", file.StatusReason);
+			Assert.Equal(1, index.Coverage.ExtractionFailed);
+			var related = await usefulEngine.FindRelatedAsync(fixture.Path, [config, first, second, third, usefulOverflow],
+				["useful.ts"], DependencyDirection.Both, cancellationToken: TestContext.Current.CancellationToken);
+			Assert.Equal("fact limit exceeded", Assert.Single(related.Seeds).NoFactsReason);
+		}
+		using (var focusEngine = CreateEngine(new DependencyFactsLimits(MaximumFactsPerFile: 2)))
+		{
+			var ranking = new ImportanceRankingService(focusEngine, new UnavailableHistoryReader());
+			var report = await ranking.RankAsync(
+				fixture.Path,
+				[config, first, second, third, usefulOverflow],
+				new FocusRankingRequest([new FocusRankingSeedRequest("useful.ts", usefulOverflow)]),
+				cancellationToken: TestContext.Current.CancellationToken);
+			var seed = Assert.Single(report.Focus!.Seeds);
+			Assert.Equal(FocusSeedState.ExtractionFailed, seed.State);
+			Assert.Equal("fact limit exceeded", seed.Reason);
+		}
+
+		using (var rawEngine = CreateEngine(new DependencyFactsLimits(MaximumRawCapturesPerFile: 4)))
+		{
+			var index = await rawEngine.IndexAsync(fixture.Path, [config, first, rawOverflow],
+				cancellationToken: TestContext.Current.CancellationToken);
+			var file = Assert.Single(index.Files, item => item.Path == "raw.ts");
+			Assert.Equal(DependencyFileStatus.ExtractionFailed, file.Status);
+			Assert.Equal("fact limit exceeded", file.StatusReason);
+		}
+
+		using var cancelledEngine = CreateEngine();
+		using var cancellation = new CancellationTokenSource();
+		await cancellation.CancelAsync();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancelledEngine.IndexAsync(
+			fixture.Path, [config, first], cancellationToken: cancellation.Token));
+	}
+
+	[Fact]
+	public async Task TypeScriptNestedOrdinaryCalls_DoNotMaterializeNestedSourceText()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var target = fixture.CreateFile("dep.ts", "export const value = 1;");
+		var nested = "value";
+		for (var index = 0; index < 256; index++) nested = $"noop({nested})";
+		var source = fixture.CreateFile("main.ts", nested + ";\nimport './dep.js';");
+		using var extractor = new TreeSitterDependencyFactExtractor();
+		using var engine = new DependencyFactsEngine(extractor, new FileDependencyConfigurationProvider());
+
+		var result = await engine.IndexAsync(fixture.Path, [config, target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "main.ts" && edge.Target == "dep.ts");
+		Assert.True(extractor.WorkState.RawCapturesVisited >= 257);
+		Assert.True(extractor.WorkState.CreatedCaptures < 20);
+		var previousMaterialization = Enumerable.Range(1, 256).Sum(depth => 5L + 6L * depth);
+		output.WriteLine($"nested-call materialization: before={previousMaterialization}, " +
+		                 $"after={extractor.WorkState.MaterializedCharacters}, " +
+		                 $"raw-captures={extractor.WorkState.RawCapturesVisited}, " +
+		                 $"created-captures={extractor.WorkState.CreatedCaptures}");
+		Assert.True(previousMaterialization > extractor.WorkState.MaterializedCharacters * 100);
+		Assert.True(extractor.WorkState.MaterializedCharacters < 2_000,
+			$"Discarded calls materialized {extractor.WorkState.MaterializedCharacters} characters.");
+		var work = extractor.WorkState;
+		var warm = await engine.IndexAsync(fixture.Path, [config, target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		Assert.True(warm.Metrics.ResolutionCacheHit);
+		Assert.Equal(work, extractor.WorkState);
+	}
+
+	[Fact]
+	public async Task TypeScriptModuleSpecifiers_RequireLiteralSyntaxAndDecodeEscapes()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var target = fixture.CreateFile("target.ts", "export const value = 1;");
+		var source = fixture.CreateFile("main.ts", """
+			require("./" + "target.js");
+			require("./\u0074arget.js");
+			require(/* retained */ "./target.js");
+			import "./target.js";
+			import("./target.js");
+			const variable = "./target.js";
+			require(variable);
+			import(`./${variable}`);
+			require(`./target.js`);
+			require("./target.js);
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [config, target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var facts = result.Files.Single(file => file.Path == "main.ts");
+		Assert.Equal(4, facts.Imports.Count(import => import.Specifier == "./target.js"));
+		Assert.Equal(4, facts.Imports.Count(import => import.Reason == "module specifier is not a string literal"));
+		Assert.True(facts.HasSyntaxErrors);
+		Assert.DoesNotContain(facts.Imports, import => import.Specifier.Contains(" + ", StringComparison.Ordinal));
+		var resolved = Assert.Single(result.Edges, edge => edge.Source == "main.ts" && edge.Target == "target.ts");
+		Assert.Equal(4, resolved.Evidence.Count);
+	}
+
+	[Fact]
+	public async Task CSharpAliases_RespectAbsoluteNamesAndLexicalNamespaceScopes()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var real = fixture.CreateFile("Models/User.cs", "namespace Models; public sealed class User { }");
+		var decoy = fixture.CreateFile("Models/Decoy.cs", "namespace Models; public sealed class Decoy { }");
+		var one = fixture.CreateFile("Models/One.cs", "namespace Models; public sealed class One { }");
+		var two = fixture.CreateFile("Models/Two.cs", "namespace Models; public sealed class Two { }");
+		var source = fixture.CreateFile("Consumers.cs", """
+			using User = Models.Decoy;
+			class RootConsumer
+			{
+				Models.User Qualified;
+				global::Models.User Absolute;
+				User Aliased;
+			}
+			namespace Repeated
+			{
+				using X = Models.One;
+				class FirstConsumer { X Value; }
+			}
+			namespace Repeated
+			{
+				using X = Models.Two;
+				class SecondConsumer { X Value; }
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [project, real, decoy, one, two, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var edges = result.Edges.Where(edge => edge.Source == "Consumers.cs").ToArray();
+
+		var userEdge = Assert.Single(edges, edge => edge.Target == "Models/User.cs");
+		Assert.Equal(2, userEdge.Evidence.Count);
+		Assert.Single(edges, edge => edge.Target == "Models/Decoy.cs");
+		Assert.Single(edges, edge => edge.Target == "Models/One.cs");
+		Assert.Single(edges, edge => edge.Target == "Models/Two.cs");
+	}
+
+	[Fact]
+	public async Task CSharpGlobalQualification_BypassesGenericShadowingAndAliases()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var global = fixture.CreateFile("User.cs", "public sealed class User { }");
+		var model = fixture.CreateFile("Models/User.cs", "namespace Models; public sealed class User { }");
+		var decoy = fixture.CreateFile("Models/Decoy.cs", "namespace Models; public sealed class Decoy { }");
+		var source = fixture.CreateFile("Box.cs", """
+			using User = Models.Decoy;
+			class Box<User>
+			{
+				User Shadowed;
+				global::User Absolute;
+				global::Models.User QualifiedAbsolute;
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, [project, global, model, decoy, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "Box.cs" && edge.Target == "User.cs");
+		Assert.Contains(result.Edges, edge => edge.Source == "Box.cs" && edge.Target == "Models/User.cs");
+		Assert.DoesNotContain(result.Edges, edge => edge.Source == "Box.cs" && edge.Target == "Models/Decoy.cs");
+		Assert.Contains(result.Files.Single(file => file.Path == "Box.cs").References,
+			reference => reference.Name == "User" && !reference.IsGlobalQualified &&
+			             reference.Status == ResolutionStatus.Unresolved);
+	}
+
+	[Fact]
+	public async Task PythonLocalImports_CreateFileEdgesButNotModuleExports()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var implementation = fixture.CreateFile("impl.py", "class Item: pass");
+		var model = fixture.CreateFile("model.py", """
+			def loader():
+			    from impl import Item as LocalItem
+			class Container:
+			    from impl import Item as ClassItem
+			""");
+		var relativeModel = fixture.CreateFile("pkg/model.py", """
+			def loader():
+			    from .impl import Item as RelativeItem
+			""");
+		var relativeImplementation = fixture.CreateFile("pkg/impl.py", "class Item: pass");
+		var relativeConsumer = fixture.CreateFile("relative_consumer.py", "from pkg.model import RelativeItem");
+		var consumer = fixture.CreateFile("consumer.py", """
+			from model import LocalItem
+			from model import ClassItem
+			""");
+		var initializer = fixture.CreateFile("pkg/__init__.py", "from impl import Item as PublicItem");
+		var packageConsumer = fixture.CreateFile("package_consumer.py", "from pkg import PublicItem");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, implementation, model, consumer, initializer, packageConsumer,
+				relativeModel, relativeImplementation, relativeConsumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+		Assert.Contains(result.Edges, edge => edge.Source == "model.py" && edge.Target == "impl.py" &&
+			edge.Status == ResolutionStatus.Resolved);
+		var unresolved = Assert.Single(result.Edges, edge => edge.Source == "consumer.py" &&
+			edge.Status == ResolutionStatus.Unresolved && edge.Reasons.Contains("name not found in module"));
+		Assert.Equal(2, unresolved.Evidence.Count);
+		Assert.Contains(result.Edges, edge => edge.Source == "package_consumer.py" &&
+			edge.Target == "impl.py" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(result.Edges, edge => edge.Source == "pkg/model.py" &&
+			edge.Target == "pkg/impl.py" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(result.Edges, edge => edge.Source == "relative_consumer.py" &&
+			edge.Status == ResolutionStatus.Unresolved && edge.Reasons.Contains("name not found in module"));
+	}
+
+	[Fact]
+	public async Task RelatedEvidence_IncludesTheProjectReferenceName()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}");
+		var target = fixture.CreateFile("register.ts", "export const value = 1;");
+		var source = fixture.CreateFile("main.ts", "import \"./register.js\";");
+		using var engine = CreateEngine();
+		var related = await engine.FindRelatedAsync(
+			fixture.Path,
+			[config, target, source],
+			["main.ts"],
+			DependencyDirection.Dependencies,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(Assert.Single(Assert.Single(related.Seeds).Dependencies).Reasons,
+			reason => reason == "import ./register.js at line 1");
+	}
+
+	[Fact]
+	public async Task MissingUnsupportedManifestFile_IsAPerFileTransientFailure()
+	{
+		using var fixture = new TemporaryDirectory();
+		var readme = fixture.CreateFile("README.md", "# transient\n");
+		var license = fixture.CreateFile("LICENSE", "fixture\n");
+		var manifest = new[] { readme, license };
+		File.Delete(readme);
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(fixture.Path, manifest,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var file = Assert.Single(result.Files, item => item.Path == "README.md");
+		Assert.Equal("README.md", file.Path);
+		Assert.Equal(DependencyFileStatus.ExtractionFailed, file.Status);
+		Assert.Equal("source file could not be read", file.StatusReason);
+		Assert.False(file.CanCache);
+		Assert.Equal(1, result.Coverage.ExtractionFailed);
+		var existing = Assert.Single(result.Files, item => item.Path == "LICENSE");
+		Assert.Equal(DependencyFileStatus.Unsupported, existing.Status);
+		Assert.True(existing.CanCache);
+	}
+
+	[Fact]
+	public async Task CSharpProjectReferences_AreTransitivelyVisibleBySdkDefault()
+	{
+		using var fixture = new TemporaryDirectory();
+		var projectA = fixture.CreateFile("A/A.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <ItemGroup><ProjectReference Include="../B/B.csproj" /></ItemGroup>
+			</Project>
+			""");
+		var projectB = fixture.CreateFile("B/B.csproj", """
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <ItemGroup><ProjectReference Include="../C/C.csproj" /></ItemGroup>
+			</Project>
+			""");
+		var projectC = fixture.CreateFile("C/C.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var consumer = fixture.CreateFile("A/Consumer.cs", "using CScope; public sealed class Consumer { public Target Value { get; } }");
+		var middle = fixture.CreateFile("B/Middle.cs", "namespace BScope; public sealed class Middle { }");
+		var target = fixture.CreateFile("C/Target.cs", "namespace CScope; public sealed class Target { }");
+		var unrelatedProject = fixture.CreateFile("D/D.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var unrelated = fixture.CreateFile("D/Other.cs", "namespace DScope; public sealed class Other { }");
+		var unresolved = fixture.CreateFile("A/OtherConsumer.cs", "using DScope; public sealed class OtherConsumer { public Other Value { get; } }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[projectA, projectB, projectC, consumer, middle, target, unrelatedProject, unrelated, unresolved],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "A/Consumer.cs" && item.Reference == "Target");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("C/Target.cs", edge.Target);
+		Assert.True(edge.CrossScope);
+		Assert.Contains(result.Edges, item => item.Source == "A/OtherConsumer.cs" && item.Reference == "Other" &&
+			item.Status == ResolutionStatus.Unresolved);
+	}
+
+	[Fact]
+	public async Task TypeScriptPackageConditions_DistinguishDynamicImportFromRequireInCommonJs()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"node16\"}}");
+		var package = fixture.CreateFile("package.json", """
+			{"imports":{"#dual":{"import":"./import.mts","require":"./require.cts"}}}
+			""");
+		var importTarget = fixture.CreateFile("import.mts", "export const value = 1;");
+		var requireTarget = fixture.CreateFile("require.cts", "export const value = 2;");
+		var source = fixture.CreateFile("main.cts", "import('#dual'); require('#dual');");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, package, importTarget, requireTarget, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "main.cts" && edge.Target == "import.mts" &&
+			edge.Reference == "#dual" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(result.Edges, edge => edge.Source == "main.cts" && edge.Target == "require.cts" &&
+			edge.Reference == "#dual" && edge.Status == ResolutionStatus.Resolved);
+		var imports = result.Files.Single(file => file.Path == "main.cts").Imports;
+		Assert.Contains(imports, import => import.ImportKind == ModuleImportKind.DynamicImport);
+		Assert.Contains(imports, import => import.ImportKind == ModuleImportKind.Require);
+	}
+
+	private static DependencyFactsEngine CreateEngine(DependencyFactsLimits? limits = null) => new(
+		new TreeSitterDependencyFactExtractor(),
+		new FileDependencyConfigurationProvider(),
+		limits);
+
+	private sealed class UnavailableHistoryReader : IProjectGitHistoryReader
+	{
+		public Task<ProjectGitHistorySnapshot> ReadAsync(
+			string sourceRoot,
+			IReadOnlyList<string> candidateFiles,
+			CancellationToken cancellationToken = default) =>
+			Task.FromResult(new ProjectGitHistorySnapshot(
+				200,
+				0,
+				new Dictionary<string, ProjectGitFileActivity>(PathComparer.Default),
+				candidateFiles.ToDictionary(
+					Path.GetFullPath,
+					static _ => ProjectGitHistoryUnavailableReason.NotRepository,
+					PathComparer.Default),
+				ProjectGitHistoryUnavailableReason.NotRepository));
+	}
+}

--- a/Tests/DevProjex.Tests.Integration/DependencyLanguageAdapterPerformanceIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyLanguageAdapterPerformanceIntegrationTests.cs
@@ -7,27 +7,39 @@ namespace DevProjex.Tests.Integration;
 public sealed class DependencyLanguageAdapterPerformanceIntegrationTests(ITestOutputHelper output)
 {
 	[Fact]
+	public void CSharpExtraction_WorkCountersRemainLinear()
+	{
+		var small = MeasureWork(2_000);
+		var large = MeasureWork(4_000);
+		output.WriteLine($"C# adapter work: 2000 facts={small.Facts}, ranges={small.VisitedRanges}, comparisons={small.Comparisons}; " +
+		                 $"4000 facts={large.Facts}, ranges={large.VisitedRanges}, comparisons={large.Comparisons}");
+
+		Assert.Equal(4_000, small.Facts);
+		Assert.Equal(8_000, large.Facts);
+		Assert.InRange(large.VisitedRanges, small.VisitedRanges * 2, small.VisitedRanges * 2 + 8);
+		Assert.InRange(large.Comparisons, small.Comparisons * 2, small.Comparisons * 2 + 8);
+	}
+
+	[Fact]
 	[Trait("Category", "LocalPerformance")]
 	public void CSharpExtraction_WithThousandsOfDeclarationsAndReferences_RemainsNearLinear()
 	{
 		_ = Measure(500);
-		var small = MeasureMedian(2_000, 5);
-		var large = MeasureMedian(4_000, 5);
+		var samples = Enumerable.Range(0, 5)
+			.SelectMany(static _ => new[] { (Count: 2_000, Elapsed: Measure(2_000)), (Count: 4_000, Elapsed: Measure(4_000)) })
+			.ToArray();
+		var small = Median(samples.Where(static sample => sample.Count == 2_000).Select(static sample => sample.Elapsed));
+		var large = Median(samples.Where(static sample => sample.Count == 4_000).Select(static sample => sample.Elapsed));
 		var ratio = large.TotalMilliseconds / small.TotalMilliseconds;
 
 		output.WriteLine($"C# fact extraction: 2000={small.TotalMilliseconds:F3} ms; " +
 		                 $"4000={large.TotalMilliseconds:F3} ms; ratio={ratio:F2}x");
 		Assert.True(large < TimeSpan.FromSeconds(5));
-		Assert.True(ratio < 3,
-			$"Doubling declarations and references took {ratio:F2}x; expected sub-quadratic scaling.");
 	}
 
-	private static TimeSpan MeasureMedian(int count, int repetitions)
+	private static TimeSpan Median(IEnumerable<TimeSpan> values)
 	{
-		var samples = Enumerable.Range(0, repetitions)
-			.Select(_ => Measure(count))
-			.OrderBy(static elapsed => elapsed)
-			.ToArray();
+		var samples = values.Order().ToArray();
 		return samples[samples.Length / 2];
 	}
 
@@ -58,4 +70,30 @@ public sealed class DependencyLanguageAdapterPerformanceIntegrationTests(ITestOu
 		Assert.Equal(count, facts.References.Count);
 		return started.Elapsed;
 	}
+
+	private static WorkMeasurement MeasureWork(int count)
+	{
+		var declarations = new DependencySyntaxCapture[count];
+		var references = new DependencySyntaxCapture[count];
+		for (var index = 0; index < count; index++)
+		{
+			var start = index * 100;
+			declarations[index] = new DependencySyntaxCapture(
+				"declaration.class", "class_declaration", $"class Type{index} {{ }}", index + 1,
+				start, start + 99, $"Type{index}");
+			references[index] = new DependencySyntaxCapture(
+				"reference.property_type", "identifier", "Target", index + 1,
+				start + 20, start + 26);
+		}
+		var context = new DependencyExtractionContext(
+			"Generated.cs", "fixture", LanguageId.CSharp, new string(' ', count * 100), "fixture",
+			false, new Dictionary<string, int>(StringComparer.Ordinal), declarations, references);
+		var facts = new CSharpDependencyLanguageAdapter().Extract(context, new DependencyFactsLimits());
+		return new WorkMeasurement(
+			facts.Declarations.Count + facts.References.Count,
+			context.Work.VisitedRanges,
+			context.Work.Comparisons);
+	}
+
+	private readonly record struct WorkMeasurement(int Facts, long VisitedRanges, long Comparisons);
 }

--- a/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyReferenceSemanticsIntegrationTests.cs
@@ -173,6 +173,9 @@ public sealed class DependencyReferenceSemanticsIntegrationTests
 		var imports = result.Files.Single(file => file.Path == "main.ts").Imports;
 		Assert.Equal(8, imports.Count(import => import.Specifier == "./register.js"));
 		Assert.Equal(2, imports.Count(import => import.Reason == "module specifier is not a string literal"));
+		Assert.Equal(6, imports.Count(import => import.ImportKind == ModuleImportKind.StaticImport));
+		Assert.Equal(2, imports.Count(import => import.ImportKind == ModuleImportKind.Require));
+		Assert.Equal(2, imports.Count(import => import.ImportKind == ModuleImportKind.DynamicImport));
 		var edges = result.Edges.Where(edge => edge.Source == "main.ts").ToArray();
 		var resolved = Assert.Single(edges, edge => edge.Reference == "./register.js" &&
 			edge.Status == ResolutionStatus.Resolved && edge.Target == "register.ts");

--- a/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
@@ -144,17 +144,30 @@ public sealed class RelatedCommandProcessTests
 		workspace.WriteFile("project/Consumers.cs",
 			"using Models; class Box<User> { User a; } class Consumer { User b; }\n");
 		workspace.WriteFile("project/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}\n");
+		workspace.WriteFile("project/package.json", "{\"imports\":{\"#dual\":{\"import\":\"./import.mts\",\"require\":\"./require.cts\"}}}\n");
 		workspace.WriteFile("project/register.ts", "export const ready = true;\n");
 		workspace.WriteFile("project/main.ts", "import \"./register.js\";\n");
+		workspace.WriteFile("project/import.mts", "export const value = 1;\n");
+		workspace.WriteFile("project/require.cts", "export const value = 2;\n");
+		workspace.WriteFile("project/dual.cts", "import('#dual'); require('#dual');\n");
 		workspace.WriteFile("project/pyproject.toml", "[project]\nname = \"fixture\"\n");
+		workspace.WriteFile("project/impl.py", "class Item: pass\n");
 		workspace.WriteFile("project/model.py", "class Container:\n    def nested(self): pass\n\nclass Item: pass\n");
 		workspace.WriteFile("project/python_consumer.py", "from model import (\n    Item,\n)\n");
+		workspace.WriteFile("project/local_model.py", "def loader():\n    from impl import Item as LocalItem\n");
+		workspace.WriteFile("project/local_consumer.py", "from local_model import LocalItem\n");
 
 		var csharp = Run(workspace, "related", "Consumers.cs", "--project", project,
 			"--format", "json", "--git-mode", "none", "--exclude", "none");
 		var typeScript = Run(workspace, "related", "main.ts", "--project", project,
 			"--format", "json", "--git-mode", "none", "--exclude", "none");
+		var conditional = Run(workspace, "related", "dual.cts", "--project", project,
+			"--format", "json", "--git-mode", "none", "--exclude", "none");
 		var python = Run(workspace, "related", "python_consumer.py", "--project", project,
+			"--format", "json", "--git-mode", "none", "--exclude", "none");
+		var localPython = Run(workspace, "related", "local_consumer.py", "--project", project,
+			"--format", "json", "--git-mode", "none", "--exclude", "none");
+		var localModel = Run(workspace, "related", "local_model.py", "--project", project,
 			"--format", "json", "--git-mode", "none", "--exclude", "none");
 
 		Assert.Equal(0, csharp.ExitCode);
@@ -166,9 +179,21 @@ public sealed class RelatedCommandProcessTests
 		}
 		Assert.Equal(0, typeScript.ExitCode);
 		Assert.Contains("register.ts", typeScript.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("import ./register.js at line 1", typeScript.StandardOutput, StringComparison.Ordinal);
+		Assert.Equal(0, conditional.ExitCode);
+		Assert.Contains("import.mts", conditional.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("require.cts", conditional.StandardOutput, StringComparison.Ordinal);
 		Assert.Equal(0, python.ExitCode);
 		Assert.Contains("model.py", python.StandardOutput, StringComparison.Ordinal);
 		Assert.DoesNotContain("nested", python.StandardOutput, StringComparison.Ordinal);
+		Assert.Equal(0, localPython.ExitCode);
+		using (var localDocument = JsonDocument.Parse(localPython.StandardOutput))
+		{
+			var localSeed = Assert.Single(localDocument.RootElement.GetProperty("seeds").EnumerateArray());
+			Assert.Empty(localSeed.GetProperty("dependencies").EnumerateArray());
+		}
+		Assert.Equal(0, localModel.ExitCode);
+		Assert.Contains("impl.py", localModel.StandardOutput, StringComparison.Ordinal);
 	}
 
 	private static TerminalTestProcessResult Run(TemporaryDirectory workspace, params string[] arguments)

--- a/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
@@ -14,11 +14,18 @@ public sealed partial class McpServerProcessTests
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("project");
 		workspace.WriteFile("project/tsconfig.json", "{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}\n");
+		workspace.WriteFile("project/package.json", "{\"imports\":{\"#dual\":{\"import\":\"./import.mts\",\"require\":\"./require.cts\"}}}\n");
 		workspace.WriteFile("project/register.ts", "export const ready = true;\n");
 		workspace.WriteFile("project/main.ts", "import \"./register.js\";\n");
+		workspace.WriteFile("project/import.mts", "export const value = 1;\n");
+		workspace.WriteFile("project/require.cts", "export const value = 2;\n");
+		workspace.WriteFile("project/dual.cts", "import('#dual'); require('#dual');\n");
 		workspace.WriteFile("project/pyproject.toml", "[project]\nname = \"fixture\"\n");
+		workspace.WriteFile("project/impl.py", "class Item: pass\n");
 		workspace.WriteFile("project/model.py", "class Container:\n    def nested(self): pass\n\nclass Item: pass\n");
 		workspace.WriteFile("project/consumer.py", "from model import (\n    Item,\n)\n");
+		workspace.WriteFile("project/local_model.py", "def loader():\n    from impl import Item as LocalItem\n");
+		workspace.WriteFile("project/local_consumer.py", "from local_model import LocalItem\n");
 		var startInfo = new ProcessStartInfo("dotnet")
 		{
 			UseShellExecute = false,
@@ -50,11 +57,29 @@ public sealed partial class McpServerProcessTests
 			var python = await client.CallToolAsync("related_files",
 				new Dictionary<string, object?> { ["path"] = "consumer.py", ["direction"] = "dependencies" },
 				progress: null, options: null, TestContext.Current.CancellationToken);
-			Assert.Contains("register.ts", Assert.IsType<TextContentBlock>(Assert.Single(typeScript.Content)).Text,
-				StringComparison.Ordinal);
+			var conditional = await client.CallToolAsync("related_files",
+				new Dictionary<string, object?> { ["path"] = "dual.cts", ["direction"] = "dependencies" },
+				progress: null, options: null, TestContext.Current.CancellationToken);
+			var localPython = await client.CallToolAsync("related_files",
+				new Dictionary<string, object?> { ["path"] = "local_consumer.py", ["direction"] = "dependencies" },
+				progress: null, options: null, TestContext.Current.CancellationToken);
+			var localModel = await client.CallToolAsync("related_files",
+				new Dictionary<string, object?> { ["path"] = "local_model.py", ["direction"] = "dependencies" },
+				progress: null, options: null, TestContext.Current.CancellationToken);
+			var typeScriptText = Assert.IsType<TextContentBlock>(Assert.Single(typeScript.Content)).Text;
+			Assert.Contains("register.ts", typeScriptText, StringComparison.Ordinal);
+			Assert.Contains("import ./register.js at line 1", typeScriptText, StringComparison.Ordinal);
+			var conditionalText = Assert.IsType<TextContentBlock>(Assert.Single(conditional.Content)).Text;
+			Assert.Contains("import.mts", conditionalText, StringComparison.Ordinal);
+			Assert.Contains("require.cts", conditionalText, StringComparison.Ordinal);
 			var pythonText = Assert.IsType<TextContentBlock>(Assert.Single(python.Content)).Text;
 			Assert.Contains("model.py", pythonText, StringComparison.Ordinal);
 			Assert.DoesNotContain("nested", pythonText, StringComparison.Ordinal);
+			var localPythonText = Assert.IsType<TextContentBlock>(Assert.Single(localPython.Content)).Text;
+			Assert.DoesNotContain("impl.py", localPythonText, StringComparison.Ordinal);
+			Assert.Contains("[No related files]", localPythonText, StringComparison.Ordinal);
+			Assert.Contains("impl.py", Assert.IsType<TextContentBlock>(Assert.Single(localModel.Content)).Text,
+				StringComparison.Ordinal);
 		}
 		process.StandardInput.Close();
 		await process.WaitForExitAsync(TestContext.Current.CancellationToken)

--- a/tools/RankingEval/results/2026-09-07-focus-v1.json
+++ b/tools/RankingEval/results/2026-09-07-focus-v1.json
@@ -1,8 +1,8 @@
 {
   "protocol": "focus-v1",
   "runDate": "2026-09-08",
-  "productSha": "798ce9bef2622fda1eb6320ef98009428388c6c7",
-  "evaluatorSha": "798ce9bef2622fda1eb6320ef98009428388c6c7",
+  "productSha": "0ce6eb3b03e724fcb3d4b54d21bf156dc468ab33",
+  "evaluatorSha": "0ce6eb3b03e724fcb3d4b54d21bf156dc468ab33",
   "repositories": [
     {
       "id": "devprojex",
@@ -57,7 +57,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.33932714617169374,
+              "irrelevantTokenShare": 0.6123213070115725,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -111,7 +111,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.33932714617169374,
+              "irrelevantTokenShare": 0.6123213070115725,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -141,7 +141,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.947125,
+              "irrelevantTokenShare": 0.9471183897987249,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -149,7 +149,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9288080505031564,
+              "irrelevantTokenShare": 0.9288036004500563,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -157,7 +157,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9288080505031564,
+              "irrelevantTokenShare": 0.9288036004500563,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -165,7 +165,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9253946420383834,
+              "irrelevantTokenShare": 0.9283467539003523,
               "oracle": false,
               "oracleAfterSeeds": false
             }
@@ -303,7 +303,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.9716232264516532,
+              "irrelevantTokenShare": 0.971625,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -357,7 +357,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.639,
+              "irrelevantTokenShare": 0.6388194097048524,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -365,7 +365,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.639,
+              "irrelevantTokenShare": 0.6388194097048524,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -373,7 +373,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.6388194097048524,
+              "irrelevantTokenShare": 0.6389097274318579,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -419,7 +419,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.8194774346793349,
+              "irrelevantTokenShare": 0.819454863715929,
               "oracle": true,
               "oracleAfterSeeds": true
             },
@@ -573,7 +573,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.34158539634908724,
+              "irrelevantTokenShare": 0.34166770846355793,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -627,7 +627,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.670875,
+              "irrelevantTokenShare": 0.6708544284017751,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -635,7 +635,7 @@
               "available": true,
               "recallNew": 0,
               "allRequired": false,
-              "irrelevantTokenShare": 0.670875,
+              "irrelevantTokenShare": 0.6708544284017751,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -805,7 +805,7 @@
               "available": true,
               "recallNew": 0.5,
               "allRequired": false,
-              "irrelevantTokenShare": 0.30614413400837553,
+              "irrelevantTokenShare": 0.3061875,
               "oracle": false,
               "oracleAfterSeeds": false
             },
@@ -825,100 +825,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2727.879,
-          "medianPeakWorkingSetBytes": 319238144,
+          "medianElapsedMilliseconds": 3014.9087,
+          "medianPeakWorkingSetBytes": 323776512,
           "elapsedMilliseconds": [
-            2860.1653,
-            2810.255,
-            2877.0395,
-            2727.879,
-            2670.9112,
-            2716.9539,
-            2701.9038
+            3714.4759,
+            3067.0234,
+            2926.7666,
+            2888.1598,
+            3430.2988,
+            3014.9087,
+            2804.3508
           ],
           "peakWorkingSetBytes": [
-            315703296,
-            320544768,
-            320876544,
-            318865408,
-            319238144,
-            319578112,
-            314736640
+            325685248,
+            325677056,
+            323383296,
+            323682304,
+            321302528,
+            324038656,
+            323776512
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 2812.7785,
-          "medianPeakWorkingSetBytes": 316973056,
+          "medianElapsedMilliseconds": 2833.842,
+          "medianPeakWorkingSetBytes": 320589824,
           "elapsedMilliseconds": [
-            2732.9258,
-            2835.4789,
-            2834.1718,
-            2937.7606,
-            2802.022,
-            2751.5557,
-            2812.7785
+            3350.486,
+            3034.8471,
+            3136.845,
+            2805.6594,
+            2795.8007,
+            2767.2754,
+            2833.842
           ],
           "peakWorkingSetBytes": [
-            318996480,
-            316833792,
-            316006400,
-            317825024,
-            316973056,
-            316104704,
-            318865408
+            320425984,
+            319266816,
+            321261568,
+            318795776,
+            323534848,
+            324120576,
+            320589824
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 982.3944,
-          "medianPeakWorkingSetBytes": 322650112,
+          "medianElapsedMilliseconds": 1011.3009,
+          "medianPeakWorkingSetBytes": 329961472,
           "elapsedMilliseconds": [
-            949.4206,
-            1073.7196,
-            963.0919,
-            993.9284,
-            1075.0218,
-            982.3944,
-            918.3786
+            1011.3009,
+            946.2785,
+            945.583,
+            1027.7539,
+            935.5279,
+            1583.8437,
+            1051.056
           ],
           "peakWorkingSetBytes": [
-            323256320,
-            319688704,
-            328351744,
-            322650112,
-            322461696,
-            329375744,
-            311386112
+            329961472,
+            332582912,
+            328626176,
+            328409088,
+            328908800,
+            331694080,
+            333402112
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 910.0667,
-          "medianPeakWorkingSetBytes": 325115904,
+          "medianElapsedMilliseconds": 974.4423,
+          "medianPeakWorkingSetBytes": 331116544,
           "elapsedMilliseconds": [
-            935.5388,
-            884.0064,
-            910.0667,
-            1174.4562,
-            1018.4942,
-            900.539,
-            898.7582
+            947.8292,
+            1424.2738,
+            954.3686,
+            1038.2425,
+            1075.3197,
+            974.4423,
+            959.8692
           ],
           "peakWorkingSetBytes": [
-            321806336,
-            329084928,
-            324386816,
-            329129984,
-            325115904,
-            326430720,
-            321871872
+            329621504,
+            332165120,
+            331116544,
+            331841536,
+            331104256,
+            331808768,
+            330285056
           ]
         }
       ]
@@ -1744,100 +1744,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 763.2784,
-          "medianPeakWorkingSetBytes": 115019776,
+          "medianElapsedMilliseconds": 856.2157,
+          "medianPeakWorkingSetBytes": 117452800,
           "elapsedMilliseconds": [
-            748.3874,
-            749.9452,
-            780.1337,
-            748.7846,
-            767.3463,
-            763.2784,
-            766.5077
+            813.4799,
+            963.7992,
+            1273.4724,
+            856.2157,
+            863.391,
+            778.9966,
+            775.4357
           ],
           "peakWorkingSetBytes": [
-            114327552,
-            115089408,
-            114987008,
-            112275456,
-            115400704,
-            116707328,
-            115019776
+            116723712,
+            119930880,
+            118779904,
+            117698560,
+            117452800,
+            117149696,
+            116617216
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 768.2812,
-          "medianPeakWorkingSetBytes": 115318784,
+          "medianElapsedMilliseconds": 796.9191,
+          "medianPeakWorkingSetBytes": 116719616,
           "elapsedMilliseconds": [
-            762.8923,
-            768.2812,
-            768.1074,
-            781.7544,
-            838.1749,
-            806.0313,
-            763.2394
+            816.1293,
+            801.0443,
+            787.0837,
+            778.7001,
+            803.4081,
+            796.9191,
+            784.3048
           ],
           "peakWorkingSetBytes": [
-            114356224,
-            115810304,
-            115646464,
-            115023872,
-            115318784,
-            112898048,
-            115580928
+            113573888,
+            116719616,
+            118767616,
+            117571584,
+            118464512,
+            113725440,
+            116383744
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 401.381,
-          "medianPeakWorkingSetBytes": 116224000,
+          "medianElapsedMilliseconds": 405.5623,
+          "medianPeakWorkingSetBytes": 112316416,
           "elapsedMilliseconds": [
-            396.3881,
-            406.5513,
-            403.6066,
-            398.9629,
-            401.381,
-            416.1997,
-            386.7873
+            412.7426,
+            410.9869,
+            405.5623,
+            419.2096,
+            401.7072,
+            402.5196,
+            401.1879
           ],
           "peakWorkingSetBytes": [
-            116224000,
-            116355072,
-            116629504,
-            116080640,
-            116072448,
-            116903936,
-            116166656
+            111828992,
+            112451584,
+            114724864,
+            111566848,
+            112316416,
+            112394240,
+            112144384
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 427.6332,
-          "medianPeakWorkingSetBytes": 116236288,
+          "medianElapsedMilliseconds": 411.8811,
+          "medianPeakWorkingSetBytes": 112619520,
           "elapsedMilliseconds": [
-            398.3431,
-            393.4496,
-            395.0501,
-            434.2664,
-            471.7958,
-            427.6332,
-            437.0509
+            408.0237,
+            422.8783,
+            426.2438,
+            411.8811,
+            414.4948,
+            409.476,
+            406.8593
           ],
           "peakWorkingSetBytes": [
-            116981760,
-            115900416,
-            114274304,
-            116236288,
-            117903360,
-            117198848,
-            115142656
+            113086464,
+            112746496,
+            112353280,
+            112640000,
+            112316416,
+            112410624,
+            112619520
           ]
         }
       ]
@@ -2663,100 +2663,100 @@
           "mode": "cold",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 478.9858,
-          "medianPeakWorkingSetBytes": 90533888,
+          "medianElapsedMilliseconds": 465.9803,
+          "medianPeakWorkingSetBytes": 90845184,
           "elapsedMilliseconds": [
-            464.4867,
-            475.0383,
-            490.9836,
-            490.9514,
-            504.6387,
-            467.1542,
-            478.9858
+            472.5331,
+            463.1425,
+            471.3504,
+            471.3547,
+            461.4724,
+            463.8626,
+            465.9803
           ],
           "peakWorkingSetBytes": [
-            90533888,
-            89976832,
-            90124288,
-            91070464,
-            90660864,
-            90415104,
-            90693632
+            90857472,
+            91418624,
+            90845184,
+            90808320,
+            91197440,
+            90664960,
+            90746880
           ]
         },
         {
           "mode": "cold",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 503.8273,
-          "medianPeakWorkingSetBytes": 90730496,
+          "medianElapsedMilliseconds": 472.3773,
+          "medianPeakWorkingSetBytes": 90685440,
           "elapsedMilliseconds": [
-            515.9594,
-            502.0043,
-            476.5579,
-            503.8273,
-            483.2454,
-            551.9325,
-            589.6398
+            473.7178,
+            477.3124,
+            469.4729,
+            478.1402,
+            472.0575,
+            472.0311,
+            472.3773
           ],
           "peakWorkingSetBytes": [
-            90841088,
-            90267648,
-            90873856,
-            90537984,
-            90066944,
-            91017216,
-            90730496
+            91418624,
+            90275840,
+            90685440,
+            90836992,
+            90660864,
+            91197440,
+            90537984
           ]
         },
         {
           "mode": "warm",
           "order": "importance-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 223.3175,
-          "medianPeakWorkingSetBytes": 91860992,
+          "medianElapsedMilliseconds": 206.6511,
+          "medianPeakWorkingSetBytes": 91987968,
           "elapsedMilliseconds": [
-            237.3139,
-            223.3175,
-            213.8131,
-            200.3682,
-            222.783,
-            225.2083,
-            236.0111
+            207.7116,
+            205.4656,
+            206.6511,
+            203.9102,
+            199.2335,
+            216.8355,
+            221.775
           ],
           "peakWorkingSetBytes": [
-            91643904,
-            92221440,
-            91746304,
-            91656192,
-            91860992,
-            92475392,
-            92479488
+            91541504,
+            91230208,
+            92454912,
+            91955200,
+            92073984,
+            92012544,
+            91987968
           ]
         },
         {
           "mode": "warm",
           "order": "focus-v1",
           "repetitions": 7,
-          "medianElapsedMilliseconds": 235.3027,
-          "medianPeakWorkingSetBytes": 92450816,
+          "medianElapsedMilliseconds": 253.8648,
+          "medianPeakWorkingSetBytes": 93028352,
           "elapsedMilliseconds": [
-            235.3027,
-            261.0536,
-            216.4641,
-            221.286,
-            230.6797,
-            244.2924,
-            241.2528
+            253.8648,
+            250.036,
+            217.2992,
+            478.2785,
+            228.3768,
+            322.9631,
+            269.9147
           ],
           "peakWorkingSetBytes": [
-            92356608,
-            93184000,
-            92450816,
-            91930624,
-            92680192,
-            93835264,
-            91885568
+            92807168,
+            93167616,
+            92094464,
+            94420992,
+            92594176,
+            93028352,
+            94068736
           ]
         }
       ]
@@ -2772,19 +2772,19 @@
     },
     "allRequiredRegressions": 0,
     "warmIncrementalMilliseconds": {
-      "devprojex": -72.32770000000005,
-      "repomix": 26.252200000000016,
-      "flask": 11.985199999999992
+      "devprojex": -36.85859999999991,
+      "repomix": 6.31880000000001,
+      "flask": 47.21369999999999
     },
     "warmIncrementalPercent": {
-      "devprojex": -7.36238928072066,
-      "repomix": 6.540469030671611,
-      "flask": 5.366887951011448
+      "devprojex": -3.6446719270199317,
+      "repomix": 1.5580343636477085,
+      "flask": 22.847059609167328
     },
     "maximumPeakWorkingSetGrowthPercent": {
-      "devprojex": 0.7642309450058397,
-      "repomix": 0.25996225205655066,
-      "flask": 0.6420832032817586
+      "devprojex": 0.35006268853110223,
+      "repomix": 0.26986616097151817,
+      "flask": 1.131000089055125
     },
     "recallPassed": true,
     "allRequiredPassed": true,


### PR DESCRIPTION
## What
- separate raw Tree-sitter traversal limits from useful dependency-fact limits and report bounded extraction explicitly
- preserve JavaScript/TypeScript import syntax, Python lexical import ownership, C# alias scope, absolute qualification, and transitive project visibility
- restore reference names in dependency evidence and handle transient unsupported-file metadata failures per file
- replace flaky complexity assertions with deterministic work counters and keep wall-clock checks local-only
- refresh the frozen focus evaluation without changing its registry, weights, seeds, gold sets, or budgets

## Why
Dependency extraction could silently lose a late import, materialize quadratic call text, bind lexical imports or aliases outside their scope, and choose the wrong package condition for dynamic imports in CommonJS files. Those outcomes made the graph depend on formatting or syntax placement instead of language semantics.

## Compatibility and safety
- no new CLI or MCP options
- existing resolution statuses and fixed diagnostic reasons remain unchanged
- project-controlled reference names appear only in edge evidence/result data
- unsupported-file I/O remains fail-closed and transient failures are not cached
- the frozen focus release gate still passes

## Validation
- targeted dependency integration tests: 96 passed, 1 platform-specific skip
- targeted real-process related/related_files tests: 6 passed
- RankingEval metric tests: 8 passed
- Release TerminalHost build: 0 warnings