### PR TITLE
fix(secrets): parse structured values by format

### DIFF
--- a/Docs/HideSecrets.md
+++ b/Docs/HideSecrets.md
@@ -118,6 +118,16 @@ URIs on RFC 2606 documentation hosts (`example.com`, `example.net`,
 TLDs) are not redacted. `localhost` is intentionally still inspected because
 development credentials can be real secrets.
 
+Structured value boundaries follow the recognized file format instead of one shared delimiter
+rule. Dotenv comments begin only outside quotes; ADO.NET pairs use semicolons while JDBC query
+parameters use ampersands; JSON property names are decoded and sensitive arrays are visited by
+scalar element; YAML quoted and block scalars follow their own boundaries; XML text and CDATA
+inherit a sensitive element; Python prefixes and triple quotes are recognized; Dockerfile
+continuations and escape directives form logical instructions; `.netrc` is read as a token stream;
+and npm authentication keys are recognized after an optional registry scope. Delimiters, quote
+marks, container punctuation, comments, and adjacent non-sensitive fields stay outside replacement
+spans.
+
 The structured tier reuses Smart Ignore's project-scope resolver and root facts.
 The nearest marked project owns its descendants, so stack-specific vocabulary
 does not leak between sibling or nested projects in a monorepo. Ordinary source
@@ -126,6 +136,9 @@ shaped credentials in source remain covered by Gitleaks rules.
 
 References and placeholders such as `${DB_PASSWORD}`, `$(DbPassword)`,
 `%DB_PASSWORD%`, `{{ secret }}`, `<password>`, and empty values are not redacted.
+For `${...}`, this exception applies only to a complete simple reference. Default expressions such
+as `${DB_PASSWORD:-literal}`, error expressions, nested expressions, escaped references, and text
+with a suffix are composite values and remain subject to redaction under a sensitive key.
 Common template values such as `changeme`, `your-password-here`, `replace_me`,
 `placeholder`, `null`, `none`, `your-api-key-here`-style templates, and repeated
 non-numeric characters are also ignored. These checks match whole values or

--- a/Docs/HideSecrets.md
+++ b/Docs/HideSecrets.md
@@ -126,7 +126,8 @@ inherit a sensitive element; Python prefixes and triple quotes are recognized; D
 continuations and escape directives form logical instructions; `.netrc` is read as a token stream;
 and npm authentication keys are recognized after an optional registry scope. Delimiters, quote
 marks, container punctuation, comments, and adjacent non-sensitive fields stay outside replacement
-spans.
+spans. In `settings.py`, direct `os.environ[...]` lookups remain references, while a literal default
+passed to `os.getenv` or `os.environ.get` is treated as the sensitive fallback value.
 
 The structured tier reuses Smart Ignore's project-scope resolver and root facts.
 The nearest marked project owns its descendants, so stack-specific vocabulary

--- a/Docs/Security.md
+++ b/Docs/Security.md
@@ -25,6 +25,11 @@ detects against both the immutable source snapshot and transformed text, project
 ranges through the transform map, and masks the union. Overlap priority selects a rule label only;
 it does not discard another finding's uncovered range.
 
+The structured tier derives replacement boundaries from the recognized dotenv, connection-string,
+JSON, YAML, XML, Python, Dockerfile, netrc, or npmrc grammar. It masks logical values while leaving
+their surrounding syntax outside the finding, and only a complete simple variable reference is
+exempt from a sensitive-key finding.
+
 Temporary redaction data is stored in private per-user directories. After an
 abnormal termination it can remain until a later DevProjex startup runs the
 scavenger, which removes stale directories once they are more than 24 hours old.

--- a/Infrastructure/Secrets/SecretDetectionTextPolicy.cs
+++ b/Infrastructure/Secrets/SecretDetectionTextPolicy.cs
@@ -47,7 +47,7 @@ internal static class SecretDetectionTextPolicy
 		value = value.Trim();
 		if (value.IsEmpty)
 			return true;
-		if (IsWrapped(value, "${", "}") ||
+		if (IsPureDollarBraceReference(value) ||
 		    IsWrapped(value, "$(", ")") ||
 		    IsWrapped(value, "{{", "}}") ||
 		    IsWrapped(value, "<", ">") ||
@@ -72,6 +72,21 @@ internal static class SecretDetectionTextPolicy
 		return true;
 	}
 
+	private static bool IsPureDollarBraceReference(ReadOnlySpan<char> value)
+	{
+		if (!IsWrapped(value, "${", "}"))
+			return false;
+		var name = value[2..^1];
+		if (name.IsEmpty || !(char.IsLetter(name[0]) || name[0] == '_'))
+			return false;
+		for (var index = 1; index < name.Length; index++)
+		{
+			if (!char.IsLetterOrDigit(name[index]) && name[index] is not '_' and not '.' and not '-')
+				return false;
+		}
+		return true;
+	}
+
 	internal static bool IsReferenceOrPlaceholder(
 		ReadOnlySpan<char> content,
 		int start,
@@ -91,7 +106,7 @@ internal static class SecretDetectionTextPolicy
 			wrapperEnd++;
 
 		return content[start] == '%' && wrapperEnd < content.Length && content[wrapperEnd] == '%' ||
-		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "${", "}") ||
+		       HasSurroundingPureDollarBraceReference(content, wrapperStart, wrapperEnd) ||
 		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "$(", ")") ||
 		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "{{", "}}") ||
 		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "<", ">") ||
@@ -170,6 +185,16 @@ internal static class SecretDetectionTextPolicy
 		valueEnd <= content.Length - suffix.Length &&
 		content.Slice(valueStart - prefix.Length, prefix.Length).SequenceEqual(prefix) &&
 		content.Slice(valueEnd, suffix.Length).SequenceEqual(suffix);
+
+	private static bool HasSurroundingPureDollarBraceReference(
+		ReadOnlySpan<char> content,
+		int valueStart,
+		int valueEnd) =>
+		valueStart >= 2 &&
+		valueEnd < content.Length &&
+		content.Slice(valueStart - 2, 2).SequenceEqual("${") &&
+		content[valueEnd] == '}' &&
+		IsPureDollarBraceReference(content[(valueStart - 2)..(valueEnd + 1)]);
 
 	private static bool IsHostOrSubdomainOf(ReadOnlySpan<char> host, string domain) =>
 		host.Equals(domain, StringComparison.OrdinalIgnoreCase) ||

--- a/Infrastructure/Secrets/SecretDetectionTextPolicy.cs
+++ b/Infrastructure/Secrets/SecretDetectionTextPolicy.cs
@@ -106,7 +106,7 @@ internal static class SecretDetectionTextPolicy
 			wrapperEnd++;
 
 		return content[start] == '%' && wrapperEnd < content.Length && content[wrapperEnd] == '%' ||
-		       HasSurroundingPureDollarBraceReference(content, wrapperStart, wrapperEnd) ||
+		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "${", "}") ||
 		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "$(", ")") ||
 		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "{{", "}}") ||
 		       HasSurroundingWrapper(content, wrapperStart, wrapperEnd, "<", ">") ||
@@ -185,16 +185,6 @@ internal static class SecretDetectionTextPolicy
 		valueEnd <= content.Length - suffix.Length &&
 		content.Slice(valueStart - prefix.Length, prefix.Length).SequenceEqual(prefix) &&
 		content.Slice(valueEnd, suffix.Length).SequenceEqual(suffix);
-
-	private static bool HasSurroundingPureDollarBraceReference(
-		ReadOnlySpan<char> content,
-		int valueStart,
-		int valueEnd) =>
-		valueStart >= 2 &&
-		valueEnd < content.Length &&
-		content.Slice(valueStart - 2, 2).SequenceEqual("${") &&
-		content[valueEnd] == '}' &&
-		IsPureDollarBraceReference(content[(valueStart - 2)..(valueEnd + 1)]);
 
 	private static bool IsHostOrSubdomainOf(ReadOnlySpan<char> host, string domain) =>
 		host.Equals(domain, StringComparison.OrdinalIgnoreCase) ||

--- a/Infrastructure/Secrets/SmartSecretsDetector.cs
+++ b/Infrastructure/Secrets/SmartSecretsDetector.cs
@@ -720,20 +720,22 @@ internal static class StructuredSecretDetector
 		if (start >= line.Length)
 			return new TextSpan(start, 0);
 
-		if (line[start] is '\'' or '"')
+		if (TryGetConnectionQuoteToken(line[start..], out var quoteToken))
 		{
-			var quote = line[start++];
+			start += quoteToken.Length;
 			var quotedEnd = start;
 			while (quotedEnd < line.Length)
 			{
-				if (line[quotedEnd] != quote)
+				if (!line[quotedEnd..].StartsWith(quoteToken, StringComparison.Ordinal))
 				{
 					quotedEnd++;
 					continue;
 				}
-				if (quotedEnd + 1 < line.Length && line[quotedEnd + 1] == quote)
+				var nextQuote = quotedEnd + quoteToken.Length;
+				if (nextQuote < line.Length &&
+				    line[nextQuote..].StartsWith(quoteToken, StringComparison.Ordinal))
 				{
-					quotedEnd += 2;
+					quotedEnd = nextQuote + quoteToken.Length;
 					continue;
 				}
 				break;
@@ -742,8 +744,70 @@ internal static class StructuredSecretDetector
 		}
 
 		var endDelimiter = queryStyle ? '&' : ';';
-		var delimiterOffset = line[start..].IndexOf(endDelimiter);
-		return TrimEnd(line, start, delimiterOffset < 0 ? line.Length : start + delimiterOffset);
+		var end = start;
+		while (end < line.Length)
+		{
+			if (line[end] == endDelimiter &&
+			    (queryStyle || !IsXmlEntityTerminator(line, start, end)))
+			{
+				break;
+			}
+			end++;
+		}
+		return TrimEnd(line, start, end);
+	}
+
+	private static bool TryGetConnectionQuoteToken(ReadOnlySpan<char> value, out string quoteToken)
+	{
+		if (!value.IsEmpty && value[0] is '\'' or '"')
+		{
+			quoteToken = value[0] == '\'' ? "'" : "\"";
+			return true;
+		}
+		if (value.StartsWith("\\\"", StringComparison.Ordinal))
+			quoteToken = "\\\"";
+		else if (value.StartsWith("\\'", StringComparison.Ordinal))
+			quoteToken = "\\'";
+		else if (value.StartsWith("&quot;", StringComparison.Ordinal))
+			quoteToken = "&quot;";
+		else if (value.StartsWith("&apos;", StringComparison.Ordinal))
+			quoteToken = "&apos;";
+		else
+		{
+			quoteToken = string.Empty;
+			return false;
+		}
+		return true;
+	}
+
+	private static bool IsXmlEntityTerminator(ReadOnlySpan<char> value, int valueStart, int semicolon)
+	{
+		var entityStart = semicolon - 1;
+		while (entityStart >= valueStart && semicolon - entityStart <= 10 && value[entityStart] != '&')
+			entityStart--;
+		if (entityStart < valueStart || value[entityStart] != '&')
+			return false;
+		var entity = value[(entityStart + 1)..semicolon];
+		if (entity.Equals("amp", StringComparison.Ordinal) ||
+		    entity.Equals("quot", StringComparison.Ordinal) ||
+		    entity.Equals("apos", StringComparison.Ordinal) ||
+		    entity.Equals("lt", StringComparison.Ordinal) ||
+		    entity.Equals("gt", StringComparison.Ordinal))
+		{
+			return true;
+		}
+		if (entity.Length < 2 || entity[0] != '#')
+			return false;
+		var hexadecimal = entity[1] is 'x' or 'X';
+		var digits = hexadecimal ? entity[2..] : entity[1..];
+		if (digits.IsEmpty)
+			return false;
+		foreach (var digit in digits)
+		{
+			if (hexadecimal ? !Uri.IsHexDigit(digit) : !char.IsAsciiDigit(digit))
+				return false;
+		}
+		return true;
 	}
 
 	private static bool LooksLikeConnectionString(ReadOnlySpan<char> line)

