### PR TITLE
perf(secrets): remove redundant content pipeline work

### DIFF
--- a/Application/Compression/CodeCompressionPrewarmer.cs
+++ b/Application/Compression/CodeCompressionPrewarmer.cs
@@ -18,7 +18,14 @@ public readonly record struct CodeCompressionWarmupProgress(
 	int ProcessedFiles,
 	int TotalFiles);
 
-/// <summary>Bounded operation-local content reused by the immediately following metrics phase.</summary>
+public readonly record struct ContentReadMetricsFact(
+	TextFileMetrics Raw,
+	TextFileMetrics Effective,
+	string TransformIdentity,
+	long SourceLength,
+	long SourceLastWriteTimeUtcTicks);
+
+/// <summary>Bounded operation-local raw and transformed metrics reused by the next metrics phase.</summary>
 public sealed class ContentReadFactSnapshot
 {
 	private readonly IReadOnlyDictionary<string, RetainedContentReadFact> _facts;
@@ -49,9 +56,23 @@ public sealed class ContentReadFactSnapshot
 		return false;
 	}
 
+	public bool TryGetMetrics(string path, string transformIdentity, out ContentReadMetricsFact metrics)
+	{
+		if (_facts.TryGetValue(path, out var retained) &&
+		    string.Equals(retained.Metrics.TransformIdentity, transformIdentity, StringComparison.Ordinal))
+		{
+			metrics = retained.Metrics;
+			return true;
+		}
+
+		metrics = default;
+		return false;
+	}
+
 	internal sealed record RetainedContentReadFact(
 		ContentReadFact Fact,
-		FileContentIdentity Identity);
+		FileContentIdentity Identity,
+		ContentReadMetricsFact Metrics);
 }
 
 /// <summary>
@@ -65,6 +86,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 	private const long MaximumInFlightBytes = 32L * 1024 * 1024;
 	private const long MaximumMaterializedFactBytes = 128L + MaximumReadBytes * sizeof(char);
 	private const long MaximumRetainedReadFactBytes = 64L * 1024 * 1024;
+	private const long CompactRetainedFactBytes = 256;
 	private const int MaximumIoParallelism = 4;
 
 	public Task<CodeCompressionWarmupResult> WarmAsync(
@@ -111,7 +133,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 					0));
 		}
 
-		var retainedPaths = BuildRetainedPathSet(context, candidates, cancellationToken);
+		var retainedPaths = BuildRetainedPathSet(candidates, cancellationToken);
 		var retainedFacts = new ConcurrentDictionary<
 			string,
 			ContentReadFactSnapshot.RetainedContentReadFact>(ProjectTreePathIdentity.CanonicalComparer);
@@ -254,7 +276,13 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 									Classification: FileContentClassification.Text,
 									RawMetrics: metrics,
 									Fingerprint: null),
-								metricsIdentity));
+								metricsIdentity,
+								new ContentReadMetricsFact(
+									metrics,
+									metrics,
+									context.TransformIdentity,
+									metricsIdentity.Length,
+									metricsIdentity.LastWriteTimeUtcTicks)));
 						}
 						scope.RecordUnsupported(path, relativePath, metrics.CharCount);
 						Increment(WarmFileOutcome.Warmed, ref warmed, ref skipped, ref failed);
@@ -303,14 +331,14 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 						continue;
 					}
 
-					if (retainedPaths.Contains(path) && identity is { } contentIdentity)
+					if (scope.TryWarmCachedAndGetPlan(
+						    path,
+						    relativePath,
+						    fact.Content!,
+						    fingerprint,
+						    out var cachedPlan))
 					{
-						TryRetainFact(path, new ContentReadFactSnapshot.RetainedContentReadFact(
-							fact,
-							contentIdentity));
-					}
-					if (scope.TryWarmCached(path, relativePath, fact.Content!, fingerprint))
-					{
+						TryRetainTransformedMetrics(path, fact, fingerprint, identity, cachedPlan!);
 						Increment(WarmFileOutcome.Warmed, ref warmed, ref skipped, ref failed);
 						ReportProgress(progress, ref processed, candidates.Count);
 						continue;
@@ -322,6 +350,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 							relativePath,
 							fact,
 							fingerprint,
+							identity,
 							lease ?? throw new InvalidOperationException("A materialized fact has no byte-budget lease.")),
 						pipelineToken).ConfigureAwait(false);
 					lease = null;
@@ -364,14 +393,20 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 				{
 					try
 					{
-						var recorded = scope.Warm(
+						var plan = scope.WarmAndGetPlan(
 							item.Path,
 							item.RelativePath,
 							item.Fact.Content!,
 							item.Fingerprint,
 							pipelineToken);
+						TryRetainTransformedMetrics(
+							item.Path,
+							item.Fact,
+							item.Fingerprint,
+							item.Identity,
+							plan);
 						Increment(
-							recorded ? WarmFileOutcome.Warmed : WarmFileOutcome.Skipped,
+							plan is not null ? WarmFileOutcome.Warmed : WarmFileOutcome.Skipped,
 							ref warmed,
 							ref skipped,
 							ref failed);
@@ -413,7 +448,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 			string path,
 			ContentReadFactSnapshot.RetainedContentReadFact retainedFact)
 		{
-			var actualBytes = retainedFact.Fact.ApproximateRetainedBytes;
+			var actualBytes = CompactRetainedFactBytes;
 			lock (retainedFactsSync)
 			{
 				if (actualBytes > MaximumRetainedReadFactBytes - retainedFactBytes ||
@@ -423,6 +458,39 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 				}
 				retainedFactBytes += actualBytes;
 			}
+		}
+
+		void TryRetainTransformedMetrics(
+			string path,
+			ContentReadFact fact,
+			ContentFingerprint fingerprint,
+			FileContentIdentity? identity,
+			CodeCompressionPlan? plan)
+		{
+			if (!retainedPaths.Contains(path) || identity is not { } contentIdentity ||
+			    fact.RawMetrics is not { IsEstimated: false } raw || !fact.IsMaterializedText ||
+			    plan is null)
+			{
+				return;
+			}
+			var effective = plan.HasEdits
+				? FileContentAnalyzer.ComputeTransformedMetrics(fact.Content, plan)
+				: raw;
+			var compact = new ContentReadFact(
+				Content: null,
+				FileContentClassification.Text,
+				raw,
+				fingerprint,
+				fact.Encoding);
+			TryRetainFact(path, new ContentReadFactSnapshot.RetainedContentReadFact(
+				compact,
+				contentIdentity,
+				new ContentReadMetricsFact(
+					raw,
+					effective,
+					context.TransformIdentity,
+					contentIdentity.Length,
+					contentIdentity.LastWriteTimeUtcTicks)));
 		}
 
 		static async Task ObserveCompletionAsync(Task[] tasks)
@@ -438,8 +506,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 		}
 	}
 
-	private HashSet<string> BuildRetainedPathSet(
-		CodeCompressionContext context,
+	private static HashSet<string> BuildRetainedPathSet(
 		IReadOnlyList<string> paths,
 		CancellationToken cancellationToken)
 	{
@@ -448,24 +515,10 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 		foreach (var path in paths)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (contentAnalyzer.ClassifyWithoutReading(path) == FileContentClassification.Binary)
-				continue;
-			var relativePath = BuildRelativePath(context.ProjectRoot, path);
-			if (!context.IsSupported(relativePath))
-			{
-				if (bytes + 128L > MaximumRetainedReadFactBytes)
-					continue;
-				retained.Add(path);
-				bytes += 128L;
-				continue;
-			}
-			if (!TryGetLength(path, out var length) || length > MaximumReadBytes)
-				continue;
-			var estimate = 128L + length * sizeof(char);
-			if (bytes + estimate > MaximumRetainedReadFactBytes)
+			if (bytes + CompactRetainedFactBytes > MaximumRetainedReadFactBytes)
 				continue;
 			retained.Add(path);
-			bytes += estimate;
+			bytes += CompactRetainedFactBytes;
 		}
 		return retained;
 	}
@@ -479,21 +532,6 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 		catch (ArgumentException)
 		{
 			return fullPath;
-		}
-	}
-
-	private static bool TryGetLength(string path, out long length)
-	{
-		try
-		{
-			length = new FileInfo(path).Length;
-			return true;
-		}
-		catch (Exception exception) when (
-			exception is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
-		{
-			length = 0;
-			return false;
 		}
 	}
 
@@ -531,6 +569,7 @@ public sealed class CodeCompressionPrewarmer(IFileContentAnalyzer contentAnalyze
 		string RelativePath,
 		ContentReadFact Fact,
 		ContentFingerprint Fingerprint,
+		FileContentIdentity? Identity,
 		WeightedByteBudget.Lease Lease);
 
 	private enum WarmFileOutcome

--- a/Application/Compression/CodeCompressionSession.cs
+++ b/Application/Compression/CodeCompressionSession.cs
@@ -1047,6 +1047,13 @@ public sealed class CodeCompressionScope : IDisposable
 		string relativePath,
 		string content,
 		CancellationToken cancellationToken)
+		=> WarmAndGetPlan(fullPath, relativePath, content, cancellationToken) is not null;
+
+	internal CodeCompressionPlan? WarmAndGetPlan(
+		string fullPath,
+		string relativePath,
+		string content,
+		CancellationToken cancellationToken)
 	{
 		ObjectDisposedException.ThrowIf(Volatile.Read(ref _completed) != 0, this);
 		var plan = session.Warm(
@@ -1060,10 +1067,10 @@ public sealed class CodeCompressionScope : IDisposable
 			transformIdentity,
 			cancellationToken);
 		if (plan is null)
-			return false;
+			return null;
 
 		RecordPlan(fullPath, plan);
-		return true;
+		return plan;
 	}
 
 	internal bool TryWarmCached(
@@ -1071,6 +1078,14 @@ public sealed class CodeCompressionScope : IDisposable
 		string relativePath,
 		string content,
 		ContentFingerprint fingerprint)
+		=> TryWarmCachedAndGetPlan(fullPath, relativePath, content, fingerprint, out _);
+
+	internal bool TryWarmCachedAndGetPlan(
+		string fullPath,
+		string relativePath,
+		string content,
+		ContentFingerprint fingerprint,
+		out CodeCompressionPlan? plan)
 	{
 		ObjectDisposedException.ThrowIf(Volatile.Read(ref _completed) != 0, this);
 		if (!session.TryGetWarmCachedPlan(
@@ -1081,7 +1096,7 @@ public sealed class CodeCompressionScope : IDisposable
 				generation,
 				kinds,
 				transformIdentity,
-				out var plan))
+				out plan))
 		{
 			return false;
 		}
@@ -1090,6 +1105,14 @@ public sealed class CodeCompressionScope : IDisposable
 	}
 
 	internal bool Warm(
+		string fullPath,
+		string relativePath,
+		string content,
+		ContentFingerprint fingerprint,
+		CancellationToken cancellationToken)
+		=> WarmAndGetPlan(fullPath, relativePath, content, fingerprint, cancellationToken) is not null;
+
+	internal CodeCompressionPlan? WarmAndGetPlan(
 		string fullPath,
 		string relativePath,
 		string content,
@@ -1108,9 +1131,9 @@ public sealed class CodeCompressionScope : IDisposable
 			transformIdentity,
 			cancellationToken);
 		if (plan is null)
-			return false;
+			return null;
 		RecordPlan(fullPath, plan);
-		return true;
+		return plan;
 	}
 
 	internal void RecordUnsupported(

--- a/Application/Diagnostics/ContentPipelineDiagnostics.cs
+++ b/Application/Diagnostics/ContentPipelineDiagnostics.cs
@@ -123,6 +123,18 @@ public static class ContentPipelineDiagnostics
 	public static void RecordOccurrenceIdComputation() =>
 		Increment(static state => ref state.OccurrenceIdComputations);
 
+	public static void RecordSecondarySecretRegexRun() =>
+		Increment(static state => ref state.SecondarySecretRegexRuns);
+
+	public static void RecordRejectedMatchLineContext() =>
+		Increment(static state => ref state.RejectedMatchLineContexts);
+
+	public static void RecordLineIndexBuild() =>
+		Increment(static state => ref state.LineIndexBuilds);
+
+	public static void RecordMeasurementPass() =>
+		Increment(static state => ref state.MeasurementPasses);
+
 	private delegate ref long CounterSelector(MeasurementState state);
 	private delegate ref long ByteCounterSelector(MeasurementState state);
 
@@ -188,6 +200,10 @@ public static class ContentPipelineDiagnostics
 		public long SourceVersionHashBytes;
 		public long PlanApplications;
 		public long OccurrenceIdComputations;
+		public long SecondarySecretRegexRuns;
+		public long RejectedMatchLineContexts;
+		public long LineIndexBuilds;
+		public long MeasurementPasses;
 		public long SourceReadBytes;
 		public long PreparedReadBytes;
 		public long PreparedWriteBytes;
@@ -231,7 +247,11 @@ public static class ContentPipelineDiagnostics
 				SourceVersionHashBytes = Volatile.Read(ref SourceVersionHashBytes),
 				QueueWaitTimeTicks = ToTimeSpanTicks(Volatile.Read(ref QueueWaitStopwatchTicks)),
 				ByteBudgetWaitTimeTicks = ToTimeSpanTicks(Volatile.Read(ref ByteBudgetWaitStopwatchTicks)),
-				ByteBudgetRequestedBytes = Volatile.Read(ref ByteBudgetRequestedBytes)
+				ByteBudgetRequestedBytes = Volatile.Read(ref ByteBudgetRequestedBytes),
+				SecondarySecretRegexRuns = Volatile.Read(ref SecondarySecretRegexRuns),
+				RejectedMatchLineContexts = Volatile.Read(ref RejectedMatchLineContexts),
+				LineIndexBuilds = Volatile.Read(ref LineIndexBuilds),
+				MeasurementPasses = Volatile.Read(ref MeasurementPasses)
 			};
 		}
 	}
@@ -333,6 +353,10 @@ public sealed record ContentPipelineDiagnosticSnapshot(
 	public long QueueWaitTimeTicks { get; init; }
 	public long ByteBudgetWaitTimeTicks { get; init; }
 	public long ByteBudgetRequestedBytes { get; init; }
+	public long SecondarySecretRegexRuns { get; init; }
+	public long RejectedMatchLineContexts { get; init; }
+	public long LineIndexBuilds { get; init; }
+	public long MeasurementPasses { get; init; }
 }
 
 public readonly record struct ContentPipelineStageDiagnosticSnapshot(long ElapsedTicks, long InvocationCount);

--- a/Application/Diagnostics/ContentPipelineDiagnostics.cs
+++ b/Application/Diagnostics/ContentPipelineDiagnostics.cs
@@ -132,6 +132,9 @@ public static class ContentPipelineDiagnostics
 	public static void RecordLineIndexBuild() =>
 		Increment(static state => ref state.LineIndexBuilds);
 
