### PR TITLE
Harden secret and Git trust boundaries

### DIFF
--- a/Application/Services/FileContentAnalyzer.cs
+++ b/Application/Services/FileContentAnalyzer.cs
@@ -911,20 +911,12 @@ public sealed class FileContentAnalyzer :
 		string path,
 		int bufferSize,
 		FileShare fileShare,
-		bool asynchronous = false)
-	{
-		UnixFileTypeInspector.EnsureRegularFile(path);
-		// Callers keep this handle for length, probing, and decoding. Besides saving an
-		// extra open/stat cycle, one handle gives each operation a more coherent file view.
-		return new FileStream(
+		bool asynchronous = false) =>
+		UnixFileTypeInspector.OpenRegularFileForSequentialRead(
 			path,
-			FileMode.Open,
-			FileAccess.Read,
-			fileShare,
 			bufferSize,
-			FileOptions.SequentialScan |
-			(asynchronous ? FileOptions.Asynchronous : FileOptions.None));
-	}
+			fileShare,
+			asynchronous);
 
 	private static bool HasKnownBinaryExtension(string path)
 	{

--- a/Application/Services/UnixFileTypeInspector.cs
+++ b/Application/Services/UnixFileTypeInspector.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace DevProjex.Application.Services;
 
@@ -7,6 +8,9 @@ public static class UnixFileTypeInspector
 {
 	private const uint FileTypeMask = 0xF000;
 	private const uint RegularFileType = 0x8000;
+	private const int ReadOnly = 0;
+	private const int GetFileStatusFlags = 3;
+	private const int SetFileStatusFlags = 4;
 
 	public static bool IsPhysicalDirectoryOrRegularFile(string path, FileAttributes attributes) =>
 		!attributes.HasFlag(FileAttributes.ReparsePoint) &&
@@ -27,12 +31,7 @@ public static class UnixFileTypeInspector
 		if (result != 0)
 			ThrowForLastError(path);
 
-		var mode = OperatingSystem.IsMacOS()
-			? buffer.MacOsMode
-			: RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-				? buffer.LinuxArm64Mode
-				: buffer.LinuxX64Mode;
-		return (mode & FileTypeMask) == RegularFileType;
+		return (GetMode(buffer) & FileTypeMask) == RegularFileType;
 	}
 
 	public static void EnsureRegularFile(string path)
@@ -40,6 +39,79 @@ public static class UnixFileTypeInspector
 		if (!IsRegularFile(path))
 			throw new IOException("The source entry is not a regular file.");
 	}