--- a/Infrastructure/Secrets/SmartSecretsDetector.cs
+++ b/Infrastructure/Secrets/SmartSecretsDetector.cs
@@ -14,7 +14,7 @@ public sealed class SmartSecretsDetector(
 	ISecretDetector providerDetector,
 	SmartIgnoreService smartIgnore) : ISecretDetector
 {
-	internal const string StructuredRulesVersion = "smart-secrets-v4";
+	internal const string StructuredRulesVersion = "smart-secrets-v5";
 
 	public string RulesIdentity =>
 		$"{providerDetector.RulesIdentity}:{StructuredRulesVersion}";
@@ -423,10 +423,44 @@ internal static class StructuredSecretDetector
 		switch (fileKind)
 		{
 			case StructuredSecretFileKind.Environment:
-				DetectEnvironmentAssignments(content, stack, findings, budget, cancellationToken);
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindDotEnvValues(content, stack, budget, cancellationToken),
+					"environment-secret",
+					EnvironmentValueOrder,
+					findings);
+				break;
+			case StructuredSecretFileKind.Npm:
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindNpmValues(content, budget, cancellationToken),
+					"environment-secret",
+					EnvironmentValueOrder,
+					findings);
+				break;
+			case StructuredSecretFileKind.Json:
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindJsonValues(content, stack, budget, cancellationToken),
+					"config-secret",
+					ConfigurationValueOrder,
+					findings);
+				break;
+			case StructuredSecretFileKind.Yaml:
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindYamlValues(content, stack, budget, cancellationToken),
+					"config-secret",
+					ConfigurationValueOrder,
+					findings);
 				break;
 			case StructuredSecretFileKind.Container:
-				DetectContainerAssignments(content, stack, findings, budget, cancellationToken);
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindDockerValues(content, stack, budget, cancellationToken),
+					"container-secret",
+					ContainerValueOrder,
+					findings);
 				break;
 			case StructuredSecretFileKind.HttpRequest:
 				DetectHttpRequestHeaders(content, findings, budget, cancellationToken);
@@ -435,7 +469,28 @@ internal static class StructuredSecretDetector
 				DetectPgPassPasswords(content, findings, budget, cancellationToken);
 				break;
 			case StructuredSecretFileKind.Netrc:
-				DetectNetrcPasswords(content, findings, budget, cancellationToken);
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindNetrcValues(content, budget, cancellationToken),
+					"netrc-password",
+					NetrcPasswordOrder,
+					findings);
+				break;
+			case StructuredSecretFileKind.Xml:
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindXmlValues(content, stack, budget, cancellationToken),
+					"config-secret",
+					ConfigurationValueOrder,
+					findings);
+				break;
+			case StructuredSecretFileKind.Python:
+				DetectStructuredValues(
+					content,
+					StructuredSecretValueLexers.FindPythonValues(content, stack, budget, cancellationToken),
+					"config-secret",
+					ConfigurationValueOrder,
+					findings);
 				break;
 			case not StructuredSecretFileKind.None:
 				DetectConfigurationValues(content, fileKind, stack, findings, budget, cancellationToken);
@@ -505,10 +560,24 @@ internal static class StructuredSecretDetector
 	internal static bool UsesScopedVocabulary(StructuredSecretFileKind fileKind) =>
 		fileKind is
 			StructuredSecretFileKind.Environment or
+			StructuredSecretFileKind.Npm or
+			StructuredSecretFileKind.Json or
+			StructuredSecretFileKind.Yaml or
 			StructuredSecretFileKind.Configuration or
 			StructuredSecretFileKind.Xml or
 			StructuredSecretFileKind.Python or
 			StructuredSecretFileKind.Container;
+
+	private static void DetectStructuredValues(
+		ReadOnlySpan<char> content,
+		IReadOnlyList<StructuredSecretValueSpan> spans,
+		string ruleId,
+		int ruleOrder,
+		ICollection<DetectedSecret> findings)
+	{
+		foreach (var span in spans)
+			AddFinding(content, span.Start, span.Length, ruleId, ruleOrder, findings);
+	}
 
 	private static void DetectCredentialUris(
 		ReadOnlySpan<char> content,
@@ -610,6 +679,7 @@ internal static class StructuredSecretDetector
 			CheckpointPeriodically(ref checkpointCounter, budget, cancellationToken);
 			if (!LooksLikeConnectionString(line))
 				continue;
+			var queryStyle = Contains(line, "jdbc:");
 
 			var position = 0;
 			while (position < line.Length)
@@ -626,7 +696,7 @@ internal static class StructuredSecretDetector
 				if (key.Equals("password", StringComparison.OrdinalIgnoreCase) ||
 				    key.Equals("pwd", StringComparison.OrdinalIgnoreCase))
 				{
-					var value = FindDelimitedValue(line, equals + 1, ';', '&');
+					var value = FindConnectionValue(line, equals + 1, queryStyle);
 					AddFinding(
 						content,
 						lineStart + value.Start,
@@ -641,6 +711,39 @@ internal static class StructuredSecretDetector
 				position = equals + 1;
 			}
 		}
+	}
+
+	private static TextSpan FindConnectionValue(ReadOnlySpan<char> line, int start, bool queryStyle)
+	{
+		while (start < line.Length && char.IsWhiteSpace(line[start]))
+			start++;
+		if (start >= line.Length)
+			return new TextSpan(start, 0);
+
+		if (line[start] is '\'' or '"')
+		{
+			var quote = line[start++];
+			var quotedEnd = start;
+			while (quotedEnd < line.Length)
+			{
+				if (line[quotedEnd] != quote)
+				{
+					quotedEnd++;
+					continue;
+				}
+				if (quotedEnd + 1 < line.Length && line[quotedEnd + 1] == quote)
+				{
+					quotedEnd += 2;
+					continue;
+				}
+				break;
+			}
+			return new TextSpan(start, quotedEnd - start);
+		}
+
+		var endDelimiter = queryStyle ? '&' : ';';
+		var delimiterOffset = line[start..].IndexOf(endDelimiter);
+		return TrimEnd(line, start, delimiterOffset < 0 ? line.Length : start + delimiterOffset);
 	}
 
 	private static bool LooksLikeConnectionString(ReadOnlySpan<char> line)
@@ -929,13 +1032,10 @@ internal static class StructuredSecretDetector
 			var credentialStart = schemeEnd;
 			while (credentialStart < line.Length && char.IsWhiteSpace(line[credentialStart]))
 				credentialStart++;
-			if (credentialStart < line.Length &&
-			    TryFindReferenceEnd(line, credentialStart, out var referenceEnd) &&
-			    IsReferenceOrPlaceholder(line[credentialStart..referenceEnd]))
-			{
-				continue;
-			}
-			var credentialEnd = credentialStart;
+			var credentialEnd = credentialStart < line.Length &&
+			                    TryFindReferenceEnd(line, credentialStart, out var referenceEnd)
+				? referenceEnd
+				: credentialStart;
 			while (credentialEnd < line.Length && !char.IsWhiteSpace(line[credentialEnd]))
 				credentialEnd++;
 			if (IsReferenceOrPlaceholder(line[credentialStart..credentialEnd]))
@@ -1515,7 +1615,7 @@ internal static class StructuredSecretDetector
 	internal static bool IsReferenceOrPlaceholder(ReadOnlySpan<char> value)
 		=> SecretDetectionTextPolicy.IsReferenceOrPlaceholder(value);
 
-	private static bool IsSensitiveKey(ReadOnlySpan<char> key, SmartSecretStack stack)
+	internal static bool IsSensitiveKey(ReadOnlySpan<char> key, SmartSecretStack stack)
 	{
 		Span<char> normalizedBuffer = stackalloc char[Math.Min(key.Length, 128)];
 		var length = 0;
@@ -1587,11 +1687,12 @@ internal static class StructuredSecretDetector
 		}
 		if (fileName[0] == '.' || fileName[0] == '_')
 		{
-			if (fileName.StartsWith(".env", StringComparison.OrdinalIgnoreCase) ||
-			    fileName.Equals(".npmrc", StringComparison.OrdinalIgnoreCase))
+			if (fileName.StartsWith(".env", StringComparison.OrdinalIgnoreCase))
 			{
 				return StructuredSecretFileKind.Environment;
 			}
+			if (fileName.Equals(".npmrc", StringComparison.OrdinalIgnoreCase))
+				return StructuredSecretFileKind.Npm;
 			if (fileName.Equals(".pgpass", StringComparison.OrdinalIgnoreCase))
 				return StructuredSecretFileKind.PgPass;
 			if (fileName.Equals(".netrc", StringComparison.OrdinalIgnoreCase) ||
@@ -1622,14 +1723,14 @@ internal static class StructuredSecretDetector
 		    (fileName.StartsWith("appsettings", StringComparison.OrdinalIgnoreCase) ||
 		     fileName.EndsWith(".tfvars.json", StringComparison.OrdinalIgnoreCase)))
 		{
-			return StructuredSecretFileKind.Configuration;
+			return StructuredSecretFileKind.Json;
 		}
 		if ((extension.Equals(".yml", StringComparison.OrdinalIgnoreCase) ||
 		     extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase)) &&
 		    (fileName.StartsWith("application", StringComparison.OrdinalIgnoreCase) ||
 		     fileName.StartsWith("docker-compose", StringComparison.OrdinalIgnoreCase) ||
 		     fileName.StartsWith("compose.", StringComparison.OrdinalIgnoreCase)))