+	public static void RecordRulePathAllowlistEvaluation() =>
+		Increment(static state => ref state.RulePathAllowlistEvaluations);
+
 	public static void RecordMeasurementPass() =>
 		Increment(static state => ref state.MeasurementPasses);
 
@@ -203,6 +206,7 @@ public static class ContentPipelineDiagnostics
 		public long SecondarySecretRegexRuns;
 		public long RejectedMatchLineContexts;
 		public long LineIndexBuilds;
+		public long RulePathAllowlistEvaluations;
 		public long MeasurementPasses;
 		public long SourceReadBytes;
 		public long PreparedReadBytes;
@@ -251,6 +255,7 @@ public static class ContentPipelineDiagnostics
 				SecondarySecretRegexRuns = Volatile.Read(ref SecondarySecretRegexRuns),
 				RejectedMatchLineContexts = Volatile.Read(ref RejectedMatchLineContexts),
 				LineIndexBuilds = Volatile.Read(ref LineIndexBuilds),
+				RulePathAllowlistEvaluations = Volatile.Read(ref RulePathAllowlistEvaluations),
 				MeasurementPasses = Volatile.Read(ref MeasurementPasses)
 			};
 		}
@@ -356,6 +361,7 @@ public sealed record ContentPipelineDiagnosticSnapshot(
 	public long SecondarySecretRegexRuns { get; init; }
 	public long RejectedMatchLineContexts { get; init; }
 	public long LineIndexBuilds { get; init; }
+	public long RulePathAllowlistEvaluations { get; init; }
 	public long MeasurementPasses { get; init; }
 }
 

--- a/Application/Secrets/SecretRedactionOutputPreparer.cs
+++ b/Application/Secrets/SecretRedactionOutputPreparer.cs
@@ -218,7 +218,7 @@ public sealed class SecretRedactionOutputPreparer
 			orderedFilePaths.Count >= ConsolidatedSnapshotFileThreshold;
 		var preparedFiles = new Dictionary<string, PreparedSecretFile>(ProjectTreePathIdentity.CanonicalComparer);
 		var transformedFileMetrics = captureTransformedMetrics
-			? new Dictionary<string, ContentFileMetrics>(ProjectTreePathIdentity.CanonicalComparer)
+			? new ContentFileMetrics?[orderedFilePaths.Count]
 			: null;
 		var unscannableFiles = new List<UnscannableFile>();
 		using var transformationScope = context.BeginOutput(orderedFilePaths, cancellationToken);
@@ -226,8 +226,9 @@ public sealed class SecretRedactionOutputPreparer
 		var requiredInspectionScope = context.Compression is null ? scope : null;
 		if (requiredInspectionScope is not null)
 		{
-			foreach (var sourcePath in orderedFilePaths)
+			for (var sourceIndex = 0; sourceIndex < orderedFilePaths.Count; sourceIndex++)
 			{
+				var sourcePath = orderedFilePaths[sourceIndex];
 				if (requiredInspectionScope.GetContentInspectionMode(sourcePath) ==
 				    SecretContentInspectionMode.None)
 				{
@@ -247,7 +248,7 @@ public sealed class SecretRedactionOutputPreparer
 									ContentPipelineDiagnostics.RecordSourceRead(sourceMetrics.SizeBytes);
 							}
 							if (ClassifySourcePath(context, sourcePath) is null && metrics.Metrics is { } textMetrics)
-								transformedFileMetrics![sourcePath] = ToContentFileMetrics(sourcePath, textMetrics);
+								transformedFileMetrics![sourceIndex] = ToContentFileMetrics(sourcePath, textMetrics);
 						}
 					}
 				}
@@ -288,7 +289,7 @@ public sealed class SecretRedactionOutputPreparer
 							// Redaction cannot promise anything about text it never decoded or fully read,
 							// so every output withholds the content and reports the exact reason.
 							if (captureTransformedMetrics && result.Content is { } estimatedContent)
-								transformedFileMetrics![sourcePath] = ToContentFileMetrics(sourcePath, estimatedContent);
+								transformedFileMetrics![prepared.SourceIndex] = ToContentFileMetrics(sourcePath, estimatedContent);
 							if (scope is not null &&
 							    (scope.GetContentInspectionMode(sourcePath) != SecretContentInspectionMode.None ||
 							     transformedTextConsumer is not null))
@@ -330,10 +331,12 @@ public sealed class SecretRedactionOutputPreparer
 							prepared.DetectionEntry,
 							compressed.Map);
 					}
-					var redactions = plan?.Spans
-						.Where(static span => span.State == SecretPreviewSpanState.Redacted)
-						.Select(static span => new PreparedSecretSpan(span.Start, span.Length))
-						.ToArray() ?? [];
+					var redactions = materializeTransformedContent
+						? plan?.Spans
+							.Where(static span => span.State == SecretPreviewSpanState.Redacted)
+							.Select(static span => new PreparedSecretSpan(span.Start, span.Length))
+							.ToArray() ?? []
+						: [];
 					IReadOnlyList<EffectiveRedactionFinding> findings = plan is null || !captureEffectiveFindings
 						? []
 						: BuildEffectiveFindings(plan.Spans, content.Content, compressed.Map);
@@ -352,9 +355,9 @@ public sealed class SecretRedactionOutputPreparer
 								cancellationToken)
 							.ConfigureAwait(false);
 					}
-					if (captureTransformedMetrics)
+					if (captureTransformedMetrics && !materializeTransformedContent)
 					{
-						transformedFileMetrics![sourcePath] = await MeasureTransformedContentAsync(
+						transformedFileMetrics![prepared.SourceIndex] = await MeasureTransformedContentAsync(
 							sourcePath,
 							transformedText,
 							plan,
@@ -379,6 +382,15 @@ public sealed class SecretRedactionOutputPreparer
 					// A completed redaction scan must remain authoritative if the source changes before output.
 					if (scope is null && ReferenceEquals(transformedText, content.Content) && redactions.Length == 0)
 					{
+						if (captureTransformedMetrics)
+						{
+							transformedFileMetrics![prepared.SourceIndex] = await MeasureTransformedContentAsync(
+								sourcePath,
+								transformedText,
+								plan,
+								ResolveEncoding(result.Encoding ?? TextFileEncoding.Utf8),
+								cancellationToken).ConfigureAwait(false);
+						}
 						preparedFiles[sourcePath] = findings.Count == 0
 							? PreparedSecretFile.Unchanged(sourcePath)
 							: new PreparedSecretFile(
@@ -418,17 +430,23 @@ public sealed class SecretRedactionOutputPreparer
 						{
 							ContentSlice = slice
 						};
+						if (captureTransformedMetrics)
+							transformedFileMetrics![prepared.SourceIndex] = ToContentFileMetrics(sourcePath, slice.Metrics);
 					}
 					else
 					{
 						var preparedPath = Path.Combine(workingDirectory.Path, $"{prepared.Index:D8}.redacted.txt");
-						await WritePreparedTextAsync(
+						var writtenMetrics = await WritePreparedTextAsync(
 								preparedPath,
+								sourcePath,
 								transformedText,
 								plan,
 								ResolveEncoding(encoding),
+								captureTransformedMetrics,
 								cancellationToken)
 							.ConfigureAwait(false);
+						if (writtenMetrics is { } metrics)
+							transformedFileMetrics![prepared.SourceIndex] = metrics;
 						preparedFiles[sourcePath] = new PreparedSecretFile(
 							sourcePath,
 							preparedPath,
@@ -469,10 +487,7 @@ public sealed class SecretRedactionOutputPreparer
 				unscannableFiles,
 				transformedFileMetrics is null
 					? []
-					: orderedFilePaths
-						.Where(transformedFileMetrics.ContainsKey)
-						.Select(path => transformedFileMetrics[path])
-						.ToArray(),
+					: transformedFileMetrics.OfType<ContentFileMetrics>().ToArray(),
 				contentStore);
 		}
 		catch
@@ -490,22 +505,10 @@ public sealed class SecretRedactionOutputPreparer
 		[EnumeratorCancellation] CancellationToken cancellationToken,
 		SecretRedactionScope? requiredInspectionScope = null)
 	{
-		var scheduled = new List<CompressionWorkItem>(orderedFilePaths.Count);
-		for (var index = 0; index < orderedFilePaths.Count; index++)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			var item = new CompressionWorkItem(index, orderedFilePaths[index]);
-			if (requiredInspectionScope?.GetContentInspectionMode(item.SourcePath) ==
-			    SecretContentInspectionMode.None)
-			{
-				continue;
-			}
-			scheduled.Add(item);
-		}
-		if (scheduled.Count == 0)
+		if (orderedFilePaths.Count == 0)
 			yield break;
 
-		var workerCount = Math.Min(MaximumTransformationWorkers, scheduled.Count);
+		var workerCount = Math.Min(MaximumTransformationWorkers, orderedFilePaths.Count);
 		using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 		using var retainedBytes = new WeightedByteBudget(MaximumTransformationInFlightBytes);
 		using var lookAhead = new SemaphoreSlim(workerCount * 2, workerCount * 2);
@@ -537,8 +540,7 @@ public sealed class SecretRedactionOutputPreparer
 			await foreach (var entry in output.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
 			{
 				pending.Add(entry.Index, entry);
-				while (nextScheduledIndex < scheduled.Count &&
-				       pending.Remove(scheduled[nextScheduledIndex].Index, out var next))
+				while (pending.Remove(nextScheduledIndex, out var next))
 				{
 					nextScheduledIndex++;
 					try
@@ -600,9 +602,20 @@ public sealed class SecretRedactionOutputPreparer
 		{
 			try
 			{
-				foreach (var template in scheduled)
+				var admissionIndex = 0;
+				for (var sourceIndex = 0; sourceIndex < orderedFilePaths.Count; sourceIndex++)
 				{
+					var sourcePath = orderedFilePaths[sourceIndex];
 					linkedCancellation.Token.ThrowIfCancellationRequested();
+					if (requiredInspectionScope?.GetContentInspectionMode(sourcePath) ==
+					    SecretContentInspectionMode.None)
+					{
+						continue;
+					}
+					var template = new CompressionWorkItem(
+						admissionIndex++,
+						sourcePath,
+						SourceIndex: sourceIndex);
 					await lookAhead.WaitAsync(linkedCancellation.Token).ConfigureAwait(false);
 					var windowLease = new WorkWindowLease(lookAhead);
 					WeightedByteBudget.Lease? byteLease = null;
@@ -794,7 +807,8 @@ public sealed class SecretRedactionOutputPreparer
 			contentLease: null,
 			detectionEntry: null,
 			item.RetainedBudget,
-			item.WindowLease);
+			item.WindowLease,
+			sourceIndex: item.EffectiveSourceIndex);
 
 	private async Task<PreparedTransformationEntry> PrepareTransformationEntryCoreAsync(
 		ContentTransformationContext context,
@@ -869,7 +883,8 @@ public sealed class SecretRedactionOutputPreparer
 				contentLease,
 				detectionEntry,
 				item.RetainedBudget,
-				item.WindowLease);
+				item.WindowLease,
+				sourceIndex: item.EffectiveSourceIndex);
 		}
 		catch
 		{
@@ -1117,9 +1132,11 @@ public sealed class SecretRedactionOutputPreparer
 			preparedPath = Path.Combine(workingDirectory.Value.Path, $"{workItem.Index:D8}.compressed.txt");
 			await WritePreparedTextAsync(
 					preparedPath,
+					sourcePath,
 					compressed.Text,
 					plan: null,
 					ResolveEncoding(encoding),
+					captureMetrics: false,
 					cancellationToken)
 				.ConfigureAwait(false);
 		}
@@ -1265,14 +1282,18 @@ public sealed class SecretRedactionOutputPreparer
 			contentLease: null,
 			detectionEntry: null,
 			item.RetainedBudget,
-			item.WindowLease);
+			item.WindowLease,
+			sourceIndex: item.EffectiveSourceIndex);
 
 	private readonly record struct CompressionWorkItem(
 		int Index,
 		string SourcePath,
 		WeightedByteBudget.Lease? RetainedBudget = null,
-		WorkWindowLease? WindowLease = null)
+		WorkWindowLease? WindowLease = null,
+		int SourceIndex = -1)
 	{
+		public int EffectiveSourceIndex => SourceIndex < 0 ? Index : SourceIndex;
+
 		public void DisposeReservations()
 		{
 			RetainedBudget?.Dispose();
@@ -1297,13 +1318,15 @@ public sealed class SecretRedactionOutputPreparer
 		IDisposable? contentLease,
 		SecretScanCacheEntry? detectionEntry = null,
 		IDisposable? retainedBudget = null,
-		IDisposable? windowLease = null) : IDisposable
+		IDisposable? windowLease = null,
+		int sourceIndex = -1) : IDisposable
 	{
 		private IDisposable? _contentLease = contentLease;
 		private IDisposable? _retainedBudget = retainedBudget;
 		private IDisposable? _windowLease = windowLease;
 
 		public int Index { get; } = index;
+		public int SourceIndex { get; } = sourceIndex < 0 ? index : sourceIndex;
 		public string SourcePath { get; } = sourcePath;
 		public SecretFileMetadata Metadata { get; } = metadata;
 		public FileContentReadResult ReadResult { get; } = readResult;
@@ -1628,14 +1651,10 @@ public sealed class SecretRedactionOutputPreparer
 						prepared.ReadResult.Classification));
 					break;
 				case FileContentClassification.Text:
-					redactionScope.AnalyzeTransformed(
+					redactionScope.ProcessDetectedEntry(
 						prepared.SourcePath,
-						prepared.Compression.Text,
+						prepared.DetectionEntry,
 						prepared.Compression.Map,
-						prepared.Metadata,
-						prepared.Compression.Map.IsIdentity
-							? prepared.SourceFingerprint
-							: null,
 						cancellationToken);
 					break;
 				default:
@@ -1754,14 +1773,10 @@ public sealed class SecretRedactionOutputPreparer
 							prepared.ReadResult.Classification));
 						break;
 					case FileContentClassification.Text:
-						redactionScope.AnalyzeTransformed(
+						redactionScope.ProcessDetectedEntry(
 							prepared.SourcePath,
-							prepared.Compression.Text,
+							prepared.DetectionEntry,
 							prepared.Compression.Map,
-							prepared.Metadata,
-							prepared.Compression.Map.IsIdentity
-								? prepared.SourceFingerprint
-								: null,
 							cancellationToken);
 						break;
 					default:
@@ -2203,11 +2218,13 @@ public sealed class SecretRedactionOutputPreparer
 		}
 	}
 