+
+	internal static FileStream OpenRegularFileForSequentialRead(
+		string path,
+		int bufferSize,
+		FileShare fileShare,
+		bool asynchronous,
+		Action? beforeOpen = null)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(path);
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
+		beforeOpen?.Invoke();
+		if (OperatingSystem.IsWindows())
+		{
+			return new FileStream(
+				path,
+				FileMode.Open,
+				FileAccess.Read,
+				fileShare,
+				bufferSize,
+				FileOptions.SequentialScan |
+				(asynchronous ? FileOptions.Asynchronous : FileOptions.None));
+		}
+
+		var nonBlocking = OperatingSystem.IsMacOS() ? 0x4 : 0x800;
+		var closeOnExec = OperatingSystem.IsMacOS() ? 0x1000000 : 0x80000;
+		var noFollow = OperatingSystem.IsMacOS() ? 0x100 : 0x20000;
+		var descriptor = OperatingSystem.IsMacOS()
+			? MacOsOpen(path, ReadOnly | nonBlocking | closeOnExec | noFollow)
+			: LinuxOpen(path, ReadOnly | nonBlocking | closeOnExec | noFollow);
+		if (descriptor < 0)
+			ThrowForLastError(path);
+
+		var handle = new SafeFileHandle((IntPtr)descriptor, ownsHandle: true);
+		try
+		{
+			NativeStatBuffer buffer;
+			var statusResult = OperatingSystem.IsMacOS()
+				? RuntimeInformation.ProcessArchitecture == Architecture.X64
+					? MacOsX64FStat(descriptor, out buffer)
+					: MacOsFStat(descriptor, out buffer)
+				: LinuxFStat(descriptor, out buffer);
+			if (statusResult != 0)
+				ThrowForLastError(path);
+			if ((GetMode(buffer) & FileTypeMask) != RegularFileType)
+				throw new IOException("The source entry is not a regular file.");
+
+			var currentFlags = OperatingSystem.IsMacOS()
+				? MacOsFcntl(descriptor, GetFileStatusFlags, 0)
+				: LinuxFcntl(descriptor, GetFileStatusFlags, 0);
+			if (currentFlags < 0)
+				ThrowForLastError(path);
+			var blockingResult = OperatingSystem.IsMacOS()
+				? MacOsFcntl(descriptor, SetFileStatusFlags, currentFlags & ~nonBlocking)
+				: LinuxFcntl(descriptor, SetFileStatusFlags, currentFlags & ~nonBlocking);
+			if (blockingResult != 0)
+				ThrowForLastError(path);
+
+			var stream = new FileStream(handle, FileAccess.Read, bufferSize, asynchronous);
+			handle = null!;
+			return stream;
+		}
+		finally
+		{
+			handle?.Dispose();
+		}
+	}
+
+	private static uint GetMode(NativeStatBuffer buffer) =>
+		OperatingSystem.IsMacOS()
+			? buffer.MacOsMode
+			: RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+				? buffer.LinuxArm64Mode
+				: buffer.LinuxX64Mode;
 
 	private static void ThrowForLastError(string path)
 	{
@@ -66,6 +138,31 @@ public static class UnixFileTypeInspector
 	private static extern int MacOsX64LStat(
 		[MarshalAs(UnmanagedType.LPUTF8Str)] string path,
 		out NativeStatBuffer buffer);
+
+	[DllImport("libc", EntryPoint = "open", SetLastError = true)]
+	private static extern int LinuxOpen(
+		[MarshalAs(UnmanagedType.LPUTF8Str)] string path,
+		int flags);
+
+	[DllImport("libSystem.B.dylib", EntryPoint = "open", SetLastError = true)]
+	private static extern int MacOsOpen(
+		[MarshalAs(UnmanagedType.LPUTF8Str)] string path,
+		int flags);
+
+	[DllImport("libc", EntryPoint = "fstat", SetLastError = true)]
+	private static extern int LinuxFStat(int descriptor, out NativeStatBuffer buffer);
+
+	[DllImport("libSystem.B.dylib", EntryPoint = "fstat", SetLastError = true)]
+	private static extern int MacOsFStat(int descriptor, out NativeStatBuffer buffer);
+
+	[DllImport("libSystem.B.dylib", EntryPoint = "fstat$INODE64", SetLastError = true)]
+	private static extern int MacOsX64FStat(int descriptor, out NativeStatBuffer buffer);
+
+	[DllImport("libc", EntryPoint = "fcntl", SetLastError = true)]
+	private static extern int LinuxFcntl(int descriptor, int command, int argument);
+
+	[DllImport("libSystem.B.dylib", EntryPoint = "fcntl", SetLastError = true)]
+	private static extern int MacOsFcntl(int descriptor, int command, int argument);
 
 	[StructLayout(LayoutKind.Explicit, Size = 256)]
 	private struct NativeStatBuffer

--- a/Application/Services/UnixFileTypeInspector.cs
+++ b/Application/Services/UnixFileTypeInspector.cs
@@ -96,7 +96,9 @@ public static class UnixFileTypeInspector
 			if (blockingResult != 0)
 				ThrowForLastError(path);
 
-			var stream = new FileStream(handle, FileAccess.Read, bufferSize, asynchronous);
+			// A descriptor created outside FileStream has no runtime async-handle marker.
+			// Keep it synchronous here; ReadAsync remains supported by FileStream's fallback.
+			var stream = new FileStream(handle, FileAccess.Read, bufferSize, isAsync: false);
 			handle = null!;
 			return stream;
 		}

--- a/Docs/Git-Safety.md
+++ b/Docs/Git-Safety.md
@@ -114,6 +114,14 @@ Before materializing files, DevProjex reads the effective filter declarations wi
 
 There is no wildcard filter override in Git. If the filter registry cannot be read or a driver name cannot be represented safely, checkout fails closed. The registered forms are detached checkout, branch checkout/reset, hard reset, worktree add/remove/prune, and the fixed `extensions.worktreeConfig` / `devprojex.branch` tracking writes. Missing objects do not trigger a fetch. Consequently, an LFS pointer or another smudge-managed file remains a pointer until a future explicit feature provides a reviewed download path; the diagnostic trace names the disabled drivers instead of making that substitution silent.
 
+Git driver subsection names are case-sensitive, so DevProjex preserves and
+disables `filter.Foo` and `filter.foo` independently; section names and property
+names remain case-insensitive. For the fixed `git config --get-regexp` safety
+query, exit code 0 is parsed and exit code 1 with empty output means no matches.
+Any other exit code, missing process result, or output-limit breach makes the
+inspection unavailable, and managed checkout and change-scope requests fail
+closed without including Git output in the user-facing diagnostic.
+
 ## ExplicitNetwork
 
 `ExplicitNetwork` is used only after validating a remote source and deciding that network access is part of the requested operation. Clone is fixed to:

--- a/Docs/HideSecrets.md
+++ b/Docs/HideSecrets.md
@@ -77,8 +77,12 @@ DevProjex ships a reviewed managed port of the default Gitleaks
   opaque binary payload cannot be redacted in place;
 - keyword prescreening limits which bounded regular expressions inspect a file;
 - entropy thresholds and upstream allowlists preserve the pinned rule semantics;
-- `gitleaks:allow` suppresses findings on that line;
+- inline markers such as `gitleaks:allow` in project content do not suppress findings;
 - expressions use the managed non-backtracking .NET engine with a timeout.
+
+Redaction exceptions are controlled only by the operator through DevProjex
+configuration. File content is untrusted input and cannot exempt itself from
+redaction in GUI, CLI, or MCP output.
 
 ### Scope-aware configuration rules
 

--- a/Docs/Security.md
+++ b/Docs/Security.md
@@ -16,6 +16,14 @@ limits documented in [McpServer.md](McpServer.md),
 | File system | MCP tools are annotated read-only and non-destructive for the source project. Remote checkouts and stored packs live in application-owned managed cache or temporary session storage; the source project is not written. Cache checkout writes require an active lease and a path inside the application-owned repository container. |
 | Supply chain | Grammar sources and secret-detection rules are pinned and hash-verified. Release channels require content receipts, static completeness checks, mutation gates, and real-entry-point smoke tests before publication. Published container artifacts include build provenance; the other channel-specific evidence is described in the release process. |
 
+Secret-redaction exceptions are operator-controlled. Project content is
+untrusted input, so inline markers such as `gitleaks:allow` cannot grant an
+exception in GUI, CLI, or MCP output.
+
+Temporary redaction data is stored in private per-user directories. After an
+abnormal termination it can remain until a later DevProjex startup runs the
+scavenger, which removes stale directories once they are more than 24 hours old.
+
 ## What is not guaranteed
 
 - Secret detection is not proof that output is safe or clean. It covers reviewed

--- a/Infrastructure/Git/GitRepositorySafetyInspector.cs
+++ b/Infrastructure/Git/GitRepositorySafetyInspector.cs
@@ -13,6 +13,11 @@ internal sealed record GitRepositorySafetyInspection(
 		new([], [], [], OldGitPromisorRepository: true, IsComplete: false);
 }
 
+internal sealed record GitInspectionProcessResult(
+	int ExitCode,
+	string Output,
+	bool ExceededOutputLimit = false);
+
 internal static class GitRepositorySafetyInspector
 {
 	private const int MaximumOutputCharacters = 256 * 1024;
@@ -25,15 +30,36 @@ internal static class GitRepositorySafetyInspector
 			repositoryPath,
 			GitProcessOperation.ReadConfigValue(GitConfigReadKind.UnsafeDrivers),
 			cancellationToken).ConfigureAwait(false);
-		if (filterResult is null)
+		var inspection = InterpretUnsafeDriverResult(filterResult);
+		if (!inspection.IsComplete)
 			return GitRepositorySafetyInspection.Unavailable;
 