-			return StructuredSecretFileKind.Configuration;
+			return StructuredSecretFileKind.Yaml;
 		if (extension.Equals(".tfvars", StringComparison.OrdinalIgnoreCase))
 			return StructuredSecretFileKind.Configuration;
 		if (extension.Equals(".py", StringComparison.OrdinalIgnoreCase) &&
@@ -1725,6 +1826,9 @@ internal static class StructuredSecretDetector
 	{
 		None,
 		Environment,
+		Npm,
+		Json,
+		Yaml,
 		Configuration,
 		Xml,
 		Python,

--- a/Infrastructure/Secrets/StructuredSecretValueLexers.cs
+++ b/Infrastructure/Secrets/StructuredSecretValueLexers.cs
@@ -1,0 +1,1236 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using DevProjex.Application.Secrets;
+
+namespace DevProjex.Infrastructure.Secrets;
+
+internal readonly record struct StructuredSecretValueSpan(int Start, int Length)
+{
+	public int End => checked(Start + Length);
+}
+
+internal static class StructuredSecretValueLexers
+{
+	private const int MaximumNestingDepth = 128;
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindDotEnvValues(
+		ReadOnlySpan<char> content,
+		SmartSecretStack stack,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var lineStart = 0;
+		while (lineStart < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			var lineEnd = FindLineEnd(content, lineStart);
+			var cursor = SkipHorizontalWhitespace(content, lineStart, lineEnd);
+			if (cursor >= lineEnd || content[cursor] == '#')
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			if (content[cursor..lineEnd].StartsWith("export", StringComparison.OrdinalIgnoreCase) &&
+			    cursor + 6 < lineEnd && char.IsWhiteSpace(content[cursor + 6]))
+			{
+				cursor = SkipHorizontalWhitespace(content, cursor + 6, lineEnd);
+			}
+
+			var equals = content[cursor..lineEnd].IndexOf('=');
+			if (equals <= 0)
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			equals += cursor;
+			var key = content[cursor..equals].Trim();
+			if (!StructuredSecretDetector.IsSensitiveKey(key, stack))
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+
+			var value = ReadDotEnvValue(content, equals + 1);
+			AddSpan(content, spans, value.Span);
+			lineStart = AdvancePastLineBreak(content, FindLineEnd(content, value.ResumeAt));
+		}
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindNpmValues(
+		ReadOnlySpan<char> content,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var lineStart = 0;
+		while (lineStart < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			var lineEnd = FindLineEnd(content, lineStart);
+			var cursor = SkipHorizontalWhitespace(content, lineStart, lineEnd);
+			if (cursor >= lineEnd || content[cursor] is '#' or ';')
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			var equals = content[cursor..lineEnd].IndexOf('=');
+			if (equals <= 0)
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			equals += cursor;
+			var key = content[cursor..equals].Trim();
+			var separator = key.LastIndexOf(':');
+			if (separator >= 0)
+				key = key[(separator + 1)..].Trim();
+			if (!IsNpmCredentialKey(key))
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+
+			AddSpan(content, spans, ReadNpmValue(content, equals + 1, lineEnd));
+			lineStart = AdvancePastLineBreak(content, lineEnd);
+		}
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindJsonValues(
+		ReadOnlySpan<char> content,
+		SmartSecretStack stack,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var cursor = 0;
+		SkipJsonTrivia(content, ref cursor);
+		if (cursor >= content.Length || content[cursor] is not '{' and not '[')
+			return spans;
+		ParseJsonValue(content, ref cursor, inheritedSensitive: false, stack, spans, depth: 0, budget, cancellationToken);
+		SkipJsonTrivia(content, ref cursor);
+		if (cursor != content.Length)
+			throw Incomplete("JSON");
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindYamlValues(
+		ReadOnlySpan<char> content,
+		SmartSecretStack stack,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var lineStart = 0;
+		while (lineStart < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			var lineEnd = FindLineEnd(content, lineStart);
+			var first = SkipHorizontalWhitespace(content, lineStart, lineEnd);
+			if (first >= lineEnd || content[first] == '#')
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			if (content[first] == '-')
+				first = SkipHorizontalWhitespace(content, first + 1, lineEnd);
+
+			var delimiter = FindYamlKeyDelimiter(content, first, lineEnd);
+			if (delimiter < 0)
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			var key = DecodeYamlScalar(content[first..delimiter].Trim());
+			if (!StructuredSecretDetector.IsSensitiveKey(key, stack))
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+
+			var valueStart = SkipHorizontalWhitespace(content, delimiter + 1, lineEnd);
+			if (valueStart < lineEnd && content[valueStart] is '|' or '>')
+			{
+				lineStart = ReadYamlBlockScalar(
+					content,
+					lineStart,
+					lineEnd,
+					valueStart,
+					spans);
+				continue;
+			}
+
+			var value = ReadYamlInlineValue(content, valueStart, lineEnd);
+			AddSpan(content, spans, value);
+			lineStart = AdvancePastLineBreak(content, lineEnd);
+		}
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindPythonValues(
+		ReadOnlySpan<char> content,
+		SmartSecretStack stack,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var lineStart = 0;
+		while (lineStart < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			var lineEnd = FindLineEnd(content, lineStart);
+			var cursor = SkipHorizontalWhitespace(content, lineStart, lineEnd);
+			if (cursor >= lineEnd || content[cursor] == '#')
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			var keyStart = cursor;
+			while (cursor < lineEnd && IsPythonIdentifierCharacter(content[cursor]))
+				cursor++;
+			if (cursor == keyStart || !StructuredSecretDetector.IsSensitiveKey(content[keyStart..cursor], stack))
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			var equals = content[cursor..lineEnd].IndexOf('=');
+			if (equals < 0)
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			cursor += equals + 1;
+			var resumeAt = lineEnd;
+			while (true)
+			{
+				cursor = SkipHorizontalWhitespace(content, cursor, FindLineEnd(content, cursor));
+				if (!TryReadPythonLiteral(content, cursor, out var literal, out resumeAt))
+					break;
+				AddSpan(content, spans, literal);
+				cursor = resumeAt;
+			}
+			lineStart = AdvancePastLineBreak(content, FindLineEnd(content, resumeAt));
+		}
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindDockerValues(
+		ReadOnlySpan<char> content,
+		SmartSecretStack stack,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var escape = FindDockerEscapeDirective(content);
+		var sourceStart = 0;
+		while (sourceStart < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			var logical = ReadDockerLogicalLine(content, sourceStart, escape);
+			ParseDockerInstruction(logical, escape, stack, spans);
+			sourceStart = logical.ResumeAt;
+		}
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindNetrcValues(
+		ReadOnlySpan<char> content,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var cursor = 0;
+		while (TryReadNetrcToken(content, ref cursor, out var token))
+		{
+			budget.Checkpoint(cancellationToken);
+			if (!content.Slice(token.Start, token.Length).Equals("password", StringComparison.OrdinalIgnoreCase))
+				continue;
+			if (TryReadNetrcToken(content, ref cursor, out var value))
+				AddSpan(content, spans, value);
+		}
+		return spans;
+	}
+
+	internal static IReadOnlyList<StructuredSecretValueSpan> FindXmlValues(
+		ReadOnlySpan<char> content,
+		SmartSecretStack stack,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		var spans = new List<StructuredSecretValueSpan>();
+		var elements = new Stack<XmlElementContext>();
+		var cursor = 0;
+		while (cursor < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			if (content[cursor] != '<')
+			{
+				var textEnd = content[cursor..].IndexOf('<');
+				textEnd = textEnd < 0 ? content.Length : cursor + textEnd;
+				if (elements.TryPeek(out var element) && element.IsSensitive)
+					AddSpan(content, spans, Trim(content, cursor, textEnd));
+				cursor = textEnd;
+				continue;
+			}
+			if (content[cursor..].StartsWith("<!--", StringComparison.Ordinal))
+			{
+				cursor = FindRequiredSuffix(content, cursor + 4, "-->", "XML");
+				continue;
+			}
+			if (content[cursor..].StartsWith("<![CDATA[", StringComparison.Ordinal))
+			{
+				var valueStart = cursor + 9;
+				var end = content[valueStart..].IndexOf("]]>", StringComparison.Ordinal);
+				if (end < 0)
+					throw Incomplete("XML");
+				if (elements.TryPeek(out var element) && element.IsSensitive)
+					AddSpan(content, spans, Trim(content, valueStart, valueStart + end));
+				cursor = valueStart + end + 3;
+				continue;
+			}
+			if (content[cursor..].StartsWith("<?", StringComparison.Ordinal))
+			{
+				cursor = FindRequiredSuffix(content, cursor + 2, "?>", "XML");
+				continue;
+			}
+			if (content[cursor..].StartsWith("<!", StringComparison.Ordinal))
+				throw new SecretDetectionException("Structured XML inspection does not permit declarations.");
+
+			var tagEnd = FindXmlTagEnd(content, cursor + 1);
+			if (tagEnd < 0)
+				throw Incomplete("XML");
+			var closing = cursor + 1 < content.Length && content[cursor + 1] == '/';
+			if (closing)
+			{
+				if (elements.Count == 0)
+					throw Incomplete("XML");
+				elements.Pop();
+				cursor = tagEnd + 1;
+				continue;
+			}
+
+			var tag = content[(cursor + 1)..tagEnd];
+			var tagCursor = 0;
+			while (tagCursor < tag.Length && char.IsWhiteSpace(tag[tagCursor]))
+				tagCursor++;
+			var nameStart = tagCursor;
+			while (tagCursor < tag.Length && IsXmlNameCharacter(tag[tagCursor]))
+				tagCursor++;
+			if (tagCursor == nameStart)
+				throw Incomplete("XML");
+			var elementName = LocalXmlName(tag[nameStart..tagCursor]);
+			var attributes = ReadXmlAttributes(tag, cursor + 1, tagCursor);
+			var inherited = elements.TryPeek(out var parent) && parent.IsSensitive;
+			var elementSensitive = inherited || StructuredSecretDetector.IsSensitiveKey(elementName, stack);
+			var keyAttributeSensitive = false;
+			foreach (var attribute in attributes)
+			{
+				if ((attribute.Name.Equals("key", StringComparison.OrdinalIgnoreCase) ||
+				     attribute.Name.Equals("name", StringComparison.OrdinalIgnoreCase)) &&
+				    StructuredSecretDetector.IsSensitiveKey(
+					    DecodeXml(content.Slice(attribute.Start, attribute.Length)),
+					    stack))
+				{
+					keyAttributeSensitive = true;
+					break;
+				}
+			}
+			foreach (var attribute in attributes)
+			{
+				if (StructuredSecretDetector.IsSensitiveKey(attribute.Name, stack) ||
+				    attribute.Name.Equals("value", StringComparison.OrdinalIgnoreCase) &&
+				    (elementSensitive || keyAttributeSensitive))
+				{
+					AddSpan(content, spans, new StructuredSecretValueSpan(attribute.Start, attribute.Length));
+				}
+			}
+			var selfClosing = tag.TrimEnd().EndsWith("/", StringComparison.Ordinal);
+			if (!selfClosing)
+				elements.Push(new XmlElementContext(elementSensitive || keyAttributeSensitive));
+			cursor = tagEnd + 1;
+		}
+		if (elements.Count != 0)
+			throw Incomplete("XML");
+		return spans;
+	}
+
+	private static DotEnvValue ReadDotEnvValue(ReadOnlySpan<char> content, int start)
+	{
+		var lineEnd = FindLineEnd(content, start);
+		start = SkipHorizontalWhitespace(content, start, lineEnd);
+		if (start >= content.Length)
+			return new DotEnvValue(new StructuredSecretValueSpan(start, 0), start);
+		if (start < lineEnd && content[start] is '\'' or '"')
+		{
+			var quote = content[start++];
+			var end = start;
+			while (end < content.Length)
+			{
+				if (content[end] == quote && !IsEscaped(content, start, end))
+					return new DotEnvValue(new StructuredSecretValueSpan(start, end - start), end + 1);
+				end++;
+			}
+			throw Incomplete("dotenv");
+		}
+
+		var endOfValue = start;
+		while (endOfValue < lineEnd)
+		{
+			if (content[endOfValue] == '#')
+			{
+				break;
+			}
+			endOfValue++;
+		}
+		return new DotEnvValue(Trim(content, start, endOfValue), endOfValue);
+	}
+
+	private static StructuredSecretValueSpan ReadNpmValue(ReadOnlySpan<char> content, int start, int lineEnd)
+	{
+		start = SkipHorizontalWhitespace(content, start, lineEnd);
+		if (start >= lineEnd)
+			return new StructuredSecretValueSpan(start, 0);
+		if (content[start] is not '\'' and not '"')
+			return Trim(content, start, lineEnd);
+		var quote = content[start++];
+		var cursor = start;
+		while (cursor < lineEnd)
+		{
+			if (content[cursor] == quote && !IsEscaped(content, start, cursor))
+				return new StructuredSecretValueSpan(start, cursor - start);
+			cursor++;
+		}
+		throw Incomplete("npmrc");
+	}
+
+	private static void ParseJsonValue(
+		ReadOnlySpan<char> content,
+		ref int cursor,
+		bool inheritedSensitive,
+		SmartSecretStack stack,
+		ICollection<StructuredSecretValueSpan> spans,
+		int depth,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		budget.Checkpoint(cancellationToken);
+		if (depth > MaximumNestingDepth || cursor >= content.Length)
+			throw Incomplete("JSON");
+		SkipJsonTrivia(content, ref cursor);
+		if (cursor >= content.Length)
+			throw Incomplete("JSON");
+		switch (content[cursor])
+		{
+			case '{':
+				ParseJsonObject(content, ref cursor, inheritedSensitive, stack, spans, depth + 1, budget, cancellationToken);
+				return;
+			case '[':
+				ParseJsonArray(content, ref cursor, inheritedSensitive, stack, spans, depth + 1, budget, cancellationToken);
+				return;
+			case '"':
+			{
+				var value = ReadJsonString(content, ref cursor);
+				if (inheritedSensitive)
+					AddSpan(content, spans, value);
+				return;
+			}
+			default:
+			{
+				var start = cursor;
+				while (cursor < content.Length &&
+				       !char.IsWhiteSpace(content[cursor]) &&
+				       content[cursor] is not ',' and not ']' and not '}')
+				{
+					cursor++;
+				}
+				if (cursor == start)
+					throw Incomplete("JSON");
+				if (inheritedSensitive)
+					AddSpan(content, spans, new StructuredSecretValueSpan(start, cursor - start));
+				return;
+			}
+		}
+	}
+
+	private static void ParseJsonObject(
+		ReadOnlySpan<char> content,
+		ref int cursor,
+		bool inheritedSensitive,
+		SmartSecretStack stack,
+		ICollection<StructuredSecretValueSpan> spans,
+		int depth,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		cursor++;
+		SkipJsonTrivia(content, ref cursor);
+		if (cursor < content.Length && content[cursor] == '}')
+		{
+			cursor++;
+			return;
+		}
+		while (cursor < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			if (content[cursor] != '"')
+				throw Incomplete("JSON");
+			var property = ReadJsonString(content, ref cursor);
+			var propertyName = DecodeJsonString(content.Slice(property.Start, property.Length));
+			SkipJsonTrivia(content, ref cursor);
+			if (cursor >= content.Length || content[cursor++] != ':')
+				throw Incomplete("JSON");
+			SkipJsonTrivia(content, ref cursor);
+			var sensitive = inheritedSensitive || StructuredSecretDetector.IsSensitiveKey(propertyName, stack);
+			ParseJsonValue(content, ref cursor, sensitive, stack, spans, depth, budget, cancellationToken);
+			SkipJsonTrivia(content, ref cursor);
+			if (cursor < content.Length && content[cursor] == ',')
+			{
+				cursor++;
+				SkipJsonTrivia(content, ref cursor);
+				if (cursor < content.Length && content[cursor] == '}')
+				{
+					cursor++;
+					return;
+				}
+				continue;
+			}
+			if (cursor < content.Length && content[cursor] == '}')
+			{
+				cursor++;
+				return;
+			}
+			throw Incomplete("JSON");
+		}
+		throw Incomplete("JSON");
+	}
+
+	private static void ParseJsonArray(
+		ReadOnlySpan<char> content,
+		ref int cursor,
+		bool inheritedSensitive,
+		SmartSecretStack stack,
+		ICollection<StructuredSecretValueSpan> spans,
+		int depth,
+		SecretFileInspectionBudget budget,
+		CancellationToken cancellationToken)
+	{
+		cursor++;
+		SkipJsonTrivia(content, ref cursor);
+		if (cursor < content.Length && content[cursor] == ']')
+		{
+			cursor++;
+			return;
+		}
+		while (cursor < content.Length)
+		{
+			budget.Checkpoint(cancellationToken);
+			ParseJsonValue(content, ref cursor, inheritedSensitive, stack, spans, depth, budget, cancellationToken);
+			SkipJsonTrivia(content, ref cursor);
+			if (cursor < content.Length && content[cursor] == ',')
+			{
+				cursor++;
+				SkipJsonTrivia(content, ref cursor);
+				if (cursor < content.Length && content[cursor] == ']')
+				{
+					cursor++;
+					return;
+				}
+				continue;
+			}
+			if (cursor < content.Length && content[cursor] == ']')
+			{
+				cursor++;
+				return;
+			}
+			throw Incomplete("JSON");
+		}
+		throw Incomplete("JSON");
+	}
+
+	private static StructuredSecretValueSpan ReadJsonString(ReadOnlySpan<char> content, ref int cursor)
+	{
+		if (cursor >= content.Length || content[cursor] != '"')
+			throw Incomplete("JSON");
+		var start = ++cursor;
+		while (cursor < content.Length)
+		{
+			if (content[cursor] == '"')
+			{
+				var result = new StructuredSecretValueSpan(start, cursor - start);
+				cursor++;
+				return result;
+			}
+			if (content[cursor] == '\\')
+			{
+				cursor++;
+				if (cursor >= content.Length)
+					throw Incomplete("JSON");
+				if (content[cursor] == 'u')
+				{
+					if (cursor > content.Length - 5)
+						throw Incomplete("JSON");
+					for (var index = cursor + 1; index <= cursor + 4; index++)
+					{
+						if (!Uri.IsHexDigit(content[index]))
+							throw Incomplete("JSON");
+					}
+					cursor += 5;
+					continue;
+				}
+				cursor++;
+				continue;
+			}
+			if (content[cursor] is '\r' or '\n' || char.IsControl(content[cursor]))
+				throw Incomplete("JSON");
+			cursor++;
+		}
+		throw Incomplete("JSON");
+	}
+
+	private static string DecodeJsonString(ReadOnlySpan<char> raw)
+	{
+		if (raw.IndexOf('\\') < 0)
+			return raw.ToString();
+		try
+		{
+			return JsonSerializer.Deserialize<string>($"\"{raw.ToString()}\"") ?? string.Empty;
+		}
+		catch (JsonException exception)
+		{
+			throw new SecretDetectionException("Structured JSON inspection encountered incomplete syntax.", exception);
+		}
+	}
+
+	private static void SkipJsonTrivia(ReadOnlySpan<char> content, ref int cursor)
+	{
+		while (cursor < content.Length)
+		{
+			if (char.IsWhiteSpace(content[cursor]))
+			{
+				cursor++;
+				continue;
+			}
+			if (cursor + 1 < content.Length && content[cursor] == '/' && content[cursor + 1] == '/')
+			{
+				cursor = AdvancePastLineBreak(content, FindLineEnd(content, cursor + 2));
+				continue;
+			}
+			if (cursor + 1 < content.Length && content[cursor] == '/' && content[cursor + 1] == '*')
+			{
+				var end = content[(cursor + 2)..].IndexOf("*/", StringComparison.Ordinal);
+				if (end < 0)
+					throw Incomplete("JSON");
+				cursor += end + 4;
+				continue;
+			}
+			break;
+		}
+	}
+
+	private static int FindYamlKeyDelimiter(ReadOnlySpan<char> content, int start, int end)
+	{
+		var quote = '\0';
+		for (var cursor = start; cursor < end; cursor++)
+		{
+			var character = content[cursor];
+			if (quote != '\0')
+			{
+				if (character == quote)
+				{
+					if (quote == '\'' && cursor + 1 < end && content[cursor + 1] == '\'')
+					{
+						cursor++;
+						continue;
+					}
+					if (!IsEscaped(content, start, cursor))
+						quote = '\0';
+				}
+				continue;
+			}
+			if (character is '\'' or '"')
+			{
+				quote = character;
+				continue;
+			}
+			if (character == ':' || character == '=')
+				return cursor;
+		}
+		return -1;
+	}
+
+	private static string DecodeYamlScalar(ReadOnlySpan<char> value)
+	{
+		value = value.Trim();
+		if (value.Length >= 2 && value[0] == '\'' && value[^1] == '\'')
+			return value[1..^1].ToString().Replace("''", "'", StringComparison.Ordinal);
+		if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+			return value[1..^1].ToString();
+		return value.ToString();
+	}
+
+	private static StructuredSecretValueSpan ReadYamlInlineValue(
+		ReadOnlySpan<char> content,
+		int start,
+		int lineEnd)
+	{
+		if (start >= lineEnd)
+			return new StructuredSecretValueSpan(start, 0);
+		if (content[start] == '\'')
+		{
+			var cursor = start + 1;
+			while (cursor < lineEnd)
+			{
+				if (content[cursor] != '\'')
+				{
+					cursor++;
+					continue;
+				}
+				if (cursor + 1 < lineEnd && content[cursor + 1] == '\'')
+				{
+					cursor += 2;
+					continue;
+				}
+				return new StructuredSecretValueSpan(start + 1, cursor - start - 1);
+			}
+			throw Incomplete("YAML");
+		}
+		if (content[start] == '"')
+		{
+			var cursor = start + 1;
+			while (cursor < lineEnd)
+			{
+				if (content[cursor] == '"' && !IsEscaped(content, start + 1, cursor))
+					return new StructuredSecretValueSpan(start + 1, cursor - start - 1);
+				cursor++;
+			}
+			throw Incomplete("YAML");
+		}
+
+		var end = start;
+		while (end < lineEnd)
+		{
+			if (content[end] == '#' && end > start && char.IsWhiteSpace(content[end - 1]))
+				break;
+			end++;
+		}
+		return Trim(content, start, end);
+	}
+
+	private static int ReadYamlBlockScalar(
+		ReadOnlySpan<char> content,
+		int headerStart,
+		int headerEnd,
+		int indicatorStart,
+		ICollection<StructuredSecretValueSpan> spans)
+	{
+		var parentIndent = CountIndent(content, headerStart, headerEnd);
+		var explicitIndent = 0;
+		for (var cursor = indicatorStart + 1; cursor < headerEnd && content[cursor] != '#'; cursor++)
+		{
+			if (content[cursor] is >= '1' and <= '9')
+				explicitIndent = content[cursor] - '0';
+		}
+		var nextLine = AdvancePastLineBreak(content, headerEnd);
+		var blockIndent = explicitIndent > 0 ? parentIndent + explicitIndent : -1;
+		while (nextLine < content.Length)
+		{
+			var lineEnd = FindLineEnd(content, nextLine);
+			var indent = CountIndent(content, nextLine, lineEnd);
+			if (indent <= parentIndent && nextLine + indent < lineEnd)
+				return nextLine;
+			if (nextLine + indent < lineEnd)
+			{
+				if (blockIndent < 0)
+					blockIndent = indent;
+				if (indent < blockIndent)
+					return nextLine;
+				AddSpan(content, spans, new StructuredSecretValueSpan(nextLine + blockIndent, lineEnd - nextLine - blockIndent));
+			}
+			nextLine = AdvancePastLineBreak(content, lineEnd);
+		}
+		return content.Length;
+	}
+
+	private static bool TryReadPythonLiteral(
+		ReadOnlySpan<char> content,
+		int start,
+		out StructuredSecretValueSpan span,
+		out int resumeAt)
+	{
+		var cursor = start;
+		while (cursor < content.Length && cursor - start < 2 && IsPythonPrefixCharacter(content[cursor]))
+			cursor++;
+		if (!IsPythonStringPrefix(content[start..cursor]))
+		{
+			span = default;
+			resumeAt = start;
+			return false;
+		}
+		if (cursor >= content.Length || content[cursor] is not '\'' and not '"')
+		{
+			span = default;
+			resumeAt = start;
+			return false;
+		}
+		var quote = content[cursor];
+		var triple = cursor + 2 < content.Length && content[cursor + 1] == quote && content[cursor + 2] == quote;
+		var delimiterLength = triple ? 3 : 1;
+		var valueStart = cursor + delimiterLength;
+		cursor = valueStart;
+		while (cursor < content.Length)
+		{
+			if (!triple && content[cursor] is '\r' or '\n')
+				throw Incomplete("Python");
+			if (content[cursor] == quote && !IsEscaped(content, valueStart, cursor))
+			{
+				if (!triple || cursor + 2 < content.Length && content[cursor + 1] == quote && content[cursor + 2] == quote)
+				{
+					span = new StructuredSecretValueSpan(valueStart, cursor - valueStart);
+					resumeAt = cursor + delimiterLength;
+					return true;
+				}
+			}
+			cursor++;
+		}
+		throw Incomplete("Python");
+	}
+
+	private static DockerLogicalLine ReadDockerLogicalLine(
+		ReadOnlySpan<char> content,
+		int sourceStart,
+		char escape)
+	{
+		var text = new StringBuilder();
+		var sourceMap = new List<int>();
+		var lineStart = sourceStart;
+		while (lineStart < content.Length)
+		{
+			var lineEnd = FindLineEnd(content, lineStart);
+			var trimmedEnd = lineEnd;
+			while (trimmedEnd > lineStart && content[trimmedEnd - 1] is ' ' or '\t')
+				trimmedEnd--;
+			var directive = content[lineStart..trimmedEnd].TrimStart();
+			var continued = !directive.StartsWith("# escape=", StringComparison.OrdinalIgnoreCase) &&
+			                trimmedEnd > lineStart && content[trimmedEnd - 1] == escape;
+			var copyEnd = continued ? trimmedEnd - 1 : lineEnd;
+			for (var cursor = lineStart; cursor < copyEnd; cursor++)
+			{
+				text.Append(content[cursor]);
+				sourceMap.Add(cursor);
+			}
+			var resumeAt = AdvancePastLineBreak(content, lineEnd);
+			if (!continued)
+				return new DockerLogicalLine(text.ToString(), sourceMap.ToArray(), resumeAt);
+			text.Append(' ');
+			sourceMap.Add(-1);
+			lineStart = resumeAt;
+		}
+		return new DockerLogicalLine(text.ToString(), sourceMap.ToArray(), content.Length);
+	}
+
+	private static void ParseDockerInstruction(
+		DockerLogicalLine logical,
+		char escape,
+		SmartSecretStack stack,
+		ICollection<StructuredSecretValueSpan> spans)
+	{
+		var text = logical.Text.AsSpan();
+		var cursor = 0;
+		while (cursor < text.Length && char.IsWhiteSpace(text[cursor]))
+			cursor++;
+		if (cursor >= text.Length || text[cursor] == '#')
+			return;
+		var directiveStart = cursor;
+		while (cursor < text.Length && char.IsLetter(text[cursor]))
+			cursor++;
+		var directive = text[directiveStart..cursor];
+		var isEnvironment = directive.Equals("ENV", StringComparison.OrdinalIgnoreCase);
+		var isArgument = directive.Equals("ARG", StringComparison.OrdinalIgnoreCase);
+		if (!isEnvironment && !isArgument)
+			return;
+		while (cursor < text.Length && char.IsWhiteSpace(text[cursor]))
+			cursor++;
+		var firstKeyStart = cursor;
+		while (cursor < text.Length && IsEnvironmentKeyCharacter(text[cursor]))
+			cursor++;
+		if (cursor == firstKeyStart)
+			return;
+		if (cursor >= text.Length || text[cursor] != '=')
+		{
+			if (!isEnvironment)
+				return;
+			var valueStart = SkipLogicalWhitespace(text, cursor);
+			if (StructuredSecretDetector.IsSensitiveKey(text[firstKeyStart..cursor], stack) &&
+			    !StructuredSecretDetector.IsReferenceOrPlaceholder(text[valueStart..]))
+				AddMappedSpans(logical, valueStart, text.Length, spans);
+			return;
+		}
+
+		cursor = firstKeyStart;
+		while (cursor < text.Length)
+		{
+			cursor = SkipLogicalWhitespace(text, cursor);
+			var keyStart = cursor;
+			while (cursor < text.Length && IsEnvironmentKeyCharacter(text[cursor]))
+				cursor++;
+			if (cursor == keyStart || cursor >= text.Length || text[cursor] != '=')
+				break;
+			var key = text[keyStart..cursor];
+			var value = ReadDockerValue(text, cursor + 1, escape, out cursor);
+			if (StructuredSecretDetector.IsSensitiveKey(key, stack) &&
+			    !StructuredSecretDetector.IsReferenceOrPlaceholder(text[value.Start..value.End]))
+				AddMappedSpans(logical, value.Start, value.End, spans);
+		}
+	}
+
+	private static StructuredSecretValueSpan ReadDockerValue(
+		ReadOnlySpan<char> text,
+		int start,
+		char escape,
+		out int next)
+	{
+		start = SkipLogicalWhitespace(text, start);
+		if (start >= text.Length)
+		{
+			next = start;
+			return new StructuredSecretValueSpan(start, 0);
+		}
+		if (text[start] is '\'' or '"')
+		{
+			var quote = text[start++];
+			var cursor = start;
+			while (cursor < text.Length)
+			{
+				if (text[cursor] == quote && !IsEscapedBy(text, start, cursor, escape))
+				{
+					next = cursor + 1;
+					return new StructuredSecretValueSpan(start, cursor - start);
+				}
+				cursor++;
+			}
+			throw Incomplete("Dockerfile");
+		}
+
+		var end = start;
+		while (end < text.Length)
+		{
+			if (char.IsWhiteSpace(text[end]) && !IsEscapedBy(text, start, end, escape))
+			{
+				var candidate = SkipLogicalWhitespace(text, end);
+				var keyEnd = candidate;
+				while (keyEnd < text.Length && IsEnvironmentKeyCharacter(text[keyEnd]))
+					keyEnd++;
+				if (keyEnd > candidate && keyEnd < text.Length && text[keyEnd] == '=')
+				{
+					next = candidate;
+					return new StructuredSecretValueSpan(start, end - start);
+				}
+			}
+			end++;
+		}
+		next = end;
+		return new StructuredSecretValueSpan(start, end - start);
+	}
+
+	private static void AddMappedSpans(
+		DockerLogicalLine logical,
+		int start,
+		int end,
+		ICollection<StructuredSecretValueSpan> spans)
+	{
+		var segmentStart = -1;
+		var previous = -2;
+		for (var cursor = start; cursor < end; cursor++)
+		{
+			var source = logical.SourceMap[cursor];
+			if (source < 0)
+			{
+				if (segmentStart >= 0)
+					AddBoundedSpan(spans, new StructuredSecretValueSpan(segmentStart, previous - segmentStart + 1));
+				segmentStart = -1;
+				previous = -2;
+				continue;
+			}
+			if (segmentStart < 0)
+				segmentStart = source;
+			else if (source != previous + 1)
+			{
+				AddBoundedSpan(spans, new StructuredSecretValueSpan(segmentStart, previous - segmentStart + 1));
+				segmentStart = source;
+			}
+			previous = source;
+		}
+		if (segmentStart >= 0)
+			AddBoundedSpan(spans, new StructuredSecretValueSpan(segmentStart, previous - segmentStart + 1));
+	}
+
+	private static bool TryReadNetrcToken(
+		ReadOnlySpan<char> content,
+		ref int cursor,
+		out StructuredSecretValueSpan token)
+	{
+		while (cursor < content.Length)
+		{
+			if (char.IsWhiteSpace(content[cursor]))
+			{
+				cursor++;
+				continue;
+			}
+			if (content[cursor] != '#')
+				break;
+			cursor = AdvancePastLineBreak(content, FindLineEnd(content, cursor));
+		}
+		if (cursor >= content.Length)
+		{
+			token = default;
+			return false;
+		}
+		if (content[cursor] is '\'' or '"')
+		{
+			var quote = content[cursor++];
+			var start = cursor;
+			while (cursor < content.Length)
+			{
+				if (content[cursor] == quote && !IsEscaped(content, start, cursor))
+				{
+					token = new StructuredSecretValueSpan(start, cursor - start);
+					cursor++;
+					return true;
+				}
+				cursor++;
+			}
+			throw Incomplete("netrc");
+		}
+		var tokenStart = cursor;
+		while (cursor < content.Length && !char.IsWhiteSpace(content[cursor]) && content[cursor] != '#')
+			cursor++;
+		token = new StructuredSecretValueSpan(tokenStart, cursor - tokenStart);
+		return token.Length > 0;
+	}
+
+	private static IReadOnlyList<XmlAttribute> ReadXmlAttributes(
+		ReadOnlySpan<char> tag,
+		int contentOffset,
+		int cursor)
+	{
+		var attributes = new List<XmlAttribute>();
+		while (cursor < tag.Length)
+		{
+			while (cursor < tag.Length && (char.IsWhiteSpace(tag[cursor]) || tag[cursor] == '/'))
+				cursor++;
+			var nameStart = cursor;
+			while (cursor < tag.Length && IsXmlNameCharacter(tag[cursor]))
+				cursor++;
+			if (cursor == nameStart)
+				break;
+			var name = LocalXmlName(tag[nameStart..cursor]).ToString();
+			while (cursor < tag.Length && char.IsWhiteSpace(tag[cursor]))
+				cursor++;
+			if (cursor >= tag.Length || tag[cursor] != '=')
+				throw Incomplete("XML");
+			cursor++;
+			while (cursor < tag.Length && char.IsWhiteSpace(tag[cursor]))
+				cursor++;
+			if (cursor >= tag.Length || tag[cursor] is not '\'' and not '"')
+				throw Incomplete("XML");
+			var quote = tag[cursor++];
+			var valueStart = cursor;
+			while (cursor < tag.Length && tag[cursor] != quote)
+				cursor++;
+			if (cursor >= tag.Length)
+				throw Incomplete("XML");
+			attributes.Add(new XmlAttribute(name, contentOffset + valueStart, cursor - valueStart));
+			cursor++;
+		}
+		return attributes;
+	}
+
+	private static int FindXmlTagEnd(ReadOnlySpan<char> content, int start)
+	{
+		var quote = '\0';
+		for (var cursor = start; cursor < content.Length; cursor++)
+		{
+			if (quote != '\0')
+			{
+				if (content[cursor] == quote)
+					quote = '\0';
+				continue;
+			}
+			if (content[cursor] is '\'' or '"')
+				quote = content[cursor];
+			else if (content[cursor] == '>')
+				return cursor;
+		}
+		return -1;
+	}
+
+	private static int FindRequiredSuffix(ReadOnlySpan<char> content, int start, string suffix, string format)
+	{
+		var offset = content[start..].IndexOf(suffix, StringComparison.Ordinal);
+		if (offset < 0)
+			throw Incomplete(format);
+		return start + offset + suffix.Length;
+	}
+
+	private static string DecodeXml(ReadOnlySpan<char> value) => WebUtility.HtmlDecode(value.ToString());
+
+	private static ReadOnlySpan<char> LocalXmlName(ReadOnlySpan<char> name)
+	{
+		var separator = name.LastIndexOf(':');
+		return separator < 0 ? name : name[(separator + 1)..];
+	}
+
+	private static bool IsXmlNameCharacter(char character) =>
+		char.IsLetterOrDigit(character) || character is '_' or '-' or ':' or '.';
+
+	private static char FindDockerEscapeDirective(ReadOnlySpan<char> content)
+	{
+		var lineStart = 0;
+		while (lineStart < content.Length)
+		{
+			var lineEnd = FindLineEnd(content, lineStart);
+			var line = content[lineStart..lineEnd].Trim();
+			if (line.IsEmpty)
+			{
+				lineStart = AdvancePastLineBreak(content, lineEnd);
+				continue;
+			}
+			if (!line.StartsWith("#", StringComparison.Ordinal))
+				break;
+			line = line[1..].TrimStart();
+			if (line.StartsWith("escape=", StringComparison.OrdinalIgnoreCase))
+			{
+				var value = line[7..].Trim();
+				if (value.Length == 1 && value[0] is '\\' or '`')
+					return value[0];
+			}
+			lineStart = AdvancePastLineBreak(content, lineEnd);
+		}
+		return '\\';
+	}
+
+	private static bool IsNpmCredentialKey(ReadOnlySpan<char> key) =>
+		key.Equals("_auth", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("_authToken", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("_password", StringComparison.OrdinalIgnoreCase);
+
+	private static void AddSpan(
+		ReadOnlySpan<char> content,
+		ICollection<StructuredSecretValueSpan> spans,
+		StructuredSecretValueSpan span)
+	{
+		if (span.Length <= 0 || span.Start < 0 || span.Start > content.Length - span.Length ||
+		    StructuredSecretDetector.IsReferenceOrPlaceholder(content.Slice(span.Start, span.Length)))
+		{
+			return;
+		}
+		AddBoundedSpan(spans, span);
+	}
+
+	private static void AddBoundedSpan(
+		ICollection<StructuredSecretValueSpan> spans,
+		StructuredSecretValueSpan span)
+	{
+		if (spans.Count >= SecretInspectionLimits.MaximumFindingsPerFile)
+		{
+			throw new SecretInspectionBudgetExceededException(
+				nameof(SecretInspectionLimits.MaximumFindingsPerFile));
+		}
+		spans.Add(span);
+	}
+
+	private static bool IsPythonPrefixCharacter(char character) =>
+		character is 'r' or 'R' or 'u' or 'U' or 'b' or 'B' or 'f' or 'F';
+
+	private static bool IsPythonStringPrefix(ReadOnlySpan<char> prefix)
+	{
+		if (prefix.IsEmpty)
+			return true;
+		if (prefix.Length == 1)
+			return IsPythonPrefixCharacter(prefix[0]);
+		return prefix.Equals("br", StringComparison.OrdinalIgnoreCase) ||
+		       prefix.Equals("rb", StringComparison.OrdinalIgnoreCase) ||
+		       prefix.Equals("fr", StringComparison.OrdinalIgnoreCase) ||
+		       prefix.Equals("rf", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static bool IsPythonIdentifierCharacter(char character) =>
+		char.IsLetterOrDigit(character) || character == '_';
+
+	private static bool IsEnvironmentKeyCharacter(char character) =>
+		char.IsLetterOrDigit(character) || character == '_';
+
+	private static int SkipLogicalWhitespace(ReadOnlySpan<char> content, int start)
+	{
+		while (start < content.Length && char.IsWhiteSpace(content[start]))
+			start++;
+		return start;
+	}
+
+	private static int SkipHorizontalWhitespace(ReadOnlySpan<char> content, int start, int end)
+	{
+		while (start < end && content[start] is ' ' or '\t')
+			start++;
+		return start;
+	}
+
+	private static int CountIndent(ReadOnlySpan<char> content, int start, int end)
+	{
+		var cursor = start;
+		while (cursor < end && content[cursor] == ' ')
+			cursor++;
+		return cursor - start;
+	}
+
+	private static int FindLineEnd(ReadOnlySpan<char> content, int start)
+	{
+		if (start >= content.Length)
+			return content.Length;
+		var offset = content[start..].IndexOfAny('\r', '\n');
+		return offset < 0 ? content.Length : start + offset;
+	}
+
+	private static int AdvancePastLineBreak(ReadOnlySpan<char> content, int lineEnd)
+	{
+		if (lineEnd >= content.Length)
+			return content.Length;
+		return content[lineEnd] == '\r' && lineEnd + 1 < content.Length && content[lineEnd + 1] == '\n'
+			? lineEnd + 2
+			: lineEnd + 1;
+	}
+
+	private static StructuredSecretValueSpan Trim(ReadOnlySpan<char> content, int start, int end)
+	{
+		while (start < end && char.IsWhiteSpace(content[start]))
+			start++;
+		while (end > start && char.IsWhiteSpace(content[end - 1]))
+			end--;
+		return new StructuredSecretValueSpan(start, end - start);
+	}
+
+	private static bool IsEscaped(ReadOnlySpan<char> content, int valueStart, int position) =>
+		IsEscapedBy(content, valueStart, position, '\\');
+
+	private static bool IsEscapedBy(
+		ReadOnlySpan<char> content,
+		int valueStart,
+		int position,
+		char escape)
+	{
+		var count = 0;
+		for (var cursor = position - 1; cursor >= valueStart && content[cursor] == escape; cursor--)
+			count++;
+		return (count & 1) != 0;
+	}
+
+	private static SecretDetectionException Incomplete(string format) =>
+		new($"Structured {format} inspection encountered incomplete syntax.");
+
+	private readonly record struct DotEnvValue(StructuredSecretValueSpan Span, int ResumeAt);
+	private readonly record struct DockerLogicalLine(string Text, int[] SourceMap, int ResumeAt);
+	private readonly record struct XmlElementContext(bool IsSensitive);
+	private readonly record struct XmlAttribute(string Name, int Start, int Length);
+}

--- a/Infrastructure/Secrets/StructuredSecretValueLexers.cs
+++ b/Infrastructure/Secrets/StructuredSecretValueLexers.cs
@@ -204,14 +204,18 @@ internal static class StructuredSecretValueLexers
 			}
 			cursor += equals + 1;
 			var resumeAt = lineEnd;
+			var foundLiteral = false;
 			while (true)
 			{
 				cursor = SkipHorizontalWhitespace(content, cursor, FindLineEnd(content, cursor));
 				if (!TryReadPythonLiteral(content, cursor, out var literal, out resumeAt))
 					break;
 				AddSpan(content, spans, literal);
+				foundLiteral = true;
 				cursor = resumeAt;
 			}
+			if (!foundLiteral && TryReadPythonFallbackLiteral(content, cursor, out var fallback, out resumeAt))
+				AddSpan(content, spans, fallback);
 			lineStart = AdvancePastLineBreak(content, FindLineEnd(content, resumeAt));
 		}
 		return spans;
@@ -796,6 +800,64 @@ internal static class StructuredSecretValueLexers
 			cursor++;
 		}
 		throw Incomplete("Python");
+	}
+
+	private static bool TryReadPythonFallbackLiteral(
+		ReadOnlySpan<char> content,
+		int start,
+		out StructuredSecretValueSpan span,
+		out int resumeAt)
+	{
+		var expression = content[start..];
+		var functionLength = expression.StartsWith("os.getenv", StringComparison.Ordinal)
+			? "os.getenv".Length
+			: expression.StartsWith("os.environ.get", StringComparison.Ordinal)
+				? "os.environ.get".Length
+				: 0;
+		if (functionLength == 0)
+		{
+			span = default;
+			resumeAt = start;
+			return false;
+		}
+
+		var cursor = SkipLogicalWhitespace(content, start + functionLength);
+		if (cursor >= content.Length || content[cursor++] != '(')
+		{
+			span = default;
+			resumeAt = start;
+			return false;
+		}
+		var depth = 1;
+		var quote = '\0';
+		for (; cursor < content.Length && depth > 0; cursor++)
+		{
+			var character = content[cursor];
+			if (quote != '\0')
+			{
+				if (character == quote && !IsEscaped(content, start, cursor))
+					quote = '\0';
+				continue;
+			}
+			if (character is '\'' or '"')
+			{
+				quote = character;
+				continue;
+			}
+			if (character == '(')
+				depth++;
+			else if (character == ')')
+				depth--;
+			else if (character == ',' && depth == 1)
+			{
+				var literalStart = SkipLogicalWhitespace(content, cursor + 1);
+				return TryReadPythonLiteral(content, literalStart, out span, out resumeAt);
+			}
+		}
+
+		span = default;
+		resumeAt = start;
+		return false;
 	}
 
 	private static DockerLogicalLine ReadDockerLogicalLine(

--- a/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/SecretRedactionOutputContractIntegrationTests.cs
@@ -84,13 +84,13 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			session,
 			ProjectCopyExportFormat.Zip);
 
-		// The previous count encoded the discarded tail of an overlapping config-secret finding.
-		// Coverage-preserving segmentation represents both valid findings without exposing that tail.
-		Assert.Equal(11, preview.Redactions.Count);
-		Assert.Equal(11, preview.Redactions.Count(static span =>
+		// The format-aware JSON lexer no longer treats Password= inside a connection-string
+		// scalar as a second JSON property. The connection-password span preserves the same coverage.
+		Assert.Equal(10, preview.Redactions.Count);
+		Assert.Equal(10, preview.Redactions.Count(static span =>
 			span.State == SecretPreviewSpanState.Redacted));
-		Assert.Equal(11, folder.RedactedValueCount);
-		Assert.Equal(11, zip.RedactedValueCount);
+		Assert.Equal(10, folder.RedactedValueCount);
+		Assert.Equal(10, zip.RedactedValueCount);
 		Assert.Equal(NormalizeForClipboard(selectedContent), contentPreviewPayload);
 		Assert.All(
 			new[] { previewPayload, contentPreviewPayload, selectedContent }.Concat(contextDocuments.Values),
@@ -2917,9 +2917,9 @@ public sealed class SecretRedactionOutputContractIntegrationTests
 			content,
 			StringComparison.Ordinal);
 		Assert.EndsWith("}}\n", content, StringComparison.Ordinal);
-		Assert.Equal(1, CountOccurrences(content, "DEVPROJEX_REDACTED[config-secret#1]"));
+		Assert.Equal(0, CountOccurrences(content, "DEVPROJEX_REDACTED[config-secret#1]"));
 		Assert.Equal(1, CountOccurrences(content, "DEVPROJEX_REDACTED[connection-password#1]"));
-		Assert.DoesNotContain(";Database=app", content, StringComparison.Ordinal);
+		Assert.Contains(";Database=app", content, StringComparison.Ordinal);
 	}
 
 	private sealed class CategorizedExactValueDetector(

--- a/Tests/DevProjex.Tests.Integration/SmartSecretsPerformanceCharacterizationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/SmartSecretsPerformanceCharacterizationTests.cs
@@ -31,7 +31,7 @@ public sealed class SmartSecretsPerformanceCharacterizationTests
 			var prefix = isConfiguration
 				? $"{{ \"Password\": \"p{index:D4}!\" }}\n"
 				: $"internal sealed class Type{index:D4} {{ string apiKeyName = \"not-a-credential\"; }}\n";
-			var content = prefix + new string('x', targetSize - prefix.Length);
+			var content = prefix + new string(isConfiguration ? ' ' : 'x', targetSize - prefix.Length);
 			var relativePath = isConfiguration
 				? $"config/appsettings.{index:D4}.json"
 				: $"src/group-{index % 40:D2}/file-{index:D4}.cs";
@@ -117,9 +117,9 @@ public sealed class SmartSecretsPerformanceCharacterizationTests
 			detectionsBeforeSelectionOnlyRefresh,
 			session.GetCacheDiagnostics().DetectionRuns);
 
-		var changed = await File.ReadAllTextAsync(paths[0], TestContext.Current.CancellationToken);
-		await File.WriteAllTextAsync(paths[0], changed[..^1] + "y", TestContext.Current.CancellationToken);
-		File.SetLastWriteTimeUtc(paths[0], DateTime.UtcNow.AddSeconds(2));
+		var changed = await File.ReadAllTextAsync(paths[1], TestContext.Current.CancellationToken);
+		await File.WriteAllTextAsync(paths[1], changed[..^1] + "y", TestContext.Current.CancellationToken);
+		File.SetLastWriteTimeUtc(paths[1], DateTime.UtcNow.AddSeconds(2));
 		_ = await preparer.DiscoverAsync(context, paths, TestContext.Current.CancellationToken);
 		Assert.Equal(fileCount * 3, analyzer.ReadCount);
 		Assert.Equal(

--- a/Tests/DevProjex.Tests.Terminal/SecretRedactionCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/SecretRedactionCommandContractTests.cs
@@ -11,6 +11,76 @@ public sealed class SecretRedactionCommandContractTests
 	private const string PrivateEmail = "ivan.petrov@corp.internal";
 
 	[Fact]
+	public void RealCli_ExportAndAnalyzeUseTheSameStructuredValueCorpus()
+	{
+		using var workspace = CreateWorkspace(includeSecret: false);
+		workspace.Temporary.WriteFile("project/.env", "DB_PASSWORD=\"dotenv # value\" # keep\n");
+		workspace.Temporary.WriteFile(
+			"project/connections.txt",
+			"Server=db;Password=ado&value;Database=app\n" +
+			"jdbc:postgresql://db/app?user=admin&password=jdbc-value&ssl=true\n");
+		workspace.Temporary.WriteFile(
+			"project/appsettings.json",
+			"{\"Passwords\":[\"json-one\",\"json-two\"],\"Port\":8080}\n");
+		workspace.Temporary.WriteFile(
+			"project/application.yml",
+			"password: |-\n  yaml-one\n  yaml-two\nport: 8080\n");
+		workspace.Temporary.WriteFile(
+			"project/web.config",
+			"<Password><![CDATA[xml-value]]></Password><Port>8080</Port>\n");
+		workspace.Temporary.WriteFile("project/settings.py", "SECRET_KEY = r\"python-value\"\n");
+		workspace.Temporary.WriteFile(
+			"project/Dockerfile",
+			"ENV NORMAL=x \\\n    DB_PASSWORD=docker-value\n");
+		workspace.Temporary.WriteFile(
+			"project/.netrc",
+			"machine host login user password\n\"netrc value\"\n");
+		workspace.Temporary.WriteFile(
+			"project/.npmrc",
+			"//registry.example.com/:_auth=npm-value\n");
+
+		var export = RunPublished(
+			workspace,
+			"export", "context", workspace.ProjectRoot,
+			"--view", "content", "--format", "json",
+			"--git-mode", "none", "--exclude", "none",
+			"--hide-secrets", "--plain", "-o", "-");
+		Assert.True(export.ExitCode == CommandLineExitCodes.Success, export.StandardError);
+		using var exportDocument = JsonDocument.Parse(export.StandardOutput);
+		var exportedContent = string.Join(
+			'\n',
+			exportDocument.RootElement.GetProperty("files").EnumerateArray()
+				.Select(static file => file.GetProperty("content").GetString()));
+
+		foreach (var value in new[]
+		         {
+			         "dotenv # value", "ado&value", "jdbc-value", "json-one", "json-two",
+			         "yaml-one", "yaml-two", "xml-value", "python-value", "docker-value",
+			         "netrc value", "npm-value"
+		         })
+		{
+			Assert.DoesNotContain(value, exportedContent, StringComparison.Ordinal);
+		}
+		Assert.Contains(" # keep", exportedContent, StringComparison.Ordinal);
+		Assert.Contains(";Database=app", exportedContent, StringComparison.Ordinal);
+		Assert.Contains("&ssl=true", exportedContent, StringComparison.Ordinal);
+		Assert.Contains("<Port>8080</Port>", exportedContent, StringComparison.Ordinal);
+		Assert.Contains("port: 8080", exportedContent, StringComparison.Ordinal);
+
+		var analyze = RunPublished(
+			workspace,
+			"analyze", workspace.ProjectRoot,
+			"--format", "json", "--git-mode", "none", "--exclude", "none",
+			"--hide-secrets", "--plain", "-o", "-");
+		Assert.True(analyze.ExitCode == CommandLineExitCodes.Success, analyze.StandardError);
+		using var analyzeDocument = JsonDocument.Parse(analyze.StandardOutput);
+		var placeholderCount = CountOccurrences(exportedContent, SecretRedactionLegend.PlaceholderPrefix);
+		Assert.Equal(
+			placeholderCount,
+			analyzeDocument.RootElement.GetProperty("redaction").GetProperty("redactedCount").GetInt32());
+	}
+
+	[Fact]
 	public async Task ExportContext_LocalProfileAppliesPersistentManualSecretMarks()
 	{
 		using var workspace = CreateWorkspace(includeSecret: false);
@@ -1443,6 +1513,27 @@ public sealed class SecretRedactionCommandContractTests
 				environment,
 				new TerminalServiceFactory(() => workspace.AppDataRoot))
 			.RunAsync(arguments, TestContext.Current.CancellationToken);
+
+	private static TerminalTestProcessResult RunPublished(Workspace workspace, params string[] arguments)
+	{
+		var startInfo = new System.Diagnostics.ProcessStartInfo("dotnet")
+		{
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		startInfo.ArgumentList.Add(PublishedApplicationLocator.FindApplicationAssembly());
+		foreach (var argument in arguments)
+			startInfo.ArgumentList.Add(argument);
+		startInfo.ArgumentList.Add("--language");
+		startInfo.ArgumentList.Add("en");
+		startInfo.ArgumentList.Add("--progress");
+		startInfo.ArgumentList.Add("never");
+		startInfo.Environment[InvocationEnvironment.TerminalHostVariable] = "1";
+		startInfo.Environment[InvocationEnvironment.InternalDataRootVariable] = workspace.AppDataRoot;
+		return TerminalTestProcess.Run(startInfo, TimeSpan.FromMinutes(1));
+	}
 
 	private static async Task AddPersistentManualSecretAsync(
 		Workspace workspace,

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
@@ -8,9 +8,9 @@ public sealed class SmartSecretsDetectorTests
 	internal static readonly SmartSecretsDetector Detector = CreateDetector();
 
 	[Fact]
-	public void RulesIdentity_UsesVersionFourForStructuredCacheInvalidation()
+	public void RulesIdentity_UsesVersionFiveForStructuredCacheInvalidation()
 	{
-		Assert.EndsWith(":smart-secrets-v4", Detector.RulesIdentity, StringComparison.Ordinal);
+		Assert.EndsWith(":smart-secrets-v5", Detector.RulesIdentity, StringComparison.Ordinal);
 	}
 
 	[Theory]

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
@@ -1,0 +1,346 @@
+using DevProjex.Application.Secrets;
+using DevProjex.Infrastructure.Secrets;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class SmartSecretsValueParserTests
+{
+	// dotenv values follow the quoting, escaping, comment, and multiline rules documented by dotenvx.
+	// Source: https://dotenvx.com/docs/env-file
+	[Theory]
+	[InlineData("DB_PASSWORD=\"ab #cd\" # comment", "ab #cd")]
+	[InlineData("DB_PASSWORD='päss,#}]'", "päss,#}]")]
+	[InlineData("DB_PASSWORD=ab,cd}ef]gh", "ab,cd}ef]gh")]
+	[InlineData("DB_PASSWORD=ab#comment", "ab")]
+	[InlineData("DB_PASSWORD=ab # comment", "ab")]
+	[InlineData("DB_PASSWORD=\"ab\\\"cd\"", "ab\\\"cd")]
+	public void DotEnv_UsesFormatSpecificQuotedAndUnquotedBoundaries(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, ".env", "environment-secret"), expected);
+	}
+
+	[Theory]
+	[InlineData("\n")]
+	[InlineData("\r\n")]
+	[InlineData("\r")]
+	public void DotEnv_QuotedLogicalValueMayCrossPhysicalLines(string newline)
+	{
+		var expected = $"ab12{newline}cd34";
+		var content = $"DB_PASSWORD='{expected}'{newline}SAFE=value";
+
+		AssertExactCoverage(content, Find(content, ".env", "environment-secret"), expected);
+	}
+
+	[Fact]
+	public void DotEnv_NonSensitiveAssignmentAndQuotedCommentStayVisible()
+	{
+		const string content = "SAFE=ab12\n# DB_PASSWORD=comment-only";
+
+		Assert.Empty(Find(content, ".env", "environment-secret"));
+	}
+
+	// ADO.NET uses semicolon-delimited pairs with doubled quote escaping; JDBC URL properties use '&'.
+	// Sources: https://learn.microsoft.com/dotnet/framework/data/adonet/connection-strings
+	//          https://docs.oracle.com/javase/8/docs/api/java/sql/DriverManager.html
+	[Theory]
+	[InlineData("Server=db;Password=ab&cd;Database=app", "ab&cd")]
+	[InlineData("Server=db;Password=\"ab\"\"cd\";Database=app", "ab\"\"cd")]
+	[InlineData("Server=db;Password='ab;cd';Database=app", "ab;cd")]
+	[InlineData("Server=db;Password=ab=cd;Database=app", "ab=cd")]
+	public void AdoNetConnectionString_UsesSemicolonPairGrammar(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, "settings.txt", "connection-password"), expected);
+	}
+
+	[Fact]
+	public void JdbcConnectionString_UsesQueryParameterGrammar()
+	{
+		const string content = "jdbc:postgresql://db/app?user=admin&password=ab12&ssl=true";
+
+		AssertExactCoverage(content, Find(content, "settings.txt", "connection-password"), "ab12");
+	}
+
+	[Fact]
+	public void UriUserInfo_RemainsDelimitedByTheAuthorityGrammar()
+	{
+		const string content = "postgres://user:ab12@db.internal/app?safe=true";
+
+		AssertExactCoverage(content, Find(content, "settings.txt", "credential-uri-password"), "ab12");
+	}
+
+	[Fact]
+	public void ConnectionString_WithoutCredentialKeyDoesNotCreateAStructuredFinding()
+	{
+		const string content = "Server=db;User ID=admin;Database=app";
+
+		Assert.Empty(Find(content, "settings.txt", "connection-password"));
+	}
+
+	// RFC 8259 strings use odd/even reverse-solidus parity and permit whitespace between tokens.
+	// Source: https://www.rfc-editor.org/rfc/rfc8259
+	[Theory]
+	[InlineData("\n")]
+	[InlineData("\r\n")]
+	[InlineData("\r")]
+	public void Json_ValueMayFollowItsPropertyOnTheNextLine(string newline)
+	{
+		var content = $"{{\"Password\":{newline}  \"ab12\",{newline}\"Port\":8080}}";
+
+		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "ab12");
+	}
+
+	[Fact]
+	public void Json_EvenBackslashesCloseTheValueWithoutCapturingTheNextProperty()
+	{
+		const string content = "{\"Password\":\"ab\\\\\",\"Host\":\"db\"}";
+
+		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "ab\\\\");
+	}
+
+	[Fact]
+	public void Json_SensitiveArrayMasksScalarDescendantsOnly()
+	{
+		const string content = "{\"Passwords\":[\"ab12\",\"cd34\"],\"Port\":8080}";
+
+		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "ab12", "cd34");
+	}
+
+	[Fact]
+	public void Json_DecodesEscapedPropertyNameBeforeSensitivityMatching()
+	{
+		const string content = "{\"Pass\\u0077ord\":\"päss🔐\",\"Port\":8080}";
+
+		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "päss🔐");
+	}
+
+	[Fact]
+	public void Json_NonSensitiveArrayAndFollowingPropertyStayVisible()
+	{
+		const string content = "{\"Hosts\":[\"db-one\",\"db-two\"],\"Port\":8080}";
+
+		Assert.Empty(Find(content, "appsettings.json", "config-secret"));
+	}
+
+	// YAML 1.2 comments require separation in plain scalars, single quotes escape by doubling,
+	// and block scalar content is selected by indentation rather than the physical line.
+	// Source: https://yaml.org/spec/1.2.2/
+	[Theory]
+	[InlineData("password: ab#cd\nsafe: keep", "ab#cd")]
+	[InlineData("password: ab # comment\nsafe: keep", "ab")]
+	[InlineData("password: 'ab''cd'\nsafe: keep", "ab''cd")]
+	public void Yaml_UsesScalarSpecificCommentsAndQuotes(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, "application.yml", "config-secret"), expected);
+	}
+
+	[Theory]
+	[InlineData("|", "\n")]
+	[InlineData("|-", "\r\n")]
+	[InlineData("|+", "\r")]
+	[InlineData(">", "\n")]
+	[InlineData("|2", "\r\n")]
+	public void Yaml_BlockScalarMasksContentButNotIndicatorOrAdjacentKey(string indicator, string newline)
+	{
+		var content = $"password: {indicator}{newline}  ab12{newline}  cd34{newline}port: 8080";
+
+		AssertExactCoverage(content, Find(content, "application.yml", "config-secret"), "ab12", "cd34");
+	}
+
+	[Fact]
+	public void Yaml_NonSensitiveBlockScalarDoesNotCreateAStructuredFinding()
+	{
+		const string content = "description: |\r\n  safe text\r\nport: 8080";
+
+		Assert.Empty(Find(content, "application.yml", "config-secret"));
+	}
+
+	[Theory]
+	[InlineData("${DB_PASS}", false)]
+	[InlineData("${DB_PASS:-ab12}", true)]
+	[InlineData("${DB_PASS}suffix", true)]
+	[InlineData("${DB_PASS?required-secret}", true)]
+	[InlineData("\\${DB_PASS}", true)]
+	[InlineData("${OUTER:-${INNER:-ab12}}", true)]
+	public void DotEnv_OnlyPureReferencesAreExcluded(string value, bool expectedFinding)
+	{
+		var content = $"DB_PASSWORD={value}";
+		var findings = Find(content, ".env", "environment-secret");
+
+		if (expectedFinding)
+			AssertExactCoverage(content, findings, value);
+		else
+			Assert.Empty(findings);
+	}
+
+	// XML character data and CDATA inherit their containing element's sensitivity; no DTD is resolved.
+	// Source: https://www.w3.org/TR/xml/
+	[Theory]
+	[InlineData("<Password><![CDATA[ab12]]></Password>", "ab12")]
+	[InlineData("<cfg:Password xmlns:cfg=\"urn:test\">ab12</cfg:Password>", "ab12")]
+	[InlineData("<add key=\"Pass&#x77;ord\" value=\"ab12\" />", "ab12")]
+	public void Xml_SensitiveContextFlowsToTextCdataAndDecodedKeyAttributes(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, "web.config", "config-secret"), expected);
+	}
+
+	[Fact]
+	public void Xml_MixedTextAndCdataMasksOnlyTextNodes()
+	{
+		const string content = "<Password>left<![CDATA[mid]]>right</Password><Port>8080</Port>";
+
+		AssertExactCoverage(content, Find(content, "web.config", "config-secret"), "left", "mid", "right");
+	}
+
+	[Fact]
+	public void Xml_NonSensitiveCdataAndAdjacentElementStayVisible()
+	{
+		const string content = "<Description><![CDATA[safe text]]></Description>\r\n<Port>8080</Port>";
+
+		Assert.Empty(Find(content, "web.config", "config-secret"));
+	}
+
+	// Python lexical prefixes and triple/adjacent strings follow the language lexical reference.
+	// Source: https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+	[Theory]
+	[InlineData("SECRET_KEY = \"\"\"ab12\"\"\"", "ab12")]
+	[InlineData("SECRET_KEY = r\"ab12\"", "ab12")]
+	[InlineData("SECRET_KEY = u'päss'", "päss")]
+	[InlineData("SECRET_KEY = b\"ab12\"", "ab12")]
+	[InlineData("SECRET_KEY = f\"ab{suffix}\"", "ab{suffix}")]
+	public void Python_RecognizesPrefixesAndTripleQuotedLiterals(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, "settings.py", "config-secret"), expected);
+	}
+
+	[Fact]
+	public void Python_AdjacentLiteralsAreSeparateExactFragments()
+	{
+		const string content = "SECRET_KEY = \"ab12\" 'cd34'\nPORT = 8080";
+
+		AssertExactCoverage(content, Find(content, "settings.py", "config-secret"), "ab12", "cd34");
+	}
+
+	[Fact]
+	public void Python_NonSensitiveLiteralDoesNotCreateAStructuredFinding()
+	{
+		const string content = "DESCRIPTION = r\"safe text\"\r\nPORT = 8080";
+
+		Assert.Empty(Find(content, "settings.py", "config-secret"));
+	}
+
+	// Dockerfile instructions use logical continuation lines and the active escape directive.
+	// Source: https://docs.docker.com/reference/dockerfile/#escape
+	[Theory]
+	[InlineData("ENV NORMAL=x \\\n    DB_PASSWORD=ab12", "ab12")]
+	[InlineData("ENV NORMAL=x \\\r\n    DB_PASSWORD=ab12", "ab12")]
+	[InlineData("# escape=`\r\nENV NORMAL=x `\r\n    DB_PASSWORD=ab12", "ab12")]
+	[InlineData("ENV DB_PASSWORD=ab\\ cd", "ab\\ cd")]
+	[InlineData("ARG DB_PASSWORD=ab12", "ab12")]
+	public void Dockerfile_UsesLogicalLinesAndEscapedValueCharacters(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, "Dockerfile", "container-secret"), expected);
+	}
+
+	[Fact]
+	public void Dockerfile_NonSensitiveLogicalAssignmentStaysVisible()
+	{
+		const string content = "ENV NAME=safe \\\r\n    PORT=8080";
+
+		Assert.Empty(Find(content, "Dockerfile", "container-secret"));
+	}
+
+	// netrc is a whitespace token stream; a newline does not terminate a pending password field.
+	// Source: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
+	[Theory]
+	[InlineData("machine host login alice password\nab12", "ab12")]
+	[InlineData("machine host login alice password\r\n\"ab 12\"", "ab 12")]
+	[InlineData("machine host login alice password 'päss word'", "päss word")]
+	public void Netrc_ReadsPasswordFromTheLogicalTokenStream(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, ".netrc", "netrc-password"), expected);
+	}
+
+	[Fact]
+	public void Netrc_AccountTokenIsNotAPasswordField()
+	{
+		const string content = "machine host login alice account ab12\r\nmacdef init";
+
+		Assert.Empty(Find(content, ".netrc", "netrc-password"));
+	}
+
+	// npm requires authentication keys to be scoped to a registry URI fragment.
+	// Source: https://docs.npmjs.com/cli/v11/configuring-npm/npmrc#auth-related-configuration
+	[Theory]
+	[InlineData("//registry.npmjs.org/:_auth=YTpi", "YTpi")]
+	[InlineData("//registry.example.com/team/:_authToken = npm-short", "npm-short")]
+	[InlineData("//registry.example.com/:_password=päss", "päss")]
+	[InlineData("//registry.example.com/:_auth=\"ab#cd\"", "ab#cd")]
+	[InlineData("_auth=YTpi", "YTpi")]
+	public void Npmrc_RecognizesScopedAndUnscopedCredentialKeys(string content, string expected)
+	{
+		AssertExactCoverage(content, Find(content, ".npmrc", "environment-secret"), expected);
+	}
+
+	[Theory]
+	[InlineData("//registry.example.com/:email=owner@example.com")]
+	[InlineData("//registry.example.com/:certfile=/safe/client.pem")]
+	[InlineData("//registry.example.com/:_auth=${NPM_AUTH}")]
+	public void Npmrc_DoesNotInventSecretsForMetadataOrPureReferences(string content)
+	{
+		Assert.Empty(Find(content, ".npmrc", "environment-secret"));
+	}
+
+	[Fact]
+	public void StructuredLexers_StopBeforeRetainingMoreThanTheFindingLimit()
+	{
+		var content = string.Join(
+			'\n',
+			Enumerable.Range(0, SecretInspectionLimits.MaximumFindingsPerFile + 1)
+				.Select(static index => $"PASSWORD=value-{index}"));
+
+		var exception = Assert.Throws<SecretInspectionBudgetExceededException>(() =>
+			StructuredSecretDetector.Detect(
+				".env",
+				content,
+				SmartSecretStack.None,
+				TestContext.Current.CancellationToken));
+		Assert.Equal(nameof(SecretInspectionLimits.MaximumFindingsPerFile), exception.LimitName);
+	}
+
+	private static DetectedSecret[] Find(string content, string path, string ruleId) =>
+		StructuredSecretDetector.Detect(
+			path,
+			content,
+			SmartSecretStack.None,
+			TestContext.Current.CancellationToken)
+		.Where(finding => finding.RuleId == ruleId)
+		.OrderBy(static finding => finding.Start)
+		.ToArray();
+
+	private static void AssertExactCoverage(
+		string content,
+		IReadOnlyList<DetectedSecret> findings,
+		params string[] expectedValues)
+	{
+		var expectedCoverage = new bool[content.Length];
+		var searchStart = 0;
+		foreach (var expectedValue in expectedValues)
+		{
+			var start = content.IndexOf(expectedValue, searchStart, StringComparison.Ordinal);
+			Assert.True(start >= 0, $"Expected value '{expectedValue}' was not present after offset {searchStart}.");
+			for (var index = start; index < start + expectedValue.Length; index++)
+				expectedCoverage[index] = true;
+			searchStart = start + expectedValue.Length;
+		}
+
+		var actualCoverage = new bool[content.Length];
+		foreach (var finding in findings)
+		{
+			Assert.Equal(finding.Value, content.Substring(finding.Start, finding.Length));
+			for (var index = finding.Start; index < finding.Start + finding.Length; index++)
+				actualCoverage[index] = true;
+		}
+
+		Assert.Equal(expectedCoverage, actualCoverage);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
@@ -52,6 +52,18 @@ public sealed class SmartSecretsValueParserTests
 		AssertExactCoverage(content, Find(content, "settings.txt", "connection-password"), expected);
 	}
 