-	private static async Task WritePreparedTextAsync(
+	private static async Task<ContentFileMetrics?> WritePreparedTextAsync(
 		string path,
+		string sourcePath,
 		string content,
 		SecretFileRedactionPlan? plan,
 		Encoding encoding,
+		bool captureMetrics,
 		CancellationToken cancellationToken)
 	{
 		using var stage = ContentPipelineDiagnostics.MeasureStage(ContentPipelineStage.RedactionAndOutput);
@@ -2223,12 +2240,15 @@ public sealed class SecretRedactionOutputPreparer
 
 		await using var stream = new FileStream(path, options);
 		await using var writer = new StreamWriter(stream, encoding);
+		var metricsWriter = captureMetrics ? new ContentMetricsTextWriter(encoding, writer) : null;
+		var destination = (TextWriter?)metricsWriter ?? writer;
 		if (plan is null)
-			await writer.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
+			await destination.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
 		else
-			await plan.WriteToAsync(writer, content, cancellationToken).ConfigureAwait(false);
+			await plan.WriteToAsync(destination, content, cancellationToken).ConfigureAwait(false);
 		await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
 		ContentPipelineDiagnostics.RecordPreparedWrite(stream.Position);
+		return metricsWriter?.Build(sourcePath);
 	}
 
 	private static async Task<ContentFileMetrics> MeasureTransformedContentAsync(
@@ -2239,6 +2259,7 @@ public sealed class SecretRedactionOutputPreparer
 		CancellationToken cancellationToken)
 	{
 		using var stage = ContentPipelineDiagnostics.MeasureStage(ContentPipelineStage.RedactionAndOutput);
+		ContentPipelineDiagnostics.RecordMeasurementPass();
 		var writer = new ContentMetricsTextWriter(encoding);
 		if (plan is null)
 			await writer.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
@@ -2273,7 +2294,9 @@ public sealed class SecretRedactionOutputPreparer
 			content.TrailingNewlineChars,
 			content.TrailingNewlineLineBreaks);
 
-	private sealed class ContentMetricsTextWriter(Encoding encoding) : TextWriter
+	private sealed class ContentMetricsTextWriter(
+		Encoding encoding,
+		TextWriter? destination = null) : TextWriter
 	{
 		private readonly Encoder _encoder = encoding.GetEncoder();
 		private FileContentAnalyzer.TextMetricsCounter _counter = new();
@@ -2292,7 +2315,7 @@ public sealed class SecretRedactionOutputPreparer
 			if (!_counter.Append(buffer.Span))
 				throw new InvalidOperationException("Decoded transformed text unexpectedly contained a null character.");
 			_encodedBytes = checked(_encodedBytes + _encoder.GetByteCount(buffer.Span, flush: false));
-			return Task.CompletedTask;
+			return destination?.WriteAsync(buffer, cancellationToken) ?? Task.CompletedTask;
 		}
 
 		public ContentFileMetrics Build(string path)

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -2495,6 +2495,27 @@ public sealed class SecretRedactionScope
 		}
 	}
 
+	internal void ProcessDetectedEntry(
+		string filePath,
+		SecretScanCacheEntry? entry,
+		ContentTransformMap transformMap,
+		CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		EnterOrderedConsumer();
+		try
+		{
+			EnsureActive();
+			if (entry?.IsUnscannable == true)
+				RecordUnscannable(filePath);
+			AccumulateFindings(filePath, entry, transformMap);
+		}
+		finally
+		{
+			ExitOrderedConsumer();
+		}
+	}
+
 	public SecretTextRedactionResult Redact(
 		string filePath,
 		string content,
@@ -2720,6 +2741,8 @@ public sealed class SecretRedactionScope
 		var candidates = entry?.Candidates ?? [];
 		var segments = entry?.Segments ?? [];
 		_outputInspectionBudget.RegisterFindings(segments.Count);
+		if (candidates.Count == 0 && segments.Count == 0)
+			return SecretFileRedactionPlan.Empty;
 		var relativePath = SecretRedactionSession.NormalizeRelativePath(_projectRoot, filePath);
 		var occurrenceIds = BuildOccurrenceIds(relativePath, entry, candidates, transformMap);
 		var identityIndexes = new int[candidates.Count];
@@ -3217,6 +3240,12 @@ internal sealed class SecretFileRedactionPlan(
 	int detectedCount,
 	int redactedCount)
 {
+	public static SecretFileRedactionPlan Empty { get; } = new(
+		Array.Empty<SecretReplacement>(),
+		Array.Empty<SecretPreviewSpan>(),
+		0,
+		0);
+
 	public IReadOnlyList<SecretReplacement> Replacements { get; } = replacements;
 	public IReadOnlyList<SecretPreviewSpan> Spans { get; } = spans;
 	public int DetectedCount { get; } = detectedCount;

--- a/Application/Services/FileContentAnalyzer.cs
+++ b/Application/Services/FileContentAnalyzer.cs
@@ -74,6 +74,8 @@ public sealed class FileContentAnalyzer :
 		// Other binary
 		".bin", ".dat", ".db", ".sqlite", ".mdb"
 	}.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+	private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> KnownBinaryExtensionLookup =
+		KnownBinaryExtensions.GetAlternateLookup<ReadOnlySpan<char>>();
 	private static readonly Encoding StrictUtf8 = new UTF8Encoding(
 		encoderShouldEmitUTF8Identifier: true,
 		throwOnInvalidBytes: true);
@@ -314,9 +316,10 @@ public sealed class FileContentAnalyzer :
 					new ClassifiedCompleteTextFileBuffer(FileContentClassification.Text));
 			}
 
-			var bomEncoding = DetectBomEncoding(stream, cancellationToken);
+			var prefix = ReadPrefix(stream, cancellationToken);
+			var bomEncoding = prefix.Encoding;
 			var encoding = bomEncoding ?? StrictUtf8;
-			if (!CheckForNullBytes(stream, cancellationToken))
+			if (!prefix.IsText)
 			{
 				return IdentifiedBuffer(
 					stream,
@@ -492,8 +495,9 @@ public sealed class FileContentAnalyzer :
 						CrLfPairCount: 0)));
 			}
 
-			var encoding = DetectBomEncoding(stream, cancellationToken);
-			if (encoding is null && !CheckForNullBytes(stream, cancellationToken))
+			var prefix = ReadPrefix(stream, cancellationToken);
+			var encoding = prefix.Encoding;
+			if (!prefix.IsText)
 				return Identified(
 					stream,
 					new FileContentMetricsResult(FileContentClassification.Binary));
@@ -519,7 +523,7 @@ public sealed class FileContentAnalyzer :
 			var metrics = CountMetricsStreaming(
 				stream,
 				sizeBytes,
-				encoding ?? StrictUtf8,
+				encoding,
 				cancellationToken,
 				calculateFingerprint: false,
 				out _,
@@ -621,8 +625,9 @@ public sealed class FileContentAnalyzer :
 				return emptySnapshot;
 			}
 
-			var encoding = DetectBomEncoding(stream, cancellationToken);
-			if (encoding is null && !CheckForNullBytes(stream, cancellationToken))
+			var prefix = ReadPrefix(stream, cancellationToken);
+			var encoding = prefix.Encoding;
+			if (!prefix.IsText)
 			{
 				return new ClassifiedFileContentSnapshot(
 					new FileContentMetricsResult(FileContentClassification.Binary));
@@ -631,7 +636,7 @@ public sealed class FileContentAnalyzer :
 			var metrics = CountMetricsStreaming(
 				stream,
 				sizeBytes,
-				encoding ?? StrictUtf8,
+				encoding,
 				cancellationToken,
 				calculateFingerprint: true,
 				out var contentFingerprint,
@@ -788,8 +793,9 @@ public sealed class FileContentAnalyzer :
 				TextFileEncoding.Utf8);
 		}
 
-		var encoding = DetectBomEncoding(stream, cancellationToken);
-		if (encoding is null && !CheckForNullBytes(stream, cancellationToken))
+		var prefix = ReadPrefix(stream, cancellationToken);
+		var encoding = prefix.Encoding;
+		if (!prefix.IsText)
 			return new ContentReadFact(null, FileContentClassification.Binary, null, null);
 
 		if (sizeBytes > maxSizeForFullRead)
@@ -840,7 +846,7 @@ public sealed class FileContentAnalyzer :
 	/// Checks first 512 bytes for null bytes to detect binary content.
 	/// Returns true if no null bytes found (text file), false otherwise (binary).
 	/// </summary>
-	private static bool CheckForNullBytes(FileStream stream, CancellationToken cancellationToken)
+	private static PrefixProbe ReadPrefix(FileStream stream, CancellationToken cancellationToken)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
 		stream.Position = 0;
@@ -848,27 +854,16 @@ public sealed class FileContentAnalyzer :
 		Span<byte> buffer = stackalloc byte[toRead];
 		int bytesRead = stream.Read(buffer);
 
-		if (TryResolveBomEncoding(buffer[..bytesRead], out _))
-			return true;
+		stream.Position = 0;
+		if (TryResolveBomEncoding(buffer[..bytesRead], out var encoding))
+			return new PrefixProbe(encoding, IsText: true);
 
 		// Span.Contains uses the runtime's vectorized search without changing the
 		// established null-byte binary detection contract.
-		return !buffer[..bytesRead].Contains((byte)0);
+		return new PrefixProbe(null, !buffer[..bytesRead].Contains((byte)0));
 	}
 
-	private static Encoding? DetectBomEncoding(
-		FileStream stream,
-		CancellationToken cancellationToken)
-	{
-		cancellationToken.ThrowIfCancellationRequested();
-		stream.Position = 0;
-		Span<byte> bom = stackalloc byte[(int)Math.Min(4, stream.Length)];
-		var bytesRead = stream.Read(bom);
-		stream.Position = 0;
-		return TryResolveBomEncoding(bom[..bytesRead], out var encoding)
-			? encoding
-			: null;
-	}
+	private readonly record struct PrefixProbe(Encoding? Encoding, bool IsText);
 
 	private static bool TryResolveBomEncoding(ReadOnlySpan<byte> value, out Encoding encoding)
 	{
@@ -924,12 +919,7 @@ public sealed class FileContentAnalyzer :
 		if (extension.IsEmpty)
 			return false;
 
-		if (KnownBinaryExtensions.TryGetAlternateLookup<ReadOnlySpan<char>>(out var lookup))
-			return lookup.Contains(extension);
-
-		// The ordinal-ignore-case frozen set supports span lookup on current runtimes.
-		// Keep a compatibility fallback so an implementation detail cannot change behavior.
-		return KnownBinaryExtensions.Contains(extension.ToString());
+		return KnownBinaryExtensionLookup.Contains(extension);
 	}
 
 	/// <summary>