-		var checkoutDrivers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		var unsafeWorkingDrivers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		var diffDrivers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		if (filterResult.ExitCode == 0)
+		var oldGitPromisor = false;
+		if (!GitRuntime.IsAtLeastVersion(2, 45))
 		{
-			foreach (var rawLine in filterResult.Output.Split(
+			var promisorResult = await RunAsync(
+				repositoryPath,
+				GitProcessOperation.ReadConfigValue(GitConfigReadKind.PromisorRemotes),
+				cancellationToken).ConfigureAwait(false);
+			if (!TryInterpretQueryResult(promisorResult, out oldGitPromisor))
+				return GitRepositorySafetyInspection.Unavailable;
+		}
+
+		return inspection with { OldGitPromisorRepository = oldGitPromisor };
+	}
+
+	internal static GitRepositorySafetyInspection InterpretUnsafeDriverResult(
+		GitInspectionProcessResult? result)
+	{
+		if (!TryInterpretQueryResult(result, out var hasMatches))
+			return GitRepositorySafetyInspection.Unavailable;
+
+		var checkoutDrivers = new HashSet<string>(StringComparer.Ordinal);
+		var unsafeWorkingDrivers = new HashSet<string>(StringComparer.Ordinal);
+		var diffDrivers = new HashSet<string>(StringComparer.Ordinal);
+		if (hasMatches)
+		{
+			foreach (var rawLine in result!.Output.Split(
 				         ['\r', '\n'],
 				         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
 			{
@@ -63,22 +89,11 @@ internal static class GitRepositorySafetyInspector
 			}
 		}
 
-		var oldGitPromisor = false;
-		if (!GitRuntime.IsAtLeastVersion(2, 45))
-		{
-			var promisorResult = await RunAsync(
-				repositoryPath,
-				GitProcessOperation.ReadConfigValue(GitConfigReadKind.PromisorRemotes),
-				cancellationToken).ConfigureAwait(false);
-			oldGitPromisor = promisorResult is null ||
-			                 promisorResult.ExitCode == 0 && !string.IsNullOrWhiteSpace(promisorResult.Output);
-		}
-
 		return new GitRepositorySafetyInspection(
-			checkoutDrivers.Order(StringComparer.OrdinalIgnoreCase).ToArray(),
-			unsafeWorkingDrivers.Order(StringComparer.OrdinalIgnoreCase).ToArray(),
-			diffDrivers.Order(StringComparer.OrdinalIgnoreCase).ToArray(),
-			oldGitPromisor);
+			checkoutDrivers.Order(StringComparer.Ordinal).ToArray(),
+			unsafeWorkingDrivers.Order(StringComparer.Ordinal).ToArray(),
+			diffDrivers.Order(StringComparer.Ordinal).ToArray(),
+			OldGitPromisorRepository: false);
 	}
 
 	public static void TraceDisabledMaterializationFilters(GitRepositorySafetyInspection inspection)
@@ -109,6 +124,21 @@ internal static class GitRepositorySafetyInspector
 		return driver.Length <= 256 &&
 		       driver.All(static character =>
 			       char.IsAsciiLetterOrDigit(character) || character is '-' or '_' or '.');
+	}
+
+	private static bool TryInterpretQueryResult(
+		GitInspectionProcessResult? result,
+		out bool hasMatches)
+	{
+		hasMatches = false;
+		if (result is null || result.ExceededOutputLimit)
+			return false;
+		if (result.ExitCode == 0)
+		{
+			hasMatches = !string.IsNullOrWhiteSpace(result.Output);
+			return true;
+		}
+		return result.ExitCode == 1 && string.IsNullOrEmpty(result.Output);
 	}
 
 	private static async Task<GitInspectionProcessResult?> RunAsync(
@@ -153,9 +183,10 @@ internal static class GitRepositorySafetyInspector
 			}
 			var standardOutput = await output.ConfigureAwait(false);
 			var standardError = await error.ConfigureAwait(false);
-			return standardOutput.ExceededLimit || standardError.ExceededLimit
-				? null
-				: new GitInspectionProcessResult(process.ExitCode, standardOutput.Text);
+			return new GitInspectionProcessResult(
+				process.ExitCode,
+				standardOutput.Text,
+				standardOutput.ExceededLimit || standardError.ExceededLimit);
 		}
 		catch (OperationCanceledException)
 		{
@@ -166,6 +197,4 @@ internal static class GitRepositorySafetyInspector
 			return null;
 		}
 	}
-
-	private sealed record GitInspectionProcessResult(int ExitCode, string Output);
 }

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -23,8 +23,6 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	private static readonly TimeSpan NonBacktrackingRegexTimeout = TimeSpan.FromSeconds(2);
 	private static readonly TimeSpan BacktrackingRegexTimeout = TimeSpan.FromMilliseconds(250);
 	private const string ResourceSuffix = ".Secrets.Rules.gitleaks-v8.30.1.toml";
-	private static readonly string EmbeddedConfigurationFileName = $"gitleaks-{RulesVersion}.toml";
-	private const string GitleaksAllowSignature = "gitleaks:allow";
 	private const string GenericApiKeyRuleId = "generic-api-key";
 	private const string PrivateKeyRuleId = "private-key";
 	private static readonly SearchValues<char> GenericDelimiters = SearchValues.Create("=>|:?,");
@@ -368,8 +366,6 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 					var lineRange = lineIndex.GetContainingLine(valueMatch.Index, valueMatch.Length);
 					var line = content.Slice(lineRange.Start, lineRange.Length);
-					if (line.Contains(GitleaksAllowSignature, StringComparison.Ordinal))
-						continue;
 					var secret = secretGroup.Value;
 					if (rule.Entropy > 0 && CalculateShannonEntropy(secret) <= rule.Entropy)
 						continue;
@@ -409,13 +405,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	private static bool ShouldInspectPath(
 		CompiledConfiguration configuration,
 		string normalizedPath) =>
-		!IsEmbeddedConfigurationPath(normalizedPath) &&
 		!configuration.GlobalAllowlists.Any(
 			allowlist => allowlist.AllowsWholeFileByPath(normalizedPath));