+	[Theory]
+	[InlineData("{\"Connection\":\"Server=db;Password=ab&cd;Database=app\"}", "ab&cd")]
+	[InlineData("const string value = \"Server=db;Password=ab&cd;Database=app\";", "ab&cd")]
+	[InlineData("<add value=\"Server=db;Password=ab&amp;cd;Database=app\" />", "ab&amp;cd")]
+	[InlineData("{\"Connection\":\"Server=db;Password=\\\"ab\\\"\\\"cd\\\";Database=app\"}", "ab\\\"\\\"cd")]
+	public void AdoNetConnectionString_PreservesBoundariesInsideHostLanguageEscaping(
+		string content,
+		string expected)
+	{
+		AssertExactCoverage(content, Find(content, "settings.txt", "connection-password"), expected);
+	}
+
 	[Fact]
 	public void JdbcConnectionString_UsesQueryParameterGrammar()
 	{
@@ -89,12 +101,33 @@ public sealed class SmartSecretsValueParserTests
 		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "ab12");
 	}
 
-	[Fact]
-	public void Json_EvenBackslashesCloseTheValueWithoutCapturingTheNextProperty()
+	[Theory]
+	[InlineData(0)]
+	[InlineData(2)]
+	[InlineData(4)]
+	[InlineData(6)]
+	public void Json_EvenBackslashesCloseTheValueWithoutCapturingTheNextProperty(int slashCount)
 	{
-		const string content = "{\"Password\":\"ab\\\\\",\"Host\":\"db\"}";
+		var expected = "ab" + new string('\\', slashCount);
+		var content = "{\"Password\":\"" + expected + "\",\"Host\":\"db\"}";
 
-		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "ab\\\\");
+		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), expected);
+	}
+
+	[Theory]
+	[InlineData(1)]
+	[InlineData(3)]
+	[InlineData(5)]
+	public void Json_OddBackslashesWithoutAClosingStringReportIncompleteSyntax(int slashCount)
+	{
+		var content = "{\"Password\":\"ab" + new string('\\', slashCount) + "\"}";
+
+		Assert.Throws<SecretDetectionException>(() =>
+			StructuredSecretDetector.Detect(
+				"appsettings.json",
+				content,
+				SmartSecretStack.None,
+				TestContext.Current.CancellationToken));
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
@@ -261,6 +261,16 @@ public sealed class SmartSecretsValueParserTests
 		Assert.Empty(Find(content, "settings.py", "config-secret"));
 	}
 