@@ -939,7 +929,7 @@ public sealed class FileContentAnalyzer :
 	private static TextFileMetrics? CountMetricsStreaming(
 		FileStream stream,
 		long sizeBytes,
-		Encoding encoding,
+		Encoding? bomEncoding,
 		CancellationToken cancellationToken,
 		bool calculateFingerprint,
 		out byte[]? contentFingerprint,
@@ -962,9 +952,8 @@ public sealed class FileContentAnalyzer :
 		try
 		{
 			var counter = new TextMetricsCounter();
-			var bomEncoding = DetectBomEncoding(stream, cancellationToken);
 			var effectiveEncoding = bomEncoding is null
-				? encoding
+				? StrictUtf8
 				: ResolveBomFallbackEncoding(bomEncoding);
 			var decoder = effectiveEncoding.GetDecoder();
 			byteBuffer = ArrayPool<byte>.Shared.Rent(StreamingBufferSize);

--- a/Apps/Avalonia/Coordinators/MetricsPipeline.cs
+++ b/Apps/Avalonia/Coordinators/MetricsPipeline.cs
@@ -162,13 +162,29 @@ internal sealed class MetricsPipeline(
 		FileMetricsVariant raw,
 		MetricsFileSourceVersion sourceVersion)
     {
-        private readonly Dictionary<string, FileMetricsVariant> _transformed = new(StringComparer.Ordinal);
+		private string? _inlineTransformIdentity;
+		private FileMetricsVariant _inlineTransformed;
+		private Dictionary<string, FileMetricsVariant>? _transformed;
 
         public FileMetricsVariant Raw { get; set; } = raw;
 		public MetricsFileSourceVersion SourceVersion { get; } = sourceVersion;
 
-        public void SetTransformed(string identity, FileMetricsVariant metrics) =>
-            _transformed[identity] = metrics;
+		public void SetTransformed(string identity, FileMetricsVariant metrics)
+		{
+			if (_inlineTransformIdentity is null ||
+			    string.Equals(_inlineTransformIdentity, identity, StringComparison.Ordinal))
+			{
+				_inlineTransformIdentity = identity;
+				_inlineTransformed = metrics;
+				return;
+			}
+
+			_transformed ??= new Dictionary<string, FileMetricsVariant>(StringComparer.Ordinal)
+			{
+				[_inlineTransformIdentity] = _inlineTransformed
+			};
+			_transformed[identity] = metrics;
+		}
 
         public bool TryGet(string identity, out FileMetricsVariant metrics)
         {
@@ -178,9 +194,47 @@ internal sealed class MetricsPipeline(
                 return true;
             }
 
-            return _transformed.TryGetValue(identity, out metrics);
+			if (string.Equals(_inlineTransformIdentity, identity, StringComparison.Ordinal))
+			{
+				metrics = _inlineTransformed;
+				return true;
+			}
+
+			if (_transformed is not null && _transformed.TryGetValue(identity, out metrics))
+				return true;
+			metrics = default;
+			return false;
         }
     }
+
+	private sealed class CoalescedMetricsProgress(Action<int> publish)
+	{
+		private int _latest = -1;
+		private int _scheduled;
+
+		public void Report(int value)
+		{
+			Interlocked.Exchange(ref _latest, value);
+			ScheduleIfNeeded();
+		}
+
+		private void ScheduleIfNeeded()
+		{
+			if (Interlocked.CompareExchange(ref _scheduled, 1, 0) != 0)
+				return;
+			Dispatcher.UIThread.Post(Drain);
+		}
+
+		private void Drain()
+		{
+			var delivered = Interlocked.Exchange(ref _latest, -1);
+			if (delivered >= 0)
+				publish(delivered);
+			Interlocked.Exchange(ref _scheduled, 0);
+			if (Volatile.Read(ref _latest) >= 0)
+				ScheduleIfNeeded();
+		}
+	}
 
     private const double CompactStatusMetricsThresholdWidth = 1050;
     private const long MaximumMetricsMaterializationBytes = 10L * 1024 * 1024;
@@ -204,6 +258,7 @@ internal sealed class MetricsPipeline(
     private DispatcherTimer? _metricsDebounceTimer;
     private CancellationTokenSource? _recalculateMetricsCts;
     private volatile bool _isBackgroundMetricsActive;
+	private TaskCompletionSource _backgroundMetricsIdle = CompletedSignal();
     private int _metricsRecalcVersion;
     private int _metricsCacheGeneration;
     private long _lastStatusTreeLines;
@@ -228,6 +283,13 @@ internal sealed class MetricsPipeline(
     private bool _metricsCancellationRequestedByUser;
     private volatile bool _hasCompleteMetricsBaseline;
     private int _disposed;
+
+	private static TaskCompletionSource CompletedSignal()
+	{
+		var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		signal.TrySetResult();
+		return signal;
+	}
 
     public bool IsBackgroundActive => _isBackgroundMetricsActive;
 
@@ -474,7 +536,7 @@ internal sealed class MetricsPipeline(
         if (_isBackgroundMetricsActive)
             _hasCompleteMetricsBaseline = false;
 
-        _isBackgroundMetricsActive = false;
+		SetBackgroundMetricsActive(false);
         _metricsCalculationCts?.Cancel();
         _recalculateMetricsCts?.Cancel();
         _compressionPrewarmCts?.Cancel();
@@ -853,7 +915,7 @@ internal sealed class MetricsPipeline(
 
         _metricsCancellationRequestedByUser = false;
         _hasCompleteMetricsBaseline = false;
-        _isBackgroundMetricsActive = true;
+		SetBackgroundMetricsActive(true);
         var statusOperationId = statusOperations.Begin(
             viewModel.StatusOperationCalculatingData,
             indeterminate: false,
@@ -909,7 +971,7 @@ internal sealed class MetricsPipeline(
             var totalFiles = filePaths.Count;
             if (totalFiles == 0)
             {
-                _isBackgroundMetricsActive = false;
+				SetBackgroundMetricsActive(false);
                 _hasCompleteMetricsBaseline = true;
                 Recalculate();
                 viewModel.StatusMetricsVisible = true;
@@ -934,7 +996,7 @@ internal sealed class MetricsPipeline(
                 stagedResults,
                 cacheGeneration);
 
-            _isBackgroundMetricsActive = false;
+			SetBackgroundMetricsActive(false);
             _hasCompleteMetricsBaseline = !hadReadFailures;
             if (statusOperations.IsActive(statusOperationId))
                 viewModel.StatusProgressValue = 100;
@@ -959,7 +1021,7 @@ internal sealed class MetricsPipeline(
                 return;
             }
 
-            _isBackgroundMetricsActive = false;
+			SetBackgroundMetricsActive(false);
             _hasCompleteMetricsBaseline = false;
             MergeStagedMetricsIntoCache(
                 stagedFilePaths,
@@ -1000,7 +1062,7 @@ internal sealed class MetricsPipeline(
                 return;
             }
 
-            _isBackgroundMetricsActive = false;
+			SetBackgroundMetricsActive(false);
             _hasCompleteMetricsBaseline = false;
             MergeStagedMetricsIntoCache(
                 stagedFilePaths,
@@ -1094,6 +1156,11 @@ internal sealed class MetricsPipeline(
         var processedCount = 0;
         var lastProgressPercent = 0;
         var hadReadFailures = 0;
+		var progress = new CoalescedMetricsProgress(progressPercent =>
+		{
+			if (_isBackgroundMetricsActive && statusOperations.IsActive(statusOperationId))
+				viewModel.StatusProgressValue = progressPercent;
+		});
         var parallelOptions = new ParallelOptions
         {
             MaxDegreeOfParallelism = maxDegreeOfParallelism,
@@ -1106,11 +1173,22 @@ internal sealed class MetricsPipeline(
             : _appliedTransformIdentity;
 
 		await Parallel.ForAsync(0, filePaths.Count, parallelOptions, async (index, ct) =>
-        {
+		{
             var filePath = filePaths[index];
             try
             {
+				ContentReadMetricsFact? retainedMetrics = null;
+				if (readFacts is not null && readFacts.TryGetMetrics(filePath, transformIdentity, out var retained))
+					retainedMetrics = retained;
+				MetricsFileSourceVersion? retainedSourceVersion = retainedMetrics is { } retainedIdentity
+					? new MetricsFileSourceVersion(
+						retainedIdentity.SourceLength,
+						retainedIdentity.SourceLastWriteTimeUtcTicks,
+						IsMissing: false)
+					: null;
 				var sourceVersionBeforeRead = TryCaptureCurrentSourceVersion(filePath);
+				if (retainedSourceVersion != sourceVersionBeforeRead)
+					retainedMetrics = null;
                 if (fileContentAnalyzer.ClassifyWithoutReading(filePath) ==
                     FileContentClassification.Binary)
                 {
@@ -1135,22 +1213,17 @@ internal sealed class MetricsPipeline(
                 TextFileMetrics? rawMetrics;
                 TextFileMetrics? effectiveMetrics;
 				MetricsFileSourceVersion? sourceVersion = null;
-				ContentReadFact? retainedFact = null;
-				if (readFacts is not null && readFacts.TryGet(filePath, out var retained))
-					retainedFact = retained;
-                if (transformationScope is not null && IsCompressible(filePath))
+				if (retainedMetrics is { } compactMetrics)
+				{
+					rawMetrics = compactMetrics.Raw;
+					effectiveMetrics = compactMetrics.Effective;
+					sourceVersion = sourceVersionBeforeRead;
+				}
+				else if (transformationScope is not null && IsCompressible(filePath))
                 {
-					ContentReadFact fact;
-					if (retainedFact is { IsMaterializedText: true })
-					{
-						fact = retainedFact;
-					}
-					else
-					{
-						fact = await fileContentAnalyzer
-							.ReadFactAsync(filePath, MaximumMetricsMaterializationBytes, ct)
-							.ConfigureAwait(false);
-					}
+					var fact = await fileContentAnalyzer
+						.ReadFactAsync(filePath, MaximumMetricsMaterializationBytes, ct)
+						.ConfigureAwait(false);
 					rawMetrics = fact.RawMetrics;
 					effectiveMetrics = rawMetrics is { IsEstimated: false } && fact.IsMaterializedText
 						? MeasureTransformed(
@@ -1165,17 +1238,10 @@ internal sealed class MetricsPipeline(
                 }
                 else
                 {
-					if (retainedFact is not null)
-					{
-						rawMetrics = retainedFact.RawMetrics;
-					}
-					else
-					{
-						var result = await fileContentAnalyzer
-							.GetClassifiedMetricsAsync(filePath, ct)
-							.ConfigureAwait(false);
-						rawMetrics = result.IsText ? result.Metrics : null;
-					}
+					var result = await fileContentAnalyzer
+						.GetClassifiedMetricsAsync(filePath, ct)
+						.ConfigureAwait(false);
+					rawMetrics = result.IsText ? result.Metrics : null;
                     effectiveMetrics = rawMetrics;
                 }
 
@@ -1212,11 +1278,7 @@ internal sealed class MetricsPipeline(
                 if (progressPercent >= observed + 5 &&
                     Interlocked.CompareExchange(ref lastProgressPercent, progressPercent, observed) == observed)
                 {
-                    await Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        if (_isBackgroundMetricsActive && statusOperations.IsActive(statusOperationId))
-                            viewModel.StatusProgressValue = progressPercent;
-                    });
+					progress.Report(progressPercent);
                 }
             }
         });
@@ -1426,9 +1488,26 @@ internal sealed class MetricsPipeline(
 
     private async Task WaitForBackgroundMetricsIdleAsync(CancellationToken cancellationToken)
     {
-        while (_isBackgroundMetricsActive)
-            await Task.Delay(10, cancellationToken);
+		while (_isBackgroundMetricsActive)
+		{
+			var signal = Volatile.Read(ref _backgroundMetricsIdle);
+			await signal.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+		}
     }
+
+	private void SetBackgroundMetricsActive(bool active)
+	{
+		if (active)
+		{
+			var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			Volatile.Write(ref _backgroundMetricsIdle, signal);
+			_isBackgroundMetricsActive = true;
+			return;
+		}
+
+		_isBackgroundMetricsActive = false;
+		Volatile.Read(ref _backgroundMetricsIdle).TrySetResult();
+	}
 
     private async Task PublishTreeMetricsWhileContentPendingAsync(
         CancellationToken token,
@@ -1646,7 +1725,7 @@ internal sealed class MetricsPipeline(
         var cacheGeneration = Volatile.Read(ref _metricsCacheGeneration);
 
         _metricsCancellationRequestedByUser = false;
-        _isBackgroundMetricsActive = true;
+		SetBackgroundMetricsActive(true);
         var statusOperationId = statusOperations.Begin(
             viewModel.StatusOperationCalculatingData,
             indeterminate: false,
@@ -1694,7 +1773,7 @@ internal sealed class MetricsPipeline(
                     Volatile.Read(ref _metricsCalculationCts),
                     metricsCts))
             {
-                _isBackgroundMetricsActive = false;
+				SetBackgroundMetricsActive(false);
             }
 
             statusOperations.Complete(statusOperationId);
@@ -1858,56 +1937,92 @@ internal sealed class MetricsPipeline(
 
 		var orderedPaths = selection.OrderedFilePaths ??
 			BuildOrderedMetricsFilePaths(selection, cancellationToken);
-		var contentOnlyAccumulator = new ExportOutputMetricsCalculator.OrderedContentMetricsAccumulator();
-		var treeAndContentAccumulator = new ExportOutputMetricsCalculator.OrderedContentMetricsAccumulator();
-		contentOnlyAccumulator.AppendRootHeader(contentOnlyRootPath);
-		lock (_metricsLock)
-        {
-			for (var index = 0; index < orderedPaths.Count; index++)
-            {
-				cancellationToken.ThrowIfCancellationRequested();
-				var path = orderedPaths[index];
-                if (!_fileMetricsCache.TryGetValue(path, out var cacheEntry) ||
-                    !cacheEntry.TryGet(_appliedTransformIdentity, out var variant) ||
-                    !variant.HasMetrics)
-                {
-                    continue;
-                }
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var cacheGeneration = Volatile.Read(ref _metricsCacheGeneration);
+			var selected = new List<(string Path, FileMetricsData Metrics)>(orderedPaths.Count);
+			EnterMetricsLock();
+			try
+			{
+				for (var index = 0; index < orderedPaths.Count; index++)
+				{
+					var path = orderedPaths[index];
+					if (_fileMetricsCache.TryGetValue(path, out var cacheEntry) &&
+					    cacheEntry.TryGet(cacheKey.TransformIdentity, out var variant) &&
+					    variant.HasMetrics)
+					{
+						selected.Add((path, variant.Metrics));
+					}
+				}
+			}
+			finally
+			{
+				Monitor.Exit(_metricsLock);
+			}
 
-                var metrics = variant.Metrics;
+			var contentAccumulator = new ExportOutputMetricsCalculator.OrderedContentMetricsAccumulator();
+			foreach (var selectedFile in selected)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				var metrics = selectedFile.Metrics;
 				var contentPath = OutputRootPathPresentation.ResolvePath(
-					MapExportDisplayPath(path, contentPathMapper),
+					MapExportDisplayPath(selectedFile.Path, contentPathMapper),
 					outputPathRedaction).Text;
 				var fileMetrics = new ContentFileMetrics(
-					Path: contentPath,
-                    SizeBytes: metrics.Size,
-                    LineCount: metrics.LineCount,
-                    CharCount: metrics.CharCount,
-                    IsEmpty: metrics.IsEmpty,
-                    IsWhitespaceOnly: metrics.IsWhitespaceOnly,
-                    IsEstimated: metrics.IsEstimated,
-                    CrLfPairCount: metrics.CrLfPairCount,
-					TrailingNewlineChars: metrics.TrailingNewlineChars,
-					TrailingNewlineLineBreaks: metrics.TrailingNewlineLineBreaks);
+					contentPath,
+					metrics.Size,
+					metrics.LineCount,
+					metrics.CharCount,
+					metrics.IsEmpty,
+					metrics.IsWhitespaceOnly,
+					metrics.IsEstimated,
+					metrics.CrLfPairCount,
+					metrics.TrailingNewlineChars,
+					metrics.TrailingNewlineLineBreaks);
+				contentAccumulator.AppendFile(fileMetrics);
+			}
 
-				contentOnlyAccumulator.AppendFile(fileMetrics);
-				treeAndContentAccumulator.AppendFile(fileMetrics);
-            }
-        }
+			if (cacheGeneration != Volatile.Read(ref _metricsCacheGeneration))
+				continue;
+			var treeAndContentMetrics = contentAccumulator.ToMetrics();
+			var computed = new ContentMetricsPair(
+				AddContentRootMetrics(treeAndContentMetrics, contentOnlyRootPath, selected.Count > 0),
+				treeAndContentMetrics);
+			lock (_computationCacheLock)
+			{
+				if (cacheGeneration != Volatile.Read(ref _metricsCacheGeneration))
+					continue;
+				_hasContentMetricsCache = true;
+				_contentMetricsCacheKey = cacheKey;
+				_contentMetricsCacheValue = computed;
+			}
+			return computed;
+		}
+	}
 
-		var computed = new ContentMetricsPair(
-            contentOnlyAccumulator.ToMetrics(),
-            treeAndContentAccumulator.ToMetrics());
-		cancellationToken.ThrowIfCancellationRequested();
-        lock (_computationCacheLock)
-        {
-            _hasContentMetricsCache = true;
-            _contentMetricsCacheKey = cacheKey;
-            _contentMetricsCacheValue = computed;
-        }
+	private static ExportOutputMetrics AddContentRootMetrics(
+		ExportOutputMetrics content,
+		string displayRootPath,
+		bool hasFiles)
+	{
+		if (string.IsNullOrWhiteSpace(displayRootPath))
+			return content;
+		var rootCharacters = ContextRootPresentation.FormatLine(displayRootPath).Length;
+		if (!hasFiles)
+			return new ExportOutputMetrics(1, rootCharacters, EstimateTokens(rootCharacters));
 
-        return computed;
-    }
+		// The content-only renderer writes the root line followed by two non-breaking-space
+		// separator lines before the first file. Metrics normalize each newline to one char.
+		var characters = checked(content.Chars + rootCharacters + 5L);
+		return new ExportOutputMetrics(
+			checked(content.Lines + 3L),
+			characters,
+			EstimateTokens(characters));
+	}
+
+	private static long EstimateTokens(long characters) =>
+		characters <= 0 ? 0 : (characters + 3) / 4;
 
     private ExportOutputMetrics GetRenderedStatusContentMetrics()
     {

--- a/Docs/HideSecrets.md
+++ b/Docs/HideSecrets.md
@@ -169,6 +169,20 @@ strings. Changed files are rescanned individually; unchanged files reuse their
 findings. Full transformed content is produced lazily for Preview or export, and
 temporary data is removed after completion or cancellation.
 
+The implementation avoids work that cannot affect those decisions. Provider-rule values are
+materialized only for accepted findings; line context is built only for line-target allowlists
+after entropy checks; path allowlists and immutable stopword search tables are reused. Preparation
+passes detection entries forward, measures materialized transformed text while writing it, and
+keeps only compact raw/effective metrics between compression prewarm and the Desktop metrics pass.
+None of these execution shortcuts changes rule inputs, allowlist AND/OR semantics, findings,
+replacement offsets, scan limits, or the fail-closed treatment of unreadable content.
+
+Performance investigations can opt into `ContentPipelineDiagnostics`. Its operation-local counters
+include secondary provider-regex runs, line-index builds, rejected-match line contexts, plan
+applications, and transformed-content-only measurement passes. Diagnostics remain inactive unless
+a measurement scope is explicitly opened. The reproducible detector and line-index harness is in
+`tools/Benchmarks/Secrets`; it is not part of the application or release payload.
+
 ## Folder and ZIP copies
 
 With Hide Secrets enabled, a project copy is intentionally not byte-for-byte

--- a/Infrastructure/Secrets/BenchmarkAssemblyInfo.cs
+++ b/Infrastructure/Secrets/BenchmarkAssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DevProjex.SecretsBenchmark")]

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using DevProjex.Application.Diagnostics;
 using DevProjex.Application.Secrets;
 using Tomlyn;
 using Tomlyn.Model;
@@ -125,7 +126,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		try
 		{
 			var normalizedPath = PathUtility.NormalizeSeparators(repositoryRelativePath);
-			return ShouldInspectPath(_configuration.Value, normalizedPath);
+			var allowlists = _configuration.Value.GlobalAllowlists;
+			return ShouldInspectPath(allowlists, EvaluateAllowlistPaths(allowlists, normalizedPath));
 		}
 		catch (RegexMatchTimeoutException exception)
 		{
@@ -226,7 +228,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		var rule = _configuration.Value.Rules.Single(candidate =>
 			candidate.Id.Equals(ruleId, StringComparison.Ordinal));
 		if (rule.ContentRegex?.Value.Match(content) is not { Success: true } match ||
-		    !TryExtractSecret(rule, match, out var secret))
+		    !TryExtractSecretRange(rule, match, out var secretOffset, out var secretLength))
 		{
 			return default;
 		}
@@ -235,8 +237,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			IsMatch: true,
 			match.Index,
 			match.Length,
-			secret.Index,
-			secret.Length);
+			secretOffset,
+			secretLength);
 	}
 
 	internal IReadOnlyList<string> InspectRunnableRuleIds(
@@ -322,7 +324,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			budget.RunRuleInitialization(allowlist.EnsureCompiled);
 		budget.Checkpoint(cancellationToken);
 		var normalizedPath = PathUtility.NormalizeSeparators(repositoryRelativePath);
-		if (!ShouldInspectPath(configuration, normalizedPath))
+		var globalPathMatches = EvaluateAllowlistPaths(configuration.GlobalAllowlists, normalizedPath);
+		if (!ShouldInspectPath(configuration.GlobalAllowlists, globalPathMatches))
 			return [];
 		Span<ulong> candidateRules = stackalloc ulong[GetCandidateWordCount(configuration.Rules.Count)];
 		configuration.KeywordPrefilter.FindCandidates(content, candidateRules, cancellationToken);
@@ -348,45 +351,60 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			if (!rule.AppliesToPath(normalizedPath))
 				continue;
 			budget.RunRuleInitialization(rule.EnsureContentAndAllowlistsCompiled);
+			var rulePathMatches = EvaluateAllowlistPaths(rule.Allowlists, normalizedPath);
 			budget.Checkpoint(cancellationToken);
 			try
 			{
 				var contentRegex = rule.ContentRegex.Value;
+				var wholeMatchFastPath = rule.CanUseWholeMatch(contentRegex);
 				foreach (var valueMatch in contentRegex.EnumerateMatches(content))
 				{
 					budget.Checkpoint(cancellationToken);
-					// ValueMatch deliberately omits capture groups. Re-running the expression over
-					// the already bounded full-match slice keeps the full file allocation-free while
-					// preserving the reviewed Gitleaks secretGroup semantics.
-					var matchText = content.Slice(valueMatch.Index, valueMatch.Length).ToString();
-					var captureMatch = contentRegex.Match(matchText);
-					if (!captureMatch.Success ||
-					    !TryExtractSecret(rule, captureMatch, out var secretGroup))
-						continue;
+					var secretOffset = 0;
+					var secretLength = valueMatch.Length;
+					if (!wholeMatchFastPath)
+					{
+						ContentPipelineDiagnostics.RecordSecondarySecretRegexRun();
+						var boundedMatch = content.Slice(valueMatch.Index, valueMatch.Length).ToString();
+						var captureMatch = contentRegex.Match(boundedMatch);
+						if (!captureMatch.Success ||
+						    !TryExtractSecretRange(rule, captureMatch, out secretOffset, out secretLength))
+							continue;
+					}
 
-					var lineRange = lineIndex.GetContainingLine(valueMatch.Index, valueMatch.Length);
-					var line = content.Slice(lineRange.Start, lineRange.Length);
-					var secret = secretGroup.Value;
+					var secret = content.Slice(valueMatch.Index + secretOffset, secretLength);
 					if (rule.Entropy > 0 && CalculateShannonEntropy(secret) <= rule.Entropy)
 						continue;
 
+					ReadOnlySpan<char> line = default;
+					var inspectedLine = false;
+					if (NeedsLine(configuration.GlobalAllowlists, globalPathMatches) ||
+					    NeedsLine(rule.Allowlists, rulePathMatches))
+					{
+						var lineRange = lineIndex.GetContainingLine(valueMatch.Index, valueMatch.Length);
+						line = content.Slice(lineRange.Start, lineRange.Length);
+						inspectedLine = true;
+					}
+
 					var context = new AllowlistContext(
 						normalizedPath,
-						secret.AsSpan(),
-						matchText.AsSpan(),
+						secret,
+						content.Slice(valueMatch.Index, valueMatch.Length),
 						line);
-					if (Allows(configuration.GlobalAllowlists, context) ||
-					    Allows(rule.Allowlists, context))
+					if (Allows(configuration.GlobalAllowlists, globalPathMatches, context) ||
+					    Allows(rule.Allowlists, rulePathMatches, context))
 					{
+						if (inspectedLine)
+							ContentPipelineDiagnostics.RecordRejectedMatchLineContext();
 						continue;
 					}
 
 					budget.RegisterFinding(cancellationToken);
 					findings.Add(new DetectedSecret(
 						rule.Id,
-						checked(valueMatch.Index + secretGroup.Index),
-						secretGroup.Length,
-						secret,
+						checked(valueMatch.Index + secretOffset),
+						secretLength,
+						secret.ToString(),
 						rule.Order));
 				}
 			}
@@ -403,10 +421,16 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	}
 
 	private static bool ShouldInspectPath(
-		CompiledConfiguration configuration,
-		string normalizedPath) =>
-		!configuration.GlobalAllowlists.Any(
-			allowlist => allowlist.AllowsWholeFileByPath(normalizedPath));
+		IReadOnlyList<CompiledAllowlist> allowlists,
+		IReadOnlyList<bool> pathMatches)
+	{
+		for (var index = 0; index < allowlists.Count; index++)
+		{
+			if (allowlists[index].AllowsWholeFileByPath(pathMatches[index]))
+				return false;
+		}
+		return true;
+	}
 
 	private static bool HasGenericApiKeyEvidence(ReadOnlySpan<char> content)
 	{
@@ -1050,20 +1074,25 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		int ruleCount) =>
 		new(candidates, ruleCount);
 
-	private static bool TryExtractSecret(
+	private static bool TryExtractSecretRange(
 		CompiledRule rule,
 		Match match,
-		out Group secretGroup)
+		out int offset,
+		out int length)
 	{
+		Group secretGroup;
 		if (rule.SecretGroup > 0)
 		{
 			if (rule.SecretGroup >= match.Groups.Count || !match.Groups[rule.SecretGroup].Success)
 			{
-				secretGroup = match.Groups[0];
+				offset = 0;
+				length = 0;
 				return false;
 			}
 			secretGroup = match.Groups[rule.SecretGroup];
-			return secretGroup.Length > 0;
+			offset = secretGroup.Index;
+			length = secretGroup.Length;
+			return length > 0;
 		}
 
 		for (var index = 1; index < match.Groups.Count; index++)
@@ -1071,18 +1100,49 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			if (!match.Groups[index].Success || match.Groups[index].Length == 0)
 				continue;
 			secretGroup = match.Groups[index];
+			offset = secretGroup.Index;
+			length = secretGroup.Length;
 			return true;
 		}
 
 		secretGroup = match.Groups[0];
-		return secretGroup.Length > 0;
+		offset = secretGroup.Index;
+		length = secretGroup.Length;
+		return length > 0;
 	}
 
-	private static bool Allows(IReadOnlyList<CompiledAllowlist> allowlists, AllowlistContext context)
+	private static bool[] EvaluateAllowlistPaths(
+		IReadOnlyList<CompiledAllowlist> allowlists,
+		string path)
 	{
-		foreach (var allowlist in allowlists)
+		if (allowlists.Count == 0)
+			return [];
+		var matches = new bool[allowlists.Count];
+		for (var index = 0; index < allowlists.Count; index++)
+			matches[index] = allowlists[index].AllowsPath(path);
+		return matches;
+	}
+
+	private static bool NeedsLine(
+		IReadOnlyList<CompiledAllowlist> allowlists,
+		IReadOnlyList<bool> pathMatches)
+	{
+		for (var index = 0; index < allowlists.Count; index++)
 		{
-			if (allowlist.Allows(context))
+			if (allowlists[index].NeedsLine(pathMatches[index]))
+				return true;
+		}
+		return false;
+	}
+
+	private static bool Allows(
+		IReadOnlyList<CompiledAllowlist> allowlists,
+		IReadOnlyList<bool> pathMatches,
+		AllowlistContext context)
+	{
+		for (var index = 0; index < allowlists.Count; index++)
+		{
+			if (allowlists[index].Allows(context, pathMatches[index]))
 				return true;
 		}
 		return false;
@@ -1134,15 +1194,20 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 		private static int[] BuildLineStarts(ReadOnlySpan<char> text)
 		{
+			ContentPipelineDiagnostics.RecordLineIndexBuild();
 			var starts = new List<int> { 0 };
-			for (var index = 0; index < text.Length; index++)
+			var consumed = 0;
+			while (consumed < text.Length)
 			{
-				if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
-					index++;
-				else if (text[index] is not ('\r' or '\n'))
-					continue;
-				if (index + 1 < text.Length)
-					starts.Add(index + 1);
+				var relative = text[consumed..].IndexOfAny('\r', '\n');
+				if (relative < 0)
+					break;
+				var separator = consumed + relative;
+				consumed = separator + 1;
+				if (text[separator] == '\r' && consumed < text.Length && text[consumed] == '\n')
+					consumed++;
+				if (consumed < text.Length)
+					starts.Add(consumed);
 			}
 			return starts.ToArray();
 		}
@@ -1393,6 +1458,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		IReadOnlyList<CompiledAllowlist> Allowlists,
 		int Order)
 	{
+		private int _wholeMatchFastPath = -1;
+
 		public void EnsurePathRegexCompiled()
 		{
 			if (PathRegex is { IsValueCreated: false })
@@ -1408,6 +1475,19 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		}
 
 		public bool AppliesToPath(string path) => PathRegex?.Value.IsMatch(path) ?? true;
+
+		public bool CanUseWholeMatch(Regex regex)
+		{
+			var cached = Volatile.Read(ref _wholeMatchFastPath);
+			if (cached >= 0)
+				return cached != 0;
+			// SecretGroup zero still means "first successful capture" in the reviewed
+			// Gitleaks contract. Whole-match reuse is safe only when the compiled expression
+			// proves that no capture group exists.
+			var canUse = SecretGroup == 0 && regex.GetGroupNumbers() is [0];
+			Volatile.Write(ref _wholeMatchFastPath, canUse ? 1 : 0);
+			return canUse;
+		}
 	}
 
 	/// <summary>
@@ -1691,13 +1771,33 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		}
 	}
 
-	private sealed record CompiledAllowlist(
-		IReadOnlyList<Lazy<Regex>> Paths,
-		IReadOnlyList<Lazy<Regex>> Regexes,
-		IReadOnlyList<string> Stopwords,
-		AllowlistRegexTarget RegexTarget,
-		bool RequireAll)
+	private sealed class CompiledAllowlist
 	{
+		private readonly SearchValues<string>? _stopwordSearchValues;
+
+		public CompiledAllowlist(
+			IReadOnlyList<Lazy<Regex>> paths,
+			IReadOnlyList<Lazy<Regex>> regexes,
+			IReadOnlyList<string> stopwords,
+			AllowlistRegexTarget regexTarget,
+			bool requireAll)
+		{
+			Paths = paths;
+			Regexes = regexes;
+			Stopwords = stopwords;
+			RegexTarget = regexTarget;
+			RequireAll = requireAll;
+			_stopwordSearchValues = stopwords.Count == 0
+				? null
+				: SearchValues.Create(stopwords.ToArray(), StringComparison.OrdinalIgnoreCase);
+		}
+
+		public IReadOnlyList<Lazy<Regex>> Paths { get; }
+		public IReadOnlyList<Lazy<Regex>> Regexes { get; }
+		public IReadOnlyList<string> Stopwords { get; }
+		public AllowlistRegexTarget RegexTarget { get; }
+		public bool RequireAll { get; }
+
 		public void EnsureCompiled()
 		{
 			foreach (var path in Paths)
@@ -1722,13 +1822,18 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 		public bool AllowsPath(string path) => Paths.Any(regex => regex.Value.IsMatch(path));
 
-		public bool AllowsWholeFileByPath(string path) =>
+		public bool AllowsWholeFileByPath(bool pathMatches) =>
 			IsPathSufficientForAllowlist(
 				RequireAll,
-				AllowsPath(path),
+				pathMatches,
 				Regexes.Count > 0 || Stopwords.Count > 0);
 
-		public bool Allows(AllowlistContext context)
+		public bool NeedsLine(bool pathMatches) =>
+			RegexTarget == AllowlistRegexTarget.Line &&
+			Regexes.Count > 0 &&
+			(RequireAll || !pathMatches);
+
+		public bool Allows(AllowlistContext context, bool pathMatches)
 		{
 			ReadOnlySpan<char> target = RegexTarget switch
 			{
@@ -1738,8 +1843,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			};
 			if (!RequireAll)
 			{
-				return Paths.Count > 0 && AllowsPath(context.Path) ||
-				       Stopwords.Count > 0 && ContainsAny(context.Secret, Stopwords) ||
+				return Paths.Count > 0 && pathMatches ||
+				       _stopwordSearchValues is not null && ContainsAny(context.Secret, _stopwordSearchValues) ||
 				       Regexes.Count > 0 && MatchesAny(target, Regexes);
 			}
 
@@ -1747,13 +1852,13 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			if (Paths.Count > 0)
 			{
 				hasCriterion = true;
-				if (!AllowsPath(context.Path))
+				if (!pathMatches)
 					return false;
 			}
-			if (Stopwords.Count > 0)
+			if (_stopwordSearchValues is not null)
 			{
 				hasCriterion = true;
-				if (!ContainsAny(context.Secret, Stopwords))
+				if (!ContainsAny(context.Secret, _stopwordSearchValues))
 				{
 					return false;
 				}
@@ -1767,15 +1872,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			return hasCriterion;
 		}
 
-		private static bool ContainsAny(ReadOnlySpan<char> value, IReadOnlyList<string> candidates)
-		{
-			foreach (var candidate in candidates)
-			{
-				if (value.Contains(candidate, StringComparison.OrdinalIgnoreCase))
-					return true;
-			}
-			return false;
-		}
+		private static bool ContainsAny(ReadOnlySpan<char> value, SearchValues<string> candidates) =>
+			value.IndexOfAny(candidates) >= 0;
 
 		private static bool MatchesAny(ReadOnlySpan<char> value, IReadOnlyList<Lazy<Regex>> regexes)
 		{

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -1205,18 +1205,15 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		{
 			ContentPipelineDiagnostics.RecordLineIndexBuild();
 			var starts = new List<int> { 0 };
-			var consumed = 0;
-			while (consumed < text.Length)
+			for (var index = 0; index < text.Length; index++)
 			{
-				var relative = text[consumed..].IndexOfAny('\r', '\n');
-				if (relative < 0)
-					break;
-				var separator = consumed + relative;
-				consumed = separator + 1;
-				if (text[separator] == '\r' && consumed < text.Length && text[consumed] == '\n')
-					consumed++;
-				if (consumed < text.Length)
-					starts.Add(consumed);
+				if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
+					index++;
+				else if (text[index] is not ('\r' or '\n'))
+					continue;
+
+				if (index + 1 < text.Length)
+					starts.Add(index + 1);
 			}
 			return starts.ToArray();
 		}

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -351,7 +351,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			if (!rule.AppliesToPath(normalizedPath))
 				continue;
 			budget.RunRuleInitialization(rule.EnsureContentAndAllowlistsCompiled);
-			var rulePathMatches = EvaluateAllowlistPaths(rule.Allowlists, normalizedPath);
+			bool[]? rulePathMatches = null;
 			budget.Checkpoint(cancellationToken);
 			try
 			{
@@ -360,6 +360,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 				foreach (var valueMatch in contentRegex.EnumerateMatches(content))
 				{
 					budget.Checkpoint(cancellationToken);
+					rulePathMatches ??= EvaluateRuleAllowlistPaths(rule.Allowlists, normalizedPath);
 					var secretOffset = 0;
 					var secretLength = valueMatch.Length;
 					if (!wholeMatchFastPath)
@@ -1121,6 +1122,14 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		for (var index = 0; index < allowlists.Count; index++)
 			matches[index] = allowlists[index].AllowsPath(path);
 		return matches;
+	}
+
+	private static bool[] EvaluateRuleAllowlistPaths(
+		IReadOnlyList<CompiledAllowlist> allowlists,
+		string path)
+	{
+		ContentPipelineDiagnostics.RecordRulePathAllowlistEvaluation();
+		return EvaluateAllowlistPaths(allowlists, path);
 	}
 
 	private static bool NeedsLine(

--- a/Tests/DevProjex.Tests.Integration/AnalyzeWithoutMaterializationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/AnalyzeWithoutMaterializationIntegrationTests.cs
@@ -37,8 +37,10 @@ public sealed class AnalyzeWithoutMaterializationIntegrationTests
 			captureEffectiveFindings: true,
 			cancellationToken: TestContext.Current.CancellationToken);
 
-		Assert.Equal(0, diagnostics.Capture().PreparedWriteBytes);
-		Assert.Equal(0, diagnostics.Capture().PreparedReadBytes);
+		var measuredDiagnostics = diagnostics.Capture();
+		Assert.Equal(0, measuredDiagnostics.PreparedWriteBytes);
+		Assert.Equal(0, measuredDiagnostics.PreparedReadBytes);
+		Assert.Equal(1, measuredDiagnostics.MeasurementPasses);
 		Assert.Equal(3, measured.TransformedFileMetrics.Count);
 		Assert.Single(measured.GetEffectiveFindings());
 		Assert.DoesNotContain("detector-excluded.txt", measuredDetector.InspectedPaths);
@@ -60,6 +62,31 @@ public sealed class AnalyzeWithoutMaterializationIntegrationTests
 
 		Assert.Equal(expected, measured.GetTransformedMetrics());
 		Assert.Equal(materialized.GetEffectiveFindings(), measured.GetEffectiveFindings());
+	}
+
+	[Fact]
+	public async Task PrepareAsync_CapturesTransformedMetricsDuringThePreparedWrite()
+	{
+		using var temporary = new TemporaryDirectory();
+		var root = temporary.CreateDirectory("project");
+		var token = "ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL";
+		var path = temporary.CreateFile("project/source.cs", $"const string Token = \"{token}\";\r\n");
+		using var session = new SecretRedactionSession(new GitleaksSecretDetector());
+		using var diagnostics = ContentPipelineDiagnostics.BeginMeasurement();
+
+		await using var prepared = await new SecretRedactionOutputPreparer(new FileContentAnalyzer())
+			.PrepareAsync(
+				new ContentTransformationContext(null, new SecretRedactionContext(root, session)),
+				[path],
+				captureEffectiveFindings: true,
+				captureTransformedMetrics: true,
+				TestContext.Current.CancellationToken);
+		var snapshot = diagnostics.Capture();
+
+		Assert.Single(prepared.TransformedFileMetrics);
+		Assert.True(snapshot.PreparedWriteBytes > 0);
+		Assert.Equal(0, snapshot.MeasurementPasses);
+		Assert.Equal(1, snapshot.PreparedFilesMaterialized);
 	}
 
 	private sealed class SelectiveCountingDetector(string excludedFileName) : ISecretDetector

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
@@ -358,7 +358,8 @@ public sealed class MetricsPipelineWarmupTests
 		await delayedMetrics.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
 		Assert.Equal(1, compressor.AnalysisCount);
-		Assert.True(compressionSession.Diagnostics.CacheHits > 0);
+		Assert.Equal(0, compressionSession.Diagnostics.CacheHits);
+		Assert.Equal(1, compressionSession.Diagnostics.PrewarmAnalyses);
 		Assert.True(pipeline.HasCompleteBaseline);
 	}
 

--- a/Tests/DevProjex.Tests.Unit/CodeCompressionSessionTests.cs
+++ b/Tests/DevProjex.Tests.Unit/CodeCompressionSessionTests.cs
@@ -136,7 +136,12 @@ public sealed class CodeCompressionSessionTests
 		Assert.Equal(0, session.Diagnostics.HashComputations);
 		Assert.NotNull(warmup.ReadFacts);
 		Assert.True(warmup.ReadFacts.TryGet(path, out var retainedFact));
+		Assert.Null(retainedFact.Content);
 		Assert.Equal(ContentFingerprint.Compute("same-content"), retainedFact.Fingerprint);
+		Assert.True(warmup.ReadFacts.TryGetMetrics(path, context.TransformIdentity, out var retainedMetrics));
+		Assert.Equal(retainedFact.RawMetrics, retainedMetrics.Raw);
+		Assert.Equal(retainedFact.RawMetrics, retainedMetrics.Effective);
+		Assert.Equal(256, warmup.ReadFacts.RetainedBytes);
 		using var output = context.BeginOutput([path]);
 		_ = output.Transform(path, "sample.cs", "same-content", TestContext.Current.CancellationToken);
 		_ = output.Complete();
@@ -314,7 +319,7 @@ public sealed class CodeCompressionSessionTests
 		Assert.Equal(1, contentDiagnostics.FullFileReads);
 		Assert.Equal(0, contentDiagnostics.ContentFingerprintComputations);
 		Assert.NotNull(result.ReadFacts);
-		Assert.Equal(128, result.ReadFacts.RetainedBytes);
+		Assert.Equal(256, result.ReadFacts.RetainedBytes);
 		Assert.True(result.ReadFacts.TryGet(path, out var retainedFact));
 		Assert.Null(retainedFact.Content);
 		Assert.Null(retainedFact.Fingerprint);
@@ -389,7 +394,7 @@ public sealed class CodeCompressionSessionTests
 	}
 
 	[Fact]
-	public async Task Prewarm_FileGrowthCannotRetainFactsBeyondTheFinalBudget()
+	public async Task Prewarm_FileGrowthRetainsOnlyCompactMetricsWithinTheFinalBudget()
 	{
 		const int grownCharacters = 9 * 1024 * 1024;
 		const long maximumRetainedBytes = 64L * 1024 * 1024;
@@ -408,7 +413,8 @@ public sealed class CodeCompressionSessionTests
 
 		Assert.Equal(paths.Length, result.WarmedFiles);
 		Assert.NotNull(result.ReadFacts);
-		Assert.True(result.ReadFacts.Count < paths.Length);
+		Assert.Equal(paths.Length, result.ReadFacts.Count);
+		Assert.Equal(paths.Length * 256, result.ReadFacts.RetainedBytes);
 		Assert.InRange(result.ReadFacts.RetainedBytes, 1, maximumRetainedBytes);
 	}
 

--- a/Tests/DevProjex.Tests.Unit/FileContentAnalyzerTests.cs
+++ b/Tests/DevProjex.Tests.Unit/FileContentAnalyzerTests.cs
@@ -35,17 +35,19 @@ public sealed class FileContentAnalyzerTests
 	[InlineData(ProbeOperation.StreamingMetrics)]
 	[InlineData(ProbeOperation.CompleteSnapshot)]
 	[InlineData(ProbeOperation.ReadFact)]
-	public async Task NullByteProbe_IoFailureIsUnreadableRatherThanBinary(ProbeOperation operation)
+	public async Task BomAndNullByteProbe_ReadsThePrefixOnce(ProbeOperation operation)
 	{
 		using var temp = new TemporaryDirectory();
 		var path = temp.CreateFile("probe.txt", "ordinary text");
+		ProbeCountingFileStream? observed = null;
 		var analyzer = new FileContentAnalyzer(
-			(filePath, _, _, _) => new ProbeFailureFileStream(filePath));
+			(filePath, _, _, _) => observed = new ProbeCountingFileStream(filePath));
 
 		var classification = await ClassifyAsync(analyzer, path, operation);
 
-		Assert.Equal(FileContentClassification.Unreadable, classification);
-		Assert.NotEqual(FileContentClassification.Binary, classification);
+		Assert.Equal(FileContentClassification.Text, classification);
+		Assert.NotNull(observed);
+		Assert.Equal(1, observed.SpanReads);
 	}
 
 	[Theory]
@@ -1110,7 +1112,7 @@ public sealed class FileContentAnalyzerTests
 		ReadFact
 	}
 
-	private sealed class ProbeFailureFileStream(string path) : FileStream(
+	private sealed class ProbeCountingFileStream(string path) : FileStream(
 		path,
 		FileMode.Open,
 		FileAccess.Read,
@@ -1120,10 +1122,11 @@ public sealed class FileContentAnalyzerTests
 	{
 		private int _spanReads;
 
+		public int SpanReads => Volatile.Read(ref _spanReads);
+
 		public override int Read(Span<byte> buffer)
 		{
-			if (Interlocked.Increment(ref _spanReads) == 2)
-				throw new IOException("Injected null-byte probe failure.");
+			Interlocked.Increment(ref _spanReads);
 			return base.Read(buffer);
 		}
 	}

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -1,4 +1,5 @@
 using DevProjex.Application.Secrets;
+using DevProjex.Application.Diagnostics;
 using DevProjex.Infrastructure.Secrets;
 
 namespace DevProjex.Tests.Unit;
@@ -338,6 +339,43 @@ public sealed class GitleaksSecretDetectorTests
 			static match => match.RuleId == "generic-api-key");
 
 		Assert.Equal(genericValue, finding.Value);
+	}
+
+	[Fact]
+	public void Detect_WholeMatchRuleAvoidsSecondaryRegexAndLineIndex()
+	{
+		var detector = new GitleaksSecretDetector();
+		detector.WarmUp(TestContext.Current.CancellationToken);
+		var token = "ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL";
+		using var measurement = ContentPipelineDiagnostics.BeginMeasurement();
+
+		var finding = Assert.Single(
+			detector.Detect("src/token.cs", token, TestContext.Current.CancellationToken),
+			static candidate => candidate.RuleId == "github-pat");
+		var diagnostics = measurement.Capture();
+
+		Assert.Equal(token, finding.Value);
+		Assert.Equal(0, diagnostics.SecondarySecretRegexRuns);
+		Assert.Equal(0, diagnostics.LineIndexBuilds);
+	}
+
+	[Fact]
+	public void Detect_RejectedEntropyDoesNotBuildLineContext()
+	{
+		var detector = new GitleaksSecretDetector();
+		detector.WarmUp(TestContext.Current.CancellationToken);
+		var content = new string('x', 64 * 1024) + "\napiKey = \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"";
+		using var measurement = ContentPipelineDiagnostics.BeginMeasurement();
+
+		var findings = detector.Detect(
+			"src/config.cs",
+			content,
+			new SecretFileInspectionBudget(TimeSpan.FromSeconds(10)),
+			TestContext.Current.CancellationToken);
+		var diagnostics = measurement.Capture();
+
+		Assert.DoesNotContain(findings, static candidate => candidate.RuleId == "generic-api-key");
+		Assert.Equal(0, diagnostics.LineIndexBuilds);
 	}
 
 	[Theory]

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -360,6 +360,23 @@ public sealed class GitleaksSecretDetectorTests
 	}
 
 	[Fact]
+	public void Detect_RulePathAllowlistsAreEvaluatedOnlyAfterTheRuleMatches()
+	{
+		var detector = new GitleaksSecretDetector();
+		detector.WarmUp(TestContext.Current.CancellationToken);
+		using var measurement = ContentPipelineDiagnostics.BeginMeasurement();
+
+		var findings = detector.Detect(
+			"src/clean.cs",
+			"public sealed class Widget { public int Value { get; init; } }",
+			TestContext.Current.CancellationToken);
+		var diagnostics = measurement.Capture();
+
+		Assert.Empty(findings);
+		Assert.Equal(0, diagnostics.RulePathAllowlistEvaluations);
+	}
+
+	[Fact]
 	public void Detect_RejectedEntropyDoesNotBuildLineContext()
 	{
 		var detector = new GitleaksSecretDetector();

--- a/tools/Benchmarks/Secrets/DevProjex.SecretsBenchmark.csproj
+++ b/tools/Benchmarks/Secrets/DevProjex.SecretsBenchmark.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <AssemblyName>DevProjex.SecretsBenchmark</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <ProjectReference Include="../../../Infrastructure/Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Benchmarks/Secrets/Measure-Operations.ps1
+++ b/tools/Benchmarks/Secrets/Measure-Operations.ps1
@@ -1,0 +1,116 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $BaselineHost,
+
+    [string] $CurrentHost = "Apps/TerminalHost/bin/Release/net10.0/win-x64/devprojex.dll",
+
+    [string] $ProjectRoot = ".",
+
+    [ValidateRange(5, 100)]
+    [int] $Repetitions = 5
+)
+
+$ErrorActionPreference = "Stop"
+
+$currentHostPath = (Resolve-Path -LiteralPath $CurrentHost).Path
+$baselineHostPath = (Resolve-Path -LiteralPath $BaselineHost).Path
+$projectRootPath = (Resolve-Path -LiteralPath $ProjectRoot).Path
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("DevProjex-SecretsOperations-" + [Guid]::NewGuid().ToString("N"))
+[void][System.IO.Directory]::CreateDirectory($scratch)
+
+function Invoke-MeasuredOperation {
+    param(
+        [string] $Build,
+        [string] $HostPath,
+        [string] $Operation,
+        [int] $Iteration,
+        [bool] $Warmup
+    )
+
+    $outputPath = Join-Path $scratch "$Build-$Operation-$Iteration.out"
+    $arguments = switch ($Operation) {
+        "analyze" {
+            @($HostPath, "analyze", $projectRootPath, "--hide-secrets", "on", "--format", "json",
+                "-o", $outputPath, "--force", "--progress", "never", "--plain")
+        }
+        "export" {
+            @($HostPath, "export", "context", $projectRootPath, "--hide-secrets", "on", "--format", "markdown",
+                "-o", $outputPath, "--force", "--progress", "never", "--plain")
+        }
+        "measure" {
+            @($HostPath, "export", "context", $projectRootPath, "--hide-secrets", "on", "--format", "markdown",
+                "--dry-run", "--progress", "never", "--plain")
+        }
+        default { throw "Unknown operation '$Operation'." }
+    }
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = "dotnet"
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $arguments) {
+        [void]$startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    if (-not $process.Start()) {
+        throw "Could not start $Build $Operation."
+    }
+    $stdout = $process.StandardOutput.ReadToEndAsync()
+    $stderr = $process.StandardError.ReadToEndAsync()
+    [long] $peakWorkingSet = 0
+    while (-not $process.WaitForExit(25)) {
+        $process.Refresh()
+        $peakWorkingSet = [Math]::Max($peakWorkingSet, $process.WorkingSet64)
+    }
+    $process.Refresh()
+    $peakWorkingSet = [Math]::Max($peakWorkingSet, $process.PeakWorkingSet64)
+    $stopwatch.Stop()
+    $stdoutText = $stdout.GetAwaiter().GetResult()
+    $stderrText = $stderr.GetAwaiter().GetResult()
+    if ($process.ExitCode -ne 0) {
+        throw "$Build $Operation failed with exit code $($process.ExitCode): $stderrText"
+    }
+
+    if ($Warmup) {
+        return
+    }
+    [pscustomobject]@{
+        Build = $Build
+        Operation = $Operation
+        Iteration = $Iteration
+        Milliseconds = [Math]::Round($stopwatch.Elapsed.TotalMilliseconds, 2)
+        PeakMiB = [Math]::Round($peakWorkingSet / 1MB, 2)
+        ReplyBytes = [Text.Encoding]::UTF8.GetByteCount($stdoutText + $stderrText)
+    }
+}
+
+try {
+    $hosts = [ordered]@{ baseline = $baselineHostPath; current = $currentHostPath }
+    foreach ($operation in @("analyze", "export", "measure")) {
+        foreach ($entry in $hosts.GetEnumerator()) {
+            Invoke-MeasuredOperation $entry.Key $entry.Value $operation 0 $true
+        }
+    }
+
+    $measurements = @()
+    foreach ($iteration in 1..$Repetitions) {
+        $orderedBuilds = if ($iteration % 2 -eq 0) { @("current", "baseline") } else { @("baseline", "current") }
+        foreach ($operation in @("analyze", "export", "measure")) {
+            foreach ($build in $orderedBuilds) {
+                $measurements += Invoke-MeasuredOperation $build $hosts[$build] $operation $iteration $false
+            }
+        }
+    }
+
+    $measurements | ConvertTo-Json -Depth 3
+}
+finally {
+    if (Test-Path -LiteralPath $scratch) {
+        Remove-Item -LiteralPath $scratch -Recurse -Force
+    }
+}

--- a/tools/Benchmarks/Secrets/Program.cs
+++ b/tools/Benchmarks/Secrets/Program.cs
@@ -1,0 +1,155 @@
+using System.Security.Cryptography;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using DevProjex.Application.Diagnostics;
+using DevProjex.Application.Secrets;
+using DevProjex.Infrastructure.Secrets;
+
+if (args is ["--verify"])
+{
+	BenchmarkVerification.Write();
+	return;
+}
+
+if (args is ["--diagnostics"])
+{
+	BenchmarkVerification.WriteDiagnostics();
+	return;
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(SecretDetectorBenchmarks).Assembly).Run(args);
+
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5)]
+public class SecretDetectorBenchmarks
+{
+	private readonly GitleaksSecretDetector _detector = new();
+	private string _content = string.Empty;
+
+	[Params("clean", "rejected-noise", "findings")]
+	public string Corpus { get; set; } = string.Empty;
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		_content = BenchmarkCorpora.Create(Corpus);
+		_detector.WarmUp();
+	}
+
+	[Benchmark]
+	public int Detect() => _detector.Detect(
+		"src/sample.cs",
+		_content,
+		new SecretFileInspectionBudget()).Count;
+}
+
+internal static class BenchmarkCorpora
+{
+	public static string Create(string corpus) => corpus switch
+	{
+		"clean" => string.Concat(Enumerable.Repeat(
+			"public sealed class Widget { public int Value { get; init; } }\n",
+			4_000)),
+		"rejected-noise" => string.Concat(Enumerable.Range(0, 4_000).Select(
+			static index => $"password_{index} = \"aaaaaaaaaaaaaaaaaaaaaaaa\";\n")),
+		"findings" => string.Concat(Enumerable.Range(0, 100).Select(
+			static index => $"api_key_{index} = \"A7d9mQ2xK4vN8sR6tY3uW5zB1cE0fG2h\";\n")),
+		_ => throw new ArgumentOutOfRangeException(nameof(corpus))
+	};
+}
+
+internal static class BenchmarkVerification
+{
+	public static void Write()
+	{
+		var detector = new GitleaksSecretDetector();
+		detector.WarmUp();
+		foreach (var corpus in new[] { "clean", "rejected-noise", "findings" })
+		{
+			var findings = detector.Detect("src/sample.cs", BenchmarkCorpora.Create(corpus));
+			using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+			foreach (var finding in findings)
+			{
+				Append(hash, finding.RuleId);
+				Append(hash, finding.Start.ToString(System.Globalization.CultureInfo.InvariantCulture));
+				Append(hash, finding.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
+				Append(hash, finding.Value);
+			}
+			Console.WriteLine($"{corpus}: findings={findings.Count}; sha256={Convert.ToHexString(hash.GetHashAndReset())}");
+		}
+	}
+
+	public static void WriteDiagnostics()
+	{
+		var detector = new GitleaksSecretDetector();
+		detector.WarmUp();
+		foreach (var corpus in new[] { "clean", "rejected-noise", "findings" })
+		{
+			using var measurement = ContentPipelineDiagnostics.BeginMeasurement();
+			var findings = detector.Detect("src/sample.cs", BenchmarkCorpora.Create(corpus));
+			var diagnostics = measurement.Capture();
+			Console.WriteLine(
+				$"{corpus}: findings={findings.Count}; secondary-regex={diagnostics.SecondarySecretRegexRuns}; " +
+				$"rejected-line-context={diagnostics.RejectedMatchLineContexts}; " +
+				$"line-index={diagnostics.LineIndexBuilds}");
+		}
+	}
+
+	private static void Append(IncrementalHash hash, string value)
+	{
+		hash.AppendData(Encoding.UTF8.GetBytes(value));
+		hash.AppendData([0]);
+	}
+}
+
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5)]
+public class LineRangeIndexBenchmarks
+{
+	private string _content = string.Empty;
+	private int[] _offsets = [];
+
+	[Params("lf", "crlf", "mixed")]
+	public string Newlines { get; set; } = string.Empty;
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		var separator = Newlines switch
+		{
+			"lf" => "\n",
+			"crlf" => "\r\n",
+			"mixed" => "\r\n",
+			_ => throw new ArgumentOutOfRangeException()
+		};
+		_content = string.Join(separator, Enumerable.Range(0, 20_000).Select(
+			static index => $"line-{index:D5}-abcdefghijklmnopqrstuvwxyz"));
+		if (Newlines == "mixed")
+			_content = _content.Replace("\r\nline-00010", "\rline-00010", StringComparison.Ordinal)
+				.Replace("\r\nline-00020", "\nline-00020", StringComparison.Ordinal);
+		_offsets = Enumerable.Range(0, 2_000)
+			.Select(index => index * (_content.Length / 2_000))
+			.ToArray();
+	}
+
+	[Benchmark]
+	public long ResolveLines()
+	{
+		var index = new GitleaksSecretDetector.LineRangeIndex(_content);
+		long checksum = 0;
+		foreach (var offset in _offsets)
+		{
+			var range = index.GetContainingLine(offset, 1);
+			checksum += range.Start + range.Length;
+		}
+		return checksum;
+	}
+
+	[Benchmark]
+	public int BuildIndex()
+	{
+		var index = new GitleaksSecretDetector.LineRangeIndex(_content);
+		return index.GetContainingLine(_content.Length - 1, 1).Start;
+	}
+}

--- a/tools/Benchmarks/Secrets/Program.cs
+++ b/tools/Benchmarks/Secrets/Program.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
 using BenchmarkDotNet.Attributes;
@@ -21,7 +22,6 @@ if (args is ["--diagnostics"])
 BenchmarkSwitcher.FromAssembly(typeof(SecretDetectorBenchmarks).Assembly).Run(args);
 
 [MemoryDiagnoser]
-[SimpleJob(warmupCount: 3, iterationCount: 5)]
 public class SecretDetectorBenchmarks
 {
 	private readonly GitleaksSecretDetector _detector = new();
@@ -104,7 +104,6 @@ internal static class BenchmarkVerification
 }
 
 [MemoryDiagnoser]
-[SimpleJob(warmupCount: 3, iterationCount: 5)]
 public class LineRangeIndexBenchmarks
 {
 	private string _content = string.Empty;
@@ -151,5 +150,80 @@ public class LineRangeIndexBenchmarks
 	{
 		var index = new GitleaksSecretDetector.LineRangeIndex(_content);
 		return index.GetContainingLine(_content.Length - 1, 1).Start;
+	}
+}
+
+[MemoryDiagnoser]
+public class StopwordLookupBenchmarks
+{
+	private string[] _stopwords = [];
+	private SearchValues<string> _searchValues = null!;
+	private string _value = string.Empty;
+
+	[Params(2, 1446)]
+	public int StopwordCount { get; set; }
+
+	[Params(false, true)]
+	public bool Match { get; set; }
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		_stopwords = ReadPinnedStopwordLists().Single(list => list.Length == StopwordCount);
+		_searchValues = SearchValues.Create(_stopwords, StringComparison.OrdinalIgnoreCase);
+		_value = Match
+			? $"prefix-{_stopwords[^1]}-suffix"
+			: "A7d9mQ2xK4vN8sR6tY3uW5zB1cE0fG2h";
+	}
+
+	[Benchmark(Baseline = true)]
+	public bool LinearContains()
+	{
+		foreach (var candidate in _stopwords)
+			if (_value.Contains(candidate, StringComparison.OrdinalIgnoreCase))
+				return true;
+		return false;
+	}
+
+	[Benchmark]
+	public bool SearchValuesContains() => _value.AsSpan().IndexOfAny(_searchValues) >= 0;
+
+	private static IReadOnlyList<string[]> ReadPinnedStopwordLists()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null)
+		{
+			var candidate = Path.Combine(directory.FullName, "Infrastructure", "Secrets", "Rules", "gitleaks-v8.30.1.toml");
+			if (File.Exists(candidate))
+				return ParseStopwordLists(File.ReadLines(candidate));
+			directory = directory.Parent;
+		}
+		throw new FileNotFoundException("Pinned Gitleaks rules were not found.");
+	}
+
+	private static IReadOnlyList<string[]> ParseStopwordLists(IEnumerable<string> lines)
+	{
+		var result = new List<string[]>();
+		List<string>? current = null;
+		foreach (var line in lines)
+		{
+			if (line.StartsWith("stopwords = [", StringComparison.Ordinal))
+			{
+				current = [];
+				continue;
+			}
+			if (current is null)
+				continue;
+			if (line == "]")
+			{
+				result.Add(current.ToArray());
+				current = null;
+				continue;
+			}
+			var value = line.Trim().TrimEnd(',');
+			if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+				current.Add(value[1..^1]);
+		}
+		return result;
 	}
 }

--- a/tools/Benchmarks/Secrets/README.md
+++ b/tools/Benchmarks/Secrets/README.md
@@ -1,0 +1,26 @@
+# Secrets and content-pipeline benchmarks
+
+Run from the repository root:
+
+```powershell
+dotnet run -c Release --project tools/Benchmarks/Secrets
+```
+
+The BenchmarkDotNet suite uses five measured iterations with `MemoryDiagnoser`. Detector inputs
+cover clean source, high-volume rejected candidates, and accepted findings; the line-index cases
+cover LF, CRLF, and mixed line endings. Operational counters for analyze, context export, the
+nonmaterializing measure path, and GUI metrics are reported by the focused integration tests that
+use `ContentPipelineDiagnostics` and `MetricsPipelineIoTestPoint`.
+
+Compare the three real-process operations against a baseline host with alternating run order:
+
+```powershell
+pwsh tools/Benchmarks/Secrets/Measure-Operations.ps1 `
+  -BaselineHost ../baseline/Apps/TerminalHost/bin/Release/net10.0/win-x64/devprojex.dll
+```
+
+The script performs one unmeasured warm-up per build and operation, then reports at least five
+measurements as JSON. It samples peak working set while the process is alive and removes its scratch
+outputs when the run finishes. `dotnet run -c Release --project tools/Benchmarks/Secrets -- --verify`
+prints deterministic finding counts and hashes for the three detector corpora; replace `--verify`
+with `--diagnostics` to print the operation-local work counters.

--- a/tools/Benchmarks/Secrets/README.md
+++ b/tools/Benchmarks/Secrets/README.md
@@ -6,9 +6,10 @@ Run from the repository root:
 dotnet run -c Release --project tools/Benchmarks/Secrets
 ```
 
-The BenchmarkDotNet suite uses five measured iterations with `MemoryDiagnoser`. Detector inputs
+The BenchmarkDotNet suite uses its default warm-up and measurement policy with `MemoryDiagnoser`. Detector inputs
 cover clean source, high-volume rejected candidates, and accepted findings; the line-index cases
-cover LF, CRLF, and mixed line endings. Operational counters for analyze, context export, the
+cover LF, CRLF, and mixed line endings. Stop-word cases compare the linear lookup with
+`SearchValues` on the actual pinned allowlist sizes. Operational counters for analyze, context export, the
 nonmaterializing measure path, and GUI metrics are reported by the focused integration tests that
 use `ContentPipelineDiagnostics` and `MetricsPipelineIoTestPoint`.
 

--- a/tools/Benchmarks/Secrets/RESULTS.md
+++ b/tools/Benchmarks/Secrets/RESULTS.md
@@ -1,0 +1,89 @@
+# Secrets and content-pipeline results
+
+Measured on 2026-09-09 on Windows 11, .NET SDK 10.0.401, on an Intel Core
+i9-13900HX. The baseline is `fe210408c2cc038cd2c1b0adf61a9130bab52b13`;
+the optimized product tree is `906da078`. BenchmarkDotNet used three warm-up
+iterations and five measured iterations. Values below are medians; the range
+or standard deviation is included so differences inside host noise stay visible.
+
+## Detector and line index
+
+| Benchmark | Baseline median | Optimized median | Change | Baseline / optimized allocation |
+|---|---:|---:|---:|---:|
+| clean source | 529.6 us | 628.5 us | +18.7% | 416 B / 416 B |
+| rejected-candidate noise | 1,567.2 us | 1,317.5 us | -15.9% | 504 B / 504 B |
+| accepted findings | 3,656.0 us | 4,082.1 us | +11.7% | 131,936 B / 131,936 B |
+| line index, LF | 247.2 us | 245.1 us | -0.9% | 342,701 B / 342,699 B |
+| line index, CRLF | 305.5 us | 302.2 us | -1.1% | 342,701 B / 342,689 B |
+| line index, mixed | 277.2 us | 284.2 us | +2.5% | 342,707 B / 342,688 B |
+
+The clean optimized run had a 149.9 us standard deviation versus 18.5 us at
+baseline; the accepted-finding run was 256.4 us versus 78.2 us. Those two
+regressions are therefore retained as observations, not claimed as stable
+effects. All line-index differences are within the measured spread. The
+rejected-candidate corpus was the intended hot path and improved while retaining
+the same allocation reading.
+
+Operation-local diagnostics for the optimized detector were:
+
+| Corpus | Findings | Secondary regex runs | Rejected line-context builds | Line-index builds |
+|---|---:|---:|---:|---:|
+| clean | 0 | 0 | 0 | 0 |
+| rejected-candidate noise | 0 | 0 | 0 | 0 |
+| accepted findings | 100 | 100 | 0 | 0 |
+
+The safe whole-match shortcut is deliberately limited to rules whose compiled
+regex exposes no capture group other than group zero. Other rules retain the
+bounded second match.
+
+## Real-process operations
+
+One unmeasured warm-up preceded five alternating baseline/optimized runs against
+the DevProjex tree. Peak working set was sampled while each process was alive.
+
+| Operation | Baseline time, median (range) | Optimized time, median (range) | Baseline / optimized peak RSS | Interpretation |
+|---|---:|---:|---:|---|
+| `analyze --format json` | 8,623.81 ms (8,230.73-12,603.79) | 8,012.67 ms (7,755.92-8,463.86) | 517.61 / 519.20 MiB | -7.1% time; RSS unchanged within 0.3% |
+| `export context --format json` | 8,847.50 ms (7,984.35-9,677.31) | 9,250.56 ms (8,219.17-10,755.82) | 518.38 / 516.53 MiB | +4.6% time, within run spread |
+| `export context --dry-run` | 7,913.79 ms (7,345.99-8,966.16) | 7,947.32 ms (6,876.98-8,272.02) | 513.63 / 511.97 MiB | +0.4% time, within noise |
+
+The dry-run response was 304 bytes in both builds. Analyze and export responses
+differed by one byte because the compared revisions format a progress/localized
+line differently; content equivalence is covered separately by the redaction
+contract tests rather than inferred from response size.
+
+## Desktop metrics pipeline
+
+The controlled provider measurement ran five times per build. The provider
+counts source-version opens, repeated content reads, time waiting for the metrics
+lock, and publication latency. Values are medians with min-max ranges.
+
+| Files / changed | Baseline publication | Optimized publication | Opens (both) | Content rereads (both) | Lock wait (both) |
+|---|---:|---:|---:|---:|---:|
+| 100 / 0 | 15.580 ms (14.958-18.119) | 15.136 ms (14.555-18.956) | 101 | 0 | 0.001-0.034 ms |
+| 100 / 1 | 15.308 ms (13.479-22.296) | 13.760 ms (13.448-15.584) | 204 | 1 | 0.001-0.002 ms |
+| 20,000 / 0 | 45.273 ms (39.056-50.425) | 34.862 ms (30.601-46.599) | 20,001 | 0 | 0.001-0.003 ms |
+| 20,000 / 1 | 46.140 ms (39.332-54.776) | 46.023 ms (40.099-52.416) | 40,004 | 1 | 0.002-0.003 ms |
+
+The unchanged 20,000-file projection shows a 23.0% lower median, while the
+changed case is effectively flat. The smaller cases overlap their ranges. A
+compact prewarm fact accounts for 256 retained bytes per eligible file instead
+of retaining its source string, still under the existing 64 MiB cap. Focused
+tests pin latest-value progress coalescing, mandatory completion/cancellation,
+generation checks, and release of retained facts.
+
+## Correctness fingerprint
+
+The baseline and optimized binaries produced identical ordered finding records
+(`rule id`, offsets, length, and value):
+
+| Corpus | Findings | Baseline SHA-256 | Optimized SHA-256 |
+|---|---:|---|---|
+| clean | 0 | `E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855` | same |
+| rejected-candidate noise | 0 | `E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855` | same |
+| accepted findings | 100 | `95C0611DA179F6CE95CE759D9C105C2BBDB6D1258080F7D2EA0B0A4EB673B8A4` | same |
+
+The targeted contract matrix additionally covers identical placeholders and
+redacted output, BOM and NUL handling, LF/CRLF boundaries, empty content,
+surrogate pairs, bounded concurrency, cancellation, transient failures, and
+lease cleanup.

--- a/tools/Benchmarks/Secrets/RESULTS.md
+++ b/tools/Benchmarks/Secrets/RESULTS.md
@@ -2,27 +2,56 @@
 
 Measured on 2026-09-09 on Windows 11, .NET SDK 10.0.401, on an Intel Core
 i9-13900HX. The baseline is `fe210408c2cc038cd2c1b0adf61a9130bab52b13`;
-the optimized product tree is `906da078`. BenchmarkDotNet used three warm-up
-iterations and five measured iterations. Values below are medians; the range
-or standard deviation is included so differences inside host noise stay visible.
+the candidate includes the lazy rule-path correction and the measured rollback
+of vectorized line indexing. BenchmarkDotNet used its default warm-up and
+measurement policy with `MemoryDiagnoser`.
 
 ## Detector and line index
 
-| Benchmark | Baseline median | Optimized median | Change | Baseline / optimized allocation |
+| Benchmark | Baseline mean (standard deviation) | Candidate mean (standard deviation) | Change | Baseline / candidate allocation |
 |---|---:|---:|---:|---:|
-| clean source | 529.6 us | 628.5 us | +18.7% | 416 B / 416 B |
-| rejected-candidate noise | 1,567.2 us | 1,317.5 us | -15.9% | 504 B / 504 B |
-| accepted findings | 3,656.0 us | 4,082.1 us | +11.7% | 131,936 B / 131,936 B |
-| line index, LF | 247.2 us | 245.1 us | -0.9% | 342,701 B / 342,699 B |
-| line index, CRLF | 305.5 us | 302.2 us | -1.1% | 342,701 B / 342,689 B |
-| line index, mixed | 277.2 us | 284.2 us | +2.5% | 342,707 B / 342,688 B |
+| clean source | 467.9 us (26.0 us) | 458.9 us (14.8 us) | -1.9% | 344 B / 416 B |
+| rejected-candidate noise | 1,122.4 us (27.7 us) | 1,032.5 us (16.3 us) | -8.0% | 432 B / 504 B |
+| accepted findings | 4,327.0 us (236.8 us) | 3,077.5 us (80.7 us) | -28.9% | 161,880 B / 131,936 B |
 
-The clean optimized run had a 149.9 us standard deviation versus 18.5 us at
-baseline; the accepted-finding run was 256.4 us versus 78.2 us. Those two
-regressions are therefore retained as observations, not claimed as stable
-effects. All line-index differences are within the measured spread. The
-rejected-candidate corpus was the intended hot path and improved while retaining
-the same allocation reading.
+The fixed 72-byte difference on the no-finding cases is retained in the table;
+the accepted-finding corpus removes 29,944 bytes per detection. The confidence
+intervals for clean source overlap slightly; no speedup is claimed there, only
+the absence of the previously observed regression.
+
+The rule-path change was also measured directly against the otherwise identical
+pre-fix tree. Clean source moved from 465.6 us (23.5 us standard deviation) to
+458.9 us (14.8 us); accepted findings from 3,087.5 us (140.5 us) to 3,077.5 us
+(80.7 us); rejected noise from 1,018.2 us (14.3 us) to 1,032.5 us (16.3 us).
+Those differences are within the observed distributions. The deterministic
+counter is the deciding evidence: a clean file performs zero rule-path allowlist
+evaluations, while matched rules evaluate each allowlist path only once.
+
+The earlier line-index experiment measured LF -0.9%, CRLF -1.1%, and mixed
++2.5%, all within run spread. It was reverted to the simpler scalar traversal.
+
+Stop-word lookup used the actual pinned lists (2 and 1,446 entries):
+
+| Stop words / result | Linear `Contains` | `SearchValues` | Allocation |
+|---|---:|---:|---:|
+| 2 / absent | 8.612 ns | 4.752 ns | 0 B / 0 B |
+| 2 / present | 10.143 ns | 13.901 ns | 0 B / 0 B |
+| 1,446 / absent | 5,476.239 ns | 104.359 ns | 0 B / 0 B |
+| 1,446 / present | 1,420.147 ns | 16.514 ns | 0 B / 0 B |
+
+The detector retains `SearchValues`: the dominant absent case wins for both
+real list sizes, and the large list wins in both branches.
+
+The six detector changes were accepted independently as follows:
+
+| Change | Measurement | Decision |
+|---|---|---|
+| defer match and capture materialization | accepted findings allocate 161,880 B at baseline and 131,936 B in the candidate | retained |
+| defer line lookup until an allowlist needs it | rejected-noise builds zero line contexts and runs 1,122.4 -> 1,032.5 us for the complete candidate | retained |
+| evaluate rule path allowlists on first match | zero evaluations on clean input; isolated timings overlap as recorded above | retained for eliminated work with no measured regression |
+| use immutable stop-word search | absent 2-word case is 1.8x faster and absent 1,446-word case is 52.5x faster | retained |
+| reuse group-zero matches | provider-shaped rules run zero secondary regex matches; rules with captures retain the reviewed path | retained |
+| vectorize line-start discovery | -1.1% to +2.5%, entirely inside noise | reverted |
 
 Operation-local diagnostics for the optimized detector were:
 
@@ -38,16 +67,16 @@ bounded second match.
 
 ## Real-process operations
 
-One unmeasured warm-up preceded five alternating baseline/optimized runs against
+One unmeasured warm-up preceded five alternating baseline/candidate runs against
 the DevProjex tree. Peak working set was sampled while each process was alive.
 
-| Operation | Baseline time, median (range) | Optimized time, median (range) | Baseline / optimized peak RSS | Interpretation |
+| Operation | Baseline time, median (range) | Candidate time, median (range) | Baseline / candidate peak RSS | Interpretation |
 |---|---:|---:|---:|---|
-| `analyze --format json` | 8,623.81 ms (8,230.73-12,603.79) | 8,012.67 ms (7,755.92-8,463.86) | 517.61 / 519.20 MiB | -7.1% time; RSS unchanged within 0.3% |
-| `export context --format json` | 8,847.50 ms (7,984.35-9,677.31) | 9,250.56 ms (8,219.17-10,755.82) | 518.38 / 516.53 MiB | +4.6% time, within run spread |
-| `export context --dry-run` | 7,913.79 ms (7,345.99-8,966.16) | 7,947.32 ms (6,876.98-8,272.02) | 513.63 / 511.97 MiB | +0.4% time, within noise |
+| `analyze --format json` | 5,473.91 ms (4,843.66-7,286.29) | 5,483.98 ms (4,704.49-6,575.66) | 521.07 / 519.55 MiB | +0.2%; distributions overlap |
+| `export context --format markdown` | 5,596.14 ms (5,403.49-7,273.35) | 5,677.66 ms (5,056.86-6,654.00) | 521.84 / 523.96 MiB | +1.5%; distributions overlap |
+| `export context --dry-run` | 5,062.91 ms (4,953.70-6,875.95) | 5,466.14 ms (5,009.98-6,854.42) | 520.38 / 521.86 MiB | +8.0%; distributions overlap |
 
-The dry-run response was 304 bytes in both builds. Analyze and export responses
+The dry-run response was 302 bytes in both builds. Analyze and export responses
 differed by one byte because the compared revisions format a progress/localized
 line differently; content equivalence is covered separately by the redaction
 contract tests rather than inferred from response size.


### PR DESCRIPTION
Reduces rejected-candidate work in secret detection, reuses detection and transformed metrics through the bounded preparation pipeline, shares file prefix inspection, and carries compact prewarm metrics into Desktop aggregation. Adds a standalone reproducible benchmark harness and records medians, spread, allocations, work counters, and finding fingerprints. Protection limits, findings, replacement semantics, and trust boundaries remain unchanged.