### PR TITLE
fix(mcp): honor config inheritance and validate selections

### DIFF
--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -153,7 +153,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	  "type": "array",
 	  "maxItems": 256,
 	  "items": { "type": "string", "minLength": 1, "maxLength": 4096 },
-	  "description": "Existing project-relative files or directories that narrow the selection."
+	  "description": "Existing project-relative files or directories that narrow the selection. Values are literal paths: *, ?, {, and [ are ordinary filename characters here, not glob syntax."
 	}
 	""";
 
@@ -250,6 +250,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	  "properties": {
 	    {{ProjectProperty}},
 	    {{BranchProperty}},
+	    {{PathsProperty}},
 	    {{IncludeProperty}},
 	    {{ExcludeProperty}}{{(agentExclusions ? ExclusionsPropertyFragment() : "")}},
 	    {{TrackedOnlyProperty}},
@@ -329,6 +330,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	    {{ProjectProperty}},
 	    {{BranchProperty}},
 	    "pattern": { "type": "string", "minLength": 1, "maxLength": 4096, "description": "A .NET regular expression, limited to 4,096 characters and a 2-second evaluation timeout, applied after redaction. Text inserted by redaction never matches." },
+	    {{PathsProperty}},
 	    {{IncludeProperty}},
 	    {{ExcludeProperty}}{{(agentExclusions ? ExclusionsPropertyFragment() : "")}},
 	    {{TrackedOnlyProperty}},
@@ -348,7 +350,8 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	  "type": "object",
 	  "properties": {
 	    {{ProjectProperty}},
-	    {{BranchProperty}}{{(agentExclusions ? ExclusionsPropertyFragment() : "")}},
+	    {{BranchProperty}},
+	    {{ProfileProperty}}{{(agentExclusions ? ExclusionsPropertyFragment() : "")}},
 	    "path": { "type": "string", "minLength": 1, "description": "Existing file path inside the effective project selection. Markdown-escaped names copied from the default get_tree format are accepted ('\\_'-style ASCII punctuation); use get_tree with format=text to copy unescaped names." },
 	    "start_line": { "description": "First 1-based line of the returned text after replacements; integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] },
 	    "end_line": { "description": "Last 1-based line of the returned text after replacements, inclusive; integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] }

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -11,6 +11,7 @@ internal sealed class DevProjexMcpTools(
 	bool agentExclusions = false)
 {
 	private const int MaximumTreeLines = 2_000;
+	private const int MaximumTreeCharacters = 50_000;
 	private const int MaximumInlinePackCharacters = 50_000;
 	internal const int MaximumStoredPackResponseCharacters = 50_000;
 	private const int MaximumStoredTreePreviewCharacters = 38_000;
@@ -77,7 +78,7 @@ internal sealed class DevProjexMcpTools(
 		});
 
 	[Description(
-		"Returns the filtered project structure without file contents. Use it to orient before reading; use analyze instead for size and token metrics, or pack_context for multi-file content. Returns Markdown, text, JSON, or XML and limits large text trees to a complete depth within 2,000 lines. project accepts a unique name or path from list_projects, or an allowed remote Git URL. Key parameters: format=markdown|text|json|xml, max_depth=0..1000, git_scope=staged|changes|diff:<ref>..<ref>, plus include/exclude patterns and max_file_bytes.")]
+		"Returns the filtered project structure without file contents. Use it to orient before reading; use analyze instead for size and token metrics, or pack_context for multi-file content. Returns Markdown, text, JSON, or XML and limits large text trees within 2,000 lines and 50,000 characters. project accepts a unique name or path from list_projects, or an allowed remote Git URL. Key parameters: paths narrows to literal files or directories; format=markdown|text|json|xml; max_depth=0..1000; git_scope=staged|changes|diff:<ref>..<ref>; include/exclude patterns and max_file_bytes narrow further.")]
 	public Task<CallToolResult> GetTree(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>
@@ -88,6 +89,7 @@ internal sealed class DevProjexMcpTools(
 				WithAgentArguments(
 					"project",
 					"branch",
+					"paths",
 					"include_patterns",
 					"exclude_patterns",
 					"max_depth",
@@ -96,22 +98,25 @@ internal sealed class DevProjexMcpTools(
 					"max_file_bytes",
 					"format"));
 			var format = ParseTreeFormat(arguments.OptionalString("format") ?? "markdown");
+			var paths = ParsePaths(arguments);
 			var includePatterns = arguments.OptionalStringArray("include_patterns");
 			var excludePatterns = arguments.OptionalStringArray("exclude_patterns");
+			var depth = arguments.OptionalInteger("max_depth", 0, 1_000);
+			var maximumFileBytes = arguments.OptionalInt64("max_file_bytes", 1, long.MaxValue);
 			var plan = await Projects.BuildPlanAsync(
 				arguments.OptionalString("project"),
 				arguments.OptionalString("branch"),
-				paths: null,
+				paths,
 				includePatterns,
 				excludePatterns,
 				profile: null,
 				arguments.OptionalBoolean("tracked_only", false),
 				arguments.OptionalString("git_scope"),
-				arguments.OptionalInt64("max_file_bytes", 1, long.MaxValue),
+				maximumFileBytes,
 				cancellationToken,
 				includeOutputMetrics: false,
-				exclusions: ParseExclusionsArgument(arguments)).ConfigureAwait(false);
-			var depth = arguments.OptionalInteger("max_depth", 0, 1_000);
+				exclusions: ParseExclusionsArgument(arguments),
+				tolerateMissingPaths: true).ConfigureAwait(false);
 			var depthFit = CalculateTreeDepthFit(
 				plan.ProjectedTree,
 				format,
@@ -130,7 +135,7 @@ internal sealed class DevProjexMcpTools(
 					plan.ProjectedTree,
 					effectiveDepth.Value,
 					cancellationToken);
-			using var treeWriter = new McpBoundedLineTextWriter(MaximumTreeLines);
+			using var treeWriter = new McpBoundedLineTextWriter(MaximumTreeLines, MaximumTreeCharacters);
 			try
 			{
 				await Projects.TreeExportService.WriteFullTreeAsync(
@@ -146,16 +151,19 @@ internal sealed class DevProjexMcpTools(
 			{
 				if (format is TreeTextFormat.Json or TreeTextFormat.Xml)
 				{
+					var guidance = !depthFit.FullTreeFits
+						? $"pass max_depth: {depthFit.DeepestCompleteDepth} for a complete document, " +
+						  "or narrow paths, include_patterns, and exclude_patterns, then retry."
+						: "narrow paths, include_patterns, or exclude_patterns, then retry.";
 					throw new McpToolException(
 						McpErrorCodes.PayloadTruncated,
 						$"{McpErrorCodes.PayloadTruncated}: the {format.ToString().ToLowerInvariant()} tree exceeds " +
-						$"the {MaximumTreeLines}-line result limit; pass max_depth: {depthFit.DeepestCompleteDepth} " +
-						"for a complete document, or narrow include_patterns and exclude_patterns, then retry.");
+						$"the {MaximumTreeLines}-line or {MaximumTreeCharacters}-character result limit; {guidance}");
 				}
 			}
 
 			var treeTruncationNotice = treeWriter.IsTruncated
-				? "[Tree truncated at 2000 lines. Narrow include_patterns, exclude_patterns, or max_depth.]"
+				? "[Tree truncated at 2000 lines or 50000 characters. Narrow paths, include_patterns, exclude_patterns, or max_depth.]"
 				: automaticDepth is { } selectedDepth
 					? $"[Tree limited to depth {selectedDepth} of {depthFit.FullDepth} to fit {MaximumTreeLines} lines; " +
 					  "pass max_depth or include_patterns for a subtree.]"
@@ -168,7 +176,7 @@ internal sealed class DevProjexMcpTools(
 					plan,
 					includeFilters: true,
 					new McpSelectionNoticeContext(
-						HasPaths: false,
+						HasPaths: HasItems(paths),
 						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns)))));
 		}, cancellationToken);
 
@@ -536,6 +544,7 @@ internal sealed class DevProjexMcpTools(
 			var packId = arguments.RequiredString("pack_id");
 			var start = arguments.OptionalInteger("start_line", 1, int.MaxValue);
 			var end = arguments.OptionalInteger("end_line", 1, int.MaxValue);
+			ValidateLineRange(start, end);
 			var pack = packs.ResolveDocument(packId);
 			var page = await ReadFilePageAsync(
 					pack,
@@ -553,7 +562,7 @@ internal sealed class DevProjexMcpTools(
 		});
 
 	[Description(
-		"Searches safe transformed project text with a timed .NET regular expression. Use it to locate symbols or phrases; use related_files instead for static dependency links, or get_file for a known file page. Returns path:line:text matches, merged context groups separated by --, and the count of additional matches beyond max_results; line numbers refer to returned text after replacements, and generated redaction replacements never match. Key parameters: pattern, context_lines=0..20, ignore_case=true|false, max_results=1..200, git_scope=staged|changes|diff:<ref>..<ref>, patterns, and max_file_bytes.")]
+		"Searches safe transformed project text with a timed .NET regular expression. Use it to locate symbols or phrases; use related_files instead for static dependency links, or get_file for a known file page. Returns path:line:text matches, merged context groups separated by --, and the count of additional matches beyond max_results; line numbers refer to returned text after replacements, and generated redaction replacements never match. Key parameters: pattern; paths narrows to literal files or directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further.")]
 	public Task<CallToolResult> SearchProject(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>
@@ -565,6 +574,7 @@ internal sealed class DevProjexMcpTools(
 					"project",
 					"branch",
 					"pattern",
+					"paths",
 					"include_patterns",
 					"exclude_patterns",
 					"context_lines",
@@ -578,13 +588,14 @@ internal sealed class DevProjexMcpTools(
 			var ignoreCase = arguments.OptionalBoolean("ignore_case", true);
 			var maximumResults = arguments.OptionalInteger("max_results", 1, 200) ?? 50;
 			var regex = new McpSearchRegex(pattern, ignoreCase);
+			var paths = ParsePaths(arguments);
 			var includePatterns = arguments.OptionalStringArray("include_patterns");
 			var excludePatterns = arguments.OptionalStringArray("exclude_patterns");
 
 			var plan = await Projects.BuildPlanAsync(
 				arguments.OptionalString("project"),
 				arguments.OptionalString("branch"),
-				paths: null,
+				paths,
 				includePatterns,
 				excludePatterns,
 				profile: null,
@@ -593,7 +604,8 @@ internal sealed class DevProjexMcpTools(
 				arguments.OptionalInt64("max_file_bytes", 1, long.MaxValue),
 				cancellationToken,
 				includeOutputMetrics: false,
-				exclusions: ParseExclusionsArgument(arguments)).ConfigureAwait(false);
+				exclusions: ParseExclusionsArgument(arguments),
+				tolerateMissingPaths: true).ConfigureAwait(false);
 			var output = new StringBuilder();
 			var totalMatches = 0;
 			var shownMatches = 0;
@@ -652,7 +664,7 @@ internal sealed class DevProjexMcpTools(
 					plan,
 					includeFilters: false,
 					new McpSelectionNoticeContext(
-						HasPaths: false,
+						HasPaths: HasItems(paths),
 						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns)))));
 		}, cancellationToken);
 
@@ -742,7 +754,7 @@ internal sealed class DevProjexMcpTools(
 		}, cancellationToken);
 
 	[Description(
-		"Reads one page of one selected file after mandatory secret and configured private-data replacement. Use it after get_tree or search_project; use pack_context instead for multiple files. Returns untrusted file text up to 1,000 lines or 50,000 characters plus continuation notes; line numbers refer to this returned text after replacements. Required: path. Optional start_line and end_line are inclusive 1-based integers or numeric strings. Files outside effective filters are unavailable; content beyond the safe inspection limit fails explicitly with DPX-MCP-PAYLOAD-TRUNCATED.")]
+		"Reads one page of one selected file after mandatory secret and configured private-data replacement. Use it after get_tree or search_project; use pack_context instead for multiple files. Returns untrusted file text up to 1,000 lines or 50,000 characters plus continuation notes; line numbers refer to this returned text after replacements. Required: path. Optional profile applies the same selection profile as analyze and pack_context; start_line and end_line are inclusive 1-based integers or numeric strings. Files outside effective filters are unavailable; content beyond the safe inspection limit fails explicitly with DPX-MCP-PAYLOAD-TRUNCATED.")]
 	public Task<CallToolResult> GetFile(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>
@@ -753,19 +765,23 @@ internal sealed class DevProjexMcpTools(
 				WithAgentArguments(
 					"project",
 					"branch",
+					"profile",
 					"path",
 					"start_line",
 					"end_line"));
 			// get_file honors the delegated set too: a file revealed by get_tree or
 			// search_project under a per-call exclusions value must stay readable.
 			var requestedPath = arguments.RequiredString("path", allowWhitespace: true);
+			var start = arguments.OptionalInteger("start_line", 1, int.MaxValue);
+			var end = arguments.OptionalInteger("end_line", 1, int.MaxValue);
+			ValidateLineRange(start, end);
 			var plan = await Projects.BuildPlanAsync(
 				arguments.OptionalString("project"),
 				arguments.OptionalString("branch"),
 				paths: [requestedPath],
 				includePatterns: null,
 				excludePatterns: null,
-				profile: null,
+				profile: arguments.OptionalString("profile"),
 				trackedOnly: false,
 				gitScope: null,
 				maximumFileBytes: null,
@@ -789,8 +805,6 @@ internal sealed class DevProjexMcpTools(
 					$"Select a file no larger than {SecretRedactionOutputPreparer.MaximumScannableFileBytes} bytes or narrow the project before retrying.");
 			}
 			var content = read.Content;
-			var start = arguments.OptionalInteger("start_line", 1, int.MaxValue);
-			var end = arguments.OptionalInteger("end_line", 1, int.MaxValue);
 			var page = McpTextRanges.Slice(
 				content.Content,
 				start,
@@ -844,11 +858,7 @@ internal sealed class DevProjexMcpTools(
 		CancellationToken cancellationToken,
 		bool includeOutputMetrics = true)
 	{
-		var paths = arguments.OptionalStringArray(
-			"paths",
-			allowWhitespace: true,
-			maximumItems: McpProjectService.MaximumRequestedPaths,
-			maximumItemScalarValues: McpProjectService.MaximumRequestedPathLength);
+		var paths = ParsePaths(arguments);
 		var includePatterns = arguments.OptionalStringArray("include_patterns");
 		var excludePatterns = arguments.OptionalStringArray("exclude_patterns");
 		var plan = await Projects.BuildPlanAsync(
@@ -1379,6 +1389,23 @@ internal sealed class DevProjexMcpTools(
 					: $" seeds={item.Seeds.ToString(CultureInfo.InvariantCulture)}"))
 			.ToArray();
 		return notices.Length == 0 ? null : string.Join('\n', notices);
+	}
+
+	private static IReadOnlyList<string>? ParsePaths(McpJsonArguments arguments) =>
+		arguments.OptionalStringArray(
+			"paths",
+			allowWhitespace: true,
+			maximumItems: McpProjectService.MaximumRequestedPaths,
+			maximumItemScalarValues: McpProjectService.MaximumRequestedPathLength);
+
+	private static void ValidateLineRange(int? start, int? end)
+	{
+		if (end is null || end >= (start ?? 1))
+			return;
+		throw new McpToolException(
+			McpErrorCodes.InvalidRange,
+			$"{McpErrorCodes.InvalidRange}: requested line range {start ?? 1}-{end} is invalid. " +
+			"Valid lines start at 1 and start_line must not exceed end_line.");
 	}
 
 	private static bool IsSafeNoFactsReason(string? reason) =>

--- a/Apps/Mcp/McpBoundedLineTextWriter.cs
+++ b/Apps/Mcp/McpBoundedLineTextWriter.cs
@@ -25,6 +25,7 @@ internal sealed class McpBoundedLineTextWriter : TextWriter
 
 	public override Encoding Encoding => Encoding.UTF8;
 	public bool IsTruncated { get; private set; }
+	public bool CharacterLimitReached { get; private set; }
 	public string Text
 	{
 		get
@@ -98,14 +99,14 @@ internal sealed class McpBoundedLineTextWriter : TextWriter
 
 			_previousWasCarriageReturn = false;
 			if (_lines.Count >= _maximumLines)
-				ThrowLimitReached();
+				ThrowLimitReached(characterLimit: false);
 			var scalarLength = char.IsHighSurrogate(character) &&
 			                   index + 1 < characters.Length &&
 			                   char.IsLowSurrogate(characters[index + 1])
 				? 2
 				: 1;
 			if (_charactersWritten > _maximumCharacters - scalarLength)
-				ThrowLimitReached();
+				ThrowLimitReached(characterLimit: true);
 			_currentLine.Append(character);
 			_charactersWritten++;
 			if (scalarLength == 2)
@@ -119,18 +120,19 @@ internal sealed class McpBoundedLineTextWriter : TextWriter
 	private void CompleteLine()
 	{
 		if (_lines.Count >= _maximumLines)
-			ThrowLimitReached();
+			ThrowLimitReached(characterLimit: false);
 		if (_charactersWritten >= _maximumCharacters)
-			ThrowLimitReached();
+			ThrowLimitReached(characterLimit: true);
 
 		_lines.Add(_currentLine.ToString());
 		_currentLine.Clear();
 		_charactersWritten++;
 	}
 
-	private void ThrowLimitReached()
+	private void ThrowLimitReached(bool characterLimit)
 	{
 		IsTruncated = true;
+		CharacterLimitReached = characterLimit;
 		throw new McpLineLimitReachedException();
 	}
 }

--- a/Apps/Mcp/McpPackRegistry.cs
+++ b/Apps/Mcp/McpPackRegistry.cs
@@ -47,7 +47,10 @@ public sealed class McpPackRegistry : IDisposable, IAsyncDisposable
 		_maximumPackBytes = maximumPackBytes;
 		_maximumSessionBytes = maximumSessionBytes;
 		TimeProvider = timeProvider ?? TimeProvider.System;
-		var productDirectory = Path.Combine(tempRoot ?? Path.GetTempPath(), "DevProjex");
+		var productDirectory = ResolveProductDirectory(
+			tempRoot,
+			Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR"),
+			Environment.UserName);
 		EnsurePrivateDirectory(productDirectory);
 		var baseDirectory = Path.Combine(productDirectory, "mcp");
 		EnsurePrivateDirectory(baseDirectory);
@@ -85,6 +88,30 @@ public sealed class McpPackRegistry : IDisposable, IAsyncDisposable
 	internal TimeProvider TimeProvider { get; }
 	internal string SessionDirectory => _sessionDirectory;
 	internal Task ScavengingCompletion => _scavengeTask;
+
+	internal static string ResolveProductDirectory(
+		string? tempRoot,
+		string? xdgRuntimeDirectory,
+		string? userName)
+	{
+		if (tempRoot is null &&
+		    !string.IsNullOrWhiteSpace(xdgRuntimeDirectory) &&
+		    Path.IsPathFullyQualified(xdgRuntimeDirectory))
+		{
+			return Path.Combine(Path.GetFullPath(xdgRuntimeDirectory), "DevProjex");
+		}
+
+		var root = Path.GetFullPath(tempRoot ?? Path.GetTempPath());
+		var identity = string.IsNullOrWhiteSpace(userName) ? "user" : userName.Trim();
+		var safeIdentity = new string(identity
+			.Select(static character => char.IsLetterOrDigit(character) || character is '-' or '_'
+				? character
+				: '-')
+			.ToArray());
+		var identityHash = Convert.ToHexString(
+			SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(identity)))[..8].ToLowerInvariant();
+		return Path.Combine(root, $"DevProjex-{safeIdentity}-{identityHash}");
+	}
 
 	public async Task<string> StoreAsync(string content, CancellationToken cancellationToken)
 	{

--- a/Apps/Mcp/McpProjectService.cs
+++ b/Apps/Mcp/McpProjectService.cs
@@ -45,7 +45,8 @@ internal sealed class McpProjectService(
 		long? maximumFileBytes,
 		CancellationToken cancellationToken,
 		bool includeOutputMetrics = true,
-		IReadOnlyList<ProjectExclusion>? exclusions = null)
+		IReadOnlyList<ProjectExclusion>? exclusions = null,
+		bool tolerateMissingPaths = false)
 	{
 		using var selectionStage = ContentPipelineDiagnostics.MeasureStage(ContentPipelineStage.Selection);
 		var parsedScope = ParseGitScope(gitScope);
@@ -141,7 +142,7 @@ internal sealed class McpProjectService(
 				$"{McpErrorCodes.ProjectUnavailable}: project preparation failed ({diagnostic.Code}: {diagnostic.Message}). " +
 				"Fix the reported project access or Git state and retry.");
 		}
-		ValidateRequestedPathCasing(plan, requested);
+		ValidateRequestedPathCasing(plan, requested, tolerateMissingPaths);
 		if (maximumFileBytes is not null)
 			plan = RefreshEffectiveFileSizes(plan);
 		var allowProjectionReuse = parsedScope is null &&
@@ -257,6 +258,8 @@ internal sealed class McpProjectService(
 		var final = await ProjectFileSizeFilter
 			.ApplyAsync(services.Planner, narrowed, maximumFileBytes, cancellationToken)
 			.ConfigureAwait(false);
+		if (tolerateMissingPaths)
+			final = AddMissingRequestedPathDiagnostics(final, requested);
 		ValidatePlanContainment(roots, projectRoot, final.IncludedFiles, cancellationToken);
 		if (allowProjectionReuse)
 		{
@@ -633,7 +636,7 @@ internal sealed class McpProjectService(
 			foreach (var path in includedFolders)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				if (requested.Directories.Contains(path) &&
+				if (MatchesRequested(path, requested.Paths, requested.Directories) &&
 				    !directoriesWithIncludedFiles.Contains(path) &&
 				    globs.IncludesDirectory(ToRelative(projectRoot, path)))
 					projectionPaths.Add(path);
@@ -962,7 +965,8 @@ internal sealed class McpProjectService(
 
 	private static void ValidateRequestedPathCasing(
 		ProjectContextPlan plan,
-		RequestedPathSelection requested)
+		RequestedPathSelection requested,
+		bool tolerateMissingPaths = false)
 	{
 		foreach (var token in requested.Tokens)
 		{
@@ -976,9 +980,35 @@ internal sealed class McpProjectService(
 			var caseMismatch = ResolveCaseMismatch(plan, token.Value);
 			if (caseMismatch is not null)
 				throw caseMismatch;
-			if (token.ResolutionError is not null)
+			if (token.ResolutionError is not null && !tolerateMissingPaths)
 				throw token.ResolutionError;
 		}
+	}
+
+	private static ProjectContextPlan AddMissingRequestedPathDiagnostics(
+		ProjectContextPlan plan,
+		RequestedPathSelection requested)
+	{
+		var missing = requested.Tokens.Where(token =>
+			token.ResolutionError is not null ||
+			token.ResolvedPath is { } resolved &&
+			!(token.IsDirectory
+				? plan.IncludedFolders.Contains(resolved, StringComparer.Ordinal)
+				: plan.IncludedFiles.Contains(resolved, StringComparer.Ordinal))).ToArray();
+		if (missing.Length == 0)
+			return plan;
+		return plan with
+		{
+			Diagnostics =
+			[
+				.. plan.Diagnostics,
+				.. missing.Select(static token => new ContextDiagnostic(
+					"DPX-SELECTION-PATH-MISSING",
+					ContextDiagnosticSeverity.Warning,
+					"A requested path is not present in the effective project tree.",
+					token.Value))
+			]
+		};
 	}
 
 	internal static IReadOnlyList<string> NormalizeRequestedPathTokens(

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -83,7 +83,9 @@ relative import needs an explicit extension while a supported CommonJS context c
 and directory probes. `.mts`/`.mjs` are ESM, `.cts`/`.cjs` are CommonJS, and ordinary
 `.ts`/`.tsx`/`.js`/`.jsx` files default to CommonJS unless the nearest `package.json` has
 `"type": "module"`. Literal `require(...)` calls are import evidence only in such a CommonJS context.
-`node10` (including its `node` alias) and `baseUrl` are marked legacy under the TypeScript 7 contract.
+`moduleResolution` accepts exactly `node10` (including its `node` alias), `classic`, `node16`,
+`nodenext`, and `bundler`, case-insensitively; any other value is reported as unsupported semantics.
+`node10`/`node` and `baseUrl` are marked legacy under the TypeScript 7 contract.
 DevProjex never guesses a `dist` to `src` mapping without configuration, and module references without
 an owning `tsconfig.json` or `jsconfig.json` stay unresolved.
 

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -87,6 +87,17 @@ and directory probes. `.mts`/`.mjs` are ESM, `.cts`/`.cjs` are CommonJS, and ord
 DevProjex never guesses a `dist` to `src` mapping without configuration, and module references without
 an owning `tsconfig.json` or `jsconfig.json` stay unresolved.
 
+TypeScript configuration supports a bounded `extends` chain when every value is one explicit relative
+path inside the project root. At most eight inheritance edges are followed; cycles, arrays, package or
+bare specifiers, and paths outside the root are reported as unsupported semantics. Child
+`compilerOptions` replace inherited values by key. Inherited `paths` and `baseUrl` remain relative to
+the configuration file that declared them, matching TypeScript's configuration-origin semantics;
+the existing legacy `baseUrl` resolution limitation described above still applies.
+Every extended file is included in the configuration fingerprint. A missing base is also recorded as
+an absent control file, so its later appearance invalidates a cached dependency snapshot. When an
+existing base is outside the effective manifest, the manifest-snapshot shortcut is bypassed; this
+keeps later edits observable without widening the selected dependency manifest.
+
 Configuration reads have four explicit outcomes: valid, missing, corrupt, and unsupported semantics.
 A malformed JSON document, a `null` or non-object `compilerOptions`, or an unsupported value shape is
 never replaced by an implicit default. References whose resolution depends on that control file remain

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -238,23 +238,28 @@ open-world.
 | Tool | Parameters | Result and limits |
 |---|---|---|
 | `list_projects` | none | First-call session inventory: allowed local roots with path, name, type, and profiles, plus the server `baseline`. A project tool accepts either a unique listed name or its absolute path. Remote projects are addressed by URL and are not added to this list. |
-| `get_tree` | `project?`, `branch?`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `git_scope?`, `max_file_bytes?`, `max_depth?`, `format?` | Effective tree in `markdown` (default), `text`, `json`, or `xml`; at most 2,000 lines. Without `max_depth`, a large human-readable tree uses the deepest complete depth that fits. |
+| `get_tree` | `project?`, `branch?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `git_scope?`, `max_file_bytes?`, `max_depth?`, `format?` | Effective tree in `markdown` (default), `text`, `json`, or `xml`; at most 2,000 lines and 50,000 characters. Without `max_depth`, a large human-readable tree uses the deepest complete depth that fits. |
 | `analyze` | `project?`, `branch?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `detail?`, `tracked_only?`, `git_scope?`, `top_files?`, `max_file_bytes?` | File, character, and token metrics plus the requested largest files by tokens. Metrics reflect the effective detail level; an uninspected ranked file carries `uninspected: true`. |
 | `pack_context` | `project?`, `branch?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `detail?`, `tracked_only?`, `git_scope?`, `max_tokens?`, `rank?`, `focus?`, `max_file_bytes?`, `view?`, `format?` | Exact DevProjex context pipeline. `max_tokens` limits estimated content tokens. `rank: "importance"` opts into importance-aware admission and document order; `focus` seeds graph-hop order within it. Inline through 50,000 characters; otherwise returns a `pack_id` valid until this server process exits. After restart, call `pack_context` again. |
 | `read_pack` | `pack_id`, `start_line?`, `end_line?` | Pages a stored result from `pack_context` or `related_files`. Inclusive, 1-based range; at most 1,000 lines or 50,000 characters per call. An `end_line` after EOF is clamped and reported. Call the originating tool again after server restart. |
-| `search_project` | `project?`, `branch?`, `pattern`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `git_scope?`, `max_file_bytes?`, `context_lines?`, `ignore_case?`, `max_results?` | Grep-style `path:line:text` matches over safe transformed text; line numbers refer to that returned text after replacements. Overlapping or adjacent context windows are merged and distinct groups use `--`. Regex patterns are limited to 4,096 characters and a 2-second timeout; `max_results` cannot exceed 200, while all additional matches are still counted. Actual text inserted by redaction never matches. Withheld files are counted in the partial-result warning. |
+| `search_project` | `project?`, `branch?`, `pattern`, `paths?`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `git_scope?`, `max_file_bytes?`, `context_lines?`, `ignore_case?`, `max_results?` | Grep-style `path:line:text` matches over safe transformed text; line numbers refer to that returned text after replacements. Overlapping or adjacent context windows are merged and distinct groups use `--`. Regex patterns are limited to 4,096 characters and a 2-second timeout; `max_results` cannot exceed 200, while all additional matches are still counted. Actual text inserted by redaction never matches. Withheld files are counted in the partial-result warning. |
 | `related_files` | `project?`, `branch?`, `path`, `direction?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `tracked_only?`, `git_scope?`, `max_file_bytes?` | Statically evidenced dependencies and dependents for one seed or up to 16 seeds. `direction` is `dependencies`, `dependents`, or `both` (default). Coverage distinguishes recognized supported languages from unsupported files and reports configuration diagnostics. Results larger than 50,000 characters use `read_pack`. |
-| `get_file` | `project?`, `branch?`, `path`, `start_line?`, `end_line?` | Redacted text from one effective file; line numbers refer to the returned text after replacements. At most 1,000 lines or 50,000 characters. An `end_line` after EOF is clamped and reported. A non-empty file that cannot be inspected under the 16 MiB mandatory-redaction boundary returns `DPX-MCP-PAYLOAD-TRUNCATED` with its byte size and the limit; it never returns an empty success. Markdown-escaped names copied from the default `get_tree` format are accepted (`\_` and other ASCII punctuation); use `get_tree` with `format: "text"` to copy unescaped names. |
+| `get_file` | `project?`, `branch?`, `profile?`, `path`, `start_line?`, `end_line?` | Redacted text from one effective file; line numbers refer to the returned text after replacements. At most 1,000 lines or 50,000 characters. An `end_line` after EOF is clamped and reported. A non-empty file that cannot be inspected under the 16 MiB mandatory-redaction boundary returns `DPX-MCP-PAYLOAD-TRUNCATED` with its byte size and the limit; it never returns an empty success. `profile` applies the same effective selection and transformations as `analyze` and `pack_context`. Markdown-escaped names copied from the default `get_tree` format are accepted (`\_` and other ASCII punctuation); use `get_tree` with `format: "text"` to copy unescaped names. |
 
 On a server started with `--allow-agent-exclusions`, `get_tree`, `analyze`,
 `pack_context`, `search_project`, `related_files`, and `get_file` additionally accept the
 `exclusions` array parameter described in the startup section, so a file
 revealed by a per-call value stays readable through the same value.
 
-For `analyze` and `pack_context`, `paths` accepts at most 256 entries and each
+For `get_tree`, `analyze`, `pack_context`, and `search_project`, `paths` accepts
+at most 256 entries and each
 entry is limited to 4,096 Unicode scalar values. Lexically equivalent entries are
 deduplicated before root-jail resolution; every unique path still passes the full
-physical containment check. Regex, glob, and `git_scope` schema lengths use the
+physical containment check. The entries name literal files or directories, so
+`*`, `?`, `{`, and `[` have no glob meaning in `paths`. The selection is narrowed
+before intersection with patterns, Git scope, and `max_file_bytes`; a missing entry
+adds the count-only `DPX-SELECTION-PATH-MISSING` warning while valid entries continue,
+and an empty intersection remains empty. Regex, glob, and `git_scope` schema lengths use the
 same Unicode scalar-value semantics at runtime.
 
 ### `related_files`
@@ -377,8 +382,9 @@ trusted plain-text trailers outside every project spotlight block, such as
 For `get_file` and `read_pack`, a requested `end_line` past EOF returns every
 available line and appends
 `[Showing lines A-N of N; end_line B exceeded the file.]`. A `start_line` past
-EOF or `end_line < start_line` remains `DPX-MCP-INVALID-RANGE` with the valid
-`1-N` interval. If the 1,000-line or 50,000-character page limit is reached
+EOF remains `DPX-MCP-INVALID-RANGE` with the valid `1-N` interval. A syntactically
+reversed range is rejected before any project or pack access and states that lines
+start at 1 and `start_line` must not exceed `end_line`. If the 1,000-line or 50,000-character page limit is reached
 before EOF, the existing
 `[Showing lines A-B of N; continue with start_line=B+1.]` trailer takes priority.
 
@@ -387,18 +393,21 @@ selects the deepest depth whose complete tree fits the 2,000-line limit and
 appends `[Tree limited to depth D of N to fit 2000 lines; pass max_depth or
 include_patterns for a subtree.]`. Node and format-header line counts are
 computed from the selected tree before rendering, so the response never stops
-mid-tree. If depth 1 itself cannot fit, the original first-2,000-line response
-and `[Tree truncated at 2000 lines ...]` trailer remain. An explicit
+mid-tree for the line limit. An independent 50,000-character cap bounds unusually
+long names; human-readable output then carries the same truncation notice. If depth 1 itself cannot fit,
+the original bounded response and `[Tree truncated at 2000 lines or 50000 characters ...]`
+trailer remain. An explicit
 `max_depth` is the caller's choice and retains that same truncation behavior.
 JSON and XML never return partial syntax: overflow remains
-`DPX-MCP-PAYLOAD-TRUNCATED`, and the error names the largest `max_depth` that
-would produce a complete document before offering pattern narrowing.
+`DPX-MCP-PAYLOAD-TRUNCATED`; line overflow names the largest `max_depth` that
+would produce a complete document, while character overflow asks the caller to
+narrow `paths` or patterns.
 The `text` tree writes its project address once, followed directly by the real
 top-level children; it does not repeat the project name as a synthetic tree node.
 Markdown tree Root values and node names escape active CommonMark, HTML, and
 entity syntax so project-controlled labels remain literal data.
 Markdown context project headings and content-only Root lines use the same
-literal escaping. `get_file.path` and `paths` in `analyze` and `pack_context`
+literal escaping. `get_file.path` and `paths` in `get_tree`, `analyze`, `pack_context`, and `search_project`
 accept these escaped spellings when the literal path does not exist; callers can
 also request `get_tree` with `format: "text"` to copy unescaped names.
 Selection warnings are appended outside project spotlight blocks so clients can
@@ -545,10 +554,14 @@ lists alternatives (at most 64 per pattern, 1,024 per array after expansion).
 on every platform — copy names from `get_tree`. Negation (`!`) and character
 classes (`[...]`) are rejected with `DPX-MCP-INVALID-PATTERN` rather than
 matched literally, because a silently empty result reads as "no such files".
-`paths` contains existing project-relative files or directories.
+`paths` contains existing project-relative files or directories for `get_tree`,
+`analyze`, `pack_context`, and `search_project`. Its entries are literal paths;
+glob metacharacters have meaning only in the pattern parameters.
 Numeric parameters accept JSON numbers and decimal numeric strings.
 Boolean parameters accept JSON booleans and the exact strings `"true"` and
 `"false"`.
+Numeric type, sign, published bounds, and line-range ordering are validated before
+the server resolves a project, reads a stored pack, plans files, or prepares content.
 
 `max_tokens` is an integer of at least 1 and accepts either a JSON number or a
 decimal numeric string. It uses the existing estimate of one token per four

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -11,6 +11,13 @@ namespace DevProjex.Infrastructure.Dependencies;
 public sealed class FileDependencyConfigurationProvider : IDependencyConfigurationProvider
 {
 	internal const int MaximumConfigurationBytes = 4 * 1024 * 1024;
+	internal const int MaximumTypeScriptExtendsDepth = 8;
+	internal const string TypeScriptExtendsShapeReason = "tsconfig extends must be one relative path string";
+	internal const string TypeScriptExtendsPackageReason = "tsconfig package extends is not supported";
+	internal const string TypeScriptExtendsOutsideRootReason = "tsconfig extends must stay inside the project root";
+	internal const string TypeScriptExtendsCycleReason = "tsconfig extends cycle is not supported";
+	internal const string TypeScriptExtendsDepthReason = "tsconfig extends exceeds the maximum depth";
+	internal const string TypeScriptExtendsUnavailableReason = "extended tsconfig is unavailable";
 	private readonly IDependencyControlFileReader _reader;
 
 	public FileDependencyConfigurationProvider()
@@ -37,6 +44,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var packageProjections = new Dictionary<string, Task<ConfigurationParseResult<PackageMapDescriptor>>>(PathComparer);
 		var diagnostics = new List<DependencyConfigurationDiagnostic>();
 		var absentControlFiles = new HashSet<string>(PathComparer);
+		var fingerprintedControlFiles = new HashSet<string>(PathComparer);
 		var transientReadFailure = 0;
 
 		Task<DependencyControlFileSnapshot> ReadSnapshotAsync(string path)
@@ -68,13 +76,88 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		async Task<ConfigurationParseResult<PackageMapDescriptor>> ReadPackageCoreAsync(string path)
 		{
 			var snapshot = await ReadSnapshotAsync(path).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, path, snapshot.FingerprintValue));
+			AddFingerprint(path, snapshot);
 			return snapshot.State == DependencyConfigurationState.Valid
 				? ParsePackageMap(Path.GetDirectoryName(path)!, snapshot.Content)
 				: ConfigurationParseResult<PackageMapDescriptor>.Failure(
 					UnavailablePackageMap(Path.GetDirectoryName(path)!, snapshot.State, snapshot.Reason),
 					snapshot.State,
 					snapshot.Reason);
+		}
+
+		void AddFingerprint(string path, DependencyControlFileSnapshot snapshot)
+		{
+			path = Path.GetFullPath(path);
+			if (fingerprintedControlFiles.Add(path))
+				fingerprintParts.Add(Fingerprint(root, path, snapshot.FingerprintValue));
+		}
+
+		async Task<ConfigurationParseResult<TypeScriptConfiguration>> ReadTypeScriptConfigAsync(
+			string configPath,
+			string scopeDirectory)
+		{
+			var chain = new HashSet<string>(PathComparer);
+			var parsed = await ReadTypeScriptLayerAsync(Path.GetFullPath(configPath), 0, chain).ConfigureAwait(false);
+			return parsed.State == DependencyConfigurationState.Valid
+				? ConfigurationParseResult<TypeScriptConfiguration>.Valid(
+					MaterializeTypeScriptConfiguration(parsed.Value, scopeDirectory))
+				: ConfigurationParseResult<TypeScriptConfiguration>.Failure(
+					TypeScriptConfiguration.Default,
+					parsed.State,
+					parsed.Reason);
+		}
+
+		async Task<ConfigurationParseResult<TypeScriptConfigurationLayer>> ReadTypeScriptLayerAsync(
+			string configPath,
+			int depth,
+			HashSet<string> chain)
+		{
+			if (!chain.Add(configPath))
+				return TypeScriptLayerFailure(DependencyConfigurationState.UnsupportedSemantics, TypeScriptExtendsCycleReason);
+
+			try
+			{
+				var snapshot = await ReadSnapshotAsync(configPath).ConfigureAwait(false);
+				AddFingerprint(configPath, snapshot);
+				if (snapshot.State != DependencyConfigurationState.Valid)
+				{
+					return TypeScriptLayerFailure(
+						snapshot.State,
+						snapshot.State == DependencyConfigurationState.Missing && depth > 0
+							? TypeScriptExtendsUnavailableReason
+							: snapshot.Reason);
+				}
+
+				var layer = ParseTypeScriptConfigLayer(configPath, snapshot.Content);
+				if (layer.State != DependencyConfigurationState.Valid || layer.Value.Extends is null)
+					return layer;
+
+				if (depth >= MaximumTypeScriptExtendsDepth)
+					return TypeScriptLayerFailure(DependencyConfigurationState.UnsupportedSemantics, TypeScriptExtendsDepthReason);
+
+				var extendedPath = ResolveTypeScriptExtendsPath(configPath, layer.Value.Extends);
+				if (extendedPath.State != DependencyConfigurationState.Valid)
+					return TypeScriptLayerFailure(extendedPath.State, extendedPath.Reason);
+				if (!IsWithin(root, extendedPath.Value))
+					return TypeScriptLayerFailure(DependencyConfigurationState.UnsupportedSemantics, TypeScriptExtendsOutsideRootReason);
+				// The engine's fast manifest snapshot can validate only files in its manifest.
+				// If an extended control file is outside that set, bypass that snapshot so this
+				// provider observes every later edit instead of reusing configuration by metadata
+				// that never included the base file.
+				if (!manifest.Contains(extendedPath.Value))
+					Interlocked.Exchange(ref transientReadFailure, 1);
+
+				var inherited = await ReadTypeScriptLayerAsync(extendedPath.Value, depth + 1, chain)
+					.ConfigureAwait(false);
+				return inherited.State == DependencyConfigurationState.Valid
+					? ConfigurationParseResult<TypeScriptConfigurationLayer>.Valid(
+						MergeTypeScriptLayers(inherited.Value, layer.Value))
+					: inherited;
+			}
+			finally
+			{
+				chain.Remove(configPath);
+			}
 		}
 
 		void AddDiagnostic(string path, DependencyConfigurationState state, string? reason, params string[] scopeIds)
@@ -92,7 +175,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		foreach (var project in manifest.Where(static path => path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)).Order(StringComparer.Ordinal))
 		{
 			var snapshot = await ReadSnapshotAsync(project).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, project, snapshot.FingerprintValue));
+			AddFingerprint(project, snapshot);
 			var scope = "csharp:" + PortableRelative(root, project);
 			var parsed = snapshot.State == DependencyConfigurationState.Valid
 				? ParseProjectReferences(project, snapshot.Content)
@@ -135,13 +218,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 
 		foreach (var configPath in manifest.Where(IsTypeScriptConfig).Order(StringComparer.Ordinal))
 		{
-			var snapshot = await ReadSnapshotAsync(configPath).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, configPath, snapshot.FingerprintValue));
-			var parsed = snapshot.State == DependencyConfigurationState.Valid
-				? ParseTypeScriptConfig(snapshot.Content)
-				: ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-					TypeScriptConfiguration.Default, snapshot.State, snapshot.Reason);
 			var directory = Path.GetDirectoryName(configPath)!;
+			var parsed = await ReadTypeScriptConfigAsync(configPath, directory).ConfigureAwait(false);
 			var package = FindNearestManifestFile(directory, root, "package.json", manifest);
 			var packageName = package is null ? null : (await ReadPackageAsync(package).ConfigureAwait(false)).Value.PackageName;
 			var scopeId = "typescript:" + PortableRelative(root, configPath);
@@ -168,7 +246,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		foreach (var configPath in manifest.Where(IsPythonConfig).Order(StringComparer.Ordinal))
 		{
 			var snapshot = await ReadSnapshotAsync(configPath).ConfigureAwait(false);
-			fingerprintParts.Add(Fingerprint(root, configPath, snapshot.FingerprintValue));
+			AddFingerprint(configPath, snapshot);
 			var directory = Path.GetDirectoryName(configPath)!;
 			var scopeId = "python:" + PortableRelative(root, configPath);
 			AddDiagnostic(configPath, snapshot.State, snapshot.Reason, scopeId);
@@ -260,7 +338,9 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	private static string NormalizeMsBuildInclude(string value) =>
 		value.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
-	private static ConfigurationParseResult<TypeScriptConfiguration> ParseTypeScriptConfig(string content)
+	private static ConfigurationParseResult<TypeScriptConfigurationLayer> ParseTypeScriptConfigLayer(
+		string configPath,
+		string content)
 	{
 		try
 		{
@@ -270,34 +350,40 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				CommentHandling = JsonCommentHandling.Skip
 			});
 			if (document.RootElement.ValueKind != JsonValueKind.Object)
-				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-					TypeScriptConfiguration.Default,
+				return TypeScriptLayerFailure(
 					DependencyConfigurationState.UnsupportedSemantics,
 					"tsconfig root must be an object");
+
+			var extends = ParseTypeScriptExtends(document.RootElement);
+			if (extends.State != DependencyConfigurationState.Valid)
+				return TypeScriptLayerFailure(extends.State, extends.Reason);
+
 			if (!document.RootElement.TryGetProperty("compilerOptions", out var options))
-				return ConfigurationParseResult<TypeScriptConfiguration>.Valid(TypeScriptConfiguration.Default);
+			{
+				return ConfigurationParseResult<TypeScriptConfigurationLayer>.Valid(
+					TypeScriptConfigurationLayer.Empty with { Extends = extends.Value });
+			}
 			if (options.ValueKind != JsonValueKind.Object)
-				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-					TypeScriptConfiguration.Default,
+				return TypeScriptLayerFailure(
 					DependencyConfigurationState.Corrupt,
 					"tsconfig compilerOptions must be an object");
 			if (options.TryGetProperty("moduleResolution", out var mode) && mode.ValueKind != JsonValueKind.String)
-				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-					TypeScriptConfiguration.Default,
+				return TypeScriptLayerFailure(
 					DependencyConfigurationState.UnsupportedSemantics,
 					"tsconfig compilerOptions.moduleResolution must be a string");
-			var moduleResolution = options.TryGetProperty("moduleResolution", out mode)
-				? mode.GetString() ?? "bundler"
-				: "bundler";
-			var legacy = moduleResolution.Equals("node10", StringComparison.OrdinalIgnoreCase) ||
-			             moduleResolution.Equals("node", StringComparison.OrdinalIgnoreCase) ||
-			             options.TryGetProperty("baseUrl", out _);
-			var allowJavaScript = options.TryGetProperty("allowJs", out var allowJs) &&
-			                      allowJs.ValueKind is JsonValueKind.True;
+
+			var hasModuleResolution = options.TryGetProperty("moduleResolution", out mode);
+			var moduleResolution = hasModuleResolution ? mode.GetString() ?? "bundler" : null;
+			var hasBaseUrl = options.TryGetProperty("baseUrl", out var baseUrlElement);
+			var baseUrl = hasBaseUrl && baseUrlElement.ValueKind == JsonValueKind.String
+				? baseUrlElement.GetString()
+				: null;
+			var hasAllowJavaScript = options.TryGetProperty("allowJs", out var allowJs);
+			var allowJavaScript = hasAllowJavaScript && allowJs.ValueKind is JsonValueKind.True;
 			var paths = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
-			if (options.TryGetProperty("paths", out var mappings) && mappings.ValueKind != JsonValueKind.Object)
-				return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-					TypeScriptConfiguration.Default,
+			var hasPaths = options.TryGetProperty("paths", out var mappings);
+			if (hasPaths && mappings.ValueKind != JsonValueKind.Object)
+				return TypeScriptLayerFailure(
 					DependencyConfigurationState.UnsupportedSemantics,
 					"tsconfig compilerOptions.paths must be an object");
 			if (mappings.ValueKind == JsonValueKind.Object)
@@ -306,25 +392,134 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				{
 					if (mapping.Value.ValueKind != JsonValueKind.Array ||
 					    mapping.Value.EnumerateArray().Any(static item => item.ValueKind != JsonValueKind.String))
-						return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-							TypeScriptConfiguration.Default,
+						return TypeScriptLayerFailure(
 							DependencyConfigurationState.UnsupportedSemantics,
 							"tsconfig path mapping must be an array of strings");
 					paths[mapping.Name] = mapping.Value.EnumerateArray()
 						.Select(static item => item.GetString()!).ToArray();
 				}
 			}
-			return ConfigurationParseResult<TypeScriptConfiguration>.Valid(
-				new TypeScriptConfiguration(moduleResolution, legacy, paths, allowJavaScript));
+			return ConfigurationParseResult<TypeScriptConfigurationLayer>.Valid(
+				new TypeScriptConfigurationLayer(
+					extends.Value,
+					new OptionalConfigurationValue<string>(hasModuleResolution, moduleResolution),
+					new OptionalConfigurationValue<TypeScriptBaseUrl>(
+						hasBaseUrl,
+						hasBaseUrl ? new TypeScriptBaseUrl(Path.GetDirectoryName(configPath)!, baseUrl) : null),
+					new OptionalConfigurationValue<TypeScriptPathMappings>(
+						hasPaths,
+						hasPaths ? new TypeScriptPathMappings(Path.GetDirectoryName(configPath)!, paths) : null),
+					new OptionalConfigurationValue<bool>(hasAllowJavaScript, allowJavaScript)));
 		}
 		catch (JsonException)
 		{
-			return ConfigurationParseResult<TypeScriptConfiguration>.Failure(
-				TypeScriptConfiguration.Default,
+			return TypeScriptLayerFailure(
 				DependencyConfigurationState.Corrupt,
 				"invalid tsconfig JSON");
 		}
 	}
+
+	private static ConfigurationParseResult<string?> ParseTypeScriptExtends(JsonElement root)
+	{
+		if (!root.TryGetProperty("extends", out var extends))
+			return ConfigurationParseResult<string?>.Valid(null);
+		if (extends.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(extends.GetString()))
+			return ConfigurationParseResult<string?>.Failure(
+				null,
+				DependencyConfigurationState.UnsupportedSemantics,
+				TypeScriptExtendsShapeReason);
+
+		var value = extends.GetString()!;
+		if (!IsExplicitRelativeTypeScriptExtends(value))
+			return ConfigurationParseResult<string?>.Failure(
+				null,
+				DependencyConfigurationState.UnsupportedSemantics,
+				TypeScriptExtendsPackageReason);
+		return ConfigurationParseResult<string?>.Valid(value);
+	}
+
+	private static bool IsExplicitRelativeTypeScriptExtends(string value) =>
+		value.StartsWith("./", StringComparison.Ordinal) ||
+		value.StartsWith("../", StringComparison.Ordinal) ||
+		value.StartsWith(".\\", StringComparison.Ordinal) ||
+		value.StartsWith("..\\", StringComparison.Ordinal);
+
+	private static ConfigurationParseResult<string> ResolveTypeScriptExtendsPath(
+		string configPath,
+		string relativePath)
+	{
+		try
+		{
+			var normalized = relativePath
+				.Replace('/', Path.DirectorySeparatorChar)
+				.Replace('\\', Path.DirectorySeparatorChar);
+			return ConfigurationParseResult<string>.Valid(
+				Path.GetFullPath(Path.Combine(Path.GetDirectoryName(configPath)!, normalized)));
+		}
+		catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+		{
+			return ConfigurationParseResult<string>.Failure(
+				string.Empty,
+				DependencyConfigurationState.UnsupportedSemantics,
+				TypeScriptExtendsShapeReason);
+		}
+	}
+
+	private static TypeScriptConfigurationLayer MergeTypeScriptLayers(
+		TypeScriptConfigurationLayer inherited,
+		TypeScriptConfigurationLayer child) =>
+		new(
+			Extends: null,
+			child.ModuleResolution.IsSpecified ? child.ModuleResolution : inherited.ModuleResolution,
+			child.BaseUrl.IsSpecified ? child.BaseUrl : inherited.BaseUrl,
+			child.Paths.IsSpecified ? child.Paths : inherited.Paths,
+			child.AllowJavaScript.IsSpecified ? child.AllowJavaScript : inherited.AllowJavaScript);
+
+	private static TypeScriptConfiguration MaterializeTypeScriptConfiguration(
+		TypeScriptConfigurationLayer layer,
+		string scopeDirectory)
+	{
+		var moduleResolution = layer.ModuleResolution.IsSpecified
+			? layer.ModuleResolution.Value ?? "bundler"
+			: "bundler";
+		var mappings = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+		if (layer.Paths.Value is { } paths)
+		{
+			var mappingRoot = layer.BaseUrl.Value is { } baseUrl
+				? ResolveTypeScriptOptionDirectory(baseUrl.DeclaringDirectory, baseUrl.Value)
+				: paths.DeclaringDirectory;
+			foreach (var mapping in paths.Values)
+			{
+				mappings[mapping.Key] = mapping.Value
+					.Select(target => RebaseTypeScriptPath(scopeDirectory, mappingRoot, target))
+					.ToArray();
+			}
+		}
+		var legacy = moduleResolution.Equals("node10", StringComparison.OrdinalIgnoreCase) ||
+		             moduleResolution.Equals("node", StringComparison.OrdinalIgnoreCase) ||
+		             layer.BaseUrl.IsSpecified;
+		return new TypeScriptConfiguration(
+			moduleResolution,
+			legacy,
+			mappings,
+			layer.AllowJavaScript.IsSpecified && layer.AllowJavaScript.Value);
+	}
+
+	private static string ResolveTypeScriptOptionDirectory(string declaringDirectory, string? relative) =>
+		string.IsNullOrEmpty(relative)
+			? declaringDirectory
+			: Path.GetFullPath(Path.Combine(declaringDirectory, relative));
+
+	private static string RebaseTypeScriptPath(string scopeDirectory, string mappingRoot, string target) =>
+		Path.GetRelativePath(scopeDirectory, Path.GetFullPath(Path.Combine(mappingRoot, target)));
+
+	private static ConfigurationParseResult<TypeScriptConfigurationLayer> TypeScriptLayerFailure(
+		DependencyConfigurationState state,
+		string? reason) =>
+		ConfigurationParseResult<TypeScriptConfigurationLayer>.Failure(
+			TypeScriptConfigurationLayer.Empty,
+			state,
+			reason);
 
 	private static ConfigurationParseResult<PackageMapDescriptor> ParsePackageMap(string directory, string content)
 	{
@@ -610,6 +805,29 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			false,
 			new Dictionary<string, IReadOnlyList<string>>(),
 			false);
+	}
+
+	private readonly record struct OptionalConfigurationValue<T>(bool IsSpecified, T? Value);
+
+	private sealed record TypeScriptBaseUrl(string DeclaringDirectory, string? Value);
+
+	private sealed record TypeScriptPathMappings(
+		string DeclaringDirectory,
+		IReadOnlyDictionary<string, IReadOnlyList<string>> Values);
+
+	private sealed record TypeScriptConfigurationLayer(
+		string? Extends,
+		OptionalConfigurationValue<string> ModuleResolution,
+		OptionalConfigurationValue<TypeScriptBaseUrl> BaseUrl,
+		OptionalConfigurationValue<TypeScriptPathMappings> Paths,
+		OptionalConfigurationValue<bool> AllowJavaScript)
+	{
+		public static readonly TypeScriptConfigurationLayer Empty = new(
+			null,
+			default,
+			default,
+			default,
+			default);
 	}
 }
 

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -18,16 +18,27 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	internal const string TypeScriptExtendsCycleReason = "tsconfig extends cycle is not supported";
 	internal const string TypeScriptExtendsDepthReason = "tsconfig extends exceeds the maximum depth";
 	internal const string TypeScriptExtendsUnavailableReason = "extended tsconfig is unavailable";
+	internal const string TypeScriptModuleResolutionReason = "tsconfig moduleResolution is not supported";
+	internal const string ProjectReferenceConditionReason = "project reference condition could not be evaluated safely";
 	private readonly IDependencyControlFileReader _reader;
+	private readonly IDependencyPathMetadata _pathMetadata;
 
 	public FileDependencyConfigurationProvider()
-		: this(new BoundedDependencyControlFileReader())
+		: this(new BoundedDependencyControlFileReader(), new DependencyPathMetadata())
 	{
 	}
 
 	internal FileDependencyConfigurationProvider(IDependencyControlFileReader reader)
+		: this(reader, new DependencyPathMetadata())
+	{
+	}
+
+	internal FileDependencyConfigurationProvider(
+		IDependencyControlFileReader reader,
+		IDependencyPathMetadata pathMetadata)
 	{
 		_reader = reader ?? throw new ArgumentNullException(nameof(reader));
+		_pathMetadata = pathMetadata ?? throw new ArgumentNullException(nameof(pathMetadata));
 	}
 
 	public async Task<DependencyResolverConfiguration> ReadAsync(
@@ -183,7 +194,14 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			var references = parsed.Value;
 			foreach (var reference in references.Where(reference => !manifest.Contains(reference)))
 			{
-				var exists = File.Exists(reference);
+				if (IsNetworkPath(reference) || !IsWithin(root, reference) ||
+				    !_pathMetadata.TryResolveContainedPath(root, reference, out var physicalReference))
+				{
+					fingerprintParts.Add(Fingerprint(root, project, "project-reference:out-of-manifest"));
+					continue;
+				}
+
+				var exists = _pathMetadata.FileExists(physicalReference);
 				fingerprintParts.Add(Fingerprint(root, reference, exists ? "present" : "missing"));
 				if (!exists)
 					absentControlFiles.Add(reference);
@@ -321,12 +339,29 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		try
 		{
 			var directory = Path.GetDirectoryName(projectPath)!;
-			return ConfigurationParseResult<string[]>.Valid(XDocument.Parse(content).Descendants()
+			var elements = XDocument.Parse(content).Descendants()
 				.Where(static element => element.Name.LocalName == "ProjectReference")
+				.Where(static element => !IsLiteralFalse(element.Attribute("ReferenceOutputAssembly")?.Value))
+				.ToArray();
+			var hasUnknownCondition = elements.Any(static element =>
+			{
+				var condition = element.Attribute("Condition")?.Value;
+				return !string.IsNullOrWhiteSpace(condition) &&
+				       !IsLiteralTrue(condition) &&
+				       !IsLiteralFalse(condition);
+			});
+			var references = elements
+				.Where(static element => IsEnabledProjectReference(element))
 				.Select(element => element.Attribute("Include")?.Value)
 				.Where(static value => !string.IsNullOrWhiteSpace(value))
 				.Select(value => Path.GetFullPath(Path.Combine(directory, NormalizeMsBuildInclude(value!))))
-				.Distinct(PathComparer).Order(StringComparer.Ordinal).ToArray());
+				.Distinct(PathComparer).Order(StringComparer.Ordinal).ToArray();
+			return hasUnknownCondition
+				? ConfigurationParseResult<string[]>.Failure(
+					references,
+					DependencyConfigurationState.UnsupportedSemantics,
+					ProjectReferenceConditionReason)
+				: ConfigurationParseResult<string[]>.Valid(references);
 		}
 		catch (System.Xml.XmlException)
 		{
@@ -373,7 +408,11 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 					"tsconfig compilerOptions.moduleResolution must be a string");
 
 			var hasModuleResolution = options.TryGetProperty("moduleResolution", out mode);
-			var moduleResolution = hasModuleResolution ? mode.GetString() ?? "bundler" : null;
+			var moduleResolution = hasModuleResolution ? mode.GetString()?.ToLowerInvariant() : null;
+			if (hasModuleResolution && !IsSupportedTypeScriptModuleResolution(moduleResolution))
+				return TypeScriptLayerFailure(
+					DependencyConfigurationState.UnsupportedSemantics,
+					TypeScriptModuleResolutionReason);
 			var hasBaseUrl = options.TryGetProperty("baseUrl", out var baseUrlElement);
 			var baseUrl = hasBaseUrl && baseUrlElement.ValueKind == JsonValueKind.String
 				? baseUrlElement.GetString()
@@ -417,6 +456,33 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				DependencyConfigurationState.Corrupt,
 				"invalid tsconfig JSON");
 		}
+	}
+
+	private static bool IsSupportedTypeScriptModuleResolution(string? value) =>
+		value is "node10" or "node" or "classic" or "node16" or "nodenext" or "bundler";
+
+	private static bool IsEnabledProjectReference(XElement element)
+	{
+		if (IsLiteralFalse(element.Attribute("ReferenceOutputAssembly")?.Value))
+			return false;
+		var condition = element.Attribute("Condition")?.Value;
+		return string.IsNullOrWhiteSpace(condition) || IsLiteralTrue(condition);
+	}
+
+	private static bool IsLiteralFalse(string? value) =>
+		NormalizeMsBuildBoolean(value).Equals("false", StringComparison.OrdinalIgnoreCase);
+
+	private static bool IsLiteralTrue(string? value) =>
+		NormalizeMsBuildBoolean(value).Equals("true", StringComparison.OrdinalIgnoreCase);
+
+	private static string NormalizeMsBuildBoolean(string? value)
+	{
+		var normalized = value?.Trim() ?? string.Empty;
+		return normalized.Length >= 2 &&
+		       (normalized[0] == '\'' && normalized[^1] == '\'' ||
+		        normalized[0] == '"' && normalized[^1] == '"')
+			? normalized[1..^1].Trim()
+			: normalized;
 	}
 
 	private static ConfigurationParseResult<string?> ParseTypeScriptExtends(JsonElement root)
@@ -779,6 +845,9 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var relative = Path.GetRelativePath(root, path);
 		return relative != ".." && !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) && !Path.IsPathRooted(relative);
 	}
+	private static bool IsNetworkPath(string path) =>
+		path.StartsWith("\\\\", StringComparison.Ordinal) ||
+		path.StartsWith("//", StringComparison.Ordinal);
 	private static StringComparer PathComparer => OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 	private static string OneLine(string value) => value.Replace('\r', ' ').Replace('\n', ' ').Trim();
 	private sealed record ConfigurationParseResult<T>(
@@ -829,6 +898,83 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			default,
 			default);
 	}
+}
+
+internal interface IDependencyPathMetadata
+{
+	bool FileExists(string path);
+	bool TryResolveContainedPath(string root, string path, out string resolvedPath);
+}
+
+internal sealed class DependencyPathMetadata : IDependencyPathMetadata
+{
+	public bool FileExists(string path) => File.Exists(path);
+
+	public bool TryResolveContainedPath(string root, string path, out string resolvedPath)
+	{
+		root = Path.GetFullPath(root);
+		path = Path.GetFullPath(path);
+		resolvedPath = path;
+		var relative = Path.GetRelativePath(root, path);
+		if (!IsContainedRelative(relative))
+			return false;
+
+		var current = root;
+		var segments = relative.Split(
+			[Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+			StringSplitOptions.RemoveEmptyEntries);
+		for (var index = 0; index < segments.Length; index++)
+		{
+			var candidate = Path.Combine(current, segments[index]);
+			FileAttributes attributes;
+			try
+			{
+				attributes = File.GetAttributes(candidate);
+			}
+			catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
+			{
+				resolvedPath = Path.Combine(current, Path.Combine(segments[index..]));
+				return true;
+			}
+			catch (Exception exception) when (
+				exception is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+			{
+				return false;
+			}
+
+			if (!attributes.HasFlag(FileAttributes.ReparsePoint))
+			{
+				current = candidate;
+				continue;
+			}
+
+			FileSystemInfo info = attributes.HasFlag(FileAttributes.Directory)
+				? new DirectoryInfo(candidate)
+				: new FileInfo(candidate);
+			var linkTarget = info.LinkTarget;
+			if (string.IsNullOrWhiteSpace(linkTarget))
+				return false;
+			var target = Path.GetFullPath(
+				Path.IsPathFullyQualified(linkTarget)
+					? linkTarget
+					: Path.Combine(Path.GetDirectoryName(candidate)!, linkTarget));
+			if (IsNetworkPath(target) || !IsContainedRelative(Path.GetRelativePath(root, target)))
+				return false;
+			current = target;
+		}
+
+		resolvedPath = current;
+		return true;
+	}
+
+	private static bool IsContainedRelative(string relative) =>
+		relative != ".." &&
+		!relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+		!Path.IsPathRooted(relative);
+
+	private static bool IsNetworkPath(string path) =>
+		path.StartsWith("\\\\", StringComparison.Ordinal) ||
+		path.StartsWith("//", StringComparison.Ordinal);
 }
 
 internal interface IDependencyControlFileReader

--- a/Tests/DevProjex.Tests.Integration/DependencyConfigurationInheritanceIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyConfigurationInheritanceIntegrationTests.cs
@@ -161,7 +161,7 @@ public sealed class DependencyConfigurationInheritanceIntegrationTests
 			TestContext.Current.CancellationToken);
 
 		Assert.Empty(result.ConfigurationDiagnostics);
-		Assert.Equal("NodeNext", Assert.Single(result.Scopes, scope => scope.HasConfiguration).ModuleResolution);
+		Assert.Equal("nodenext", Assert.Single(result.Scopes, scope => scope.HasConfiguration).ModuleResolution);
 	}
 
 	[Fact]
@@ -189,7 +189,7 @@ public sealed class DependencyConfigurationInheritanceIntegrationTests
 		Assert.Empty(present.AbsentControlFiles);
 		Assert.Empty(present.ConfigurationDiagnostics);
 		Assert.NotEqual(missing.Fingerprint, present.Fingerprint);
-		Assert.Equal("NodeNext", Assert.Single(present.Scopes, scope => scope.HasConfiguration).ModuleResolution);
+		Assert.Equal("nodenext", Assert.Single(present.Scopes, scope => scope.HasConfiguration).ModuleResolution);
 	}
 
 	[Fact]
@@ -239,6 +239,173 @@ public sealed class DependencyConfigurationInheritanceIntegrationTests
 		Assert.False(scope.AllowJavaScript);
 		Assert.Empty(scope.TypeScriptPaths);
 		Assert.Empty(result.ConfigurationDiagnostics);
+	}
+
+	[Theory]
+	[InlineData("node10", "node10")]
+	[InlineData("NODE", "node")]
+	[InlineData("Classic", "classic")]
+	[InlineData("node16", "node16")]
+	[InlineData("NodeNext", "nodenext")]
+	[InlineData("BUNDLER", "bundler")]
+	public async Task ModuleResolutionUsesTheSupportedCaseInsensitiveVocabulary(string configured, string expected)
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			$"{{\"compilerOptions\":{{\"moduleResolution\":\"{configured}\"}}}}");
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		Assert.Empty(result.ConfigurationDiagnostics);
+		Assert.Equal(expected, Assert.Single(result.Scopes, scope => scope.HasConfiguration).ModuleResolution);
+	}
+
+	[Fact]
+	public async Task UnknownModuleResolutionUsesAConstantDiagnostic()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"future-mode\"}}");
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		var diagnostic = Assert.Single(result.ConfigurationDiagnostics);
+		Assert.Equal(DependencyConfigurationState.UnsupportedSemantics, diagnostic.State);
+		Assert.Equal(FileDependencyConfigurationProvider.TypeScriptModuleResolutionReason, diagnostic.Reason);
+	}
+
+	[Fact]
+	public async Task ProjectReferencesIgnoreFalseAndUnevaluatedConditions()
+	{
+		using var fixture = new TemporaryDirectory();
+		var rootProject = fixture.CreateFile(
+			"Root.csproj",
+			"""
+			<Project>
+			  <ItemGroup>
+			    <ProjectReference Include="Enabled.csproj" Condition="true" />
+			    <ProjectReference Include="False.csproj" Condition="false" />
+			    <ProjectReference Include="Quoted.csproj" Condition="'false'" />
+			    <ProjectReference Include="Unknown.csproj" Condition="'$(Configuration)' == 'Debug'" />
+			    <ProjectReference Include="OutputDisabled.csproj" ReferenceOutputAssembly="false" />
+			  </ItemGroup>
+			</Project>
+			""");
+		var projects = new[]
+		{
+			rootProject,
+			fixture.CreateFile("Enabled.csproj", "<Project />"),
+			fixture.CreateFile("False.csproj", "<Project />"),
+			fixture.CreateFile("Quoted.csproj", "<Project />"),
+			fixture.CreateFile("Unknown.csproj", "<Project />"),
+			fixture.CreateFile("OutputDisabled.csproj", "<Project />")
+		};
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			projects,
+			TestContext.Current.CancellationToken);
+
+		var rootScope = Assert.Single(result.Scopes, scope => scope.ScopeId == "csharp:Root.csproj");
+		Assert.Equal(["csharp:Enabled.csproj"], rootScope.ProjectReferences);
+		Assert.Equal(DependencyConfigurationState.UnsupportedSemantics, rootScope.ConfigurationState);
+		Assert.Equal(
+			FileDependencyConfigurationProvider.ProjectReferenceConditionReason,
+			rootScope.ConfigurationDiagnostic);
+	}
+
+	[Fact]
+	public async Task ExternalAndNetworkProjectReferencesAreRejectedBeforeMetadataAccess()
+	{
+		using var fixture = new TemporaryDirectory();
+		using var outside = new TemporaryDirectory();
+		var safeMissing = Path.Combine(fixture.Path, "Missing.csproj");
+		var project = fixture.CreateFile(
+			"Root.csproj",
+			$"""
+			<Project><ItemGroup>
+			  <ProjectReference Include="Missing.csproj" />
+			  <ProjectReference Include="{Path.Combine(outside.Path, "Outside.csproj")}" />
+			  <ProjectReference Include="\\\\server\\share\\Remote.csproj" />
+			</ItemGroup></Project>
+			""");
+		var metadata = new RecordingPathMetadata();
+		var provider = new FileDependencyConfigurationProvider(
+			new BoundedDependencyControlFileReader(),
+			metadata);
+
+		var result = await provider.ReadAsync(
+			fixture.Path,
+			[project],
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal([safeMissing], metadata.FileExistenceChecks, PathComparer.Default);
+		Assert.All(metadata.ContainmentChecks, path => Assert.True(IsWithin(fixture.Path, path)));
+		Assert.Contains(safeMissing, result.AbsentControlFiles, PathComparer.Default);
+	}
+
+	[Fact]
+	public async Task ProjectReferenceSymlinkOutsideTheRootIsNotProbedAsAControlFile()
+	{
+		using var fixture = new TemporaryDirectory();
+		using var outside = new TemporaryDirectory();
+		var outsideProject = outside.CreateFile("Outside.csproj", "<Project />");
+		var link = Path.Combine(fixture.Path, "Linked.csproj");
+		try
+		{
+			File.CreateSymbolicLink(link, outsideProject);
+		}
+		catch (Exception exception) when (
+			exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+		{
+			Assert.Skip($"File symbolic links are unavailable: {exception.GetType().Name}.");
+			return;
+		}
+		var project = fixture.CreateFile(
+			"Root.csproj",
+			"<Project><ItemGroup><ProjectReference Include=\"Linked.csproj\" /></ItemGroup></Project>");
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[project],
+			TestContext.Current.CancellationToken);
+
+		Assert.DoesNotContain(link, result.AbsentControlFiles, PathComparer.Default);
+	}
+
+	private static bool IsWithin(string root, string path)
+	{
+		var relative = Path.GetRelativePath(root, path);
+		return relative != ".." &&
+		       !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+		       !Path.IsPathRooted(relative);
+	}
+
+	private sealed class RecordingPathMetadata : IDependencyPathMetadata
+	{
+		public List<string> FileExistenceChecks { get; } = [];
+		public List<string> ContainmentChecks { get; } = [];
+
+		public bool FileExists(string path)
+		{
+			FileExistenceChecks.Add(path);
+			return false;
+		}
+
+		public bool TryResolveContainedPath(string root, string path, out string resolvedPath)
+		{
+			ContainmentChecks.Add(path);
+			resolvedPath = path;
+			return true;
+		}
 	}
 
 	private static DependencyFactsEngine CreateEngine() =>

--- a/Tests/DevProjex.Tests.Integration/DependencyConfigurationInheritanceIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyConfigurationInheritanceIntegrationTests.cs
@@ -1,0 +1,246 @@
+using DevProjex.Application.Dependencies;
+using DevProjex.Infrastructure.Dependencies;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class DependencyConfigurationInheritanceIntegrationTests
+{
+	[Fact]
+	public async Task InheritedPathsResolveRelativeToTheConfigThatDeclaredThem()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"extends\":\"./configs/base.json\"}");
+		fixture.CreateFile("configs/base.json", "{\"compilerOptions\":{\"paths\":{\"@model\":[\"../src/model.ts\"]}}}");
+		var source = fixture.CreateFile("src/main.ts", "import { model } from '@model';");
+		var target = fixture.CreateFile("src/model.ts", "export const model = 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge =>
+			edge.Source == "src/main.ts" && edge.Target == "src/model.ts" && edge.Status == ResolutionStatus.Resolved);
+	}
+
+	[Fact]
+	public async Task InheritedBaseUrlAndPathsRetainTheirDeclaringConfigOrigin()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"extends\":\"./configs/base.json\"}");
+		fixture.CreateFile(
+			"configs/base.json",
+			"{\"compilerOptions\":{\"baseUrl\":\"../sources\",\"paths\":{\"@model\":[\"model.ts\"]}}}");
+		var source = fixture.CreateFile("main.ts", "import { model } from '@model';");
+		var target = fixture.CreateFile("sources/model.ts", "export const model = 1;");
+		var configuration = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config, source, target],
+			TestContext.Current.CancellationToken);
+		Assert.Equal([Path.Combine("sources", "model.ts")],
+			Assert.Single(configuration.Scopes, scope => scope.HasConfiguration).TypeScriptPaths["@model"]);
+		Assert.True(Assert.Single(configuration.Scopes, scope => scope.HasConfiguration).LegacyTypeScriptConfiguration);
+	}
+
+	[Fact]
+	public async Task InheritedNodeNextRejectsExtensionlessEsmImport()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"extends\":\"./base.json\"}");
+		fixture.CreateFile("base.json", "{\"compilerOptions\":{\"moduleResolution\":\"NodeNext\"}}");
+		var package = fixture.CreateFile("package.json", "{\"type\":\"module\"}");
+		var source = fixture.CreateFile("main.ts", "import value from './dep';");
+		var target = fixture.CreateFile("dep.ts", "export default 1;");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, package, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, edge => edge.Source == "main.ts" && edge.Reference == "./dep");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Contains(edge.Reasons, reason => reason.Contains("extension required", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task ChildCompilerOptionsOverrideInheritedKeys()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"extends\":\"./base.json\",\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"paths\":{\"alias\":[\"new.ts\"]}}}");
+		fixture.CreateFile(
+			"base.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"NodeNext\",\"paths\":{\"alias\":[\"old.ts\"]}}}");
+		var package = fixture.CreateFile("package.json", "{\"type\":\"module\"}");
+		var source = fixture.CreateFile("main.ts", "import value from './dep'; import { chosen } from 'alias';");
+		var dependency = fixture.CreateFile("dep.ts", "export default 1;");
+		var oldTarget = fixture.CreateFile("old.ts", "export const chosen = 'old';");
+		var newTarget = fixture.CreateFile("new.ts", "export const chosen = 'new';");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, package, source, dependency, oldTarget, newTarget],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "main.ts" && edge.Target == "dep.ts");
+		Assert.Contains(result.Edges, edge => edge.Source == "main.ts" && edge.Target == "new.ts");
+		Assert.DoesNotContain(result.Edges, edge => edge.Source == "main.ts" && edge.Target == "old.ts");
+	}
+
+	[Theory]
+	[InlineData("{\"extends\":\"@tsconfig/node20/tsconfig.json\"}", "tsconfig package extends is not supported")]
+	[InlineData("{\"extends\":\"base.json\"}", "tsconfig package extends is not supported")]
+	[InlineData("{\"extends\":[\"./base.json\"]}", "tsconfig extends must be one relative path string")]
+	[InlineData("{\"extends\":\"../outside.json\"}", "tsconfig extends must stay inside the project root")]
+	public async Task UnsupportedExtendsFormsUseConstantDiagnostics(string content, string reason)
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", content);
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		var diagnostic = Assert.Single(result.ConfigurationDiagnostics);
+		Assert.Equal(DependencyConfigurationState.UnsupportedSemantics, diagnostic.State);
+		Assert.Equal(reason, diagnostic.Reason);
+	}
+
+	[Fact]
+	public async Task ExtendsCycleAndDepthLimitUseConstantDiagnostics()
+	{
+		using var cycle = new TemporaryDirectory();
+		var cycleConfig = cycle.CreateFile("tsconfig.json", "{\"extends\":\"./base.json\"}");
+		cycle.CreateFile("base.json", "{\"extends\":\"./tsconfig.json\"}");
+		var cycleResult = await new FileDependencyConfigurationProvider().ReadAsync(
+			cycle.Path,
+			[cycleConfig],
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(
+			"tsconfig extends cycle is not supported",
+			Assert.Single(cycleResult.ConfigurationDiagnostics).Reason);
+
+		using var deep = new TemporaryDirectory();
+		var deepConfig = deep.CreateFile("tsconfig.json", "{\"extends\":\"./base-1.json\"}");
+		for (var index = 1; index <= FileDependencyConfigurationProvider.MaximumTypeScriptExtendsDepth; index++)
+		{
+			deep.CreateFile(
+				$"base-{index}.json",
+				$"{{\"extends\":\"./base-{index + 1}.json\"}}");
+		}
+		var deepResult = await new FileDependencyConfigurationProvider().ReadAsync(
+			deep.Path,
+			[deepConfig],
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(
+			"tsconfig extends exceeds the maximum depth",
+			Assert.Single(deepResult.ConfigurationDiagnostics).Reason);
+	}
+
+	[Fact]
+	public async Task EightExtendsEdgesAreSupported()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"extends\":\"./base-1.json\"}");
+		for (var index = 1; index < FileDependencyConfigurationProvider.MaximumTypeScriptExtendsDepth; index++)
+			fixture.CreateFile($"base-{index}.json", $"{{\"extends\":\"./base-{index + 1}.json\"}}");
+		fixture.CreateFile(
+			$"base-{FileDependencyConfigurationProvider.MaximumTypeScriptExtendsDepth}.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"NodeNext\"}}");
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		Assert.Empty(result.ConfigurationDiagnostics);
+		Assert.Equal("NodeNext", Assert.Single(result.Scopes, scope => scope.HasConfiguration).ModuleResolution);
+	}
+
+	[Fact]
+	public async Task MissingExtendedConfigIsObservedAndItsAppearanceChangesFingerprint()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"extends\":\"./base.json\"}");
+		var provider = new FileDependencyConfigurationProvider();
+
+		var missing = await provider.ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+		var basePath = Path.Combine(fixture.Path, "base.json");
+		Assert.Contains(basePath, missing.AbsentControlFiles, PathComparer.Default);
+		Assert.Equal(DependencyConfigurationState.Missing, Assert.Single(missing.ConfigurationDiagnostics).State);
+		Assert.Equal("extended tsconfig is unavailable", Assert.Single(missing.ConfigurationDiagnostics).Reason);
+
+		File.WriteAllText(basePath, "{\"compilerOptions\":{\"moduleResolution\":\"NodeNext\"}}");
+		var present = await provider.ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		Assert.Empty(present.AbsentControlFiles);
+		Assert.Empty(present.ConfigurationDiagnostics);
+		Assert.NotEqual(missing.Fingerprint, present.Fingerprint);
+		Assert.Equal("NodeNext", Assert.Single(present.Scopes, scope => scope.HasConfiguration).ModuleResolution);
+	}
+
+	[Fact]
+	public async Task ExtendedConfigChangeInvalidatesTheDependencySnapshot()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{\"extends\":\"./base.json\"}");
+		var baseConfig = fixture.CreateFile("base.json", "{\"compilerOptions\":{\"paths\":{\"alias\":[\"first.ts\"]}}}");
+		var source = fixture.CreateFile("main.ts", "import { value } from 'alias';");
+		var firstTarget = fixture.CreateFile("first.ts", "export const value = 1;");
+		var secondTarget = fixture.CreateFile("other.ts", "export const value = 2;");
+		var manifest = new[] { config, source, firstTarget, secondTarget };
+		using var engine = CreateEngine();
+
+		var first = await engine.IndexAsync(
+			fixture.Path,
+			manifest,
+			cancellationToken: TestContext.Current.CancellationToken);
+		Assert.Contains(first.Edges, edge => edge.Source == "main.ts" && edge.Target == "first.ts");
+
+		File.WriteAllText(baseConfig, "{\"compilerOptions\":{\"paths\":{\"alias\":[\"other.ts\"]}}}");
+		File.SetLastWriteTimeUtc(baseConfig, DateTime.UtcNow.AddSeconds(2));
+		var second = await engine.IndexAsync(
+			fixture.Path,
+			manifest,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(second.Edges, edge => edge.Source == "main.ts" && edge.Target == "other.ts");
+		Assert.DoesNotContain(second.Edges, edge => edge.Source == "main.ts" && edge.Target == "first.ts");
+		Assert.False(second.Metrics.ResolutionCacheHit);
+	}
+
+	[Fact]
+	public async Task ConfigWithoutExtendsKeepsBundlerDefaults()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{}");
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		var scope = Assert.Single(result.Scopes, scope => scope.HasConfiguration);
+		Assert.Equal("bundler", scope.ModuleResolution);
+		Assert.False(scope.LegacyTypeScriptConfiguration);
+		Assert.False(scope.AllowJavaScript);
+		Assert.Empty(scope.TypeScriptPaths);
+		Assert.Empty(result.ConfigurationDiagnostics);
+	}
+
+	private static DependencyFactsEngine CreateEngine() =>
+		new(new TreeSitterDependencyFactExtractor(), new FileDependencyConfigurationProvider());
+}

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1523,8 +1523,9 @@ public sealed class McpServerIntegrationTests
 			Assert.True(published.GetProperty("uniqueItems").GetBoolean());
 			var propertyNames = schema.GetProperty("properties").EnumerateObject().Select(static property => property.Name).ToArray();
 			var globAnchor = Array.IndexOf(propertyNames, "exclude_patterns");
+			var profileAnchor = Array.IndexOf(propertyNames, "profile");
 			Assert.Equal(
-				globAnchor >= 0 ? globAnchor + 1 : Array.IndexOf(propertyNames, "branch") + 1,
+				Math.Max(globAnchor, Math.Max(profileAnchor, Array.IndexOf(propertyNames, "branch"))) + 1,
 				Array.IndexOf(propertyNames, "exclusions"));
 			var required = schema.TryGetProperty("required", out var requiredElement)
 				? requiredElement.EnumerateArray().Select(static item => item.GetString()).ToArray()
@@ -1833,7 +1834,11 @@ public sealed class McpServerIntegrationTests
 				throw new InvalidOperationException("Project services must remain deferred before EOF.");
 			});
 
-		var packRoot = Path.Combine(temporaryRoot, "DevProjex", "mcp");
+		var productRoot = McpPackRegistry.ResolveProductDirectory(
+			temporaryRoot,
+			xdgRuntimeDirectory: null,
+			Environment.UserName);
+		var packRoot = Path.Combine(productRoot, "mcp");
 		Assert.Empty(Directory.EnumerateDirectories(packRoot));
 		Assert.Equal(0, Volatile.Read(ref serviceCreationCount));
 	}

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1006,6 +1006,17 @@ public sealed class McpServerIntegrationTests
 		var analysis = await server.CallAsync(
 			"analyze",
 			new Dictionary<string, object?> { ["paths"] = new[] { escapedPath } });
+		var selectedTree = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?> { ["paths"] = new[] { escapedPath }, ["format"] = "text" });
+		var search = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "markdown-path-marker",
+				["paths"] = new[] { escapedPath },
+				["context_lines"] = 0
+			});
 		var pack = await server.CallAsync(
 			"pack_context",
 			new Dictionary<string, object?>
@@ -1018,6 +1029,8 @@ public sealed class McpServerIntegrationTests
 		Assert.NotEqual(true, file.IsError);
 		Assert.Contains("markdown-path-marker", Text(file), StringComparison.Ordinal);
 		Assert.Equal(1, analysis.StructuredContent?.GetProperty("files").GetInt32());
+		Assert.Contains("image_58500.txt", Text(selectedTree), StringComparison.Ordinal);
+		Assert.Contains("image_58500.txt:1:markdown-path-marker", Text(search), StringComparison.Ordinal);
 		Assert.NotEqual(true, pack.IsError);
 		Assert.Contains("markdown-path-marker", Text(pack), StringComparison.Ordinal);
 
@@ -1043,8 +1056,10 @@ public sealed class McpServerIntegrationTests
 	}
 
 	[Theory]
+	[InlineData("get_tree")]
 	[InlineData("analyze")]
 	[InlineData("pack_context")]
+	[InlineData("search_project")]
 	public async Task WrongCasePathsArgumentsNameTheListedSpellingAcrossPlatforms(string toolName)
 	{
 		using var workspace = new TemporaryDirectory();
@@ -1052,9 +1067,10 @@ public sealed class McpServerIntegrationTests
 		File.WriteAllText(Path.Combine(project, "Anchor.cs"), "anchor-marker\n");
 		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
 
-		var result = await server.CallAsync(
-			toolName,
-			new Dictionary<string, object?> { ["paths"] = new[] { "anchor.CS" } });
+		var arguments = new Dictionary<string, object?> { ["paths"] = new[] { "anchor.CS" } };
+		if (toolName == "search_project")
+			arguments["pattern"] = "anchor";
+		var result = await server.CallAsync(toolName, arguments);
 
 		// Selection diagnostics intentionally use the spelling already exposed by get_tree,
 		// so a copied request behaves consistently on case-sensitive and insensitive volumes.
@@ -1907,13 +1923,13 @@ public sealed class McpServerIntegrationTests
 		var expectedParameters = new Dictionary<string, string[]>(StringComparer.Ordinal)
 		{
 			["list_projects"] = [],
-			["get_tree"] = ["project", "branch", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "max_depth", "format"],
+			["get_tree"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "max_depth", "format"],
 			["analyze"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "profile", "detail", "tracked_only", "git_scope", "top_files", "max_file_bytes"],
 			["pack_context"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "profile", "detail", "tracked_only", "git_scope", "rank", "focus", "max_tokens", "max_file_bytes", "view", "format"],
 			["read_pack"] = ["pack_id", "start_line", "end_line"],
-			["search_project"] = ["project", "branch", "pattern", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "context_lines", "ignore_case", "max_results"],
+			["search_project"] = ["project", "branch", "pattern", "paths", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "context_lines", "ignore_case", "max_results"],
 			["related_files"] = ["project", "branch", "path", "direction", "include_patterns", "exclude_patterns", "profile", "tracked_only", "git_scope", "max_file_bytes"],
-			["get_file"] = ["project", "branch", "path", "start_line", "end_line"]
+			["get_file"] = ["project", "branch", "profile", "path", "start_line", "end_line"]
 		};
 		foreach (var tool in tools)
 		{
@@ -1930,7 +1946,7 @@ public sealed class McpServerIntegrationTests
 			Assert.DoesNotContain("max_tokens", required);
 			Assert.DoesNotContain("format", required);
 		}
-		foreach (var toolName in new[] { "analyze", "pack_context" })
+		foreach (var toolName in new[] { "get_tree", "analyze", "pack_context", "search_project" })
 		{
 			var paths = tools.Single(tool => tool.Name == toolName)
 				.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("paths");
@@ -1938,6 +1954,7 @@ public sealed class McpServerIntegrationTests
 			Assert.Equal(
 				McpProjectService.MaximumRequestedPathLength,
 				paths.GetProperty("items").GetProperty("maxLength").GetInt32());
+			Assert.Contains("literal paths", paths.GetProperty("description").GetString(), StringComparison.Ordinal);
 		}
 		var searchBoolean = tools.Single(static tool => tool.Name == "search_project")
 			.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("ignore_case");
@@ -1953,6 +1970,12 @@ public sealed class McpServerIntegrationTests
 			.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("path");
 		Assert.Contains("default get_tree format", filePath.GetProperty("description").GetString(), StringComparison.Ordinal);
 		Assert.Contains("format=text", filePath.GetProperty("description").GetString(), StringComparison.Ordinal);
+		Assert.Contains(
+			"listed by list_projects.profiles",
+			tools.Single(static tool => tool.Name == "get_file")
+				.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("profile")
+				.GetProperty("description").GetString(),
+			StringComparison.Ordinal);
 		var treeFormat = tools.Single(static tool => tool.Name == "get_tree")
 			.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("format");
 		Assert.Equal("markdown", treeFormat.GetProperty("default").GetString());
@@ -2224,7 +2247,35 @@ public sealed class McpServerIntegrationTests
 		Assert.NotEqual(true, truncatedText.IsError);
 		AssertTrustedTrailerOutsideSpotlight(
 			truncatedText,
-			"[Tree truncated at 2000 lines. Narrow include_patterns, exclude_patterns, or max_depth.]");
+			"[Tree truncated at 2000 lines or 50000 characters. Narrow paths, include_patterns, exclude_patterns, or max_depth.]");
+	}
+
+	[Fact]
+	public async Task GetTreeCapsCharactersEvenWhenTheLineLimitIsNotReached()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		for (var index = 0; index < 320; index++)
+		{
+			var name = $"{index:D3}-{new string('x', 170)}.txt";
+			File.WriteAllText(Path.Combine(project, name), string.Empty);
+		}
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var text = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?> { ["format"] = "text", ["max_depth"] = 1 });
+		var json = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?> { ["format"] = "json", ["max_depth"] = 1 });
+
+		Assert.NotEqual(true, text.IsError);
+		AssertTrustedTrailerOutsideSpotlight(
+			text,
+			"[Tree truncated at 2000 lines or 50000 characters. Narrow paths, include_patterns, exclude_patterns, or max_depth.]");
+		Assert.True(json.IsError);
+		Assert.Contains(McpErrorCodes.PayloadTruncated, Text(json), StringComparison.Ordinal);
+		Assert.Contains("50000-character result limit", Text(json), StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -2274,7 +2325,7 @@ public sealed class McpServerIntegrationTests
 		Assert.NotEqual(true, explicitDepth.IsError);
 		AssertTrustedTrailerOutsideSpotlight(
 			explicitDepth,
-			"[Tree truncated at 2000 lines. Narrow include_patterns, exclude_patterns, or max_depth.]");
+			"[Tree truncated at 2000 lines or 50000 characters. Narrow paths, include_patterns, exclude_patterns, or max_depth.]");
 		foreach (var structured in new[] { json, xml })
 		{
 			Assert.True(structured.IsError);
@@ -3131,12 +3182,12 @@ public sealed class McpServerIntegrationTests
 				["start_line"] = 20,
 				["end_line"] = 10
 			});
-		foreach (var invalid in new[] { invalidFileStart, invalidFileOrdering })
-		{
-			Assert.True(invalid.IsError);
-			Assert.Contains(McpErrorCodes.InvalidRange, Text(invalid), StringComparison.Ordinal);
-			Assert.Contains("Valid lines are 1-44", Text(invalid), StringComparison.Ordinal);
-		}
+		Assert.True(invalidFileStart.IsError);
+		Assert.Contains(McpErrorCodes.InvalidRange, Text(invalidFileStart), StringComparison.Ordinal);
+		Assert.Contains("Valid lines are 1-44", Text(invalidFileStart), StringComparison.Ordinal);
+		Assert.True(invalidFileOrdering.IsError);
+		Assert.Contains(McpErrorCodes.InvalidRange, Text(invalidFileOrdering), StringComparison.Ordinal);
+		Assert.Contains("Valid lines start at 1", Text(invalidFileOrdering), StringComparison.Ordinal);
 
 		var stored = await server.CallAsync(
 			"pack_context",
@@ -3177,12 +3228,12 @@ public sealed class McpServerIntegrationTests
 				["start_line"] = 20,
 				["end_line"] = 10
 			});
-		foreach (var invalid in new[] { invalidPackStart, invalidPackOrdering })
-		{
-			Assert.True(invalid.IsError);
-			Assert.Contains(McpErrorCodes.InvalidRange, Text(invalid), StringComparison.Ordinal);
-			Assert.Contains($"Valid lines are 1-{totalLines}", Text(invalid), StringComparison.Ordinal);
-		}
+		Assert.True(invalidPackStart.IsError);
+		Assert.Contains(McpErrorCodes.InvalidRange, Text(invalidPackStart), StringComparison.Ordinal);
+		Assert.Contains($"Valid lines are 1-{totalLines}", Text(invalidPackStart), StringComparison.Ordinal);
+		Assert.True(invalidPackOrdering.IsError);
+		Assert.Contains(McpErrorCodes.InvalidRange, Text(invalidPackOrdering), StringComparison.Ordinal);
+		Assert.Contains("Valid lines start at 1", Text(invalidPackOrdering), StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -4874,6 +4925,33 @@ public sealed class McpServerIntegrationTests
 			"selected-empty-directory");
 	}
 
+	[Fact]
+	public async Task GetFileUsesTheSameExplicitProfileSelectionAsPackContext()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(Path.Combine(project, ".gitignore"), "profile-visible.txt\n");
+		File.WriteAllText(Path.Combine(project, "profile-visible.txt"), "profile-visible-marker");
+		var profile = WriteUnfilteredPortableProfile(project);
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var baseline = await server.CallAsync(
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "profile-visible.txt" });
+		var profiled = await server.CallAsync(
+			"get_file",
+			new Dictionary<string, object?>
+			{
+				["path"] = "profile-visible.txt",
+				["profile"] = profile
+			});
+
+		Assert.True(baseline.IsError);
+		Assert.Contains(McpErrorCodes.PathNotFound, Text(baseline), StringComparison.Ordinal);
+		Assert.NotEqual(true, profiled.IsError);
+		Assert.Contains("profile-visible-marker", Text(profiled), StringComparison.Ordinal);
+	}
+
 	[Theory]
 	[InlineData("text")]
 	[InlineData("json")]
@@ -5948,6 +6026,302 @@ public sealed class McpServerIntegrationTests
 		Assert.Equal(0, extractor.ParseCount);
 		Assert.Equal(0, diagnostics.FullFileReads);
 		Assert.Equal(0, diagnostics.SourceReadBytes);
+	}
+
+	[Fact]
+	public async Task GetTreeAndSearchPathsNarrowFilesDirectoriesAndLiteralNames()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.CreateDirectory("project/selected/empty folder");
+		File.WriteAllText(Path.Combine(project, "selected", "keep file.txt"), "selected-marker\n");
+		File.WriteAllText(Path.Combine(project, "selected", "drop.txt"), "drop-marker\n");
+		File.WriteAllText(Path.Combine(project, "other.txt"), "other-marker\n");
+		File.WriteAllText(Path.Combine(project, "literal[brace{.txt"), "literal-marker\n");
+		var literalPaths = new List<string> { "literal[brace{.txt" };
+		if (!OperatingSystem.IsWindows())
+		{
+			literalPaths.Add("literal*question?{brace[file.txt");
+			File.WriteAllText(Path.Combine(project, literalPaths[^1]), "all-literal-marker\n");
+		}
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			gitMode: GitFilteringMode.None,
+			exclusions: []);
+
+		var tree = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "selected/keep file.txt", "selected/empty folder" }.Concat(literalPaths).ToArray(),
+				["format"] = "text"
+			});
+		var search = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "marker",
+				["paths"] = new[] { "selected/keep file.txt" }.Concat(literalPaths).ToArray(),
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			});
+		var byPaths = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "marker",
+				["paths"] = new[] { "selected" },
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			});
+		var byPattern = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "marker",
+				["include_patterns"] = new[] { "selected/**" },
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			});
+
+		Assert.NotEqual(true, tree.IsError);
+		Assert.Contains("keep file.txt", Text(tree), StringComparison.Ordinal);
+		Assert.Contains("empty folder", Text(tree), StringComparison.Ordinal);
+		Assert.Contains("literal[brace{.txt", Text(tree), StringComparison.Ordinal);
+		if (!OperatingSystem.IsWindows())
+		{
+			Assert.Contains("literal*question?{brace[file.txt", Text(tree), StringComparison.Ordinal);
+			Assert.Contains("literal*question?{brace[file.txt:1:all-literal-marker", Text(search), StringComparison.Ordinal);
+		}
+		Assert.DoesNotContain("drop.txt", Text(tree), StringComparison.Ordinal);
+		Assert.DoesNotContain("other.txt", Text(tree), StringComparison.Ordinal);
+		Assert.NotEqual(true, search.IsError);
+		Assert.Contains("selected/keep file.txt:1:selected-marker", Text(search), StringComparison.Ordinal);
+		Assert.Contains("literal[brace{.txt:1:literal-marker", Text(search), StringComparison.Ordinal);
+		Assert.DoesNotContain("drop-marker", Text(search), StringComparison.Ordinal);
+		Assert.DoesNotContain("other-marker", Text(search), StringComparison.Ordinal);
+		Assert.Equal(ExtractSpotlightBody(Text(byPattern)), ExtractSpotlightBody(Text(byPaths)));
+	}
+
+	[Theory]
+	[InlineData("markdown")]
+	[InlineData("text")]
+	[InlineData("json")]
+	[InlineData("xml")]
+	public async Task GetTreePathsKeepSelectedEmptyDirectoriesInEveryFormat(string format)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.CreateDirectory("project/selected/empty folder");
+		File.WriteAllText(Path.Combine(project, "selected", "keep.txt"), string.Empty);
+		File.WriteAllText(Path.Combine(project, "outside.txt"), string.Empty);
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			gitMode: GitFilteringMode.None,
+			exclusions: []);
+
+		var tree = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "selected" },
+				["format"] = format
+			});
+
+		Assert.NotEqual(true, tree.IsError);
+		Assert.Contains("empty folder", Text(tree), StringComparison.Ordinal);
+		Assert.Contains("keep.txt", Text(tree), StringComparison.Ordinal);
+		Assert.DoesNotContain("outside.txt", Text(tree), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task PathsMissingIntersectionAndFileLimitNeverFallBackToTheProject()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.CreateDirectory("project/selected");
+		File.WriteAllText(Path.Combine(project, "selected", "large.txt"), "large-marker-" + new string('x', 128));
+		File.WriteAllText(Path.Combine(project, "other.txt"), "other-marker\n");
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			gitMode: GitFilteringMode.None,
+			exclusions: []);
+
+		var missing = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "marker",
+				["paths"] = new[] { "missing.txt", "other.txt" },
+				["context_lines"] = 0
+			});
+		var emptyIntersection = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "selected" },
+				["include_patterns"] = new[] { "other.txt" },
+				["format"] = "text"
+			});
+		var sizeLimited = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "marker",
+				["paths"] = new[] { "selected" },
+				["max_file_bytes"] = 64,
+				["context_lines"] = 0
+			});
+
+		Assert.False(missing.IsError == true, Text(missing));
+		Assert.Contains("other.txt:1:other-marker", Text(missing), StringComparison.Ordinal);
+		Assert.Contains("DPX-SELECTION-PATH-MISSING", Text(missing), StringComparison.Ordinal);
+		Assert.DoesNotContain("missing.txt", Text(missing), StringComparison.Ordinal);
+		Assert.False(emptyIntersection.IsError == true, Text(emptyIntersection));
+		Assert.DoesNotContain("large.txt", Text(emptyIntersection), StringComparison.Ordinal);
+		Assert.DoesNotContain("other.txt", Text(emptyIntersection), StringComparison.Ordinal);
+		Assert.Contains("DPX-SELECTION-PATH-MISSING", Text(emptyIntersection), StringComparison.Ordinal);
+		Assert.False(sizeLimited.IsError == true, Text(sizeLimited));
+		Assert.DoesNotContain("large-marker", Text(sizeLimited), StringComparison.Ordinal);
+		Assert.DoesNotContain("other-marker", Text(sizeLimited), StringComparison.Ordinal);
+		Assert.Contains("max_file_bytes: 64", Text(sizeLimited), StringComparison.Ordinal);
+		Assert.Contains("DPX-SELECTION-PATH-MISSING", Text(sizeLimited), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task GetTreeAndSearchPathsHonorCaseRootJailAndGitScope()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repository = workspace.CreateDirectory("repository");
+		File.WriteAllText(Path.Combine(repository, "Tracked.txt"), "baseline\n");
+		InitializeCommittedRepository(repository);
+		File.WriteAllText(Path.Combine(repository, "Tracked.txt"), "staged-marker\n");
+		File.WriteAllText(Path.Combine(repository, "OutsideScope.txt"), "outside-marker\n");
+		RunGit(repository, "add", "--", "Tracked.txt");
+		await using var server = await McpTestServer.StartAsync(
+			repository,
+			workspace.Path,
+			gitMode: GitFilteringMode.None,
+			exclusions: []);
+
+		var tree = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "Tracked.txt", "OutsideScope.txt" },
+				["git_scope"] = "staged",
+				["format"] = "text"
+			});
+		var search = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "marker",
+				["paths"] = new[] { "Tracked.txt", "OutsideScope.txt" },
+				["git_scope"] = "staged",
+				["context_lines"] = 0
+			});
+		var wrongCase = await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?> { ["paths"] = new[] { "tracked.txt" } });
+		Assert.NotEqual(true, tree.IsError);
+		Assert.Contains("Tracked.txt", Text(tree), StringComparison.Ordinal);
+		Assert.DoesNotContain("OutsideScope.txt", Text(tree), StringComparison.Ordinal);
+		Assert.NotEqual(true, search.IsError);
+		Assert.Contains("Tracked.txt:1:staged-marker", Text(search), StringComparison.Ordinal);
+		Assert.DoesNotContain("outside-marker", Text(search), StringComparison.Ordinal);
+		Assert.True(wrongCase.IsError);
+		Assert.Contains(McpErrorCodes.PathNotFound, Text(wrongCase), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task GetTreeAndSearchPathsRejectSymlinksOutsideTheRoot()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var outside = workspace.CreateFile("outside.txt", "outside-jail-marker\n");
+		var link = Path.Combine(project, "outside-link.txt");
+		CreateFileAliasOrSkip(link, outside);
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			gitMode: GitFilteringMode.None,
+			exclusions: []);
+
+		var escaped = await server.CallAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "outside",
+				["paths"] = new[] { "outside-link.txt" }
+			});
+
+		Assert.True(escaped.IsError);
+		Assert.Contains(McpErrorCodes.RootViolation, Text(escaped), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task InvalidNumericArgumentsFailBeforeRemoteProjectResolution()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var remoteServicesCreated = 0;
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			allowRemote: true,
+			remoteServicesFactory: () =>
+			{
+				Interlocked.Increment(ref remoteServicesCreated);
+				throw new InvalidOperationException("Invalid arguments must fail before remote resolution.");
+			});
+		const string remote = "https://example.invalid/owner/repository.git";
+		using var measurement = ContentPipelineDiagnostics.BeginMeasurement();
+
+		var cases = new (string Tool, Dictionary<string, object?> Arguments)[]
+		{
+			("get_file", new() { ["project"] = remote, ["path"] = "file.txt", ["start_line"] = -1 }),
+			("get_file", new() { ["project"] = remote, ["path"] = "file.txt", ["end_line"] = true }),
+			("get_file", new() { ["project"] = remote, ["path"] = "file.txt", ["start_line"] = 2, ["end_line"] = 1 }),
+			("get_tree", new() { ["project"] = remote, ["max_depth"] = -1 }),
+			("search_project", new() { ["project"] = remote, ["pattern"] = "x", ["context_lines"] = -1 }),
+			("search_project", new() { ["project"] = remote, ["pattern"] = "x", ["max_results"] = 0 }),
+			("pack_context", new() { ["project"] = remote, ["max_tokens"] = 0 }),
+			("pack_context", new() { ["project"] = remote, ["max_file_bytes"] = 0 })
+		};
+		foreach (var item in cases)
+		{
+			var result = await server.CallAsync(item.Tool, item.Arguments);
+			Assert.True(result.IsError);
+			Assert.StartsWith(McpErrorCodes.InvalidRange, Text(result), StringComparison.Ordinal);
+		}
+
+		var readPack = await server.CallAsync(
+			"read_pack",
+			new Dictionary<string, object?>
+			{
+				["pack_id"] = "not-resolved",
+				["start_line"] = 2,
+				["end_line"] = 1
+			});
+		Assert.True(readPack.IsError);
+		Assert.StartsWith(McpErrorCodes.InvalidRange, Text(readPack), StringComparison.Ordinal);
+		var readPackType = await server.CallAsync(
+			"read_pack",
+			new Dictionary<string, object?> { ["pack_id"] = "not-resolved", ["start_line"] = false });
+		Assert.True(readPackType.IsError);
+		Assert.StartsWith(McpErrorCodes.InvalidRange, Text(readPackType), StringComparison.Ordinal);
+		Assert.Equal(0, Volatile.Read(ref remoteServicesCreated));
+		var diagnostics = measurement.Capture();
+		Assert.Equal(0, diagnostics.FullFileReads);
+		Assert.Equal(0, diagnostics.SourceReadBytes);
+		Assert.Equal(0, diagnostics.PreparedFilesMaterialized);
+		Assert.Equal(0, diagnostics.Stages[ContentPipelineStage.Selection].InvocationCount);
+		Assert.Equal(0, diagnostics.Stages[ContentPipelineStage.SourceRead].InvocationCount);
+		Assert.Equal(0, diagnostics.Stages[ContentPipelineStage.RedactionAndOutput].InvocationCount);
 	}
 
 	private static int[] ExtractPackLineMarkers(string text) =>

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1525,7 +1525,11 @@ public sealed class McpServerIntegrationTests
 			var globAnchor = Array.IndexOf(propertyNames, "exclude_patterns");
 			var profileAnchor = Array.IndexOf(propertyNames, "profile");
 			Assert.Equal(
-				Math.Max(globAnchor, Math.Max(profileAnchor, Array.IndexOf(propertyNames, "branch"))) + 1,
+				(globAnchor >= 0
+					? globAnchor
+					: profileAnchor >= 0
+						? profileAnchor
+						: Array.IndexOf(propertyNames, "branch")) + 1,
 				Array.IndexOf(propertyNames, "exclusions"));
 			var required = schema.TryGetProperty("required", out var requiredElement)
 				? requiredElement.EnumerateArray().Select(static item => item.GetString()).ToArray()

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -125,6 +125,10 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("[Dependency configuration]", server, StringComparison.Ordinal);
 		Assert.Contains("spotlighted JSON serialization", normalizedServer, StringComparison.Ordinal);
 		Assert.Contains("reply ≈ E", server, StringComparison.Ordinal);
+		Assert.Contains("For `get_tree`, `analyze`, `pack_context`, and `search_project`, `paths` accepts", normalizedServer, StringComparison.Ordinal);
+		Assert.Contains("The entries name literal files or directories", normalizedServer, StringComparison.Ordinal);
+		Assert.Contains("at most 2,000 lines and 50,000 characters", normalizedServer, StringComparison.Ordinal);
+		Assert.Contains("`profile` applies the same effective selection", normalizedServer, StringComparison.Ordinal);
 
 		Assert.Contains("MCP agent ergonomics changes four v5.2 behaviors", normalizedVersion, StringComparison.Ordinal);
 		Assert.Contains("there is no strict-range switch", normalizedVersion, StringComparison.Ordinal);

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.Paths.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.Paths.cs
@@ -1,0 +1,52 @@
+using ModelContextProtocol.Protocol;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	[Fact]
+	public async Task RealProcessGetTreeAndSearchProjectAcceptLiteralPathsNarrowing()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("paths-project");
+		workspace.WriteFile("paths-project/src/Selected file.txt", "selected-process-marker\n");
+		workspace.WriteFile("paths-project/src/Other.txt", "other-process-marker\n");
+		workspace.WriteFile("paths-project/Outside.txt", "outside-process-marker\n");
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		var tree = await server.Client.CallToolAsync(
+			"get_tree",
+			new Dictionary<string, object?>
+			{
+				["paths"] = new[] { "src/Selected file.txt" },
+				["format"] = "text"
+			},
+			progress: null,
+			options: null,
+			TestContext.Current.CancellationToken);
+		var search = await server.Client.CallToolAsync(
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "process-marker",
+				["paths"] = new[] { "src" },
+				["include_patterns"] = new[] { "**/Selected file.txt" },
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			},
+			progress: null,
+			options: null,
+			TestContext.Current.CancellationToken);
+
+		var treeText = AllProcessText(tree);
+		Assert.Contains("Selected file.txt", treeText, StringComparison.Ordinal);
+		Assert.DoesNotContain("Other.txt", treeText, StringComparison.Ordinal);
+		Assert.DoesNotContain("Outside.txt", treeText, StringComparison.Ordinal);
+		var searchText = AllProcessText(search);
+		Assert.Contains("src/Selected file.txt:1:selected-process-marker", searchText, StringComparison.Ordinal);
+		Assert.DoesNotContain("other-process-marker", searchText, StringComparison.Ordinal);
+		Assert.DoesNotContain("outside-process-marker", searchText, StringComparison.Ordinal);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs
@@ -88,6 +88,19 @@ public sealed class McpInfrastructureTests
 	}
 
 	[Fact]
+	public async Task BoundedTreeWriter_StopsAtTheCharacterLimitWithoutSplittingASurrogatePair()
+	{
+		using var writer = new McpBoundedLineTextWriter(maximumLines: 10, maximumCharacters: 5);
+
+		await Assert.ThrowsAsync<McpLineLimitReachedException>(async () =>
+			await writer.WriteAsync("abcd😀tail".AsMemory(), TestContext.Current.CancellationToken));
+
+		Assert.True(writer.IsTruncated);
+		Assert.True(writer.CharacterLimitReached);
+		Assert.Equal("abcd", writer.Text);
+	}
+
+	[Fact]
 	public void TopFileRanking_RemainsBoundedAndUsesStableContractOrder()
 	{
 		var ranking = new TopFileRanking(capacity: 3);
@@ -1123,7 +1136,9 @@ public sealed class McpInfrastructureTests
 	public async Task PackSweepRemovesOnlyStaleOwnedSessionsAndPreservesAnActiveLease()
 	{
 		using var workspace = new TemporaryDirectory();
-		var baseDirectory = Path.Combine(workspace.Path, "DevProjex", "mcp");
+		var baseDirectory = Path.Combine(
+			McpPackRegistry.ResolveProductDirectory(workspace.Path, null, Environment.UserName),
+			"mcp");
 		var stale = Path.Combine(baseDirectory, new string('a', 32));
 		Directory.CreateDirectory(stale);
 		File.WriteAllText(Path.Combine(stale, ".session.lock"), string.Empty);
@@ -1157,7 +1172,9 @@ public sealed class McpInfrastructureTests
 		File.WriteAllText(protectedFile, "keep");
 		Directory.SetLastWriteTimeUtc(target, DateTime.UtcNow.AddDays(-2));
 
-		var baseDirectory = Path.Combine(workspace.Path, "DevProjex", "mcp");
+		var baseDirectory = Path.Combine(
+			McpPackRegistry.ResolveProductDirectory(workspace.Path, null, Environment.UserName),
+			"mcp");
 		Directory.CreateDirectory(baseDirectory);
 		var link = Path.Combine(baseDirectory, new string('b', 32));
 		try
@@ -1223,7 +1240,10 @@ public sealed class McpInfrastructureTests
 	{
 		using var workspace = new TemporaryDirectory();
 		using var target = new TemporaryDirectory();
-		var productDirectory = Path.Combine(workspace.Path, "DevProjex");
+		var productDirectory = McpPackRegistry.ResolveProductDirectory(
+			workspace.Path,
+			null,
+			Environment.UserName);
 		Directory.CreateDirectory(productDirectory);
 		var link = Path.Combine(productDirectory, "mcp");
 		try
@@ -1247,7 +1267,10 @@ public sealed class McpInfrastructureTests
 	{
 		using var workspace = new TemporaryDirectory();
 		using var target = new TemporaryDirectory();
-		var link = Path.Combine(workspace.Path, "DevProjex");
+		var link = McpPackRegistry.ResolveProductDirectory(
+			workspace.Path,
+			null,
+			Environment.UserName);
 		try
 		{
 			Directory.CreateSymbolicLink(link, target.Path);
@@ -1262,6 +1285,35 @@ public sealed class McpInfrastructureTests
 
 		Assert.Contains("symbolic link", storageException.Message, StringComparison.Ordinal);
 		Assert.Empty(Directory.EnumerateFileSystemEntries(target.Path));
+	}
+
+	[Fact]
+	public void PackStorageUsesXdgRuntimeDirectoryWhenAvailable()
+	{
+		using var runtime = new TemporaryDirectory();
+
+		var productDirectory = McpPackRegistry.ResolveProductDirectory(
+			tempRoot: null,
+			runtime.Path,
+			"alice");
+
+		Assert.Equal(Path.Combine(runtime.Path, "DevProjex"), productDirectory);
+	}
+
+	[Fact]
+	public void ForeignLegacyTempParentDoesNotBlockUserNamespacedStorage()
+	{
+		using var workspace = new TemporaryDirectory();
+		var legacyProductDirectory = Path.Combine(workspace.Path, "DevProjex");
+		File.WriteAllText(legacyProductDirectory, "owned by another account");
+
+		using var registry = new McpPackRegistry(workspace.Path);
+
+		Assert.True(Directory.Exists(registry.SessionDirectory));
+		Assert.False(
+			Path.GetFullPath(registry.SessionDirectory).StartsWith(
+				Path.GetFullPath(legacyProductDirectory) + Path.DirectorySeparatorChar,
+				OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

- resolve bounded relative tsconfig inheritance with origin-aware compiler options and explicit unsupported states
- reject unsafe or indeterminate project-reference semantics before external metadata access
- validate MCP numeric arguments before project or pack work and add literal paths narrowing to get_tree and search_project
- isolate temporary MCP packs per user, bound tree characters, and let get_file use explicit profiles

## Verification

- targeted dependency configuration and TypeScript integration tests
- targeted MCP infrastructure, catalog, selection, range, tree-limit, and profile tests
- real-process get_tree/search paths test
- MCP documentation contract tests
- Release TerminalHost build with zero warnings

Closes #313