+	[Fact]
+	public void Python_EnvironmentReferenceStaysVisibleButLiteralFallbackIsSensitive()
+	{
+		const string reference = "SECRET_KEY = os.environ[\"SECRET_KEY\"]";
+		const string fallback = "SECRET_KEY = os.getenv(\"SECRET_KEY\", r\"ab12\")";
+
+		Assert.Empty(Find(reference, "settings.py", "config-secret"));
+		AssertExactCoverage(fallback, Find(fallback, "settings.py", "config-secret"), "ab12");
+	}
+
 	// Dockerfile instructions use logical continuation lines and the active escape directive.
 	// Source: https://docs.docker.com/reference/dockerfile/#escape
 	[Theory]

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsValueParserTests.cs
@@ -154,6 +154,14 @@ public sealed class SmartSecretsValueParserTests
 		Assert.Empty(Find(content, "appsettings.json", "config-secret"));
 	}
 
+	[Fact]
+	public void Json_SensitiveNestedContainersAndCommentsPreserveAdjacentSyntax()
+	{
+		const string content = "{/* retained */\"Password\":{\"primary\":\"ab12\",\"backup\":[\"cd34\"]},\"Port\":8080}";
+
+		AssertExactCoverage(content, Find(content, "appsettings.json", "config-secret"), "ab12", "cd34");
+	}
+
 	// YAML 1.2 comments require separation in plain scalars, single quotes escape by doubling,
 	// and block scalar content is selected by indentation rather than the physical line.
 	// Source: https://yaml.org/spec/1.2.2/
