### PR TITLE
Fix Python dependency and project configuration semantics

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -65,6 +65,7 @@ public sealed record DependencyScopeDescriptor(
 	public DependencyConfigurationState ConfigurationState { get; init; } = DependencyConfigurationState.Valid;
 	public string? ConfigurationDiagnostic { get; init; }
 	public bool HasTypeScriptCustomConditions { get; init; }
+	public bool DisableTransitiveProjectReferences { get; init; }
 }
 
 public sealed record PackageMapDescriptor(

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1714,10 +1714,14 @@ public sealed class DependencyFactsEngine : IDisposable
 				? import.Specifier
 				: string.Join('.', parts.Concat(import.Specifier.Split('.', StringSplitOptions.RemoveEmptyEntries)));
 			var candidates = ProbePythonModule(source, module).ToList();
-			var moduleEntityExists = candidates.Count > 0;
+			var moduleCandidates = candidates.ToArray();
+			var moduleEntityExists = moduleCandidates.Length > 0;
 			if (import.ImportedName is { Length: > 0 } and not "*")
 			{
-				var provided = candidates
+				if (moduleCandidates.Any(candidate => HasConditionalPythonBinding(candidate, import.ImportedName)))
+					return Edge(source, import, ResolutionStatus.Unresolved, null,
+						"conditional Python re-export bindings are not indexed", []);
+				var provided = moduleCandidates
 					.SelectMany(candidate => ResolvePythonStaticBinding(
 						candidate,
 						import.ImportedName,
@@ -1743,8 +1747,16 @@ public sealed class DependencyFactsEngine : IDisposable
 						return FinishImport(source, import, candidates);
 				}
 				if (candidates.Count == 0 && moduleEntityExists)
+				{
+					if (moduleCandidates.Any(candidate => HasPythonModuleAssignment(candidate, import.ImportedName)))
+						return Edge(source, import, ResolutionStatus.Unresolved, null,
+							"Python module assignment bindings are not indexed", []);
+					if (moduleCandidates.Any(HasPythonWildcardReExport))
+						return Edge(source, import, ResolutionStatus.Unresolved, null,
+							"Python wildcard re-export bindings are not indexed", []);
 					return Edge(source, import, ResolutionStatus.Unresolved, null,
 						"name not found in module", []);
+				}
 			}
 			if (candidates.Count == 0 && !moduleEntityExists)
 			{
@@ -1776,7 +1788,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				SimpleName(declaration.Identity.QualifiedName) == name))
 				return [candidate];
 			foreach (var import in facts.Imports.Where(import => import.ContainingDeclaration is null &&
-				string.Equals(import.Alias ?? import.ImportedName ?? import.Specifier.Split('.').Last(), name, StringComparison.Ordinal)))
+				string.Equals(PythonBoundName(import), name, StringComparison.Ordinal)).Reverse())
 			{
 				var sourceModule = PythonModule(facts);
 				var sourcePackage = Path.GetFileNameWithoutExtension(candidate) == "__init__"
@@ -1806,8 +1818,11 @@ public sealed class DependencyFactsEngine : IDisposable
 						.Order(StringComparer.Ordinal)
 						.ToArray();
 					if (nested.Length > 0) return nested;
-					var childTargets = ProbePythonModule(facts, child).ToArray();
-					if (childTargets.Length > 0) return childTargets;
+					if (moduleTargets.Any(IsPythonPackageInitializer))
+					{
+						var childTargets = ProbePythonModule(facts, child).ToArray();
+						if (childTargets.Length > 0) return childTargets;
+					}
 				}
 				else
 				{
@@ -1820,41 +1835,105 @@ public sealed class DependencyFactsEngine : IDisposable
 
 		private int CountPythonNamespacePortions(FileFacts source, string module)
 		{
-			if (module.Length == 0) return 0;
-			var relative = module.Replace('.', '/').Trim('/') + '/';
-			var portions = 0;
-			foreach (var root in PythonRootPrefixes(source))
+			var segments = module.Split('.', StringSplitOptions.RemoveEmptyEntries);
+			if (segments.Length == 0) return 0;
+			var searchDirectories = PythonRootPrefixes(source).ToList();
+			for (var segmentIndex = 0; segmentIndex < segments.Length; segmentIndex++)
 			{
-				var prefix = string.Join('/', new[] { root, relative }.Where(static value => value.Length > 0));
-				var init = prefix + "__init__.py";
-				if (!_files.ContainsKey(init) && _manifestDirectoryPrefixes.Contains(prefix))
-					portions++;
+				var namespaceDirectories = new List<string>();
+				string? concrete = null;
+				foreach (var directory in searchDirectories)
+				{
+					var prefix = string.Join('/', new[] { directory, segments[segmentIndex] }
+						.Where(static value => value.Length > 0));
+					concrete = new[]
+					{
+						prefix + "/__init__.py",
+						prefix + ".py",
+						prefix + "/__init__.pyi",
+						prefix + ".pyi"
+					}.FirstOrDefault(_files.ContainsKey);
+					if (concrete is not null) break;
+					if (_manifestDirectoryPrefixes.Contains(prefix + '/'))
+						namespaceDirectories.Add(prefix);
+				}
+				var isLast = segmentIndex == segments.Length - 1;
+				if (concrete is not null)
+				{
+					if (isLast || !IsPythonPackageInitializer(concrete)) return 0;
+					searchDirectories = [concrete[..concrete.LastIndexOf('/')]];
+					continue;
+				}
+				if (namespaceDirectories.Count == 0) return 0;
+				if (isLast) return namespaceDirectories.Count;
+				searchDirectories = namespaceDirectories;
 			}
-			return portions;
+			return 0;
 		}
 
 		private IEnumerable<string> ProbePythonModule(FileFacts source, string module)
 		{
-			var relative = module.Replace('.', '/');
-			foreach (var root in PythonRootPrefixes(source))
+			var segments = module.Split('.', StringSplitOptions.RemoveEmptyEntries);
+			if (segments.Length == 0) yield break;
+			var searchDirectories = PythonRootPrefixes(source).ToList();
+			for (var segmentIndex = 0; segmentIndex < segments.Length; segmentIndex++)
 			{
-				var prefix = string.Join('/', new[] { root, relative }.Where(static value => value.Length > 0));
-				var implementation = new[] { prefix + "/__init__.py", prefix + ".py" }
-					.FirstOrDefault(_files.ContainsKey);
-				if (implementation is not null)
+				var isLast = segmentIndex == segments.Length - 1;
+				var namespaceDirectories = new List<string>();
+				string? concrete = null;
+				var concreteIsPackage = false;
+				foreach (var directory in searchDirectories)
 				{
-					yield return implementation;
-					yield break;
+					var prefix = string.Join('/', new[] { directory, segments[segmentIndex] }
+						.Where(static value => value.Length > 0));
+					concrete = new[]
+					{
+						prefix + "/__init__.py",
+						prefix + ".py",
+						prefix + "/__init__.pyi",
+						prefix + ".pyi"
+					}.FirstOrDefault(_files.ContainsKey);
+					if (concrete is not null)
+					{
+						concreteIsPackage = IsPythonPackageInitializer(concrete);
+						break;
+					}
+					if (_manifestDirectoryPrefixes.Contains(prefix + '/'))
+						namespaceDirectories.Add(prefix);
 				}
-				var stub = new[] { prefix + "/__init__.pyi", prefix + ".pyi" }
-					.FirstOrDefault(_files.ContainsKey);
-				if (stub is not null)
+				if (concrete is not null)
 				{
-					yield return stub;
-					yield break;
+					if (isLast)
+					{
+						yield return concrete;
+						yield break;
+					}
+					else if (!concreteIsPackage)
+						yield break;
+					searchDirectories = [concrete[..concrete.LastIndexOf('/')]];
+					continue;
 				}
+				if (namespaceDirectories.Count == 0)
+					yield break;
+				searchDirectories = namespaceDirectories;
 			}
 		}
+
+		private bool HasPythonModuleAssignment(string candidate, string name) =>
+			_files.TryGetValue(candidate, out var facts) &&
+			facts.Aliases.ContainsKey("$python-assignment:" + name);
+
+		private bool HasPythonWildcardReExport(string candidate) =>
+			_files.TryGetValue(candidate, out var facts) && facts.Imports.Any(static import =>
+				import.ContainingDeclaration is null && import.IsWildcard);
+
+		private bool HasConditionalPythonBinding(string candidate, string name) =>
+			_files.TryGetValue(candidate, out var facts) && facts.Imports.Any(import =>
+				import.ContainingDeclaration == "$conditional-import" &&
+				string.Equals(PythonBoundName(import), name, StringComparison.Ordinal));
+
+		private static string PythonBoundName(ImportFact import) =>
+			import.Alias ?? import.ImportedName ?? import.Specifier.Split('.')[0];
 
 		private IReadOnlyList<string> PythonRootPrefixes(FileFacts source)
 		{
@@ -2321,6 +2400,15 @@ public sealed class DependencyFactsEngine : IDisposable
 			var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
 			foreach (var scope in scopes.Values)
 			{
+				if (scope.LanguageId == LanguageId.CSharp && scope.DisableTransitiveProjectReferences)
+				{
+					result[scope.ScopeId] = new[] { scope.ScopeId }
+						.Concat(scope.ProjectReferences.Where(scopes.ContainsKey))
+						.Distinct(StringComparer.Ordinal)
+						.Order(StringComparer.Ordinal)
+						.ToArray();
+					continue;
+				}
 				var pending = new Queue<string>();
 				var visited = new HashSet<string>(StringComparer.Ordinal);
 				pending.Enqueue(scope.ScopeId);

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -52,8 +52,11 @@ C# compilation scopes come from `.csproj` ownership and `ProjectReference` entri
 Both `/` and `\` in an MSBuild `Include` are normalized as project-reference separators on every OS;
 this normalization never applies to ordinary Unix filenames. Project-reference visibility is
 transitive, matching the SDK default: if A references B and B references C, source in A can resolve
-declarations from C. The configuration model does not yet expose
-`DisableTransitiveProjectReferences`; a project that opts out cannot currently narrow that visibility.
+declarations from C. A literal `DisableTransitiveProjectReferences=true` narrows the owning project's
+visibility to itself and its direct project references; literal `false` and the SDK default remain
+transitive. A non-literal value is diagnosed and treated as absent because DevProjex does not evaluate
+MSBuild properties. Static `Compile Include`, `Compile Remove`, and linked-file membership likewise
+remain unsupported: the affected compilation scope stays unresolved instead of guessing membership.
 Global usings and aliases are shared
 within the owning scope. Non-global usings and aliases apply only inside their compilation-unit or
 namespace-block lexical scope; repeated blocks for the same namespace do not leak aliases into one
@@ -145,6 +148,12 @@ output uses the same three values in a trusted `[Dependency configuration]` line
 once, then derives all scope, package-name, package-map, and external-package projections from that same
 snapshot, so a result cannot mix two versions of one configuration file. UTF-8 control files are
 accepted with or without a BOM; malformed byte sequences remain corrupt.
+`pyproject.toml` is parsed as TOML, including multiline dependency arrays, optional dependency tables,
+Poetry dependency tables, extras, environment markers, and named direct-URL requirements. Malformed
+TOML is corrupt rather than a partially accepted configuration. When multiple otherwise-valid owning
+configuration files of one language have the same root, ownership is diagnosed as unsupported instead
+of choosing one by filename order. A nested Python configuration owns only its subtree; files outside
+that subtree retain the root fallback scope.
 
 Python relative imports start at the source package. `from module import Name` first checks classes,
 functions, and static import aliases provided by either an ordinary module or a package initializer.
@@ -158,10 +167,17 @@ Only a package may then fall back to a child module of that name. Regular and na
 combined as package entities rather than being represented by an arbitrary file under the namespace;
 a requested child is resolved to that child. A package initializer takes precedence over a same-named module file. Within a package,
 a statically provided or re-exported name is resolved before a same-named child module. `.py` is
-preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and `__all__` affects
+preferred to `.pyi`, bounded static re-exports through `__init__` are followed, and the last repeated
+unconditional binding wins. A conditional re-export remains unresolved because its active branch is
+not evaluated. A direct dotted import binds its top-level name unless it has an alias.
+Every dotted segment must remain within the regular or namespace package selected by its parent; an
+ordinary module cannot acquire children from a same-named directory. `__all__` affects
 wildcard imports only. A missing imported name remains `Unresolved` with a constant reason instead of
 turning the existence of the module into evidence for that name. Relative imports that would escape the top-level package remain unresolved.
-Dynamic `__all__`, `setup.py`, and import hooks are not executed and remain unresolved. Separate
+Only a module-level assignment can establish `__all__` policy; docstrings and assignments inside a
+function or class do not. Module-level value assignments and wildcard re-export expansion are not
+indexed, and report explicit unresolved limitations rather than guessed bindings. Dynamic `__all__`,
+`setup.py`, and import hooks are not executed and remain unresolved. Separate
 complete `sys.stdlib_module_names` snapshots cover Python
 3.12 and 3.13. A decisive `requires-python`/`python_requires` constraint selects its snapshot;
 otherwise only names found in both snapshots are classified as external.

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -798,9 +798,17 @@ internal sealed partial class PythonDependencyLanguageAdapter : DependencyLangua
 					capture.NodeType, Site(context, capture)))));
 		if (declarations.Length + imports.Length + references.Count > limits.MaximumFactsPerFile)
 			return Failed(context);
-		var metadata = DynamicAllRegex().IsMatch(context.Source)
-			? new Dictionary<string, string>(StringComparer.Ordinal) { ["$dynamic-all"] = "true" }
-			: new Dictionary<string, string>(StringComparer.Ordinal);
+		var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+		foreach (var capture in context.References.Where(static capture =>
+			capture.Name == "context.module_assignment" && capture.ContainingDeclaration is null))
+		{
+			var assignment = ModuleAssignmentRegex().Match(capture.Text);
+			if (!assignment.Success) continue;
+			var name = assignment.Groups["name"].Value;
+			metadata["$python-assignment:" + name] = "true";
+			if (name == "__all__" && DynamicAllValueRegex().IsMatch(assignment.Groups["value"].Value))
+				metadata["$dynamic-all"] = "true";
+		}
 		return Complete(context, declarations, imports, references, aliases: metadata);
 	}
 
@@ -824,5 +832,6 @@ internal sealed partial class PythonDependencyLanguageAdapter : DependencyLangua
 	private static readonly HashSet<string> Keywords = new(
 		["def", "class", "None", "True", "False", "str", "int", "float", "bool", "bytes", "list", "dict", "tuple", "set", "object", "typing", "self", "cls"], StringComparer.Ordinal);
 	[GeneratedRegex(@"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*", RegexOptions.CultureInvariant)] private static partial Regex TypeRegex();
-	[GeneratedRegex(@"(?m)^\s*__all__\s*=\s*[A-Za-z_]", RegexOptions.CultureInvariant)] private static partial Regex DynamicAllRegex();
+	[GeneratedRegex(@"^\s*(?<name>[^\W\d]\w*)\s*=\s*(?<value>[\s\S]*)$", RegexOptions.CultureInvariant)] private static partial Regex ModuleAssignmentRegex();
+	[GeneratedRegex(@"^\s*[^\W\d]", RegexOptions.CultureInvariant)] private static partial Regex DynamicAllValueRegex();
 }

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -6,6 +6,8 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using DevProjex.Application.Dependencies;
 using DevProjex.Application.Services;
+using Tomlyn;
+using Tomlyn.Model;
 
 namespace DevProjex.Infrastructure.Dependencies;
 
@@ -22,6 +24,10 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	internal const string TypeScriptModuleResolutionReason = "tsconfig moduleResolution is not supported";
 	internal const string TypeScriptCustomConditionsReason = "tsconfig customConditions are not supported";
 	internal const string ProjectReferenceConditionReason = "project reference condition could not be evaluated safely";
+	internal const string CompileItemMembershipReason = "C# Compile item membership is not supported";
+	internal const string DisableTransitiveProjectReferencesReason = "DisableTransitiveProjectReferences could not be evaluated safely";
+	internal const string InvalidPyProjectReason = "invalid pyproject TOML";
+	internal const string AmbiguousConfigurationOwnershipReason = "multiple owning dependency configurations";
 	private readonly IDependencyControlFileReader _reader;
 	private readonly IDependencyPathMetadata _pathMetadata;
 
@@ -63,6 +69,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var csharpProjects = new Dictionary<string, (
 			string Scope,
 			string[] References,
+			bool DisableTransitiveReferences,
 			DependencyConfigurationState State,
 			string? Reason)>(PathComparer);
 		var snapshots = new Dictionary<string, Task<DependencyControlFileSnapshot>>(PathComparer);
@@ -230,8 +237,9 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			var scope = "csharp:" + PortableRelative(root, project);
 			var parsed = snapshot.State == DependencyConfigurationState.Valid
 				? ParseProjectReferences(project, snapshot.Content)
-				: ConfigurationParseResult<string[]>.Failure([], snapshot.State, snapshot.Reason);
-			var references = parsed.Value;
+				: ConfigurationParseResult<CSharpProjectConfiguration>.Failure(
+					CSharpProjectConfiguration.Default, snapshot.State, snapshot.Reason);
+			var references = parsed.Value.ProjectReferences;
 			foreach (var reference in references.Where(reference => !manifest.Contains(reference)))
 			{
 				if (IsNetworkPath(reference) || !IsWithin(root, reference) ||
@@ -246,8 +254,21 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				if (!exists)
 					absentControlFiles.Add(reference);
 			}
-			csharpProjects[project] = (scope, references, parsed.State, parsed.Reason);
+			csharpProjects[project] = (
+				scope,
+				references,
+				parsed.Value.DisableTransitiveProjectReferences,
+				parsed.State,
+				parsed.Reason);
 			AddDiagnostic(project, parsed.State, parsed.Reason, scope);
+			if (parsed.Value.HasInvalidDisableTransitiveProjectReferences)
+			{
+				diagnostics.Add(new DependencyConfigurationDiagnostic(
+					PortableRelative(root, project),
+					DependencyConfigurationState.UnsupportedSemantics,
+					DisableTransitiveProjectReferencesReason,
+					[scope]));
+			}
 		}
 		foreach (var pair in csharpProjects.OrderBy(static pair => pair.Key, StringComparer.Ordinal))
 		{
@@ -269,7 +290,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				true)
 			{
 				ConfigurationState = pair.Value.State,
-				ConfigurationDiagnostic = pair.Value.Reason
+				ConfigurationDiagnostic = pair.Value.Reason,
+				DisableTransitiveProjectReferences = pair.Value.DisableTransitiveReferences
 			});
 		}
 
@@ -308,24 +330,28 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			AddFingerprint(configPath, snapshot);
 			var directory = Path.GetDirectoryName(configPath)!;
 			var scopeId = "python:" + PortableRelative(root, configPath);
-			AddDiagnostic(configPath, snapshot.State, snapshot.Reason, scopeId);
+			var python = snapshot.State == DependencyConfigurationState.Valid
+				? ParsePythonConfiguration(configPath, snapshot.Content)
+				: ConfigurationParseResult<PythonConfiguration>.Failure(
+					PythonConfiguration.Default, snapshot.State, snapshot.Reason);
+			AddDiagnostic(configPath, python.State, python.Reason, scopeId);
 			scopes.Add(new DependencyScopeDescriptor(
 				scopeId,
 				directory,
 				LanguageId.Python,
 				[], null, false,
 				new Dictionary<string, IReadOnlyList<string>>(), null,
-				snapshot.State == DependencyConfigurationState.Valid
-					? ParsePythonDependencies(configPath, snapshot.Content)
-					: new HashSet<string>(),
+				python.Value.Dependencies,
 				new[] { directory, Path.Combine(directory, "src") },
 				true,
-				snapshot.State == DependencyConfigurationState.Valid ? ParsePythonVersion(snapshot.Content) : null)
+				python.Value.Version)
 			{
-				ConfigurationState = snapshot.State,
-				ConfigurationDiagnostic = snapshot.Reason
+				ConfigurationState = python.State,
+				ConfigurationDiagnostic = python.Reason
 			});
 		}
+
+		MarkAmbiguousScopeOwnership(scopes, diagnostics, root);
 
 		AddFallbackScope(scopes, root, LanguageId.CSharp);
 		AddFallbackScope(scopes, root, LanguageId.TypeScript);
@@ -375,12 +401,29 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		return result;
 	}
 
-	private static ConfigurationParseResult<string[]> ParseProjectReferences(string projectPath, string content)
+	private static ConfigurationParseResult<CSharpProjectConfiguration> ParseProjectReferences(string projectPath, string content)
 	{
 		try
 		{
 			var directory = Path.GetDirectoryName(projectPath)!;
-			var elements = XDocument.Parse(content).Descendants()
+			var document = XDocument.Parse(content);
+			var compileItems = document.Descendants()
+				.Where(static element => element.Name.LocalName == "Compile")
+				.Where(static element => element.Attributes().Any(attribute =>
+					attribute.Name.LocalName is "Include" or "Remove" or "Link"))
+				.ToArray();
+			var disableValues = document.Descendants()
+				.Where(static element => element.Name.LocalName == "DisableTransitiveProjectReferences")
+				.Select(static element => element.Value.Trim())
+				.ToArray();
+			var disableTransitive = disableValues.LastOrDefault() switch
+			{
+				var candidate when IsLiteralTrue(candidate) => true,
+				_ => false
+			};
+			var invalidDisableTransitive = disableValues.Any(static value =>
+				!IsLiteralTrue(value) && !IsLiteralFalse(value));
+			var elements = document.Descendants()
 				.Where(static element => element.Name.LocalName == "ProjectReference")
 				.Where(static element => !IsLiteralFalse(element.Attribute("ReferenceOutputAssembly")?.Value))
 				.ToArray();
@@ -397,17 +440,28 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				.Where(static value => !string.IsNullOrWhiteSpace(value))
 				.Select(value => Path.GetFullPath(Path.Combine(directory, NormalizeMsBuildInclude(value!))))
 				.Distinct(PathComparer).Order(StringComparer.Ordinal).ToArray();
+			var projectConfiguration = new CSharpProjectConfiguration(
+				references,
+				disableTransitive,
+				invalidDisableTransitive);
+			if (compileItems.Length > 0)
+				return ConfigurationParseResult<CSharpProjectConfiguration>.Failure(
+					projectConfiguration,
+					DependencyConfigurationState.UnsupportedSemantics,
+					CompileItemMembershipReason);
 			return hasUnknownCondition
-				? ConfigurationParseResult<string[]>.Failure(
-					references,
+				? ConfigurationParseResult<CSharpProjectConfiguration>.Failure(
+					projectConfiguration,
 					DependencyConfigurationState.UnsupportedSemantics,
 					ProjectReferenceConditionReason)
-				: ConfigurationParseResult<string[]>.Valid(references);
+				: ConfigurationParseResult<CSharpProjectConfiguration>.Valid(projectConfiguration);
 		}
 		catch (System.Xml.XmlException)
 		{
-			return ConfigurationParseResult<string[]>.Failure(
-				[], DependencyConfigurationState.Corrupt, "invalid project XML");
+			return ConfigurationParseResult<CSharpProjectConfiguration>.Failure(
+				CSharpProjectConfiguration.Default,
+				DependencyConfigurationState.Corrupt,
+				"invalid project XML");
 		}
 	}
 
@@ -761,11 +815,94 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	private static PackageTargetDescriptor UnsupportedPackageTarget(string reason) =>
 		new(PackageTargetKind.Unsupported, null, [], reason);
 
+	private static ConfigurationParseResult<PythonConfiguration> ParsePythonConfiguration(
+		string path,
+		string content)
+	{
+		if (!Path.GetFileName(path).Equals("pyproject.toml", StringComparison.OrdinalIgnoreCase))
+		{
+			return ConfigurationParseResult<PythonConfiguration>.Valid(new PythonConfiguration(
+				ParseSetupDependencies(content),
+				ParsePythonVersion(content)));
+		}
+
+		try
+		{
+			var root = TomlSerializer.Deserialize<TomlTable>(content) ??
+				throw new InvalidOperationException("TOML root is unavailable.");
+			var dependencies = new HashSet<string>(StringComparer.Ordinal);
+			string? version = null;
+			if (TryGetTable(root, "project", out var project))
+			{
+				AddTomlRequirements(project, "dependencies", dependencies);
+				if (project.TryGetValue("requires-python", out var requiresPython) && requiresPython is string constraint)
+					version = ParsePythonVersionConstraint(constraint);
+				if (TryGetTable(project, "optional-dependencies", out var optional))
+					foreach (var value in optional.Values.OfType<TomlArray>())
+						AddTomlRequirements(value, dependencies);
+			}
+			if (TryGetTable(root, "tool", out var tool) &&
+			    TryGetTable(tool, "poetry", out var poetry))
+			{
+				if (TryGetTable(poetry, "dependencies", out var poetryDependencies))
+				{
+					foreach (var key in poetryDependencies.Keys)
+						AddRequirement(key, dependencies);
+					if (poetryDependencies.TryGetValue("python", out var pythonConstraint) && pythonConstraint is string constraint)
+						version ??= ParsePythonVersionConstraint(constraint);
+				}
+				if (TryGetTable(poetry, "group", out var groups))
+				{
+					foreach (var group in groups.Values.OfType<TomlTable>())
+						if (TryGetTable(group, "dependencies", out var groupDependencies))
+							foreach (var key in groupDependencies.Keys)
+								AddRequirement(key, dependencies);
+				}
+			}
+			return ConfigurationParseResult<PythonConfiguration>.Valid(
+				new PythonConfiguration(dependencies, version));
+		}
+		catch (Exception exception) when (exception is TomlException or InvalidOperationException)
+		{
+			return ConfigurationParseResult<PythonConfiguration>.Failure(
+				PythonConfiguration.Default,
+				DependencyConfigurationState.Corrupt,
+				InvalidPyProjectReason);
+		}
+	}
+
+	private static bool TryGetTable(TomlTable table, string key, out TomlTable value)
+	{
+		if (table.TryGetValue(key, out var candidate) && candidate is TomlTable nested)
+		{
+			value = nested;
+			return true;
+		}
+		value = null!;
+		return false;
+	}
+
+	private static void AddTomlRequirements(TomlTable table, string key, ISet<string> result)
+	{
+		if (table.TryGetValue(key, out var value) && value is TomlArray requirements)
+			AddTomlRequirements(requirements, result);
+	}
+
+	private static void AddTomlRequirements(TomlArray requirements, ISet<string> result)
+	{
+		foreach (var requirement in requirements.OfType<string>())
+			AddRequirement(requirement, result);
+	}
+
 	private static string? ParsePythonVersion(string content)
 	{
 		var match = PythonVersionRegex.Match(content);
-		if (!match.Success) return null;
-		var constraint = match.Groups["constraint"].Value.Replace(" ", string.Empty, StringComparison.Ordinal);
+		return match.Success ? ParsePythonVersionConstraint(match.Groups["constraint"].Value) : null;
+	}
+
+	private static string? ParsePythonVersionConstraint(string value)
+	{
+		var constraint = value.Replace(" ", string.Empty, StringComparison.Ordinal);
 		if (constraint.Contains(">=3.13", StringComparison.Ordinal) ||
 		    constraint.Contains("==3.13", StringComparison.Ordinal) ||
 		    constraint.Contains("~=3.13", StringComparison.Ordinal))
@@ -777,12 +914,10 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		return null;
 	}
 
-	private static IReadOnlySet<string> ParsePythonDependencies(string path, string content)
+	private static IReadOnlySet<string> ParseSetupDependencies(string content)
 	{
 		var result = new HashSet<string>(StringComparer.Ordinal);
-		var isToml = Path.GetFileName(path).Equals("pyproject.toml", StringComparison.OrdinalIgnoreCase);
 		var section = string.Empty;
-		var dependencyList = false;
 		var setupRequirementList = false;
 		foreach (var line in content.Split('\n'))
 		{
@@ -790,25 +925,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			if (value.StartsWith('[') && value.EndsWith(']'))
 			{
 				section = value.Trim('[', ']').Trim();
-				dependencyList = false;
 				setupRequirementList = false;
-				continue;
-			}
-			if (isToml)
-			{
-				var optional = section.Equals("project.optional-dependencies", StringComparison.OrdinalIgnoreCase);
-				var poetry = section.Equals("tool.poetry.dependencies", StringComparison.OrdinalIgnoreCase) ||
-				             section.Equals("tool.poetry.group.dev.dependencies", StringComparison.OrdinalIgnoreCase);
-				if (section.Equals("project", StringComparison.OrdinalIgnoreCase) &&
-				    value.StartsWith("dependencies", StringComparison.OrdinalIgnoreCase) &&
-				    value.Contains('='))
-					dependencyList = !value.Contains(']');
-				if (dependencyList || optional ||
-				    section.Equals("project", StringComparison.OrdinalIgnoreCase) && value.StartsWith("dependencies", StringComparison.OrdinalIgnoreCase))
-					AddQuotedRequirements(value, result);
-				if (poetry && value.Contains('='))
-					AddRequirement(value[..value.IndexOf('=')], result);
-				if (dependencyList && value.Contains(']')) dependencyList = false;
 				continue;
 			}
 
@@ -834,25 +951,16 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		return result;
 	}
 
-	private static void AddQuotedRequirements(string value, ISet<string> result)
-	{
-		foreach (Match match in QuotedRequirementRegex.Matches(value))
-			AddRequirement(match.Groups["requirement"].Value, result);
-	}
-
 	private static void AddRequirement(string value, ISet<string> result)
 	{
 		var candidate = value.Trim().Trim('"', '\'', ',', '[', ']');
-		if (candidate.Length == 0 || candidate.Contains("://", StringComparison.Ordinal) ||
+		if (candidate.Length == 0 || candidate.Contains("://", StringComparison.Ordinal) && !candidate.Contains('@') ||
 		    candidate.Contains("::", StringComparison.Ordinal)) return;
 		var match = RequirementNameRegex.Match(candidate);
 		if (match.Success && !match.Groups["name"].Value.Equals("python", StringComparison.OrdinalIgnoreCase))
 			result.Add(match.Groups["name"].Value.Replace('-', '_'));
 	}
 
-	private static readonly Regex QuotedRequirementRegex = new(
-		"[\\\"'](?<requirement>[^\\\"']+)[\\\"']",
-		RegexOptions.CultureInvariant);
 	private static readonly Regex RequirementNameRegex = new(
 		"^(?<name>[A-Za-z0-9][A-Za-z0-9_.-]*)",
 		RegexOptions.CultureInvariant);
@@ -892,6 +1000,44 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 
 	private static bool IsTypeScriptConfig(string path) => Path.GetFileName(path) is "tsconfig.json" or "jsconfig.json";
 	private static bool IsPythonConfig(string path) => Path.GetFileName(path) is "pyproject.toml" or "setup.cfg";
+	private static void MarkAmbiguousScopeOwnership(
+		IList<DependencyScopeDescriptor> scopes,
+		ICollection<DependencyConfigurationDiagnostic> diagnostics,
+		string root)
+	{
+		var ambiguous = scopes
+			.Where(static scope => scope.HasConfiguration)
+			.GroupBy(scope => (scope.LanguageId, Root: Path.GetFullPath(scope.Root)))
+			.Where(static group => group.Count() > 1 && group.All(scope =>
+				scope.ConfigurationState == DependencyConfigurationState.Valid))
+			.ToArray();
+		foreach (var group in ambiguous)
+		{
+			var scopeIds = group.Select(static scope => scope.ScopeId)
+				.Order(StringComparer.Ordinal).ToArray();
+			foreach (var scope in group)
+			{
+				var index = scopes.IndexOf(scope);
+				scopes[index] = scope with
+				{
+					ConfigurationState = DependencyConfigurationState.UnsupportedSemantics,
+					ConfigurationDiagnostic = AmbiguousConfigurationOwnershipReason
+				};
+				diagnostics.Add(new DependencyConfigurationDiagnostic(
+					ScopeConfigurationPath(scope.ScopeId),
+					DependencyConfigurationState.UnsupportedSemantics,
+					AmbiguousConfigurationOwnershipReason,
+					scopeIds));
+			}
+		}
+	}
+
+	private static string ScopeConfigurationPath(string scopeId)
+	{
+		var separator = scopeId.IndexOf(':');
+		return separator < 0 ? scopeId : scopeId[(separator + 1)..];
+	}
+
 	private static string? FindNearestManifestFile(string directory, string root, string name, IReadOnlySet<string> manifest)
 	{
 		while (IsWithin(root, directory))
@@ -905,7 +1051,9 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	}
 	private static void AddFallbackScope(ICollection<DependencyScopeDescriptor> scopes, string root, LanguageId language)
 	{
-		if (scopes.Any(scope => scope.LanguageId == language)) return;
+		if (scopes.Any(scope => scope.LanguageId == language &&
+		    (language != LanguageId.Python || PathComparer.Equals(
+			    Path.GetFullPath(scope.Root), Path.GetFullPath(root))))) return;
 		scopes.Add(new DependencyScopeDescriptor(
 			$"root:{language.ToString().ToLowerInvariant()}", root, language, [],
 			language == LanguageId.TypeScript ? "bundler" : null, false,
@@ -942,6 +1090,17 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			T value,
 			DependencyConfigurationState state,
 			string? reason) => new(value, state, reason ?? "configuration is unavailable");
+	}
+	private sealed record CSharpProjectConfiguration(
+		string[] ProjectReferences,
+		bool DisableTransitiveProjectReferences,
+		bool HasInvalidDisableTransitiveProjectReferences)
+	{
+		public static CSharpProjectConfiguration Default { get; } = new([], false, false);
+	}
+	private sealed record PythonConfiguration(IReadOnlySet<string> Dependencies, string? Version)
+	{
+		public static PythonConfiguration Default { get; } = new(new HashSet<string>(), null);
 	}
 	private sealed record TypeScriptConfiguration(
 		string ModuleResolution,

--- a/Infrastructure/Dependencies/Languages/python/references.scm
+++ b/Infrastructure/Dependencies/Languages/python/references.scm
@@ -1,3 +1,4 @@
 (import_statement) @import.direct
 (import_from_statement) @import.from
 (type) @reference.type
+(assignment) @context.module_assignment

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -570,6 +570,9 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		{
 			var text = materialization.Read(node);
 			return CreateCapture(captureName, node, text, null, 0, false,
+				captureName == "context.module_assignment"
+					? FindContainingDeclaration(node, materialization)
+					: null,
 				evidence: OneLineEvidence(text));
 		}
 
@@ -653,10 +656,17 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 	private static string? FindImportOwner(
 		string captureName,
 		Node node,
-		NodeTextMaterializationCounter materialization) =>
-		captureName is "import.direct" or "import.from"
-			? FindContainingDeclaration(node, materialization)
-			: null;
+		NodeTextMaterializationCounter materialization)
+	{
+		if (captureName is not ("import.direct" or "import.from")) return null;
+		var declaration = FindContainingDeclaration(node, materialization);
+		if (declaration is not null) return declaration;
+		for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+			if (parent.Type is "if_statement" or "for_statement" or "while_statement" or
+			    "try_statement" or "with_statement" or "match_statement")
+				return "$conditional-import";
+		return null;
+	}
 
 	private static DependencySyntaxCapture CreateCapture(
 		string captureName,

--- a/Tests/DevProjex.Tests.Integration/DependencyPythonAndConfigurationSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyPythonAndConfigurationSemanticsIntegrationTests.cs
@@ -1,0 +1,522 @@
+using DevProjex.Application.Dependencies;
+using DevProjex.Infrastructure.Compression;
+using DevProjex.Infrastructure.Dependencies;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
+{
+	[Fact]
+	public async Task New025_DottedImportsBindTheTopLevelNameUnlessAliased()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var package = fixture.CreateFile("pkg/__init__.py", string.Empty);
+		var target = fixture.CreateFile("pkg/sub.py", "VALUE = 1");
+		var facade = fixture.CreateFile("facade.py", "import pkg.sub\nimport pkg.sub as alias");
+		var consumer = fixture.CreateFile("consumer.py", "from facade import pkg\nfrom facade import alias");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, package, target, facade, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "consumer.py" && edge.Reference == "facade" &&
+			edge.Target == "pkg/sub.py" && edge.Status == ResolutionStatus.Resolved && edge.Evidence.Count == 2);
+	}
+
+	[Fact]
+	public async Task New057_ReExportDoesNotTreatAnOrdinaryModuleAsAPackage()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var ordinaryModule = fixture.CreateFile("module.py", "VALUE = 1");
+		var falseChild = fixture.CreateFile("module/Name.py", "class Name: pass");
+		var facade = fixture.CreateFile("facade.py", "from module import Name");
+		var consumer = fixture.CreateFile("consumer.py", "from facade import Name");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, ordinaryModule, falseChild, facade, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item =>
+			item.Source == "consumer.py" && item.Reference == "facade");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
+		Assert.DoesNotContain("module/Name.py", edge.Candidates);
+	}
+
+	[Fact]
+	public async Task New067_PyProjectDependenciesUseTomlArrayBoundaries()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"pyproject.toml",
+			"""
+			[project]
+			name = "fixture"
+			dependencies = [
+			  "requests[socks]",
+			  "quoted-bracket; python_version == ']'",
+			  "pydantic",
+			]
+			""");
+		var source = fixture.CreateFile("consumer.py", "import pydantic");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.External, edge.Status);
+		Assert.Equal("declared Python package outside the manifest", Assert.Single(edge.Reasons));
+	}
+
+	[Theory]
+	[InlineData("[project]\nname = \"unterminated")]
+	[InlineData("[project]\ndependencies = [\n  \"requests\",")]
+	public async Task New068_InvalidPyProjectTomlIsCorrupt(string content)
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", content);
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		var diagnostic = Assert.Single(result.ConfigurationDiagnostics);
+		Assert.Equal(DependencyConfigurationState.Corrupt, diagnostic.State);
+		Assert.Equal("invalid pyproject TOML", diagnostic.Reason);
+		var scope = Assert.Single(result.Scopes, item => item.HasConfiguration);
+		Assert.Equal(DependencyConfigurationState.Corrupt, scope.ConfigurationState);
+		Assert.Empty(scope.PythonExternalPackages);
+		Assert.Null(scope.PythonVersion);
+	}
+
+	[Fact]
+	public async Task New069_NamedDirectUrlDependencyRetainsItsDistributionName()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"pyproject.toml",
+			"[project]\nname = \"fixture\"\ndependencies = [\"company-sdk @ https://packages.invalid/sdk.whl\"]");
+		var source = fixture.CreateFile("consumer.py", "import company_sdk");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.External, edge.Status);
+		Assert.Equal("declared Python package outside the manifest", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task New069_BareDirectUrlDoesNotInventAPackageName()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"pyproject.toml",
+			"[project]\nname = \"fixture\"\ndependencies = [\"https://packages.invalid/sdk.whl\"]");
+
+		var result = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		Assert.Empty(Assert.Single(result.Scopes, item => item.HasConfiguration).PythonExternalPackages);
+	}
+
+	[Fact]
+	public async Task New070_NestedPyProjectDoesNotChangeUnownedRootFiles()
+	{
+		using var fixture = new TemporaryDirectory();
+		var module = fixture.CreateFile("module.py", "VALUE = 1");
+		var source = fixture.CreateFile("consumer.py", "import module");
+		var nestedConfig = fixture.CreateFile("tools/pyproject.toml", "[project]\nname = \"tools\"");
+
+		using var beforeEngine = CreateEngine();
+		var before = await beforeEngine.IndexAsync(
+			fixture.Path,
+			[module, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		using var afterEngine = CreateEngine();
+		var after = await afterEngine.IndexAsync(
+			fixture.Path,
+			[module, source, nestedConfig],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var beforeEdge = Assert.Single(before.Edges, item => item.Source == "consumer.py");
+		var afterEdge = Assert.Single(after.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(beforeEdge.Status, afterEdge.Status);
+		Assert.Equal(beforeEdge.Target, afterEdge.Target);
+		Assert.Equal(beforeEdge.Reasons, afterEdge.Reasons);
+	}
+
+	[Fact]
+	public async Task New071_ModuleFileBlocksDottedChildResolution()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var parentModule = fixture.CreateFile("pkg.py", "VALUE = 1");
+		var falseChild = fixture.CreateFile("pkg/sub/child.py", "VALUE = 2");
+		var source = fixture.CreateFile("consumer.py", "import pkg.sub");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, parentModule, falseChild, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
+	}
+
+	[Fact]
+	public async Task New071_RegularPackageBlocksChildrenFromAnotherRoot()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var package = fixture.CreateFile("pkg/__init__.py", string.Empty);
+		var falseChild = fixture.CreateFile("src/pkg/sub.py", "VALUE = 1");
+		var source = fixture.CreateFile("consumer.py", "import pkg.sub");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, package, falseChild, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
+	}
+
+	[Fact]
+	public async Task New072_LastUnconditionalReExportBindingWins()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var old = fixture.CreateFile("old.py", "class Model: pass");
+		var current = fixture.CreateFile("current.py", "class Model: pass");
+		var facade = fixture.CreateFile("facade.py", "from old import Model\nfrom current import Model");
+		var consumer = fixture.CreateFile("consumer.py", "from facade import Model");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, old, current, facade, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item =>
+			item.Source == "consumer.py" && item.Reference == "facade");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("current.py", edge.Target);
+	}
+
+	[Fact]
+	public async Task New072_ConditionalReExportDoesNotClaimOneTarget()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var old = fixture.CreateFile("old.py", "class Model: pass");
+		var current = fixture.CreateFile("current.py", "class Model: pass");
+		var facade = fixture.CreateFile(
+			"facade.py",
+			"from old import Model\nif enabled:\n    from current import Model");
+		var consumer = fixture.CreateFile("consumer.py", "from facade import Model");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, old, current, facade, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item =>
+			item.Source == "consumer.py" && item.Reference == "facade");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
+		Assert.Equal("conditional Python re-export bindings are not indexed", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task New073_DocstringAndLocalAllAssignmentsDoNotSetModulePolicy()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var module = fixture.CreateFile(
+			"module.py",
+			"""
+			'''Example:
+			__all__ = build_names()
+			'''
+			def configure():
+			    __all__ = build_names()
+			class Item: pass
+			""");
+		var source = fixture.CreateFile("consumer.py", "from module import *");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, module, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("module.py", edge.Target);
+	}
+
+	[Fact]
+	public async Task New073_ModuleLevelDynamicAllRemainsExplicitlyUnresolved()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var module = fixture.CreateFile("module.py", "__all__ = build_names()\nclass Item: pass");
+		var source = fixture.CreateFile("consumer.py", "from module import *");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, module, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var moduleFacts = Assert.Single(result.Files, item => item.Path == "module.py");
+		Assert.True(moduleFacts.Aliases.ContainsKey("$dynamic-all"),
+			string.Join(", ", moduleFacts.Aliases.Keys));
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal("dynamic __all__ is an unsupported mechanism", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task New024_ModuleAssignmentsHaveAnExplicitResolutionLimitation()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var settings = fixture.CreateFile("settings.py", "API_VERSION = \"1\"\nDEFAULTS = dict()");
+		var source = fixture.CreateFile("consumer.py", "from settings import API_VERSION\nfrom settings import DEFAULTS");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, settings, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(2, edge.Evidence.Count);
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal("Python module assignment bindings are not indexed", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task New074_WildcardReExportHasAnExplicitResolutionLimitation()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var model = fixture.CreateFile("model.py", "__all__ = [\"Item\"]\nclass Item: pass");
+		var facade = fixture.CreateFile("facade.py", "from model import *");
+		var source = fixture.CreateFile("consumer.py", "from facade import Item");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, model, facade, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item =>
+			item.Source == "consumer.py" && item.Reference == "facade");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal("Python wildcard re-export bindings are not indexed", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task New064_EqualRootConfigurationsFailClosedAsAmbiguousOwnership()
+	{
+		using var fixture = new TemporaryDirectory();
+		var pyproject = fixture.CreateFile(
+			"pyproject.toml",
+			"[project]\nname = \"fixture\"\ndependencies = [\"alpha\"]");
+		var setup = fixture.CreateFile("setup.cfg", "[options]\ninstall_requires =\n  beta");
+		var source = fixture.CreateFile("consumer.py", "import alpha");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[pyproject, setup, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "consumer.py");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal("multiple owning dependency configurations", Assert.Single(edge.Reasons));
+		Assert.Equal(2, result.Coverage.ConfigurationDiagnostics.Count(item =>
+			item.Reason == "multiple owning dependency configurations"));
+	}
+
+	[Fact]
+	public async Task New065_StaticCompileItemsFailClosedWithoutEvaluatingMsBuild()
+	{
+		using var fixture = new TemporaryDirectory();
+		var project = fixture.CreateFile(
+			"Fixture.csproj",
+			"<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><Compile Remove=\"Removed.cs\" /></ItemGroup></Project>");
+		var kept = fixture.CreateFile("Kept.cs", "namespace Models; public sealed class Item { }");
+		var removed = fixture.CreateFile("Removed.cs", "namespace Models; public sealed class Item { }");
+		var consumer = fixture.CreateFile("Consumer.cs", "using Models; public sealed class Consumer { Item Value; }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[project, kept, removed, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item =>
+			item.Source == "Consumer.cs" && item.Reference == "Item");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal("C# Compile item membership is not supported", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task New066_FilteredOwningConfigurationHasAnExplicitMissingReason()
+	{
+		using var fixture = new TemporaryDirectory();
+		fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = fixture.CreateFile("Target.cs", "namespace Models; public sealed class Item { }");
+		var source = fixture.CreateFile("Consumer.cs", "using Models; public sealed class Consumer { Item Value; }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item => item.Source == "Consumer.cs");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal("no owning .csproj in the manifest", Assert.Single(edge.Reasons));
+	}
+
+	[Fact]
+	public async Task DisableTransitiveProjectReferencesLimitsVisibilityToDirectProjects()
+	{
+		using var fixture = new TemporaryDirectory();
+		var projectA = fixture.CreateFile(
+			"A/A.csproj",
+			"<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences></PropertyGroup><ItemGroup><ProjectReference Include=\"../B/B.csproj\" /></ItemGroup></Project>");
+		var projectB = fixture.CreateFile(
+			"B/B.csproj",
+			"<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><ProjectReference Include=\"../C/C.csproj\" /></ItemGroup></Project>");
+		var projectC = fixture.CreateFile("C/C.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var middle = fixture.CreateFile("B/Middle.cs", "namespace BScope; public sealed class Middle { }");
+		var target = fixture.CreateFile("C/Target.cs", "namespace CScope; public sealed class Target { }");
+		var source = fixture.CreateFile(
+			"A/Consumer.cs",
+			"using BScope; using CScope; public sealed class Consumer { Middle Direct; Target Transitive; }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[projectA, projectB, projectC, middle, target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "A/Consumer.cs" && edge.Reference == "Middle" &&
+			edge.Status == ResolutionStatus.Resolved && edge.Target == "B/Middle.cs");
+		Assert.Contains(result.Edges, edge => edge.Source == "A/Consumer.cs" && edge.Reference == "Target" &&
+			edge.Status == ResolutionStatus.Unresolved && edge.Target is null);
+	}
+
+	[Theory]
+	[InlineData("false", true, 0)]
+	[InlineData("conditional", true, 1)]
+	public async Task DisableTransitiveProjectReferencesLiteralPolicyIsDeterministic(
+		string value,
+		bool targetIsVisible,
+		int expectedDiagnostics)
+	{
+		using var fixture = new TemporaryDirectory();
+		var projectA = fixture.CreateFile(
+			"A/A.csproj",
+			$"<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><DisableTransitiveProjectReferences>{value}</DisableTransitiveProjectReferences></PropertyGroup><ItemGroup><ProjectReference Include=\"../B/B.csproj\" /></ItemGroup></Project>");
+		var projectB = fixture.CreateFile(
+			"B/B.csproj",
+			"<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><ProjectReference Include=\"../C/C.csproj\" /></ItemGroup></Project>");
+		var projectC = fixture.CreateFile("C/C.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = fixture.CreateFile("C/Target.cs", "namespace CScope; public sealed class Target { }");
+		var source = fixture.CreateFile("A/Consumer.cs", "using CScope; public sealed class Consumer { Target Value; }");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[projectA, projectB, projectC, target, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, item =>
+			item.Source == "A/Consumer.cs" && item.Reference == "Target");
+		Assert.Equal(targetIsVisible ? ResolutionStatus.Resolved : ResolutionStatus.Unresolved, edge.Status);
+		Assert.Equal(expectedDiagnostics, result.Coverage.ConfigurationDiagnostics.Count(item =>
+			item.Reason == "DisableTransitiveProjectReferences could not be evaluated safely"));
+	}
+
+	[Fact]
+	public async Task New078_TransientGrammarResolutionFailureIsRetried()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
+		var source = fixture.CreateFile("module.py", "class Item: pass");
+		using var locator = new FailOnceGrammarLibraryLocator(CodeCompressionFactory.CreateLocator());
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(locator),
+			new FileDependencyConfigurationProvider());
+
+		var first = await engine.IndexAsync(
+			fixture.Path,
+			[config, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+		fixture.CreateFile("module.py", "class Item: pass\nclass Other: pass");
+		var second = await engine.IndexAsync(
+			fixture.Path,
+			[config, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal(DependencyFileStatus.ExtractionFailed,
+			Assert.Single(first.Files, item => item.Path == "module.py").Status);
+		Assert.Equal(DependencyFileStatus.Supported,
+			Assert.Single(second.Files, item => item.Path == "module.py").Status);
+		Assert.Equal(2, locator.ResolveCalls);
+	}
+
+	private static DependencyFactsEngine CreateEngine() => new(
+		new TreeSitterDependencyFactExtractor(),
+		new FileDependencyConfigurationProvider());
+
+	private sealed class FailOnceGrammarLibraryLocator(IGrammarLibraryLocator inner)
+		: IGrammarLibraryLocator, IDisposable
+	{
+		private int _resolveCalls;
+
+		public int ResolveCalls => Volatile.Read(ref _resolveCalls);
+		public string StrategyName => inner.StrategyName;
+		public IReadOnlyList<string> EnumerateLibraries() => inner.EnumerateLibraries();
+
+		public string Resolve(string libraryBaseName)
+		{
+			if (Interlocked.Increment(ref _resolveCalls) == 1)
+				throw new IOException("transient grammar lookup failure");
+			return inner.Resolve(libraryBaseName);
+		}
+
+		public void Dispose()
+		{
+			if (inner is IDisposable disposable)
+				disposable.Dispose();
+		}
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedCommandProcessTests.cs
@@ -4,6 +4,30 @@ namespace DevProjex.Tests.Terminal;
 
 public sealed class RelatedCommandProcessTests
 {
+	[Fact]
+	public void RealPublishedCommandUsesPythonDottedImportBindingAndPackageBoundaries()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/pyproject.toml", "[project]\nname = \"fixture\"\n");
+		workspace.WriteFile("project/pkg/__init__.py", string.Empty);
+		workspace.WriteFile("project/pkg/sub.py", "class Item: pass\n");
+		workspace.WriteFile("project/facade.py", "import pkg.sub\n");
+		workspace.WriteFile("project/consumer.py", "from facade import pkg\n");
+
+		var result = Run(
+			workspace,
+			"related", "consumer.py",
+			"--project", project,
+			"--format", "json",
+			"--git-mode", "none",
+			"--exclude", "none");
+
+		Assert.True(result.ExitCode == 0, result.StandardError + result.StandardOutput);
+		Assert.Contains("pkg/sub.py", result.StandardOutput, StringComparison.Ordinal);
+		Assert.DoesNotContain("unresolved", result.StandardOutput, StringComparison.Ordinal);
+	}
+
 	[Theory]
 	[InlineData("text")]
 	[InlineData("json")]

--- a/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RelatedFilesMcpProcessTests.cs
@@ -32,6 +32,10 @@ public sealed partial class McpServerProcessTests
 		workspace.WriteFile("project/consumer.py", "from model import (\n    Item,\n)\n");
 		workspace.WriteFile("project/local_model.py", "def loader():\n    from impl import Item as LocalItem\n");
 		workspace.WriteFile("project/local_consumer.py", "from local_model import LocalItem\n");
+		workspace.WriteFile("project/pkg/__init__.py", string.Empty);
+		workspace.WriteFile("project/pkg/sub.py", "class Item: pass\n");
+		workspace.WriteFile("project/facade.py", "import pkg.sub\n");
+		workspace.WriteFile("project/dotted_consumer.py", "from facade import pkg\n");
 		var startInfo = new ProcessStartInfo("dotnet")
 		{
 			UseShellExecute = false,
@@ -75,6 +79,9 @@ public sealed partial class McpServerProcessTests
 			var localModel = await client.CallToolAsync("related_files",
 				new Dictionary<string, object?> { ["path"] = "local_model.py", ["direction"] = "dependencies" },
 				progress: null, options: null, TestContext.Current.CancellationToken);
+			var dottedPython = await client.CallToolAsync("related_files",
+				new Dictionary<string, object?> { ["path"] = "dotted_consumer.py", ["direction"] = "dependencies" },
+				progress: null, options: null, TestContext.Current.CancellationToken);
 			var typeScriptText = Assert.IsType<TextContentBlock>(Assert.Single(typeScript.Content)).Text;
 			Assert.Contains("register.ts", typeScriptText, StringComparison.Ordinal);
 			Assert.Contains("View.tsx", typeScriptText, StringComparison.Ordinal);
@@ -93,6 +100,9 @@ public sealed partial class McpServerProcessTests
 			Assert.Contains("[No related files]", localPythonText, StringComparison.Ordinal);
 			Assert.Contains("impl.py", Assert.IsType<TextContentBlock>(Assert.Single(localModel.Content)).Text,
 				StringComparison.Ordinal);
+			var dottedPythonText = Assert.IsType<TextContentBlock>(Assert.Single(dottedPython.Content)).Text;
+			Assert.Contains("pkg/sub.py", dottedPythonText, StringComparison.Ordinal);
+			Assert.DoesNotContain(" — unresolved — ", dottedPythonText, StringComparison.Ordinal);
 		}
 		process.StandardInput.Close();
 		await process.WaitForExitAsync(TestContext.Current.CancellationToken)

--- a/tools/RankingEval/results/2026-09-09-python-configuration.json
+++ b/tools/RankingEval/results/2026-09-09-python-configuration.json
@@ -1,0 +1,2795 @@
+{
+  "protocol": "focus-v1",
+  "runDate": "2026-09-09",
+  "productSha": "fb771aa58bb591a0501562dc91451b1ceced23dd",
+  "evaluatorSha": "fb771aa58bb591a0501562dc91451b1ceced23dd",
+  "repositories": [
+    {
+      "id": "devprojex",
+      "commit": "c249c30944b15771f351ff2057f77817b1706ea4",
+      "candidateFiles": 2299,
+      "cells": [
+        {
+          "task": "token-budget-report",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7883941970985493,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.71525,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7151075537768884,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "token-budget-report",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.89425,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8575893973493374,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8576072009001126,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "token-budget-report",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9471216951059441,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9288125,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9288125,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9224220133496799,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "mandatory-redaction",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8864716179044762,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8864432216108054,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.3715,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8483127297026395,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "mandatory-redaction",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.94325,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6857107138392299,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.94325,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6208716633991856,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "mandatory-redaction",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9716214526815852,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5632579072384049,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.842875,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5300013453518095,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "nested-git-changes",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6388194097048524,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6388194097048524,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6388194097048524,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5310165638194219,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "nested-git-changes",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8194774346793349,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.819454863715929,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8195,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5310165638194219,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "nested-git-changes",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.90975,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.90975,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.90975,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5310165638194219,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "stored-mcp-pack",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "stored-mcp-pack",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.34158539634908724,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.34175,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.34158539634908724,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.2597694686533596,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "stored-mcp-pack",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.670875,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6708544284017751,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.670875,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.2597694686533596,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "remote-clone-cache",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "remote-clone-cache",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "remote-clone-cache",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        }
+      ],
+      "performance": [
+        {
+          "mode": "cold",
+          "order": "importance-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 2818.2717,
+          "medianPeakWorkingSetBytes": 338132992,
+          "elapsedMilliseconds": [
+            2735.9493,
+            2776.4708,
+            2782.1276,
+            2818.2717,
+            2840.6768,
+            2918.8173,
+            3014.8329
+          ],
+          "peakWorkingSetBytes": [
+            331337728,
+            339169280,
+            339341312,
+            338833408,
+            332996608,
+            338132992,
+            333725696
+          ]
+        },
+        {
+          "mode": "cold",
+          "order": "focus-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 2896.2742,
+          "medianPeakWorkingSetBytes": 338558976,
+          "elapsedMilliseconds": [
+            3203.6234,
+            2896.2742,
+            2933.7269,
+            3021.211,
+            2816.4076,
+            2844.4979,
+            2875.2404
+          ],
+          "peakWorkingSetBytes": [
+            341540864,
+            339341312,
+            338558976,
+            338137088,
+            335253504,
+            340348928,
+            336424960
+          ]
+        },
+        {
+          "mode": "warm",
+          "order": "importance-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 865.589,
+          "medianPeakWorkingSetBytes": 340955136,
+          "elapsedMilliseconds": [
+            855.5071,
+            1040.4616,
+            969.5762,
+            865.589,
+            829.0458,
+            901.8338,
+            859.7947
+          ],
+          "peakWorkingSetBytes": [
+            344354816,
+            348205056,
+            324616192,
+            339283968,
+            340955136,
+            342192128,
+            326365184
+          ]
+        },
+        {
+          "mode": "warm",
+          "order": "focus-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 820.7703,
+          "medianPeakWorkingSetBytes": 345239552,
+          "elapsedMilliseconds": [
+            964.9283,
+            790.487,
+            801.9987,
+            849.4207,
+            820.7703,
+            813.81,
+            1002.9069
+          ],
+          "peakWorkingSetBytes": [
+            345239552,
+            338874368,
+            347832320,
+            341815296,
+            348282880,
+            349851648,
+            343674880
+          ]
+        }
+      ]
+    },
+    {
+      "id": "repomix",
+      "commit": "85e3969b010c72b905203812d1a3f5beb84a2102",
+      "candidateFiles": 951,
+      "cells": [
+        {
+          "task": "git-frequency-order",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7333666833416709,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7333666833416709,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7333666833416709,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7193259610321222,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "git-frequency-order",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8667333416677084,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8667166791697924,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8666833416708354,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8499225679290441,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "git-frequency-order",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9333666708338543,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9333666708338543,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9333708356772298,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9299007036233313,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "mcp-path-confinement",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7271817954488622,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.72725,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7271135567783892,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.704095470572281,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "mcp-path-confinement",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8635908977244311,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.437125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.43684342171085544,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.36568530778982955,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "mcp-path-confinement",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.9318125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.718544909056816,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.718544909056816,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.4956317204301075,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "remote-config-trust",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.15075,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.15075,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.15053763440860216,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.14947421131697547,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "remote-config-trust",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.575375,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5752688172043011,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.575375,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5639840841997176,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "remote-config-trust",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7876875,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7876476839407389,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7876609576197025,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7860831234256926,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "local-pack-pipeline",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.09325,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.09302325581395349,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.09279639819909954,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.05300261096605744,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "local-pack-pipeline",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.54656832104013,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.546625,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5465116279069767,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.536604062859333,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "local-pack-pipeline",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7733125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.773284160520065,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7733125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7689072953169799,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "mcp-pack-codebase",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.3508377094273568,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.3508377094273568,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.3506753376688344,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.31558133403638283,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "mcp-pack-codebase",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6754188547136785,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.539125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.248906113264158,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.538779084313235,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "mcp-pack-codebase",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8377297162145269,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.5563125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6245,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.5258165787188565,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        }
+      ],
+      "performance": [
+        {
+          "mode": "cold",
+          "order": "importance-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 783.7992,
+          "medianPeakWorkingSetBytes": 115712000,
+          "elapsedMilliseconds": [
+            997.4275,
+            780.9329,
+            783.7992,
+            770.8314,
+            825.2675,
+            761.4455,
+            818.5385
+          ],
+          "peakWorkingSetBytes": [
+            120881152,
+            114974720,
+            119914496,
+            114647040,
+            115712000,
+            115351552,
+            119545856
+          ]
+        },
+        {
+          "mode": "cold",
+          "order": "focus-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 829.1158,
+          "medianPeakWorkingSetBytes": 115724288,
+          "elapsedMilliseconds": [
+            858.4447,
+            802.198,
+            814.2195,
+            833.5276,
+            829.1158,
+            828.955,
+            830.942
+          ],
+          "peakWorkingSetBytes": [
+            115724288,
+            120053760,
+            115724288,
+            120066048,
+            117096448,
+            115687424,
+            115523584
+          ]
+        },
+        {
+          "mode": "warm",
+          "order": "importance-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 473.6319,
+          "medianPeakWorkingSetBytes": 128684032,
+          "elapsedMilliseconds": [
+            446.3238,
+            467.1668,
+            432.6932,
+            500.4889,
+            495.8905,
+            473.6319,
+            491.4376
+          ],
+          "peakWorkingSetBytes": [
+            128684032,
+            128086016,
+            128147456,
+            127463424,
+            128692224,
+            129110016,
+            129028096
+          ]
+        },
+        {
+          "mode": "warm",
+          "order": "focus-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 478.6408,
+          "medianPeakWorkingSetBytes": 129093632,
+          "elapsedMilliseconds": [
+            458.8489,
+            453.1157,
+            454.7227,
+            523.587,
+            478.6408,
+            484.6523,
+            521.3759
+          ],
+          "peakWorkingSetBytes": [
+            129093632,
+            129470464,
+            129200128,
+            127066112,
+            128729088,
+            128684032,
+            129110016
+          ]
+        }
+      ]
+    },
+    {
+      "id": "flask",
+      "commit": "d318b683471101618febed18996405ad26462110",
+      "candidateFiles": 212,
+      "cells": [
+        {
+          "task": "blueprint-errors",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "blueprint-errors",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.134,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.13378344586146537,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.13378344586146537,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.1036356579117609,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "blueprint-errors",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.567,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.567,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5669458682335292,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5555555555555556,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "session-cookie",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.040010002500625155,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.040010002500625155,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.040010002500625155,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "session-cookie",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.520125,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5200050012503126,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.520125,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5196446446446447,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "session-cookie",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7600625,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7600625,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7600475029689355,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7595515470374546,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "cli-discovery",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "cli-discovery",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "cli-discovery",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.4067754234639665,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.4067383422927866,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.4068125,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": null,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.40036643922163256,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        },
+        {
+          "task": "context-lifetime",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "context-lifetime",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.4122280570142536,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.4123015376922115,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.412375,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.4062894670371306,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "context-lifetime",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7061507688461057,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7061691355709732,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7061875,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6946807819705137,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "json-provider",
+          "budget": 4000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6401600400100025,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.50875,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5086271567891973,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.5086271567891973,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.422737955346651,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "json-provider",
+          "budget": 8000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0.5,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8200800200050012,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7543442930366295,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7543135783945987,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.7543442930366295,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.6623711340206185,
+              "oracle": false,
+              "oracleAfterSeeds": false
+            }
+          }
+        },
+        {
+          "task": "json-provider",
+          "budget": 16000,
+          "orders": {
+            "current": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 1,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "importance-v1": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8771721465183148,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "seed-first": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8771721465183148,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-v1": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.24425,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "focus-ppr": {
+              "available": true,
+              "recallNew": 0,
+              "allRequired": false,
+              "irrelevantTokenShare": 0.8771875,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            },
+            "directed-from-seed": {
+              "available": true,
+              "recallNew": 1,
+              "allRequired": true,
+              "irrelevantTokenShare": 0.24173825797955728,
+              "oracle": true,
+              "oracleAfterSeeds": true
+            }
+          }
+        }
+      ],
+      "performance": [
+        {
+          "mode": "cold",
+          "order": "importance-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 528.7513,
+          "medianPeakWorkingSetBytes": 92540928,
+          "elapsedMilliseconds": [
+            563.7567,
+            528.7513,
+            529.3713,
+            585.5499,
+            515.4068,
+            502.9885,
+            502.9241
+          ],
+          "peakWorkingSetBytes": [
+            92360704,
+            93143040,
+            93179904,
+            91820032,
+            92999680,
+            91373568,
+            92540928
+          ]
+        },
+        {
+          "mode": "cold",
+          "order": "focus-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 518.8303,
+          "medianPeakWorkingSetBytes": 93011968,
+          "elapsedMilliseconds": [
+            516.7879,
+            525.6114,
+            518.8303,
+            504.449,
+            528.5742,
+            513.3002,
+            526.2326
+          ],
+          "peakWorkingSetBytes": [
+            92991488,
+            93466624,
+            92946432,
+            93093888,
+            93011968,
+            93089792,
+            91303936
+          ]
+        },
+        {
+          "mode": "warm",
+          "order": "importance-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 194.7045,
+          "medianPeakWorkingSetBytes": 93048832,
+          "elapsedMilliseconds": [
+            194.7045,
+            182.1982,
+            206.7971,
+            204.3318,
+            179.4784,
+            203.0388,
+            186.5946
+          ],
+          "peakWorkingSetBytes": [
+            93171712,
+            92884992,
+            93245440,
+            92917760,
+            93048832,
+            92487680,
+            93265920
+          ]
+        },
+        {
+          "mode": "warm",
+          "order": "focus-v1",
+          "repetitions": 7,
+          "medianElapsedMilliseconds": 193.9303,
+          "medianPeakWorkingSetBytes": 93245440,
+          "elapsedMilliseconds": [
+            212.5021,
+            211.296,
+            193.9303,
+            183.2817,
+            184.3889,
+            187.5571,
+            198.3571
+          ],
+          "peakWorkingSetBytes": [
+            93245440,
+            93208576,
+            93343744,
+            93028352,
+            93671424,
+            92729344,
+            93515776
+          ]
+        }
+      ]
+    }
+  ],
+  "criterion": {
+    "eligibleCells": 15,
+    "overallRecallNewDelta": 0.36666666666666664,
+    "repositoryRecallNewDelta": {
+      "devprojex": 0.2,
+      "repomix": 0.3888888888888889,
+      "flask": 1
+    },
+    "allRequiredRegressions": 0,
+    "warmIncrementalMilliseconds": {
+      "devprojex": -44.818700000000035,
+      "repomix": 5.00890000000004,
+      "flask": -0.7742000000000075
+    },
+    "warmIncrementalPercent": {
+      "devprojex": -5.177826890129153,
+      "repomix": 1.0575512333523227,
+      "flask": -0.3976282006836039
+    },
+    "maximumPeakWorkingSetGrowthPercent": {
+      "devprojex": 1.2565923042731346,
+      "repomix": 0.3182990100900786,
+      "flask": 0.5090072146239986
+    },
+    "recallPassed": true,
+    "allRequiredPassed": true,
+    "timePassed": true,
+    "memoryPassed": true,
+    "passed": true
+  }
+}


### PR DESCRIPTION
## Summary

- parse `pyproject.toml` as TOML and fail closed on corrupt input
- preserve named direct-URL dependencies and isolate nested Python scopes
- enforce Python package boundaries, dotted binding names, last-binding semantics, and module-level `__all__`
- diagnose unsupported assignment, wildcard re-export, Compile membership, and ambiguous ownership semantics
- honor literal `DisableTransitiveProjectReferences` without evaluating MSBuild
- add real CLI and MCP related-files coverage

## Validation

- `Dependency*` integration tests: 197 passed, 2 platform-specific skipped
- `Dependency*` unit tests: 16 passed
- targeted CLI/MCP related process tests: 8 passed
- RankingEval: PASS, 15 eligible cells, RecallNew delta 0.3667

No tags, merges, or publication were performed.