-
-	private static bool IsEmbeddedConfigurationPath(string normalizedPath) =>
-		normalizedPath.Equals(EmbeddedConfigurationFileName, StringComparison.OrdinalIgnoreCase) ||
-		normalizedPath.EndsWith('/' + EmbeddedConfigurationFileName, StringComparison.OrdinalIgnoreCase);
 
 	private static bool HasGenericApiKeyEvidence(ReadOnlySpan<char> content)
 	{

--- a/Tests/DevProjex.Tests.Integration/GitSafeProfileAdversarialIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitSafeProfileAdversarialIntegrationTests.cs
@@ -148,6 +148,89 @@ public sealed class GitSafeProfileAdversarialIntegrationTests
 	}
 
 	[Fact]
+	public async Task ManagedCheckoutDisablesCaseDistinctFilterDriversWithoutExecutingEither()
+	{
+		using var fixture = await HostileGitFixture.CreateAsync(TestContext.Current.CancellationToken);
+		var container = fixture.CreateManagedContainer("case-distinct-managed");
+		var basePath = Path.Combine(container, RepositoryCacheLayout.BaseDirectoryName);
+		Directory.Move(fixture.RepositoryPath, basePath);
+		fixture.RepositoryPath = basePath;
+		await File.WriteAllTextAsync(
+			Path.Combine(basePath, ".gitattributes"),
+			"tracked.txt filter=foo\n",
+			TestContext.Current.CancellationToken);
+		fixture.RunGit("add", ".gitattributes");
+		fixture.RunGit("commit", "-m", "case-sensitive filter attribute");
+		fixture.RunGit("config", "filter.Foo.smudge", "cat");
+		fixture.RunGit("config", "filter.foo.smudge", fixture.CreateMarkerCommand("lowercase-smudge"));
+		File.Delete(Path.Combine(basePath, "tracked.txt"));
+
+		var inspection = await GitRepositorySafetyInspector.InspectAsync(
+			basePath,
+			TestContext.Current.CancellationToken);
+		Assert.True(inspection.IsComplete);
+		Assert.Contains("Foo", inspection.CheckoutFilterDrivers);
+		Assert.Contains("foo", inspection.CheckoutFilterDrivers);
+
+		await using var lease = await RepositoryFileLease.AcquireExclusiveAsync(
+			RepositoryCacheLayout.GetBaseOperationLockPath(container, basePath),
+			TestContext.Current.CancellationToken);
+		await RunProtectedAsync(
+			basePath,
+			GitProcessOperation.ManagedCheckout(
+				GitManagedCheckoutKind.HardReset,
+				"HEAD",
+				filterDrivers: inspection.CheckoutFilterDrivers),
+			TestContext.Current.CancellationToken);
+
+		Assert.False(File.Exists(fixture.MarkerPath("lowercase-smudge")));
+	}
+
+	[Fact]
+	public async Task CorruptRepositoryConfigMakesInspectionCheckoutAndScopeUnavailable()
+	{
+		using var fixture = await HostileGitFixture.CreateAsync(TestContext.Current.CancellationToken);
+		var container = fixture.CreateManagedContainer("corrupt-managed");
+		var basePath = Path.Combine(container, RepositoryCacheLayout.BaseDirectoryName);
+		Directory.Move(fixture.RepositoryPath, basePath);
+		fixture.RepositoryPath = basePath;
+		await File.AppendAllTextAsync(
+			Path.Combine(basePath, ".git", "config"),
+			"\n[broken\n",
+			TestContext.Current.CancellationToken);
+
+		var inspection = await GitRepositorySafetyInspector.InspectAsync(
+			basePath,
+			TestContext.Current.CancellationToken);
+		Assert.False(inspection.IsComplete);
+
+		var service = new GitRepositoryService(allowFileTransportForTests: true);
+		Assert.False(await service.SwitchBranchAsync(
+			basePath,
+			"main",
+			cancellationToken: TestContext.Current.CancellationToken));
+
+		var worktrees = new GitWorktreeManager();
+		Assert.False(await worktrees.PreparePrimaryAsync(
+			basePath,
+			"main",
+			TestContext.Current.CancellationToken));
+
+		var scope = await new GitScopePathProvider(PlatformGitPathComparisonSemanticsResolver.Instance).ResolveAsync(
+			basePath,
+			GitFilteringMode.Changes,
+			diffRange: null,
+			TestContext.Current.CancellationToken);
+		Assert.False(scope.IsAvailable);
+		Assert.Equal("Git safety configuration could not be inspected.", scope.FailureReason);
+		Assert.Null(scope.FailureDetail);
+		var diagnostic = GitScopeFilter.CreateUnavailableDiagnostic(basePath, scope);
+		Assert.Equal(GitScopeFilter.UnavailableDiagnosticCode, diagnostic.Code);
+		Assert.Equal("Git safety configuration could not be inspected.", diagnostic.Message);
+		Assert.Null(diagnostic.Detail);
+	}
+
+	[Fact]
 	public async Task ExplicitNetworkRejectsMutableRepositoryTransportOverridesBeforeFetch()
 	{
 		using var fixture = await HostileGitFixture.CreateAsync(TestContext.Current.CancellationToken);

--- a/Tests/DevProjex.Tests.Terminal/SecretRedactionCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/SecretRedactionCommandContractTests.cs
@@ -862,6 +862,34 @@ public sealed class SecretRedactionCommandContractTests
 		}
 	}
 
