### PR TITLE
fix(secrets): preserve complete detection coverage

### DIFF
--- a/Application/Secrets/SecretRedactionOutputPreparer.cs
+++ b/Application/Secrets/SecretRedactionOutputPreparer.cs
@@ -864,12 +864,13 @@ public sealed class SecretRedactionOutputPreparer
 			    result.Classification == FileContentClassification.Text)
 			{
 				using var detectionStage = ContentPipelineDiagnostics.MeasureStage(ContentPipelineStage.Detection);
-				detectionEntry = redactionScope.DetectTransformedContent(
+				detectionEntry = redactionScope.DetectSourceAndTransformedContent(
 					item.SourcePath,
+					result.Content!.Content,
 					compression.Text,
 					compression.Map,
 					coherentRead.Metadata,
-					compression.Map.IsIdentity ? readFact.Fingerprint : null,
+					readFact.Fingerprint,
 					cancellationToken);
 			}
 

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -3022,28 +3022,7 @@ public sealed class SecretRedactionScope
 			.ThenBy(static match => match.Start)
 			.ThenByDescending(static match => match.Length)
 			.ToArray();
-		var survivors = new List<DetectedSecret>(merged.Length);
-		var acceptedDetectorIntervals = new Dictionary<RedactionFindingCategory, SortedSet<DetectorInterval>>();
-		foreach (var candidate in merged)
-		{
-			if (!IsMarked(candidate))
-			{
-				if (!acceptedDetectorIntervals.TryGetValue(candidate.Category, out var intervals))
-				{
-					intervals = new SortedSet<DetectorInterval>(DetectorIntervalStartComparer.Instance);
-					acceptedDetectorIntervals.Add(candidate.Category, intervals);
-				}
-				var interval = new DetectorInterval(
-					candidate.Start,
-					checked(candidate.Start + candidate.Length));
-				if (HasOverlap(intervals, interval))
-					continue;
-				intervals.Add(interval);
-			}
-			survivors.Add(candidate);
-		}
-
-		var candidates = survivors.ToArray();
+		var candidates = merged;
 		var starts = new Dictionary<int, List<int>>();
 		var ends = new Dictionary<int, List<int>>();
 		var boundaries = new int[candidates.Length * 2];
@@ -3104,26 +3083,6 @@ public sealed class SecretRedactionScope
 		candidates.Add(candidateIndex);
 	}
 
-	private static bool HasOverlap(
-		SortedSet<DetectorInterval> intervals,
-		DetectorInterval candidate)
-	{
-		if (intervals.Count == 0)
-			return false;
-		var predecessors = intervals.GetViewBetween(
-			DetectorInterval.Minimum,
-			new DetectorInterval(candidate.Start, int.MaxValue));
-		if (predecessors.Count > 0 && predecessors.Max.End > candidate.Start)
-			return true;
-		var successors = intervals.GetViewBetween(
-			new DetectorInterval(candidate.Start, int.MinValue),
-			DetectorInterval.Maximum);
-		return successors.Count > 0 && successors.Min.Start < candidate.End;
-	}
-
-	private static bool IsMarked(DetectedSecret match) =>
-		(match.Source & (SecretFindingSource.PersistentMark | SecretFindingSource.SessionMark)) != 0;
-
 	private static DetectedSecret MergeExactMatches(IEnumerable<DetectedSecret> group)
 	{
 		var matches = group.ToArray();
@@ -3172,12 +3131,6 @@ public sealed class SecretRedactionScope
 		public static ResolvedSecretFindingSet Empty { get; } = new([], []);
 	}
 
-	private readonly record struct DetectorInterval(int Start, int End)
-	{
-		public static DetectorInterval Minimum { get; } = new(int.MinValue, int.MinValue);
-		public static DetectorInterval Maximum { get; } = new(int.MaxValue, int.MaxValue);
-	}
-
 	private sealed class DetectedSecretPriorityComparer : IComparer<DetectedSecret>
 	{
 		public static DetectedSecretPriorityComparer Instance { get; } = new();
@@ -3207,17 +3160,6 @@ public sealed class SecretRedactionScope
 
 		private static bool IsMarked(DetectedSecret match) =>
 			(match.Source & (SecretFindingSource.PersistentMark | SecretFindingSource.SessionMark)) != 0;
-	}
-
-	private sealed class DetectorIntervalStartComparer : IComparer<DetectorInterval>
-	{
-		public static DetectorIntervalStartComparer Instance { get; } = new();
-
-		public int Compare(DetectorInterval left, DetectorInterval right)
-		{
-			var startComparison = left.Start.CompareTo(right.Start);
-			return startComparison != 0 ? startComparison : left.End.CompareTo(right.End);
-		}
 	}
 
 }

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -3388,7 +3388,28 @@ public sealed class SecretRedactionScope
 			.ThenBy(static match => match.Start)
 			.ThenByDescending(static match => match.Length)
 			.ToArray();
-		var candidates = merged;
+		var survivors = new List<DetectedSecret>(merged.Length);
+		var acceptedDetectorIntervals = new Dictionary<RedactionFindingCategory, SortedSet<DetectorInterval>>();
+		foreach (var candidate in merged)
+		{
+			if (!IsMarked(candidate))
+			{
+				if (!acceptedDetectorIntervals.TryGetValue(candidate.Category, out var intervals))
+				{
+					intervals = new SortedSet<DetectorInterval>(DetectorIntervalStartComparer.Instance);
+					acceptedDetectorIntervals.Add(candidate.Category, intervals);
+				}
+				var interval = new DetectorInterval(
+					candidate.Start,
+					checked(candidate.Start + candidate.Length));
+				if (IsGenericRule(candidate.RuleId) && HasOverlap(intervals, interval))
+					continue;
+				AddCoveredInterval(intervals, interval);
+			}
+			survivors.Add(candidate);
+		}
+
+		var candidates = survivors.ToArray();
 		var starts = new Dictionary<int, List<int>>();
 		var ends = new Dictionary<int, List<int>>();
 		var boundaries = new int[candidates.Length * 2];
@@ -3449,6 +3470,56 @@ public sealed class SecretRedactionScope
 		candidates.Add(candidateIndex);
 	}
 
+	private static bool HasOverlap(
+		SortedSet<DetectorInterval> intervals,
+		DetectorInterval candidate)
+	{
+		if (intervals.Count == 0)
+			return false;
+		var predecessors = intervals.GetViewBetween(
+			DetectorInterval.Minimum,
+			new DetectorInterval(candidate.Start, int.MaxValue));
+		if (predecessors.Count > 0 && predecessors.Max.End > candidate.Start)
+			return true;
+		var successors = intervals.GetViewBetween(
+			new DetectorInterval(candidate.Start, int.MinValue),
+			DetectorInterval.Maximum);
+		return successors.Count > 0 && successors.Min.Start < candidate.End;
+	}
+
+	private static void AddCoveredInterval(
+		SortedSet<DetectorInterval> intervals,
+		DetectorInterval candidate)
+	{
+		var start = candidate.Start;
+		var end = candidate.End;
+		var predecessors = intervals.GetViewBetween(
+			DetectorInterval.Minimum,
+			new DetectorInterval(start, int.MaxValue));
+		if (predecessors.Count > 0 && predecessors.Max.End >= start)
+		{
+			var predecessor = predecessors.Max;
+			start = predecessor.Start;
+			end = Math.Max(end, predecessor.End);
+			intervals.Remove(predecessor);
+		}
+		while (true)
+		{
+			var successors = intervals.GetViewBetween(
+				new DetectorInterval(start, int.MinValue),
+				DetectorInterval.Maximum);
+			if (successors.Count == 0 || successors.Min.Start > end)
+				break;
+			var successor = successors.Min;
+			end = Math.Max(end, successor.End);
+			intervals.Remove(successor);
+		}
+		intervals.Add(new DetectorInterval(start, end));
+	}
+
+	private static bool IsMarked(DetectedSecret match) =>
+		(match.Source & (SecretFindingSource.PersistentMark | SecretFindingSource.SessionMark)) != 0;
+
 	private static DetectedSecret MergeExactMatches(IEnumerable<DetectedSecret> group)
 	{
 		var matches = group.ToArray();
@@ -3497,6 +3568,12 @@ public sealed class SecretRedactionScope
 		public static ResolvedSecretFindingSet Empty { get; } = new([], []);
 	}
 
+	private readonly record struct DetectorInterval(int Start, int End)
+	{
+		public static DetectorInterval Minimum { get; } = new(int.MinValue, int.MinValue);
+		public static DetectorInterval Maximum { get; } = new(int.MaxValue, int.MaxValue);
+	}
+
 	private sealed class DetectedSecretPriorityComparer : IComparer<DetectedSecret>
 	{
 		public static DetectedSecretPriorityComparer Instance { get; } = new();
@@ -3526,6 +3603,17 @@ public sealed class SecretRedactionScope
 
 		private static bool IsMarked(DetectedSecret match) =>
 			(match.Source & (SecretFindingSource.PersistentMark | SecretFindingSource.SessionMark)) != 0;
+	}
+
+	private sealed class DetectorIntervalStartComparer : IComparer<DetectorInterval>
+	{
+		public static DetectorIntervalStartComparer Instance { get; } = new();
+
+		public int Compare(DetectorInterval left, DetectorInterval right)
+		{
+			var startComparison = left.Start.CompareTo(right.Start);
+			return startComparison != 0 ? startComparison : left.End.CompareTo(right.End);
+		}
 	}
 
 }

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -1823,8 +1823,41 @@ public sealed class SecretRedactionSession : IDisposable
 		_scanCache.Store(alias, detectionExecuted: false);
 	}
 