@@ -222,6 +230,14 @@ public sealed class SmartSecretsValueParserTests
 		const string content = "<Password>left<![CDATA[mid]]>right</Password><Port>8080</Port>";
 
 		AssertExactCoverage(content, Find(content, "web.config", "config-secret"), "left", "mid", "right");
+	}
+
+	[Fact]
+	public void Xml_MultilineAttributesAndCommentsPreserveMarkup()
+	{
+		const string content = "<!-- retained -->\r\n<add\r\n key=\"Password\"\r\n value=\"ab12\" />";
+
+		AssertExactCoverage(content, Find(content, "web.config", "config-secret"), "ab12");
 	}
 
 	[Fact]
@@ -348,6 +364,24 @@ public sealed class SmartSecretsValueParserTests
 				SmartSecretStack.None,
 				TestContext.Current.CancellationToken));
 		Assert.Equal(nameof(SecretInspectionLimits.MaximumFindingsPerFile), exception.LimitName);
+	}
+
+	[Theory]
+	[InlineData(".env", "DB_PASSWORD=\"unterminated")]
+	[InlineData("appsettings.json", "{\"Password\":\"unterminated}")]
+	[InlineData("application.yml", "password: 'unterminated")]
+	[InlineData("web.config", "<Password><![CDATA[unterminated</Password>")]
+	[InlineData("settings.py", "SECRET_KEY = \"\"\"unterminated")]
+	[InlineData("Dockerfile", "ENV DB_PASSWORD=\"unterminated")]
+	[InlineData(".netrc", "machine host password \"unterminated")]
+	public void IncompleteStructuredValueDoesNotBecomeAConfidentPartialFinding(string path, string content)
+	{
+		Assert.Throws<SecretDetectionException>(() =>
+			StructuredSecretDetector.Detect(
+				path,
+				content,
+				SmartSecretStack.None,
+				TestContext.Current.CancellationToken));
 	}
 
 	private static DetectedSecret[] Find(string content, string path, string ruleId) =>