+	[Fact]
+	public async Task ExportContext_HideSecretsIgnoresInlineAllowMarkerFromProjectContent()
+	{
+		using var workspace = CreateWorkspace(includeSecret: false);
+		workspace.Temporary.WriteFile(
+			"project/src/inline-allow.cs",
+			$"const string token = \"{GithubToken}\"; // gitleaks:allow\n");
+		var environment = new TestTerminalEnvironment();
+
+		var exitCode = await RunAsync(
+			workspace,
+			environment,
+			[
+				"export", "context", workspace.ProjectRoot,
+				"--view", "content",
+				"--format", "text",
+				"--git-mode", "none",
+				"--hide-secrets",
+				"--plain",
+				"-o", "-"
+			]);
+
+		Assert.Equal(CommandLineExitCodes.Success, exitCode);
+		Assert.DoesNotContain(GithubToken, environment.StandardOutput, StringComparison.Ordinal);
+		Assert.Contains("DEVPROJEX_REDACTED[github-pat#1]", environment.StandardOutput, StringComparison.Ordinal);
+		Assert.Empty(environment.StandardError);
+	}
+
 	[Theory]
 	[InlineData("folder")]
 	[InlineData("zip")]

--- a/Tests/DevProjex.Tests.Unit/GitRepositorySafetyInspectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositorySafetyInspectorTests.cs
@@ -1,0 +1,66 @@
+namespace DevProjex.Tests.Unit;
+
+public sealed class GitRepositorySafetyInspectorTests
+{
+	[Fact]
+	public void InterpretUnsafeDriverResult_ExitZeroPreservesCaseDistinctDriverNames()
+	{
+		var inspection = GitRepositorySafetyInspector.InterpretUnsafeDriverResult(
+			new GitInspectionProcessResult(
+				0,
+				"filter.Foo.smudge\nfilter.foo.smudge\nFILTER.Bar.CLEAN\n" +
+				"diff.Q.textconv\ndiff.q.command\ndiff.external\n"));
+
+		Assert.True(inspection.IsComplete);
+		Assert.Equal(["Bar", "Foo", "foo"], inspection.CheckoutFilterDrivers);
+		Assert.Equal(["Bar"], inspection.UnsafeWorkingTreeDrivers);
+		Assert.Equal(["Q", "external", "q"], inspection.ExternalDiffDrivers);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(1)]
+	public void InterpretUnsafeDriverResult_EmptySuccessfulQueryMeansNoDrivers(int exitCode)
+	{
+		var inspection = GitRepositorySafetyInspector.InterpretUnsafeDriverResult(
+			new GitInspectionProcessResult(exitCode, string.Empty));
+
+		Assert.True(inspection.IsComplete);
+		Assert.Empty(inspection.CheckoutFilterDrivers);
+		Assert.Empty(inspection.UnsafeWorkingTreeDrivers);
+		Assert.Empty(inspection.ExternalDiffDrivers);
+	}
+
+	[Fact]
+	public void InterpretUnsafeDriverResult_ExitOneWithOutputIsUnavailable()
+	{
+		var inspection = GitRepositorySafetyInspector.InterpretUnsafeDriverResult(
+			new GitInspectionProcessResult(1, "unexpected"));
+
+		Assert.False(inspection.IsComplete);
+	}
+
+	[Fact]
+	public void InterpretUnsafeDriverResult_Exit128IsUnavailable()
+	{
+		var inspection = GitRepositorySafetyInspector.InterpretUnsafeDriverResult(
+			new GitInspectionProcessResult(128, string.Empty));
+
+		Assert.False(inspection.IsComplete);
+	}
+
+	[Fact]
+	public void InterpretUnsafeDriverResult_NullProcessResultIsUnavailable()
+	{
+		Assert.False(GitRepositorySafetyInspector.InterpretUnsafeDriverResult(null).IsComplete);
+	}
+
+	[Fact]
+	public void InterpretUnsafeDriverResult_OutputLimitIsUnavailable()
+	{
+		var inspection = GitRepositorySafetyInspector.InterpretUnsafeDriverResult(
+			new GitInspectionProcessResult(0, "filter.safe.smudge", ExceededOutputLimit: true));
+
+		Assert.False(inspection.IsComplete);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -171,14 +171,24 @@ public sealed class GitleaksSecretDetectorTests
 	}
 
 	[Fact]
-	public void Detect_BundledConfigurationPath_DoesNotReportRuleExamplesAsSecrets()
+	public void Detect_ProjectFileNamedLikeBundledConfiguration_IsInspectedLikeAnyOtherToml()
 	{
-		var ruleExample = "bedrock-api-" + "key-YmVkcm9jay5hbWF6b25hd3MuY29t";
+		const string token = "ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL";
+		const string content = "token = \"" + token + "\"";
 
-		Assert.Empty(Detector.Detect(
+		var obvious = Detector.Detect(
+			"obvious.toml",
+			content,
+			TestContext.Current.CancellationToken);
+		var resourceNamed = Detector.Detect(
 			"Infrastructure/Secrets/Rules/gitleaks-v8.30.1.toml",
-			ruleExample,
-			TestContext.Current.CancellationToken));
+			content,
+			TestContext.Current.CancellationToken);
+
+		Assert.NotEmpty(obvious);
+		Assert.Equal(
+			obvious.Select(static finding => (finding.RuleId, finding.Value)),
+			resourceNamed.Select(static finding => (finding.RuleId, finding.Value)));
 	}
 
 	[Fact]
@@ -371,11 +381,14 @@ public sealed class GitleaksSecretDetectorTests
 	}
 
 	[Fact]