+	internal bool TryGetCachedFindingsByContent(
+		string projectRoot,
+		string filePath,
+		SecretFileMetadata metadata,
+		string contentFingerprint,
+		ISecretDetectionScope detectorScope,
+		bool includeAutomaticDetection,
+		int markedSecretsRevision,
+		string transformIdentity,
+		long generation,
+		CancellationToken generationToken,
+		out SecretScanCacheEntry entry)
+	{
+		lock (_sync)
+		{
+			ThrowIfGenerationIsNotCurrentLocked(generation, generationToken);
+			return _scanCache.TryGetByContent(
+				filePath,
+				metadata,
+				contentFingerprint,
+				GetRulesIdentity(
+					detectorScope,
+					filePath,
+					NormalizeRelativePath(projectRoot, filePath),
+					includeAutomaticDetection),
+				transformIdentity,
+				markedSecretsRevision,
+				out entry);
+		}
+	}
+
 	internal SecretScanCacheEntry StoreCombinedTransformFindings(
 		SecretScanCacheEntry source,
+		string contentFingerprint,
+		string transformIdentity,
 		IReadOnlyList<SecretFindingCandidateMetadata> candidates,
 		IReadOnlyList<SecretFindingSegmentMetadata> segments,
 		long generation,
@@ -1832,13 +1865,15 @@ public sealed class SecretRedactionSession : IDisposable
 	{
 		var combined = source with
 		{
+			ContentFingerprint = contentFingerprint,
+			TransformIdentity = transformIdentity,
 			Candidates = candidates,
 			Segments = segments,
 			ApproximateRetainedBytes = EstimateRetainedBytes(
 				source.NormalizedPath,
-				source.ContentFingerprint,
+				contentFingerprint,
 				source.RulesIdentity,
-				source.TransformIdentity,
+				transformIdentity,
 				source.OccurrenceProjectRoot,
 				source.OccurrenceRelativePath,
 				candidates,
@@ -2252,6 +2287,7 @@ public sealed class SecretRedactionSnapshotPublishedEventArgs(SecretRedactionSna
 
 public sealed class SecretRedactionScope
 {
+	private const string TransformedDetectionStageSuffix = "\u001ftransformed-detection-v1";
 	private const byte CandidateRepresented = 1;
 	private const byte CandidateRedacted = 2;
 	private readonly SecretRedactionSession _session;
@@ -2680,14 +2716,47 @@ public sealed class SecretRedactionScope
 			cancellationToken,
 			transformMap: null,
 			knownFingerprint: sourceFingerprint);
-		var transformedEntry = DetectTransformed(
+		ContentPipelineDiagnostics.RecordContentFingerprint();
+		var transformedFingerprint = SecretRedactionSession.HashValue(transformedContent.AsSpan());
+		var combinedFingerprint = sourceEntry.ContentFingerprint + transformedFingerprint;
+		var includeAutomaticDetection = inspectionMode == SecretContentInspectionMode.AutomaticAndManual;
+		if (_session.TryGetCachedFindingsByContent(
+			    _projectRoot,
+			    filePath,
+			    metadata,
+			    combinedFingerprint,
+			    _detectorScope,
+			    includeAutomaticDetection,
+			    _markedSecretsRevision,
+			    _transformIdentity,
+			    _generation,
+			    _generationToken,
+			    out var combinedEntry))
+		{
+			return combinedEntry;
+		}
+
+		EnsureScannableLength(filePath, transformedContent.Length);
+		var transformedEntry = _session.GetOrDetectFindings(
+			_projectRoot,
 			filePath,
 			transformedContent,
-			transformMap,
 			metadata,
-			knownFingerprint: null,
+			_detectorScope,
+			_markedSecretsMatcher,
+			includeAutomaticDetection,
+			_markedSecretsRevision,
+			_transformIdentity + TransformedDetectionStageSuffix,
+			_generation,
+			_generationToken,
+			cancellationToken,
+			transformMap);
+		return MergeDetectionEntries(
+			sourceEntry,
+			transformedEntry,
+			combinedFingerprint,
+			transformMap,
 			cancellationToken);
-		return MergeDetectionEntries(sourceEntry, transformedEntry!, transformMap, cancellationToken);
 	}
 
 	internal SecretFileRedactionPlan CreatePlanFromDetectedContent(
@@ -2771,6 +2840,7 @@ public sealed class SecretRedactionScope
 	private SecretScanCacheEntry MergeDetectionEntries(
 		SecretScanCacheEntry sourceEntry,
 		SecretScanCacheEntry transformedEntry,
+		string combinedFingerprint,
 		ContentTransformMap transformMap,
 		CancellationToken cancellationToken)
 	{
@@ -2795,6 +2865,8 @@ public sealed class SecretRedactionScope
 		var segments = BuildSegments(candidates);
 		return _session.StoreCombinedTransformFindings(
 			transformedEntry,
+			combinedFingerprint,
+			_transformIdentity,
 			candidates,
 			segments,
 			_generation,

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -2661,10 +2661,10 @@ public sealed class SecretRedactionScope
 				cancellationToken);
 		}
 
-		EnsureScannableLength(filePath, sourceContent.Length);
 		var inspectionMode = GetContentInspectionMode(filePath);
 		if (inspectionMode == SecretContentInspectionMode.None)
 			return null;
+		EnsureScannableLength(filePath, sourceContent.Length);
 		var sourceEntry = _session.GetOrDetectFindings(
 			_projectRoot,
 			filePath,

--- a/Application/Secrets/SecretRedactionSession.cs
+++ b/Application/Secrets/SecretRedactionSession.cs
@@ -1823,6 +1823,35 @@ public sealed class SecretRedactionSession : IDisposable
 		_scanCache.Store(alias, detectionExecuted: false);
 	}
 
+	internal SecretScanCacheEntry StoreCombinedTransformFindings(
+		SecretScanCacheEntry source,
+		IReadOnlyList<SecretFindingCandidateMetadata> candidates,
+		IReadOnlyList<SecretFindingSegmentMetadata> segments,
+		long generation,
+		CancellationToken generationToken)
+	{
+		var combined = source with
+		{
+			Candidates = candidates,
+			Segments = segments,
+			ApproximateRetainedBytes = EstimateRetainedBytes(
+				source.NormalizedPath,
+				source.ContentFingerprint,
+				source.RulesIdentity,
+				source.TransformIdentity,
+				source.OccurrenceProjectRoot,
+				source.OccurrenceRelativePath,
+				candidates,
+				segments)
+		};
+		lock (_sync)
+		{
+			ThrowIfGenerationIsNotCurrentLocked(generation, generationToken);
+			_scanCache.Store(combined, detectionExecuted: false);
+		}
+		return combined;
+	}
+
 	internal SecretScanCacheEntry StoreBinary(
 		string projectRoot,
 		string filePath,
@@ -2612,6 +2641,55 @@ public sealed class SecretRedactionScope
 			knownFingerprint,
 			cancellationToken);
 
+	internal SecretScanCacheEntry? DetectSourceAndTransformedContent(
+		string filePath,
+		string sourceContent,
+		string transformedContent,
+		ContentTransformMap transformMap,
+		SecretFileMetadata metadata,
+		ContentFingerprint? sourceFingerprint,
+		CancellationToken cancellationToken)
+	{
+		if (transformMap.IsIdentity)
+		{
+			return DetectTransformed(
+				filePath,
+				transformedContent,
+				transformMap,
+				metadata,
+				sourceFingerprint,
+				cancellationToken);
+		}
+
+		EnsureScannableLength(filePath, sourceContent.Length);
+		var inspectionMode = GetContentInspectionMode(filePath);
+		if (inspectionMode == SecretContentInspectionMode.None)
+			return null;
+		var sourceEntry = _session.GetOrDetectFindings(
+			_projectRoot,
+			filePath,
+			sourceContent,
+			metadata,
+			_detectorScope,
+			_markedSecretsMatcher,
+			inspectionMode == SecretContentInspectionMode.AutomaticAndManual,
+			_markedSecretsRevision,
+			transformIdentity: string.Empty,
+			_generation,
+			_generationToken,
+			cancellationToken,
+			transformMap: null,
+			knownFingerprint: sourceFingerprint);
+		var transformedEntry = DetectTransformed(
+			filePath,
+			transformedContent,
+			transformMap,
+			metadata,
+			knownFingerprint: null,
+			cancellationToken);
+		return MergeDetectionEntries(sourceEntry, transformedEntry!, transformMap, cancellationToken);
+	}
+
 	internal SecretFileRedactionPlan CreatePlanFromDetectedContent(
 		string filePath,
 		SecretScanCacheEntry? entry,
@@ -2660,13 +2738,7 @@ public sealed class SecretRedactionScope
 		// first and the plan describes its output, so gating on the on-disk size would refuse work
 		// the scanner is about to do on a fraction of that text - the limit would fight the very
 		// setting a user enables to get under it.
-		if (content.Length > SecretRedactionOutputPreparer.MaximumScannableFileBytes)
-		{
-			throw new SecretScanLimitExceededException(
-				filePath,
-				content.Length,
-				SecretRedactionOutputPreparer.MaximumScannableFileBytes);
-		}
+		EnsureScannableLength(filePath, content.Length);
 		return _session.GetOrDetectFindings(
 			_projectRoot,
 			filePath,
@@ -2684,6 +2756,228 @@ public sealed class SecretRedactionScope
 			knownFingerprint,
 			allowIdentityTransformFallback:
 				knownFingerprint is not null && transformMap?.IsIdentity == true);
+	}
+
+	private static void EnsureScannableLength(string filePath, int contentLength)
+	{
+		if (contentLength <= SecretRedactionOutputPreparer.MaximumScannableFileBytes)
+			return;
+		throw new SecretScanLimitExceededException(
+			filePath,
+			contentLength,
+			SecretRedactionOutputPreparer.MaximumScannableFileBytes);
+	}
+
+	private SecretScanCacheEntry MergeDetectionEntries(
+		SecretScanCacheEntry sourceEntry,
+		SecretScanCacheEntry transformedEntry,
+		ContentTransformMap transformMap,
+		CancellationToken cancellationToken)
+	{
+		var projected = new List<SecretFindingCandidateMetadata>(
+			sourceEntry.Candidates.Count + transformedEntry.Candidates.Count);
+		projected.AddRange(transformedEntry.Candidates);
+		foreach (var sourceCandidate in sourceEntry.Candidates)
+		{
+			foreach (var range in ProjectSourceRange(sourceCandidate, transformMap, cancellationToken))
+				projected.Add(CopyCandidateAt(sourceCandidate, range.Start, range.Length));
+		}
+
+		if (projected.Count == 0)
+			return transformedEntry;
+		var candidates = projected
+			.GroupBy(static candidate => (candidate.RawStart, candidate.RawLength, candidate.Category))
+			.Select(static group => MergeExactCandidates(group))
+			.Order(SecretFindingCandidatePriorityComparer.Instance)
+			.ThenBy(static candidate => candidate.RawStart)
+			.ThenByDescending(static candidate => candidate.RawLength)
+			.ToArray();
+		var segments = BuildSegments(candidates);
+		return _session.StoreCombinedTransformFindings(
+			transformedEntry,
+			candidates,
+			segments,
+			_generation,
+			_generationToken);
+	}
+
+	private static IEnumerable<(int Start, int Length)> ProjectSourceRange(
+		SecretFindingCandidateMetadata candidate,
+		ContentTransformMap transformMap,
+		CancellationToken cancellationToken)
+	{
+		var sourceEnd = checked(candidate.RawStart + candidate.RawLength);
+		var projectedStart = -1;
+		var projectedEnd = -1;
+		for (var sourceOffset = candidate.RawStart; sourceOffset < sourceEnd; sourceOffset++)
+		{
+			if ((sourceOffset & 1023) == 0)
+				cancellationToken.ThrowIfCancellationRequested();
+			var retained = transformMap.TryToTransformed(sourceOffset, out var transformedStart) &&
+			               transformMap.TryMapSourceBackedRange(
+				               transformedStart,
+				               transformedLength: 1,
+				               out var mappedSourceStart,
+				               out var mappedSourceLength) &&
+			               mappedSourceStart == sourceOffset &&
+			               mappedSourceLength == 1;
+			if (retained && (projectedStart < 0 || transformedStart == projectedEnd))
+			{
+				if (projectedStart < 0)
+					projectedStart = transformedStart;
+				projectedEnd = transformedStart + 1;
+				continue;
+			}
+
+			if (projectedStart >= 0)
+			{
+				yield return (projectedStart, projectedEnd - projectedStart);
+				projectedStart = -1;
+				projectedEnd = -1;
+			}
+			if (retained)
+			{
+				projectedStart = transformedStart;
+				projectedEnd = transformedStart + 1;
+			}
+		}
+		if (projectedStart >= 0)
+			yield return (projectedStart, projectedEnd - projectedStart);
+	}
+
+	private static SecretFindingCandidateMetadata MergeExactCandidates(
+		IEnumerable<SecretFindingCandidateMetadata> group)
+	{
+		var candidates = group.ToArray();
+		var winner = candidates.Order(SecretFindingCandidatePriorityComparer.Instance).First();
+		var source = candidates.Aggregate(
+			(SecretFindingSource)0,
+			static (current, candidate) => current | candidate.Source);
+		var winnerSources = candidates.Where(candidate =>
+			candidate.Category == winner.Category &&
+			string.Equals(candidate.RuleId, winner.RuleId, StringComparison.Ordinal));
+		return new SecretFindingCandidateMetadata(
+			winner.RawStart,
+			winner.RawLength,
+			winner.RuleId,
+			winner.ValueFingerprint,
+			winner.RuleOrder,
+			source,
+			winnerSources.Select(static candidate => candidate.PersistentMarkHash)
+				.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)),
+			winnerSources.Select(static candidate => candidate.SessionMarkId)
+				.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)),
+			winnerSources.Select(static candidate => candidate.PersistentMarkId)
+				.FirstOrDefault(static value => value is not null),
+			winner.Category,
+			winner.OccurrenceCoordinateIdentity);
+	}
+
+	private static SecretFindingCandidateMetadata CopyCandidateAt(
+		SecretFindingCandidateMetadata candidate,
+		int start,
+		int length) =>
+		new(
+			start,
+			length,
+			candidate.RuleId,
+			candidate.ValueFingerprint,
+			candidate.RuleOrder,
+			candidate.Source,
+			candidate.PersistentMarkHash,
+			candidate.SessionMarkId,
+			candidate.PersistentMarkId,
+			candidate.Category,
+			candidate.OccurrenceCoordinateIdentity);
+
+	private static IReadOnlyList<SecretFindingSegmentMetadata> BuildSegments(
+		IReadOnlyList<SecretFindingCandidateMetadata> candidates)
+	{
+		var starts = new Dictionary<int, List<int>>();
+		var ends = new Dictionary<int, List<int>>();
+		var boundaries = new int[candidates.Count * 2];
+		for (var index = 0; index < candidates.Count; index++)
+		{
+			var candidate = candidates[index];
+			var end = checked(candidate.RawStart + candidate.RawLength);
+			boundaries[index * 2] = candidate.RawStart;
+			boundaries[index * 2 + 1] = end;
+			AddCandidateBoundary(starts, candidate.RawStart, index);
+			AddCandidateBoundary(ends, end, index);
+		}
+		Array.Sort(boundaries);
+
+		var active = new SortedSet<int>();
+		var segments = new List<SecretFindingSegmentMetadata>(Math.Max(0, candidates.Count * 2 - 1));
+		var boundaryIndex = 0;
+		while (boundaryIndex < boundaries.Length)
+		{
+			var boundary = boundaries[boundaryIndex];
+			while (boundaryIndex < boundaries.Length && boundaries[boundaryIndex] == boundary)
+				boundaryIndex++;
+			if (ends.TryGetValue(boundary, out var ending))
+			{
+				foreach (var candidateIndex in ending)
+					active.Remove(candidateIndex);
+			}
+			if (starts.TryGetValue(boundary, out var starting))
+			{
+				foreach (var candidateIndex in starting)
+					active.Add(candidateIndex);
+			}
+			if (active.Count > 0 && boundaryIndex < boundaries.Length)
+			{
+				var nextBoundary = boundaries[boundaryIndex];
+				if (nextBoundary > boundary)
+					segments.Add(new SecretFindingSegmentMetadata(boundary, nextBoundary - boundary, active.ToArray()));
+			}
+		}
+		return segments;
+	}
+
+	private static void AddCandidateBoundary(
+		IDictionary<int, List<int>> events,
+		int position,
+		int candidateIndex)
+	{
+		if (!events.TryGetValue(position, out var indexes))
+		{
+			indexes = [];
+			events.Add(position, indexes);
+		}
+		indexes.Add(candidateIndex);
+	}
+
+	private sealed class SecretFindingCandidatePriorityComparer : IComparer<SecretFindingCandidateMetadata>
+	{
+		public static SecretFindingCandidatePriorityComparer Instance { get; } = new();
+
+		public int Compare(SecretFindingCandidateMetadata? left, SecretFindingCandidateMetadata? right)
+		{
+			if (ReferenceEquals(left, right))
+				return 0;
+			if (left is null)
+				return 1;
+			if (right is null)
+				return -1;
+			var result = IsMarked(right).CompareTo(IsMarked(left));
+			if (result != 0)
+				return result;
+			result = left.Category.CompareTo(right.Category);
+			if (result != 0)
+				return result;
+			result = IsGenericRule(left.RuleId).CompareTo(IsGenericRule(right.RuleId));
+			if (result != 0)
+				return result;
+			result = left.RuleOrder.CompareTo(right.RuleOrder);
+			return result != 0 ? result : string.Compare(left.RuleId, right.RuleId, StringComparison.Ordinal);
+		}
+
+		private static bool IsMarked(SecretFindingCandidateMetadata candidate) =>
+			(candidate.Source & (SecretFindingSource.PersistentMark | SecretFindingSource.SessionMark)) != 0;
+
+		private static bool IsGenericRule(string ruleId) =>
+			ruleId.Equals("generic-api-key", StringComparison.Ordinal);
 	}
 
 	internal IDisposable TrackFullContentBuffer() => _session.TrackFullContentBuffer();

--- a/Docs/HideSecrets.md
+++ b/Docs/HideSecrets.md
@@ -2,10 +2,12 @@
 
 Hide Secrets and [Hide private data](HidePrivateData.md) share one redaction pipeline and
 one set of Preview decisions. Overlapping findings are rendered as non-overlapping segments with
-an ordered candidate stack. Keeping a secret finding changes that whole occurrence across all of
-its fragments, while text still covered by non-kept private-data findings remains redacted. The
-original segment appears only after every candidate in its stack is kept. The full overlap
-contract is described in [HidePrivateData.md](HidePrivateData.md).
+an ordered candidate stack. Their replacement coverage is the union of every valid finding; rule
+priority chooses the label for a segment, never removes an uncovered tail of another finding.
+Keeping a secret finding changes that whole occurrence across all of its fragments, while text
+still covered by non-kept private-data findings remains redacted. The original segment appears
+only after every candidate in its stack is kept. The full overlap contract is described in
+[HidePrivateData.md](HidePrivateData.md).
 
 **Smart Secrets** is DevProjex's local, deterministic credential-detection engine.
 **Hide Secrets** is the opt-in switch that applies its decisions to produced output.
@@ -76,7 +78,8 @@ DevProjex ships a reviewed managed port of the default Gitleaks
 - the one path-only PKCS#12 rule is intentionally excluded because a filename or
   opaque binary payload cannot be redacted in place;
 - keyword prescreening limits which bounded regular expressions inspect a file;
-- entropy thresholds and upstream allowlists preserve the pinned rule semantics;
+- entropy thresholds preserve the pinned rule semantics, while reviewed export-policy overrides
+  are versioned separately from the pinned source;
 - inline markers such as `gitleaks:allow` in project content do not suppress findings;
 - expressions use the managed non-backtracking .NET engine with a timeout.
 
@@ -146,6 +149,13 @@ does not bundle or launch Gitleaks and has no native scanning dependency.
 Attribution is recorded in
 [`THIRD-PARTY-NOTICES.md`](../THIRD-PARTY-NOTICES.md).
 
+Two reviewed export-policy differences apply after that verified snapshot is loaded. The upstream
+boolean expression is scoped to the whole candidate value, so `true`, `false`, and `null` remain
+examples without suppressing provider-shaped values that merely contain those words. Upstream path
+allowlists remain noise controls for `generic-api-key` and entropy-only candidates. A selected text
+file is still inspected by rules with a fixed provider prefix, including lock, vendor, and SVG
+paths; selecting text for export is not evidence that its contents are safe.
+
 ## Text, binary files, and limits
 
 Only selected text files are inspected. Binary files are not scanned and pass
@@ -163,19 +173,22 @@ Detection errors and regex timeouts still stop the operation on every surface. T
 was never inspected is never emitted, an uninspected file is never passed off as
 inspected, and a file left out of a copy is always named.
 
-The count scan stores compact spans, rule ids, file fingerprints, and hashed value
-identities in a bounded LRU cache. It does not retain complete source or redacted
-strings. Changed files are rescanned individually; unchanged files reuse their
-findings. Full transformed content is produced lazily for Preview or export, and
-temporary data is removed after completion or cancellation.
+The count scan stores compact spans, rule ids, file fingerprints, transform identities, and hashed
+value identities in a bounded LRU cache. It does not retain complete source or redacted strings.
+Changed files are rescanned individually; unchanged source and transformation results reuse their
+findings. When code transformations change the text, detection runs on the immutable source and on
+the transformed result. Retained source findings are projected through the transform map and their
+coverage is merged with findings created by the transformed text. An identity transform scans only
+once. Full transformed content is produced lazily for Preview or export, and temporary data is
+removed after completion or cancellation.
 
 The implementation avoids work that cannot affect those decisions. Provider-rule values are
 materialized only for accepted findings; line context is built only for line-target allowlists
 after entropy checks; path allowlists and immutable stopword search tables are reused. Preparation
 passes detection entries forward, measures materialized transformed text while writing it, and
 keeps only compact raw/effective metrics between compression prewarm and the Desktop metrics pass.
-None of these execution shortcuts changes rule inputs, allowlist AND/OR semantics, findings,
-replacement offsets, scan limits, or the fail-closed treatment of unreadable content.
+These execution shortcuts preserve authoritative regex matches, complete finding coverage,
+replacement offsets, scan limits, and the fail-closed treatment of unreadable content.
 
 Performance investigations can opt into `ContentPipelineDiagnostics`. Its operation-local counters
 include secondary provider-regex runs, line-index builds, rejected-match line contexts, plan

--- a/Docs/Security.md
+++ b/Docs/Security.md
@@ -20,6 +20,11 @@ Secret-redaction exceptions are operator-controlled. Project content is
 untrusted input, so inline markers such as `gitleaks:allow` cannot grant an
 exception in GUI, CLI, or MCP output.
 
+Code transformations cannot weaken redaction for characters that remain in the output. DevProjex
+detects against both the immutable source snapshot and transformed text, projects retained source
+ranges through the transform map, and masks the union. Overlap priority selects a rule label only;
+it does not discard another finding's uncovered range.
+
 Temporary redaction data is stored in private per-user directories. After an
 abnormal termination it can remain until a later DevProjex startup runs the
 scavenger, which removes stale directories once they are more than 24 hours old.

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -482,11 +482,21 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	{
 		// Gitleaks permits up to five separators before the captured value. Try each
 		// legal boundary instead of consuming them greedily: '=' is both a separator
-		// and a legal first character of the provider-neutral value grammar.
+		// and a legal first character of the provider-neutral value grammar. The first
+		// syntactically valid range is not necessarily the range with sufficient entropy.
+		candidate = default;
+		var bestEntropy = double.NegativeInfinity;
 		for (var skipped = 0; skipped <= 5 && valueStart < content.Length; skipped++, valueStart++)
 		{
-			if (TryReadGenericApiKeyCandidate(content, valueStart, out candidate))
-				return true;
+			if (TryReadGenericApiKeyCandidate(content, valueStart, out var current))
+			{
+				var entropy = CalculateShannonEntropy(current);
+				if (entropy > bestEntropy)
+				{
+					candidate = current;
+					bestEntropy = entropy;
+				}
+			}
 			if (skipped == 5 ||
 			    !char.IsWhiteSpace(content[valueStart]) &&
 			    content[valueStart] is not ('=' or '\'' or '"' or '`'))
@@ -495,8 +505,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			}
 		}
 
-		candidate = default;
-		return false;
+		return bestEntropy > double.NegativeInfinity;
 	}
 
 	private static int GetGenericDelimiterLength(ReadOnlySpan<char> content, int start)

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -127,16 +127,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	public bool ShouldInspectPath(string repositoryRelativePath)
 	{
 		ArgumentNullException.ThrowIfNull(repositoryRelativePath);
-		try
-		{
-			var normalizedPath = PathUtility.NormalizeSeparators(repositoryRelativePath);
-			var allowlists = _configuration.Value.GlobalAllowlists;
-			return ShouldInspectPath(allowlists, EvaluateAllowlistPaths(allowlists, normalizedPath));
-		}
-		catch (RegexMatchTimeoutException exception)
-		{
-			throw new SecretDetectionException("Secret path policy evaluation timed out.", exception);
-		}
+		return true;
 	}
 
 	internal GitleaksCandidateStatistics InspectCandidates(
@@ -335,8 +326,6 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		budget.Checkpoint(cancellationToken);
 		var normalizedPath = PathUtility.NormalizeSeparators(repositoryRelativePath);
 		var globalPathMatches = EvaluateAllowlistPaths(configuration.GlobalAllowlists, normalizedPath);
-		if (!ShouldInspectPath(configuration.GlobalAllowlists, globalPathMatches))
-			return [];
 		Span<ulong> candidateRules = stackalloc ulong[GetCandidateWordCount(configuration.Rules.Count)];
 		configuration.KeywordPrefilter.FindCandidates(content, candidateRules, cancellationToken);
 
@@ -370,7 +359,6 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 				foreach (var valueMatch in contentRegex.EnumerateMatches(content))
 				{
 					budget.Checkpoint(cancellationToken);
-					rulePathMatches ??= EvaluateRuleAllowlistPaths(rule.Allowlists, normalizedPath);
 					var secretOffset = 0;
 					var secretLength = valueMatch.Length;
 					if (!wholeMatchFastPath)
@@ -386,11 +374,14 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 					var secret = content.Slice(valueMatch.Index + secretOffset, secretLength);
 					if (rule.Entropy > 0 && CalculateShannonEntropy(secret) <= rule.Entropy)
 						continue;
+					var usePathAllowlists = UsesHeuristicPathPolicy(rule, secret);
+					if (usePathAllowlists)
+						rulePathMatches ??= EvaluateRuleAllowlistPaths(rule.Allowlists, normalizedPath);
 
 					ReadOnlySpan<char> line = default;
 					var inspectedLine = false;
-					if (NeedsLine(configuration.GlobalAllowlists, globalPathMatches) ||
-					    NeedsLine(rule.Allowlists, rulePathMatches))
+					if (NeedsLine(configuration.GlobalAllowlists, globalPathMatches, usePathAllowlists) ||
+					    NeedsLine(rule.Allowlists, rulePathMatches, usePathAllowlists))
 					{
 						var lineRange = lineIndex.GetContainingLine(valueMatch.Index, valueMatch.Length);
 						line = content.Slice(lineRange.Start, lineRange.Length);
@@ -402,8 +393,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 						secret,
 						content.Slice(valueMatch.Index, valueMatch.Length),
 						line);
-					if (Allows(configuration.GlobalAllowlists, globalPathMatches, context) ||
-					    Allows(rule.Allowlists, rulePathMatches, context))
+					if (Allows(configuration.GlobalAllowlists, globalPathMatches, context, usePathAllowlists) ||
+					    Allows(rule.Allowlists, rulePathMatches, context, usePathAllowlists))
 					{
 						if (inspectedLine)
 							ContentPipelineDiagnostics.RecordRejectedMatchLineContext();
@@ -431,13 +422,15 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 		return findings;
 	}
 
-	private static bool ShouldInspectPath(
-		IReadOnlyList<CompiledAllowlist> allowlists,
-		IReadOnlyList<bool> pathMatches)
+	private static bool UsesHeuristicPathPolicy(CompiledRule rule, ReadOnlySpan<char> secret)
 	{
-		for (var index = 0; index < allowlists.Count; index++)
+		if (rule.Id.Equals(GenericApiKeyRuleId, StringComparison.Ordinal))
+			return true;
+		if (rule.Entropy <= 0)
+			return false;
+		foreach (var keyword in rule.Keywords)
 		{
-			if (allowlists[index].AllowsWholeFileByPath(pathMatches[index]))
+			if (secret.StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
 				return false;
 		}
 		return true;
@@ -1144,11 +1137,14 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 	private static bool NeedsLine(
 		IReadOnlyList<CompiledAllowlist> allowlists,
-		IReadOnlyList<bool> pathMatches)
+		IReadOnlyList<bool>? pathMatches,
+		bool usePathAllowlists)
 	{
 		for (var index = 0; index < allowlists.Count; index++)
 		{
-			if (allowlists[index].NeedsLine(pathMatches[index]))
+			if (allowlists[index].NeedsLine(
+				    usePathAllowlists && pathMatches is not null && pathMatches[index],
+				    usePathAllowlists))
 				return true;
 		}
 		return false;
@@ -1156,12 +1152,16 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 	private static bool Allows(
 		IReadOnlyList<CompiledAllowlist> allowlists,
-		IReadOnlyList<bool> pathMatches,
-		AllowlistContext context)
+		IReadOnlyList<bool>? pathMatches,
+		AllowlistContext context,
+		bool usePathAllowlists)
 	{
 		for (var index = 0; index < allowlists.Count; index++)
 		{
-			if (allowlists[index].Allows(context, pathMatches[index]))
+			if (allowlists[index].Allows(
+				    context,
+				    usePathAllowlists && pathMatches is not null && pathMatches[index],
+				    usePathAllowlists))
 				return true;
 		}
 		return false;
@@ -1868,12 +1868,12 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 				pathMatches,
 				Regexes.Count > 0 || Stopwords.Count > 0);
 
-		public bool NeedsLine(bool pathMatches) =>
+		public bool NeedsLine(bool pathMatches, bool usePathAllowlists) =>
 			RegexTarget == AllowlistRegexTarget.Line &&
 			Regexes.Count > 0 &&
-			(RequireAll || !pathMatches);
+			(RequireAll || !usePathAllowlists || !pathMatches);
 
-		public bool Allows(AllowlistContext context, bool pathMatches)
+		public bool Allows(AllowlistContext context, bool pathMatches, bool usePathAllowlists)
 		{
 			ReadOnlySpan<char> target = RegexTarget switch
 			{
@@ -1883,13 +1883,13 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 			};
 			if (!RequireAll)
 			{
-				return Paths.Count > 0 && pathMatches ||
+				return usePathAllowlists && Paths.Count > 0 && pathMatches ||
 				       _stopwordSearchValues is not null && ContainsAny(context.Secret, _stopwordSearchValues) ||
 				       Regexes.Count > 0 && MatchesAny(target, Regexes);
 			}
 
 			var hasCriterion = false;
-			if (Paths.Count > 0)
+			if (usePathAllowlists && Paths.Count > 0)
 			{
 				hasCriterion = true;
 				if (!pathMatches)

--- a/Infrastructure/Secrets/GitleaksSecretDetector.cs
+++ b/Infrastructure/Secrets/GitleaksSecretDetector.cs
@@ -26,6 +26,9 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	private const string ResourceSuffix = ".Secrets.Rules.gitleaks-v8.30.1.toml";
 	private const string GenericApiKeyRuleId = "generic-api-key";
 	private const string PrivateKeyRuleId = "private-key";
+	internal const string PolicyOverrideVersion = "devprojex-export-v1";
+	internal const string UpstreamBooleanAllowlistPattern = "(?i)^true|false|null$";
+	internal const string WholeValueBooleanAllowlistPattern = "(?i)^(?:true|false|null)$";
 	private static readonly SearchValues<char> GenericDelimiters = SearchValues.Create("=>|:?,");
 	// Reviewed override for the upstream private-key rule. The upstream body pattern accepts any
 	// character, so in a file that merely mentions PEM markers - test fixtures, documentation -
@@ -79,7 +82,8 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	public int RuleCount => _configuration.Value.Rules.Count;
 	// The "+pkb" marker records the reviewed private-key override so cached findings produced by
 	// the unbounded upstream pattern are never mistaken for results of the bounded one.
-	public string RulesIdentity => $"gitleaks:{RulesVersion}:{ConfigurationSha256}+pkb";
+	public string RulesIdentity =>
+		$"gitleaks:{RulesVersion}:{ConfigurationSha256}+pkb+{PolicyOverrideVersion}";
 
 	public void WarmUp(CancellationToken cancellationToken = default)
 	{
@@ -219,6 +223,12 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 	internal IReadOnlyList<string> InspectRuleIds() =>
 		_configuration.Value.Rules.Select(static rule => rule.Id).ToArray();
+
+	internal IReadOnlyList<string> InspectGlobalAllowlistRegexPatterns() =>
+		_configuration.Value.GlobalAllowlists
+			.SelectMany(static allowlist => allowlist.Regexes)
+			.Select(static regex => regex.Value.ToString())
+			.ToArray();
 
 	internal bool InspectRuleSpecificEvidence(string ruleId, ReadOnlySpan<char> content) =>
 		HasRuleSpecificEvidence(ruleId, content);
@@ -1292,7 +1302,7 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 
 		var globalAllowlists = root.TryGetValue("allowlist", out var globalAllowlistValue) &&
 		                       globalAllowlistValue is TomlTable globalAllowlist
-			? new[] { CompileAllowlist(globalAllowlist) }
+			? new[] { CompileGlobalAllowlist(globalAllowlist) }
 			: [];
 		var rules = new List<CompiledRule>(ruleTables.Count);
 		for (var order = 0; order < ruleTables.Count; order++)
@@ -1362,12 +1372,36 @@ public sealed class GitleaksSecretDetector : ISecretDetector
 	// bounded finding context under the same hard timeout; using the interpreted engine here
 	// avoids retaining tens of megabytes of lazy symbolic DFA state for exclusion predicates.
 	private static CompiledAllowlist CompileAllowlist(TomlTable table) =>
+		CompileAllowlist(table, GetStringArray(table, "regexes"));
+
+	private static CompiledAllowlist CompileGlobalAllowlist(TomlTable table)
+	{
+		var regexPatterns = GetStringArray(table, "regexes");
+		var overrideCount = 0;
+		for (var index = 0; index < regexPatterns.Length; index++)
+		{
+			if (!regexPatterns[index].Equals(UpstreamBooleanAllowlistPattern, StringComparison.Ordinal))
+				continue;
+			regexPatterns[index] = WholeValueBooleanAllowlistPattern;
+			overrideCount++;
+		}
+		if (overrideCount != 1)
+		{
+			throw new SecretDetectionException(
+				"The reviewed global boolean allowlist changed and its export-policy override needs a new review.");
+		}
+		return CompileAllowlist(table, regexPatterns);
+	}
+
+	private static CompiledAllowlist CompileAllowlist(
+		TomlTable table,
+		IReadOnlyList<string> regexPatterns) =>
 		new(
 			GetStringArray(table, "paths").Select(pattern => CreateDeferredRegex(
 				pattern,
 				"allowlist path",
 				useNonBacktracking: false)).ToArray(),
-			GetStringArray(table, "regexes").Select(pattern => CreateDeferredRegex(
+			regexPatterns.Select(pattern => CreateDeferredRegex(
 				pattern,
 				"allowlist expression",
 				useNonBacktracking: false)).ToArray(),

--- a/Tests/DevProjex.Tests.Integration/AnalyzeWithoutMaterializationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/AnalyzeWithoutMaterializationIntegrationTests.cs
@@ -40,11 +40,12 @@ public sealed class AnalyzeWithoutMaterializationIntegrationTests
 		var measuredDiagnostics = diagnostics.Capture();
 		Assert.Equal(0, measuredDiagnostics.PreparedWriteBytes);
 		Assert.Equal(0, measuredDiagnostics.PreparedReadBytes);
-		Assert.Equal(1, measuredDiagnostics.MeasurementPasses);
+		// Selected lock files still reach fixed-prefix provider rules; only heuristic rules retain path allowlists.
+		Assert.Equal(2, measuredDiagnostics.MeasurementPasses);
 		Assert.Equal(3, measured.TransformedFileMetrics.Count);
 		Assert.Single(measured.GetEffectiveFindings());
 		Assert.DoesNotContain("detector-excluded.txt", measuredDetector.InspectedPaths);
-		Assert.DoesNotContain("package-lock.json", measuredDetector.InspectedPaths);
+		Assert.Contains("package-lock.json", measuredDetector.InspectedPaths);
 
 		using var materializedSession = new SecretRedactionSession(
 			new SelectiveCountingDetector("detector-excluded.txt"));

--- a/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
@@ -84,11 +84,13 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			session,
 			ProjectCopyExportFormat.Zip);
 
-		Assert.Equal(10, preview.Redactions.Count);
-		Assert.Equal(10, preview.Redactions.Count(static span =>
+		// The previous count encoded the discarded tail of an overlapping config-secret finding.
+		// Coverage-preserving segmentation represents both valid findings without exposing that tail.
+		Assert.Equal(11, preview.Redactions.Count);
+		Assert.Equal(11, preview.Redactions.Count(static span =>
 			span.State == SecretPreviewSpanState.Redacted));
-		Assert.Equal(10, folder.RedactedValueCount);
-		Assert.Equal(10, zip.RedactedValueCount);
+		Assert.Equal(11, folder.RedactedValueCount);
+		Assert.Equal(11, zip.RedactedValueCount);
 		Assert.Equal(NormalizeForClipboard(selectedContent), contentPreviewPayload);
 		Assert.All(
 			new[] { previewPayload, contentPreviewPayload, selectedContent }.Concat(contextDocuments.Values),
@@ -1465,6 +1467,104 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 	}
 
 	[Fact]
+	public async Task StripComments_PreservesSourceFindingWhenItsKeywordIsRemoved()
+	{
+		const string token = "pat7o9mw4c058sei5.bb075cee667b90855a4471502369a2bd7e93f38ba6aa8039a2527e577ca5793a";
+		using var temporary = new TemporaryDirectory();
+		var sourceRoot = temporary.CreateDirectory("source-finding-project");
+		var path = temporary.CreateFile(
+			"source-finding-project/State.cs",
+			$"// airtable credential{Environment.NewLine}internal static class State {{ public const string Value = \"{token}\"; }}");
+		using var redactionSession = new SecretRedactionSession(new GitleaksSecretDetector());
+		using var compressionSession = CodeCompressionFactory.CreateSession();
+		var context = ContentTransformationContext.For(
+			new CodeCompressionContext(
+				sourceRoot,
+				compressionSession,
+				CodeTransformKinds.Comments),
+			new SecretRedactionContext(sourceRoot, redactionSession))!;
+		var preparer = new SecretRedactionOutputPreparer(new FileContentAnalyzer());
+		await using var compressionOnly = await preparer.PrepareAsync(
+			ContentTransformationContext.For(
+				new CodeCompressionContext(
+					sourceRoot,
+					compressionSession,
+					CodeTransformKinds.Comments),
+				redaction: null)!,
+			[path],
+			TestContext.Current.CancellationToken);
+		var transformedBeforeRedaction = await File.ReadAllTextAsync(
+			compressionOnly.GetFile(path).ContentPath,
+			TestContext.Current.CancellationToken);
+
+		var analysis = await preparer.AnalyzeAsync(
+			context,
+			[path],
+			TestContext.Current.CancellationToken);
+		await using var prepared = await preparer.PrepareAsync(
+			context,
+			[path],
+			TestContext.Current.CancellationToken);
+		var output = await File.ReadAllTextAsync(
+			prepared.GetFile(path).ContentPath,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(1, analysis.DetectedCount);
+		Assert.Equal(1, analysis.RedactedCount);
+		AssertExactReplacement(
+			transformedBeforeRedaction,
+			output,
+			token,
+			"DEVPROJEX_REDACTED[airtable-personnal-access-token#1]");
+		Assert.Equal(2, redactionSession.GetCacheDiagnostics().DetectionRuns);
+	}
+
+	[Fact]
+	public async Task StripComments_DetectsFindingCreatedByTransformation()
+	{
+		const string secret = "joined-secret-value-42";
+		using var temporary = new TemporaryDirectory();
+		var sourceRoot = temporary.CreateDirectory("transformed-finding-project");
+		var path = temporary.CreateFile(
+			"transformed-finding-project/State.cs",
+			$"// removed detector context{Environment.NewLine}" +
+			$"internal static class State {{ public const string Value = \"{secret}\"; }}");
+		var detector = new ExactValueWhenMarkerAbsentDetector(secret, "removed detector context");
+		using var redactionSession = new SecretRedactionSession(detector);
+		using var compressionSession = CodeCompressionFactory.CreateSession();
+		var compression = new CodeCompressionContext(
+			sourceRoot,
+			compressionSession,
+			CodeTransformKinds.Comments);
+		var preparer = new SecretRedactionOutputPreparer(new FileContentAnalyzer());
+		await using var compressionOnly = await preparer.PrepareAsync(
+			ContentTransformationContext.For(compression, redaction: null)!,
+			[path],
+			TestContext.Current.CancellationToken);
+		var transformedBeforeRedaction = await File.ReadAllTextAsync(
+			compressionOnly.GetFile(path).ContentPath,
+			TestContext.Current.CancellationToken);
+		var context = ContentTransformationContext.For(
+			compression,
+			new SecretRedactionContext(sourceRoot, redactionSession))!;
+
+		await using var prepared = await preparer.PrepareAsync(
+			context,
+			[path],
+			TestContext.Current.CancellationToken);
+		var output = await File.ReadAllTextAsync(
+			prepared.GetFile(path).ContentPath,
+			TestContext.Current.CancellationToken);
+
+		AssertExactReplacement(
+			transformedBeforeRedaction,
+			output,
+			secret,
+			"DEVPROJEX_REDACTED[exact-value#1]");
+		Assert.Equal(2, detector.CallCount);
+	}
+
+	[Fact]
 	public async Task PrepareWithoutFindingCapturePublishesCountsWithoutMaterializingDescriptors()
 	{
 		const string secret = "capture-only-on-request-secret-value-42";
@@ -2673,11 +2773,7 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 		AssertNoTextSecret(File.ReadAllText(Path.Combine(result.DestinationPath, "config", "settings.json")));
 		var connection = File.ReadAllText(Path.Combine(result.DestinationPath, "config", "appsettings.json"));
 		AssertNoTextSecret(connection);
-		Assert.Contains(
-			"Host=db;Username=admin;Pass" +
-			"word=DEVPROJEX_REDACTED[connection-password#1];Database=app",
-			connection,
-			StringComparison.Ordinal);
+		AssertConnectionStringCoverage(connection);
 		AssertNoTextSecret(File.ReadAllText(Path.Combine(result.DestinationPath, "config", "service.txt")));
 		AssertNoTextSecret(File.ReadAllText(Path.Combine(result.DestinationPath, "config", "web.config")));
 		AssertNoTextSecret(File.ReadAllText(Path.Combine(result.DestinationPath, ".env")));
@@ -2715,11 +2811,7 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 		AssertNoTextSecret(ReadZipText(archive, "config/settings.json"));
 		var connection = ReadZipText(archive, "config/appsettings.json");
 		AssertNoTextSecret(connection);
-		Assert.Contains(
-			"Host=db;Username=admin;Pass" +
-			"word=DEVPROJEX_REDACTED[connection-password#1];Database=app",
-			connection,
-			StringComparison.Ordinal);
+		AssertConnectionStringCoverage(connection);
 		AssertNoTextSecret(ReadZipText(archive, "config/service.txt"));
 		AssertNoTextSecret(ReadZipText(archive, "config/web.config"));
 		AssertNoTextSecret(ReadZipText(archive, ".env"));
@@ -2752,6 +2844,18 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			item.FullName.EndsWith(suffix, StringComparison.Ordinal));
 		using var reader = new StreamReader(entry.Open(), Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
 		return reader.ReadToEnd();
+	}
+
+	private static void AssertConnectionStringCoverage(string content)
+	{
+		Assert.StartsWith(
+			"{\"ConnectionStrings\":{\"Main\":\"Host=db;Username=admin;Password=",
+			content,
+			StringComparison.Ordinal);
+		Assert.EndsWith("}}\n", content, StringComparison.Ordinal);
+		Assert.Equal(1, CountOccurrences(content, "DEVPROJEX_REDACTED[config-secret#1]"));
+		Assert.Equal(1, CountOccurrences(content, "DEVPROJEX_REDACTED[connection-password#1]"));
+		Assert.DoesNotContain(";Database=app", content, StringComparison.Ordinal);
 	}
 
 	private sealed class CategorizedExactValueDetector(
@@ -2861,6 +2965,30 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 		for (var offset = 0; (offset = value.IndexOf(search, offset, StringComparison.Ordinal)) >= 0; offset += search.Length)
 			count++;
 		return count;
+	}
+
+	private static void AssertExactReplacement(
+		string transformedBeforeRedaction,
+		string actual,
+		string sensitiveValue,
+		string replacement)
+	{
+		var start = transformedBeforeRedaction.IndexOf(sensitiveValue, StringComparison.Ordinal);
+		Assert.True(
+			start >= 0,
+			$"The transformed control text must retain the asserted sensitive range. Actual: {transformedBeforeRedaction}");
+		Assert.Equal(
+			transformedBeforeRedaction[..start],
+			actual[..start]);
+		Assert.Equal(
+			transformedBeforeRedaction[(start + sensitiveValue.Length)..],
+			actual[(start + replacement.Length)..]);
+		Assert.Equal(
+			string.Concat(
+				transformedBeforeRedaction.AsSpan(0, start),
+				replacement,
+				transformedBeforeRedaction.AsSpan(start + sensitiveValue.Length)),
+			actual);
 	}
 
 	private static string NormalizeForClipboard(string text)
@@ -3080,6 +3208,25 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 
 			Interlocked.Increment(ref _forcedReadFactCount);
 			return ValueTask.FromResult(new ContentReadFact(null, classification, null, null));
+		}
+	}
+
+	private sealed class ExactValueWhenMarkerAbsentDetector(string secret, string marker) : ISecretDetector
+	{
+		public int CallCount { get; private set; }
+
+		public IReadOnlyList<DetectedSecret> Detect(
+			string repositoryRelativePath,
+			string content,
+			CancellationToken cancellationToken = default)
+		{
+			CallCount++;
+			if (content.Contains(marker, StringComparison.Ordinal))
+				return [];
+			var index = content.IndexOf(secret, StringComparison.Ordinal);
+			return index < 0
+				? []
+				: [new DetectedSecret("exact-value", index, secret.Length, secret, RuleOrder: 0)];
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
@@ -1565,6 +1565,70 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 	}
 
 	[Fact]
+	public async Task StripComments_InvalidatesCombinedFindingsWhenOnlyRemovedSourceTextChanges()
+	{
+		const string token = "pat7o9mw4c058sei5.bb075cee667b90855a4471502369a2bd7e93f38ba6aa8039a2527e577ca5793a";
+		using var temporary = new TemporaryDirectory();
+		var sourceRoot = temporary.CreateDirectory("source-fingerprint-project");
+		var path = temporary.CreateFile(
+			"source-fingerprint-project/State.cs",
+			$"// airtable{Environment.NewLine}" +
+			$"internal static class State {{ public const string Value = \"{token}\"; }}");
+		var originalTimestamp = File.GetLastWriteTimeUtc(path);
+		var originalLength = new FileInfo(path).Length;
+		using var redactionSession = new SecretRedactionSession(new GitleaksSecretDetector());
+		using var compressionSession = CodeCompressionFactory.CreateSession();
+		var compression = new CodeCompressionContext(
+			sourceRoot,
+			compressionSession,
+			CodeTransformKinds.Comments);
+		var context = ContentTransformationContext.For(
+			compression,
+			new SecretRedactionContext(sourceRoot, redactionSession))!;
+		var preparer = new SecretRedactionOutputPreparer(new FileContentAnalyzer());
+
+		await using (var first = await preparer.PrepareAsync(
+			             context,
+			             [path],
+			             TestContext.Current.CancellationToken))
+		{
+			var output = await File.ReadAllTextAsync(
+				first.GetFile(path).ContentPath,
+				TestContext.Current.CancellationToken);
+			Assert.Contains(
+				"DEVPROJEX_REDACTED[airtable-personnal-access-token#1]",
+				output,
+				StringComparison.Ordinal);
+		}
+
+		await File.WriteAllTextAsync(
+			path,
+			$"// aaaaaaaa{Environment.NewLine}" +
+			$"internal static class State {{ public const string Value = \"{token}\"; }}",
+			TestContext.Current.CancellationToken);
+		File.SetLastWriteTimeUtc(path, originalTimestamp);
+		Assert.Equal(originalLength, new FileInfo(path).Length);
+		await using var second = await preparer.PrepareAsync(
+			context,
+			[path],
+			TestContext.Current.CancellationToken);
+		var secondOutput = await File.ReadAllTextAsync(
+			second.GetFile(path).ContentPath,
+			TestContext.Current.CancellationToken);
+		await using var compressionOnly = await preparer.PrepareAsync(
+			ContentTransformationContext.For(compression, redaction: null)!,
+			[path],
+			TestContext.Current.CancellationToken);
+		var transformedControl = await File.ReadAllTextAsync(
+			compressionOnly.GetFile(path).ContentPath,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(transformedControl, secondOutput);
+		Assert.Contains(token, secondOutput, StringComparison.Ordinal);
+		Assert.Equal(3, redactionSession.GetCacheDiagnostics().DetectionRuns);
+	}
+
+	[Fact]
 	public async Task PrepareWithoutFindingCapturePublishesCountsWithoutMaterializingDescriptors()
 	{
 		const string secret = "capture-only-on-request-secret-value-42";

--- a/Tests/DevProjex.Tests.Terminal/SecretRedactionCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/SecretRedactionCommandContractTests.cs
@@ -503,6 +503,69 @@ public sealed class SecretRedactionCommandContractTests
 		Assert.Empty(environment.StandardError);
 	}
 
+	[Fact]
+	public async Task ExportAndAnalyze_PreserveSourceDetectedCoverageWhenCommentsAreStripped()
+	{
+		const string token = "pat7o9mw4c058sei5.bb075cee667b90855a4471502369a2bd7e93f38ba6aa8039a2527e577ca5793a";
+		using var workspace = CreateWorkspace(includeSecret: false);
+		workspace.Temporary.WriteFile(
+			"project/src/source-detected.cs",
+			$"// airtable credential{Environment.NewLine}" +
+			$"internal static class SourceDetected {{ public const string Value = \"{token}\"; }}{Environment.NewLine}");
+		var export = new TestTerminalEnvironment();
+
+		var exportExitCode = await RunAsync(
+			workspace,
+			export,
+			[
+				"export", "context", workspace.ProjectRoot,
+				"--view", "content",
+				"--format", "text",
+				"--git-mode", "none",
+				"--hide-secrets",
+				"--strip-comments",
+				"--plain",
+				"-o", "-"
+			]);
+
+		Assert.Equal(CommandLineExitCodes.Success, exportExitCode);
+		Assert.Contains(
+			"public const string Value = \"DEVPROJEX_REDACTED[airtable-personnal-access-token#1]\";",
+			export.StandardOutput,
+			StringComparison.Ordinal);
+		Assert.DoesNotContain(token, export.StandardOutput, StringComparison.Ordinal);
+		Assert.DoesNotContain(token, export.StandardError, StringComparison.Ordinal);
+		Assert.Empty(export.StandardError);
+
+		var analyze = new TestTerminalEnvironment();
+		var analyzeExitCode = await RunAsync(
+			workspace,
+			analyze,
+			[
+				"analyze", workspace.ProjectRoot,
+				"--git-mode", "none",
+				"--hide-secrets",
+				"--strip-comments",
+				"--findings",
+				"--format", "json",
+				"--plain",
+				"-o", "-"
+			]);
+
+		Assert.Equal(CommandLineExitCodes.Success, analyzeExitCode);
+		using var document = JsonDocument.Parse(analyze.StandardOutput);
+		var redaction = document.RootElement.GetProperty("redaction");
+		Assert.Equal(1, redaction.GetProperty("matchedCount").GetInt32());
+		Assert.Equal(1, redaction.GetProperty("redactedCount").GetInt32());
+		var finding = Assert.Single(
+			document.RootElement.GetProperty("findings").EnumerateArray(),
+			static item => item.GetProperty("relativePath").GetString() == "src/source-detected.cs");
+		Assert.Equal("airtable-personnal-access-token", finding.GetProperty("ruleId").GetString());
+		Assert.DoesNotContain(token, analyze.StandardOutput, StringComparison.Ordinal);
+		Assert.DoesNotContain(token, analyze.StandardError, StringComparison.Ordinal);
+		Assert.Empty(analyze.StandardError);
+	}
+
 	[Theory]
 	[InlineData("\n")]
 	[InlineData("\r\n")]

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -455,6 +455,62 @@ public sealed class GitleaksSecretDetectorTests
 		Assert.Equal(genericValue, finding.Value);
 	}
 
+	[Fact]
+	public void Detect_GenericFastGateChecksEveryPermittedSeparatorBoundary()
+	{
+		const string content = "password======aB3dE6gH9jK2";
+		var oracle = Detector.InspectRuleMatch("generic-api-key", content);
+		Assert.True(oracle.IsMatch);
+
+		var finding = Assert.Single(
+			Detector.Detect("src/config.txt", content, TestContext.Current.CancellationToken),
+			static match => match.RuleId == "generic-api-key");
+
+		Assert.Equal(oracle.MatchStart + oracle.SecretStart, finding.Start);
+		Assert.Equal(oracle.SecretLength, finding.Length);
+		Assert.Equal("aB3dE6gH9jK2", finding.Value);
+	}
+
+	[Fact(Timeout = 30_000)]
+	public void Detect_GenericFastGateMatchesRegexAndEntropyOracleAcrossSeparatorCorpus()
+	{
+		var delimiters = new[] { "=", ">", ":", "::=", "||", "=>", "?=", "," };
+		var paddings = new[] { string.Empty, " ", "\t", "'", "\"", "`", "=", "=====" };
+		var terminators = new[] { string.Empty, ";", "\n", "\\n" };
+		var values = new[]
+		{
+			"aB3dE6gH9jK2",
+			"A7d9mQ2xK4vN8sR6tY3uW5zB1cE0fG2h"
+		};
+		var verified = 0;
+
+		foreach (var delimiter in delimiters)
+		foreach (var padding in paddings)
+		foreach (var value in values)
+		foreach (var terminator in terminators)
+		{
+			var content = string.Concat("password", delimiter, padding, value, terminator);
+			var oracle = Detector.InspectRuleMatch("generic-api-key", content);
+			if (!oracle.IsMatch)
+				continue;
+			var expectedValue = content.AsSpan(
+				oracle.MatchStart + oracle.SecretStart,
+				oracle.SecretLength);
+			if (GitleaksSecretDetector.CalculateShannonEntropy(expectedValue.ToString()) <= 3.5d)
+				continue;
+
+			var finding = Assert.Single(
+				Detector.Detect("src/config.txt", content, TestContext.Current.CancellationToken),
+				static match => match.RuleId == "generic-api-key");
+			Assert.Equal(oracle.MatchStart + oracle.SecretStart, finding.Start);
+			Assert.Equal(oracle.SecretLength, finding.Length);
+			Assert.Equal(expectedValue.ToString(), finding.Value);
+			verified++;
+		}
+
+		Assert.True(verified >= 100, $"The generic fast-gate oracle covered only {verified} positive variants.");
+	}
+
 	public static IEnumerable<object[]> GenericApiKeyGateWhitespaceVariants()
 	{
 		yield return [string.Empty];

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -55,6 +55,34 @@ public sealed class GitleaksSecretDetectorTests
 	}
 
 	[Fact]
+	public void EmbeddedConfiguration_PreservesPinnedSnapshotAndAppliesVersionedBooleanOverride()
+	{
+		Assert.Equal(
+			"0CEEB4F9C567F9F80EE05E8E37EEBA4646DF809F69C736A64D5B8B1398EB3E4C",
+			GitleaksSecretDetector.ConfigurationSha256);
+		Assert.Equal(GitleaksSecretDetector.ExpectedRuleCount, Detector.RuleCount);
+		Assert.Contains(GitleaksSecretDetector.PolicyOverrideVersion, Detector.RulesIdentity, StringComparison.Ordinal);
+
+		var patterns = Detector.InspectGlobalAllowlistRegexPatterns();
+
+		Assert.Contains(GitleaksSecretDetector.WholeValueBooleanAllowlistPattern, patterns);
+		Assert.DoesNotContain(GitleaksSecretDetector.UpstreamBooleanAllowlistPattern, patterns);
+	}
+
+	[Fact]
+	public void Detect_GlobalBooleanAllowlistDoesNotSuppressAProviderTokenContainingFalse()
+	{
+		const string token = "ghp_falseA7d9mQ2xK4vN8sR6tY3uW5zB1cE0fG2";
+
+		var finding = Assert.Single(
+			Detector.Detect("notes.txt", token, TestContext.Current.CancellationToken),
+			static candidate => candidate.RuleId == "github-pat");
+
+		Assert.Equal(token, finding.Value);
+		Assert.Equal((0, token.Length), (finding.Start, finding.Length));
+	}
+
+	[Fact]
 	public void KeywordPrefilter_MatchesTheLinearCandidateOracleAcrossPinnedCasesAndUnicodeCaseFolding()
 	{
 		var cases = LoadUpstreamCorpus()

--- a/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitleaksSecretDetectorTests.cs
@@ -579,13 +579,15 @@ public sealed class GitleaksSecretDetectorTests
 	}
 
 	[Fact]
-	public void Detect_GlobalPathAllowlist_IsAppliedBeforeRules()
+	public void Detect_GlobalPathAllowlist_DoesNotSuppressProviderShapedRules()
 	{
 		const string content = "const token = \"ghp_" + "a7D9mQ2xK4vN8sR6tY3uW5zB1cE0fG2hJ9pL\";";
 
-		Assert.False(Detector.ShouldInspectPath("fixtures/image.svg"));
+		Assert.True(Detector.ShouldInspectPath("fixtures/image.svg"));
 		Assert.True(Detector.ShouldInspectPath("src/config.cs"));
-		Assert.Empty(Detector.Detect("fixtures/image.svg", content, TestContext.Current.CancellationToken));
+		Assert.Contains(
+			Detector.Detect("fixtures/image.svg", content, TestContext.Current.CancellationToken),
+			static finding => finding.RuleId == "github-pat");
 	}
 
 	[Theory]

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
@@ -547,13 +547,42 @@ public sealed class SmartSecretsDetectorTests
 	[InlineData("go.mod")]
 	[InlineData("package-lock.json")]
 	[InlineData("vendor/module/config.txt")]
-	public void Detect_ProviderRulesStillRespectProviderPathAllowlist(string path)
+	public void Detect_ProviderRulesInspectSelectedTextDespiteUpstreamPathAllowlist(string path)
 	{
-		const string providerToken = "AKIAIOSFODNN7EXAMPLE";
+		const string providerToken = "AKIAZ7M3Q5X2P6N4R7T5";
 
 		var findings = Detector.Detect(path, providerToken, TestContext.Current.CancellationToken);
 
-		Assert.DoesNotContain(findings, static finding => finding.RuleId == "aws-access-token");
+		// This intentionally replaces the old upstream repository-scan policy: once a text file is
+		// selected for export, a provider-shaped token must not be trusted because of its file name.
+		Assert.Contains(findings, static finding => finding.RuleId == "aws-access-token");
+	}
+
+	[Fact]
+	public void Detect_PackageLockIntegrityPayloadDoesNotCreateProviderNoise()
+	{
+		const string content =
+			"{ \"integrity\": \"sha512-z7M3Q5X2P6N4R7T5A9C8E2G6H4J1K0L9M8N7P6Q5R4S3T2U1V0W9X8Y7Z6A5B4C3\" }";
+
+		var findings = Detector.Detect(
+			"package-lock.json",
+			content,
+			TestContext.Current.CancellationToken);
+
+		Assert.Empty(findings);
+	}
+
+	[Fact]
+	public void Detect_GenericEntropyRuleStillRespectsUpstreamPathAllowlist()
+	{
+		const string content = "api_key = \"A7d9mQ2xK4vN8sR6tY3uW5zB1cE0fG2h\"";
+
+		var findings = Detector.Detect(
+			"package-lock.json",
+			content,
+			TestContext.Current.CancellationToken);
+
+		Assert.DoesNotContain(findings, static finding => finding.RuleId == "generic-api-key");
 	}
 
 	[Theory]

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
@@ -220,6 +220,100 @@ public sealed class SmartSecretsDetectorTests
 		Assert.Equal(2, resolved.Count(static finding => finding.RuleId == "http-cookie"));
 	}
 
+	[Fact]
+	public void ResolveSegmentedFindings_PreservesTheUnionOfEveryValidFinding()
+	{
+		var cases = new IReadOnlyList<DetectedSecret>[]
+		{
+			[
+				Finding("preferred", 2, 4, -20),
+				Finding("same-range", 2, 4, 10)
+			],
+			[
+				Finding("inner", 4, 2, -20),
+				Finding("outer", 2, 8, 10)
+			],
+			[
+				Finding("left", 1, 5, -20),
+				Finding("right", 4, 5, 10)
+			],
+			[
+				Finding("first", 1, 4, -30),
+				Finding("middle", 4, 4, -20),
+				Finding("last", 7, 4, -10)
+			],
+			[
+				Finding("secret", 1, 4, -20),
+				Finding("private", 4, 4, -10, RedactionFindingCategory.PrivateData)
+			],
+			[
+				Finding("detector", 1, 4, -20),
+				Finding("manual", 4, 4, 10) with { Source = SecretFindingSource.SessionMark }
+			]
+		};
+
+		foreach (var findings in cases)
+		{
+			var resolved = SecretRedactionScope.ResolveNonOverlappingMatches(findings);
+
+			AssertCoverageEqualsUnion(findings, resolved);
+		}
+
+		static DetectedSecret Finding(
+			string ruleId,
+			int start,
+			int length,
+			int order,
+			RedactionFindingCategory category = RedactionFindingCategory.Secrets) =>
+			new(ruleId, start, length, new string('s', length), order, Category: category);
+	}
+
+	[Fact]
+	public void ResolveSegmentedFindings_EnvironmentValueRetainsCoverageAroundCredentialUri()
+	{
+		const string content = "DB_PASSWORD=\"prefixhttps://u:ab12@db.internal/tail\"";
+		var valueStart = content.IndexOf('"') + 1;
+		var valueLength = content.LastIndexOf('"') - valueStart;
+		var rawFindings = StructuredSecretDetector.Detect(
+			".env",
+			content,
+			SmartSecretStack.None,
+			TestContext.Current.CancellationToken);
+		var environment = Assert.Single(
+			rawFindings,
+			static finding => finding.RuleId == "environment-secret");
+		var uriPassword = Assert.Single(
+			rawFindings,
+			static finding => finding.RuleId == "credential-uri-password");
+
+		Assert.Equal((valueStart, valueLength), (environment.Start, environment.Length));
+		Assert.True(uriPassword.Start > environment.Start);
+		Assert.True(uriPassword.Start + uriPassword.Length < environment.Start + environment.Length);
+
+		var resolved = SecretRedactionScope.ResolveNonOverlappingMatches(rawFindings);
+
+		AssertCoverageEqualsUnion(rawFindings, resolved);
+		Assert.All(
+			Enumerable.Range(valueStart, valueLength),
+			offset => Assert.Contains(resolved, finding => Covers(finding, offset)));
+	}
+
+	private static void AssertCoverageEqualsUnion(
+		IReadOnlyList<DetectedSecret> expectedFindings,
+		IReadOnlyList<DetectedSecret> actualSegments)
+	{
+		var length = expectedFindings.Max(static finding => finding.Start + finding.Length) + 1;
+		for (var offset = 0; offset < length; offset++)
+		{
+			Assert.Equal(
+				expectedFindings.Any(finding => Covers(finding, offset)),
+				actualSegments.Any(finding => Covers(finding, offset)));
+		}
+	}
+
+	private static bool Covers(DetectedSecret finding, int offset) =>
+		offset >= finding.Start && offset < finding.Start + finding.Length;
+
 	[Theory]
 	[InlineData("Host=db;Username=admin;Pass" + "word=postgres;Database=app", "postgres")]
 	[InlineData("Server=db;User Id=sa;P" + "wd=Admin123!;Initial Catalog=app", "Admin123!")]


### PR DESCRIPTION
## Why

Secret masking could discard uncovered tails of overlapping findings, suppress provider-shaped values through broad upstream allowlists, reject a regex-valid generic key in the fast gate, or lose a source finding after content transformation removed its keyword context.

## Changes

- preserve the union of valid overlapping finding ranges while retaining per-segment rule priority and established generic-overlap precedence
- apply a versioned whole-value boolean allowlist override without changing the pinned Gitleaks snapshot
- limit upstream path allowlists to generic and entropy-only candidates after a text file is selected
- examine every valid generic-key separator boundary before entropy rejection
- detect separately on source and transformed text, project retained source ranges, merge both stages, and cache by source/transform identity
- document the reviewed export policy and transformation monotonicity contract

## Observable behavior

- a narrower high-priority finding no longer exposes the remainder of a wider valid finding
- fixed provider-prefix credentials are inspected in selected lock, vendor, and SVG text
- `true`, `false`, and `null` remain whole-value examples, but substrings no longer suppress a provider token
- comment stripping and code compression cannot expose retained characters from a source finding

## Verification

- targeted Gitleaks, Smart Secrets, redaction, inspection-budget, path-isolation, and private-data composition unit tests
- targeted redaction/output integration tests
- CLI export and analyze coverage with comment stripping
- documentation contract tests
- Release build of TerminalHost with zero warnings
- alternating baseline/current operational measurements for identity and `--strip-comments` paths