### PR DESCRIPTION
## Why

The structured secret detector reused line and delimiter helpers across incompatible configuration formats. Valid quoted, multiline, escaped, array, registry-scoped, and logical-line values could therefore be truncated or include adjacent syntax.

## Changes

- add format-specific value lexers for dotenv, JSON, YAML, XML, Python, Dockerfile, netrc, and npmrc
- separate ADO.NET password pairs from JDBC query parameters and URI userinfo, including host-language escaping
- exclude only complete simple variable references; redact composite defaults and suffixes
- keep punctuation, comments, quote delimiters, container syntax, and adjacent fields outside replacement spans
- version the structured detector identity for cache isolation
- document the exact boundary and failure model

## Observable correction

A connection string stored inside a JSON scalar now produces only its exact `connection-password` span. The old generic parser also interpreted `Password=` inside the scalar as a JSON property and consumed `;Database=app`; the existing output fixture therefore changes from 11 redaction spans to 10 while preserving complete secret coverage and retaining the non-secret database field.

## Verification

- exact UTF-16 coverage assertions for 90 structured parser cases, including LF, CRLF, CR, Unicode, quoting, escaping, multiline values, positive and negative controls, and explicit incomplete syntax
- targeted Smart Secrets, Gitleaks, redaction, inspection-budget, path-isolation, and documentation tests
- real-process CLI export/analyze corpus parity
- provider corpus unchanged: 100 findings, SHA-256 `95C0611DA179F6CE95CE759D9C105C2BBDB6D1258080F7D2EA0B0A4EB673B8A4`