-	public void Detect_GitleaksAllowMarker_SuppressesFindingOnThatLine()
+	public void Detect_GitleaksAllowMarker_IsUntrustedContentAndDoesNotSuppressFinding()
 	{
 		const string content = "const token = \"ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL\"; // gitleaks:allow";
 
-		Assert.Empty(Detector.Detect("src/example.cs", content, TestContext.Current.CancellationToken));
+		// Project content cannot grant itself an exception from operator-controlled redaction.
+		Assert.Single(
+			Detector.Detect("src/example.cs", content, TestContext.Current.CancellationToken),
+			static finding => finding.RuleId == "github-pat");
 	}
 
 	[Fact]
@@ -392,7 +405,7 @@ public sealed class GitleaksSecretDetectorTests
 	}
 
 	[Fact]
-	public void Detect_GitleaksAllowMarker_AppliesToTheFullMultilineMatchContext()
+	public void Detect_GitleaksAllowMarker_DoesNotSuppressAMultilineFinding()
 	{
 		const string content =
 			"-----BEGIN " + "PRIVATE KEY-----\n" +
@@ -401,13 +414,14 @@ public sealed class GitleaksSecretDetectorTests
 			"Ks14IReLcYgA" + "DhoXk56ZzXI=\n" +
 			"-----END " + "PRIVATE KEY----- // gitleaks:allow";
 
-		Assert.DoesNotContain(
+		// The marker is untrusted even when it occurs inside the finding's multiline context.
+		Assert.Contains(
 			Detector.Detect("src/key.pem", content, TestContext.Current.CancellationToken),
 			static finding => finding.RuleId == "private-key");
 	}
 
 	[Fact]
-	public void Detect_MultilineAllowMarkerDoesNotSuppressANestedFindingFromALaterRule()
+	public void Detect_MultilineAllowMarkerSuppressesNeitherOuterNorNestedFinding()
 	{
 		var pulumiToken = "pul-" + string.Concat(Enumerable.Repeat("a7d9b3c5", 5));
 		var content =
@@ -419,7 +433,8 @@ public sealed class GitleaksSecretDetectorTests
 
 		var findings = Detector.Detect("src/key.pem", content, TestContext.Current.CancellationToken);
 
-		Assert.DoesNotContain(findings, static finding => finding.RuleId == "private-key");
+		// One content-controlled marker must not suppress either finding.
+		Assert.Contains(findings, static finding => finding.RuleId == "private-key");
 		var nested = Assert.Single(findings, static finding => finding.RuleId == "pulumi-api-token");
 		Assert.Equal(pulumiToken, nested.Value);
 	}
@@ -463,6 +478,7 @@ public sealed class GitleaksSecretDetectorTests
 		var content = new string('x', 1024 * 1024) +
 		              string.Concat(Enumerable.Range(0, findingCount).Select(index =>
 			              $" token{index}=\"{token}\";")) +
+		              " // gitleaks:allow " +
 		              new string('y', 1024 * 1024);
 		var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
 

--- a/Tests/DevProjex.Tests.Unit/SecretFileOpenTrustBoundaryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SecretFileOpenTrustBoundaryTests.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using DevProjex.Application.Services;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class SecretFileOpenTrustBoundaryTests
+{
+	[Fact]
+	public async Task UnixRegularFileReplacedByFifoBeforeOpenIsRejectedWithoutWaitingForWriter()
+	{
+		if (OperatingSystem.IsWindows())
+			Assert.Skip("FIFO trust-boundary coverage is Unix-only.");
+
+		using var temporary = new TemporaryDirectory();
+		var path = temporary.CreateFile("candidate.txt", "safe");
+		Assert.True(UnixFileTypeInspector.IsRegularFile(path));
+		var openTask = Task.Run(() => Record.Exception(() =>
+		{
+			using var stream = UnixFileTypeInspector.OpenRegularFileForSequentialRead(
+				path,
+				bufferSize: 1,
+				FileShare.ReadWrite | FileShare.Delete,
+				asynchronous: false,
+				beforeOpen: () =>
+				{
+					File.Delete(path);
+					CreateFifoOrSkip(path);
+				});
+		}));
+
+		var completed = await Task.WhenAny(
+			openTask,
+			Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+		Assert.Same(openTask, completed);
+		Assert.IsType<IOException>(await openTask);
+	}
+
+	[Fact]
+	public async Task FileContentAnalyzerRejectsFifoWithoutWaitingForWriter()
+	{
+		if (OperatingSystem.IsWindows())
+			Assert.Skip("FIFO trust-boundary coverage is Unix-only.");
+
+		using var temporary = new TemporaryDirectory();
+		var path = Path.Combine(temporary.Path, "source.txt");
+		CreateFifoOrSkip(path);
+		var readTask = Task.Run(async () =>
+			await new FileContentAnalyzer().ReadClassifiedAsync(
+				path,
+				1024,
+				TestContext.Current.CancellationToken));
+
+		var completed = await Task.WhenAny(
+			readTask,
+			Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+		Assert.Same(readTask, completed);
+		Assert.Equal(FileContentClassification.Unreadable, (await readTask).Classification);
+	}
+
+	private static void CreateFifoOrSkip(string path)
+	{
+		var startInfo = new ProcessStartInfo("mkfifo")
+		{
+			UseShellExecute = false,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		startInfo.ArgumentList.Add(path);
+		try
+		{
+			using var process = Process.Start(startInfo);
+			if (process is null)
+				Assert.Skip("mkfifo could not be started.");
+			var output = process.StandardOutput.ReadToEnd();
+			var error = process.StandardError.ReadToEnd();
+			if (!process.WaitForExit(5_000))
+			{
+				process.Kill(entireProcessTree: true);
+				Assert.Skip("mkfifo did not complete within five seconds.");
+			}
+			if (process.ExitCode != 0)
+				Assert.Skip($"mkfifo is unavailable: {error}{output}");
+		}
+		catch (System.ComponentModel.Win32Exception)
+		{
+			Assert.Skip("mkfifo is not available in this environment.");
+		}
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/SecretFileOpenTrustBoundaryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SecretFileOpenTrustBoundaryTests.cs
@@ -57,6 +57,27 @@ public sealed class SecretFileOpenTrustBoundaryTests
 		Assert.Equal(FileContentClassification.Unreadable, (await readTask).Classification);
 	}
 
+	[Fact]
+	public async Task UnixDescriptorOpenSupportsAnAsynchronousReadConsumer()
+	{
+		if (OperatingSystem.IsWindows())
+			Assert.Skip("Unix descriptor coverage is Unix-only.");
+
+		using var temporary = new TemporaryDirectory();
+		var path = temporary.CreateFile("source.txt", "safe");
+		await using var stream = UnixFileTypeInspector.OpenRegularFileForSequentialRead(
+			path,
+			bufferSize: 1,
+			FileShare.ReadWrite | FileShare.Delete,
+			asynchronous: true);
+		var buffer = new byte[4];
+
+		var read = await stream.ReadAsync(buffer, TestContext.Current.CancellationToken);
+
+		Assert.Equal(4, read);
+		Assert.Equal("safe", Encoding.UTF8.GetString(buffer));
+	}
+
 	private static void CreateFifoOrSkip(string path)
 	{
 		var startInfo = new ProcessStartInfo("mkfifo")


### PR DESCRIPTION
## Summary
- ignore project-controlled `gitleaks:allow` markers and scan project files named like the embedded rules resource
- open Unix content through a nonblocking, descriptor-validated regular-file path
- preserve case-distinct Git driver names and fail closed when the safety query is unavailable
- document the redaction, temporary-data, and Git inspection trust boundaries

## Targeted verification
- `GitleaksSecretDetectorTests`, `SmartSecretsDetectorTests`, `GitRepositorySafetyInspectorTests`, `SecretFileOpenTrustBoundaryTests`, `FileContentAnalyzerTests`
- `SecretRedactionCommandContractTests`, `DocumentationAndPackagingContractTests`
- `SecretRedactionOutputContractIntegrationTests`, `GitSafeProfileAdversarialIntegrationTests`

Unix FIFO assertions are platform-specific and will execute on Linux/macOS CI.