### PR TITLE
Harden Git remote sources and cache operations

### DIFF
--- a/Application/Services/RepositoryWebPathPresentationService.cs
+++ b/Application/Services/RepositoryWebPathPresentationService.cs
@@ -15,7 +15,7 @@ public sealed class RepositoryWebPathPresentationService
         if (string.IsNullOrWhiteSpace(localRootPath) || string.IsNullOrWhiteSpace(repositoryUrl))
             return null;
 
-        if (!RepositoryUrlUtility.IsSupportedCloneSource(repositoryUrl))
+        if (!IsSafePresentationSource(repositoryUrl))
             return null;
 
         string normalizedRootPath;
@@ -62,6 +62,15 @@ public sealed class RepositoryWebPathPresentationService
         }
 
         return filePath => MapToRepositoryPath(filePath, normalizedRootPath, displayRootPath);
+    }
+
+    private static bool IsSafePresentationSource(string repositoryUrl)
+    {
+        if (RepositoryUrlUtility.IsNetworkCloneSource(repositoryUrl))
+            return true;
+
+        var normalized = RepositoryUrlUtility.ToSafeDisplay(repositoryUrl);
+        return Uri.TryCreate(normalized, UriKind.Absolute, out var uri) && uri.IsFile;
     }
 
     private static string NormalizeRepositoryUrl(string repositoryUrl)

--- a/Docs/Git-Safety.md
+++ b/Docs/Git-Safety.md
@@ -50,7 +50,17 @@ The child environment starts with only the available values from this allowlist:
 PATH HOME USERPROFILE TEMP TMP SystemRoot LANG LC_ALL
 ```
 
-`SSH_AUTH_SOCK` is added only for `ExplicitNetwork`. Repository-selection variables such as `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, object-directory variables, namespaces, discovery overrides, and external `GIT_CONFIG_*` injection are removed. DevProjex then adds its own profile variables. A password, when explicitly supplied for a remote source, exists only in the temporary askpass environment and never in argv or a persisted remote URL.
+`ExplicitNetwork` additionally inherits only `SSH_AUTH_SOCK` and the operator's
+`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`, `SSL_CERT_DIR`, and
+`GIT_SSL_CAINFO` values. These values come from the DevProjex process environment,
+not repository configuration. Repository-selection variables such as `GIT_DIR`,
+`GIT_WORK_TREE`, `GIT_INDEX_FILE`, object-directory variables, namespaces,
+discovery overrides, and external `GIT_CONFIG_*` injection are removed. DevProjex
+then adds its own profile variables. A password, when explicitly supplied for a
+remote source, exists only in the temporary askpass environment and never in argv
+or a persisted remote URL. The same in-memory askpass session is reused for
+explicit branch listing and update operations for that source and is disposed with
+the Git service.
 
 ## LocalRead
 
@@ -147,6 +157,16 @@ Online branch listing uses `ls-remote --heads <saved-url>`. Before fetch or `ls-
 
 HTTPS allows only `https`; SSH/SCP sources allow only `ssh`. The v5.2 product has no explicit opt-in surface for `http`, `git`, or `file`, so those transports are rejected. `ext` and unknown remote helpers are always rejected. SSH uses one absolute executable selected from safe `PATH` entries and retains non-interactive `BatchMode=yes`. Network operations have a ten-minute deadline. Credential helpers remain disabled; the existing temporary DevProjex askpass flow is the only password path.
 
+Clone and fetch also share the repository-cache resource policy. DevProjex checks
+free space on the destination filesystem before clone, monitors the application-owned
+staging or cache directory while Git runs, and terminates the complete process tree
+with `DPX-GIT-CACHE-QUOTA` if the configured cache-size limit is exceeded.
+
+GitHub ZIP fallback applies a separate no-progress deadline while reading the
+response body as well as compressed and extracted byte limits. It reports the ref
+that was actually downloaded. Unix symbolic-link entries are skipped with a counted
+`DPX-ZIP-SYMLINK-SKIPPED` diagnostic instead of being materialized as regular files.
+
 ## Operation registry
 
 | Operation | Profile | Pinned purpose |
@@ -173,7 +193,10 @@ No MCP argument, repository value, profile file, or command-line token selects a
 
 - Full no-demand-fetch guarantees require Git 2.45 or newer. Older versions ignore `GIT_NO_LAZY_FETCH`; ordinary repositories continue to work, but DevProjex refuses LocalRead for a partial clone with a promisor remote.
 - Disabling fsmonitor can make reads slower in very large working trees. It avoids executing an untrusted monitor and does not change the selected file set.
-- Isolating system/global config intentionally removes user `insteadOf`, proxy, exclude, and credential-helper behavior. Explicit credentials still use the DevProjex askpass session.
+- Isolating system/global config intentionally removes user `insteadOf`, exclude,
+  and credential-helper behavior. Explicit network operations retain only the
+  operator environment proxy and certificate variables listed above; repository
+  proxy, TLS, header, cookie, and transport overrides remain rejected.
 - Disabling smudge/clean/process during managed materialization leaves LFS and similar pointer files unchanged. No background download is attempted.
 - The `changes` scope cannot reproduce Git's exact working comparison without a configured clean/process filter. It fails with `DPX-GIT-UNSAFE-FILTER` and names the driver. Staged and ref-to-ref comparisons remain available because they do not require that working-tree conversion.
 

--- a/Docs/Git-Safety.md
+++ b/Docs/Git-Safety.md
@@ -160,7 +160,9 @@ HTTPS allows only `https`; SSH/SCP sources allow only `ssh`. The v5.2 product ha
 Clone and fetch also share the repository-cache resource policy. DevProjex checks
 free space on the destination filesystem before clone, monitors the application-owned
 staging or cache directory while Git runs, and terminates the complete process tree
-with `DPX-GIT-CACHE-QUOTA` if the configured cache-size limit is exceeded.
+with `DPX-GIT-CACHE-QUOTA` if the configured cache-size limit is exceeded. A transfer
+rejected before launch because the destination filesystem lacks the required reserve
+reports `DPX-GIT-CACHE-RESERVE`; the diagnostic does not disclose filesystem sizes.
 
 GitHub ZIP fallback applies a separate no-progress deadline while reading the
 response body as well as compressed and extracted byte limits. It reports the ref

--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -159,3 +159,19 @@ Use an explicit version tag for reproducible automation, for example
 `ghcr.io/avazbek22/devprojex:5.2`. The untagged examples use Docker's `latest`
 tag only after a release workflow has published it. Alpine and other musl hosts
 are not supported.
+
+## Remote sources
+
+Remote Git sources accept HTTPS URLs, SSH URLs, and SCP-style SSH sources. Plain
+HTTP, the unauthenticated `git://` protocol, and `file://` URLs are rejected before
+cache staging begins. A normal existing local directory remains a local project,
+not a remote source.
+
+HTTPS credentials may be supplied through URL user information for an explicit
+remote operation. The password is passed only through the temporary non-interactive
+askpass channel; it is not stored in the repository URL or cache index. Branch
+listing, switching, and updates reuse that source session. Corporate proxies and
+certificate bundles may be supplied through `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`,
+`SSL_CERT_FILE`, `SSL_CERT_DIR`, or `GIT_SSL_CAINFO` in the DevProjex process
+environment. Repository-local credential helpers, proxy settings, URL rewrites,
+and TLS overrides are not used.

--- a/Infrastructure/Git/GitProcessStartInfoFactory.cs
+++ b/Infrastructure/Git/GitProcessStartInfoFactory.cs
@@ -6,6 +6,16 @@ internal static class GitProcessStartInfoFactory
 	[
 		"PATH", "HOME", "USERPROFILE", "TEMP", "TMP", "SystemRoot", "LANG", "LC_ALL"
 	];
+	private static readonly string[] ExplicitNetworkEnvironmentVariables =
+	[
+		"SSH_AUTH_SOCK",
+		"HTTPS_PROXY",
+		"HTTP_PROXY",
+		"NO_PROXY",
+		"SSL_CERT_FILE",
+		"SSL_CERT_DIR",
+		"GIT_SSL_CAINFO"
+	];
 
 	public static ProcessStartInfo Create(
 		string? workingDirectory,
@@ -128,7 +138,12 @@ internal static class GitProcessStartInfoFactory
 				AddConfig(startInfo, $"protocol.allow={operation.AllowedProtocols}");
 				AddConfig(startInfo, "http.extraHeader=");
 				AddConfig(startInfo, "http.cookieFile=");
-				AddConfig(startInfo, "http.proxy=");
+				if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GIT_SSL_CAINFO")))
+				{
+					AddConfig(startInfo, "http.schannelUseSSLCAInfo=true");
+					if (OperatingSystem.IsWindows())
+						AddConfig(startInfo, "http.sslBackend=openssl");
+				}
 				AddConfig(startInfo, "remote.origin.uploadpack=");
 				break;
 			default:
@@ -150,7 +165,10 @@ internal static class GitProcessStartInfoFactory
 		foreach (var name in CommonEnvironmentVariables)
 			inherited[name] = Environment.GetEnvironmentVariable(name);
 		if (profile == GitProcessProfile.ExplicitNetwork)
-			inherited["SSH_AUTH_SOCK"] = Environment.GetEnvironmentVariable("SSH_AUTH_SOCK");
+		{
+			foreach (var name in ExplicitNetworkEnvironmentVariables)
+				inherited[name] = Environment.GetEnvironmentVariable(name);
+		}
 
 		startInfo.Environment.Clear();
 		foreach (var (name, value) in inherited)

--- a/Infrastructure/Git/GitRemoteDiffRangeResolver.cs
+++ b/Infrastructure/Git/GitRemoteDiffRangeResolver.cs
@@ -258,8 +258,8 @@ public sealed class GitRemoteDiffRangeResolver
 			cancellationToken).ConfigureAwait(false);
 		if (configured is not { ExitCode: 0 } ||
 		    !string.Equals(
-			    RepositoryUrlUtility.GetComparisonKey(configured.Output.Trim()),
-			    RepositoryUrlUtility.GetComparisonKey(expectedRemoteUrl),
+			    RepositoryUrlUtility.GetSourceCacheKey(configured.Output.Trim()),
+			    RepositoryUrlUtility.GetSourceCacheKey(expectedRemoteUrl),
 			    StringComparison.Ordinal))
 		{
 			return false;

--- a/Infrastructure/Git/GitRemoteIdentityStore.cs
+++ b/Infrastructure/Git/GitRemoteIdentityStore.cs
@@ -11,6 +11,7 @@ internal static class GitRemoteIdentityStore
 	public static void Write(
 		string repositoryPath,
 		string remoteUrl,
+		string? sourceIdentityUrl = null,
 		bool allowFileTransport = false)
 	{
 		var gitDirectory = ResolveCommonGitDirectory(repositoryPath);
@@ -18,7 +19,11 @@ internal static class GitRemoteIdentityStore
 			throw new InvalidOperationException("The cloned repository metadata is unavailable.");
 		var safeUrl = GitNetworkPolicy.ValidateUrl(remoteUrl, allowFileTransport);
 		var path = Path.Combine(gitDirectory, IdentityFileName);
-		File.WriteAllText(path, safeUrl, new UTF8Encoding(false));
+		var safeSourceIdentity = RepositoryUrlUtility.ToSafeSourceIdentity(sourceIdentityUrl ?? safeUrl);
+		File.WriteAllText(
+			path,
+			safeUrl + "\n" + safeSourceIdentity,
+			new UTF8Encoding(false));
 		if (!OperatingSystem.IsWindows())
 			File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
 	}
@@ -34,14 +39,39 @@ internal static class GitRemoteIdentityStore
 			{
 				return false;
 			}
-			var saved = File.ReadAllText(path).Trim();
+			var saved = File.ReadLines(path).FirstOrDefault()?.Trim();
+			if (string.IsNullOrEmpty(saved))
+				return false;
 			return string.Equals(
-				RepositoryUrlUtility.GetComparisonKey(saved),
-				RepositoryUrlUtility.GetComparisonKey(remoteUrl),
+				RepositoryUrlUtility.GetSourceCacheKey(saved),
+				RepositoryUrlUtility.GetSourceCacheKey(remoteUrl),
 				StringComparison.Ordinal);
 		}
 		catch
 		{
+			return false;
+		}
+	}
+
+	public static bool TryReadSourceIdentity(string repositoryPath, out string sourceIdentity)
+	{
+		sourceIdentity = string.Empty;
+		try
+		{
+			var path = Path.Combine(ResolveCommonGitDirectory(repositoryPath), IdentityFileName);
+			var info = new FileInfo(path);
+			if (!info.Exists || info.Length <= 0 || info.Length > MaximumIdentityLength ||
+			    !UnixFileTypeInspector.IsRegularFile(path))
+			{
+				return false;
+			}
+			var lines = File.ReadLines(path).Take(2).ToArray();
+			sourceIdentity = (lines.Length > 1 ? lines[1] : lines[0]).Trim();
+			return RepositoryUrlUtility.GetSourceCacheKey(sourceIdentity).Length > 0;
+		}
+		catch
+		{
+			sourceIdentity = string.Empty;
 			return false;
 		}
 	}

--- a/Infrastructure/Git/GitRepositoryResourceLimits.cs
+++ b/Infrastructure/Git/GitRepositoryResourceLimits.cs
@@ -1,0 +1,72 @@
+namespace DevProjex.Infrastructure.Git;
+
+internal sealed record GitRepositoryResourceLimits
+{
+	private const long GiB = 1024L * 1024 * 1024;
+
+	public static GitRepositoryResourceLimits Default { get; } = new();
+
+	public long MaximumRepositoryBytes { get; init; } = RepositoryCachePolicy.DefaultMaximumSizeBytes;
+	public long FreeSpaceReserveBytes { get; init; } = GiB;
+	public TimeSpan PollInterval { get; init; } = TimeSpan.FromMilliseconds(100);
+	public Func<string, long>? AvailableFreeSpace { get; init; }
+
+	public GitRepositoryResourceLimits Validate()
+	{
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(MaximumRepositoryBytes);
+		ArgumentOutOfRangeException.ThrowIfNegative(FreeSpaceReserveBytes);
+		if (PollInterval <= TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(PollInterval));
+		return this;
+	}
+
+	public long GetAvailableFreeSpace(string destinationPath)
+	{
+		var probePath = ResolveExistingDestinationParent(destinationPath);
+		if (AvailableFreeSpace is not null)
+			return AvailableFreeSpace(probePath);
+		var driveRoot = ResolveDestinationDriveRoot(
+			probePath,
+			DriveInfo.GetDrives().Select(static drive => drive.Name));
+		return new DriveInfo(driveRoot).AvailableFreeSpace;
+	}
+
+	internal static string ResolveDestinationDriveRoot(
+		string destinationPath,
+		IEnumerable<string> driveRoots)
+	{
+		var fullPath = Path.GetFullPath(destinationPath);
+		var comparison = OperatingSystem.IsWindows()
+			? StringComparison.OrdinalIgnoreCase
+			: StringComparison.Ordinal;
+		var selected = driveRoots
+			.Select(Path.GetFullPath)
+			.Where(root => IsWithin(fullPath, root, comparison))
+			.OrderByDescending(static root => root.Length)
+			.FirstOrDefault();
+		return selected ?? Path.GetPathRoot(fullPath) ?? fullPath;
+	}
+
+	private static string ResolveExistingDestinationParent(string destinationPath)
+	{
+		var current = Path.GetFullPath(destinationPath);
+		while (!Directory.Exists(current))
+		{
+			var parent = Path.GetDirectoryName(current);
+			if (string.IsNullOrEmpty(parent) || string.Equals(parent, current, StringComparison.Ordinal))
+				break;
+			current = parent;
+		}
+		return current;
+	}
+
+	private static bool IsWithin(string path, string root, StringComparison comparison)
+	{
+		if (path.Equals(root, comparison))
+			return true;
+		var prefix = root.EndsWith(Path.DirectorySeparatorChar)
+			? root
+			: root + Path.DirectorySeparatorChar;
+		return path.StartsWith(prefix, comparison);
+	}
+}

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.IO.Enumeration;
 using System.Runtime.ExceptionServices;
 using System.Security;
 using DevProjex.Infrastructure.Processes;
@@ -982,7 +983,7 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 		var quotaExceeded = 0;
 		using var quotaMonitorCancellation = CancellationTokenSource.CreateLinkedTokenSource(operationToken);
 		var quotaMonitor = quotaPath is null
-			? Task.CompletedTask
+			? Task.FromResult(default(QuotaMonitorState))
 			: MonitorRepositoryQuotaAsync(
 				process,
 				quotaPath,
@@ -1003,9 +1004,20 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
         try
         {
 			await WaitForExitOrTerminateAsync(process, operationToken);
+			var processExitTimestamp = Stopwatch.GetTimestamp();
 			quotaMonitorCancellation.Cancel();
-			await ObserveQuotaMonitorAsync(quotaMonitor).ConfigureAwait(false);
-			if (quotaPath is not null && ExceedsRepositoryQuota(quotaPath))
+			var quotaMonitorState = await ObserveQuotaMonitorAsync(quotaMonitor).ConfigureAwait(false);
+			TimeSpan? lastScanAge = quotaMonitorState.LastScanCompletedTimestamp switch
+			{
+				{ } lastScanTimestamp when processExitTimestamp > lastScanTimestamp =>
+					Stopwatch.GetElapsedTime(lastScanTimestamp, processExitTimestamp),
+				{ } => TimeSpan.Zero,
+				_ => null
+			};
+			if (quotaPath is not null &&
+			    Volatile.Read(ref quotaExceeded) == 0 &&
+			    ShouldPerformFinalQuotaScan(lastScanAge, _resourceLimits.PollInterval) &&
+			    ExceedsRepositoryQuota(quotaPath))
 				Interlocked.Exchange(ref quotaExceeded, 1);
 			var outputCompleted = await GitProcessOutputReader
 				.WaitForCompletionAfterExitAsync(process, outputPump, errorPump)
@@ -1091,17 +1103,22 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 		}
 	}
 
-	private async Task MonitorRepositoryQuotaAsync(
+	private async Task<QuotaMonitorState> MonitorRepositoryQuotaAsync(
 		Process process,
 		string path,
 		Action markExceeded,
 		CancellationToken cancellationToken)
 	{
+		long? lastScanCompletedTimestamp = null;
 		try
 		{
+			await Task.Yield();
 			while (!process.HasExited)
 			{
-				if (ExceedsRepositoryQuota(path))
+				var scanStartedTimestamp = Stopwatch.GetTimestamp();
+				var exceeded = ExceedsRepositoryQuota(path);
+				lastScanCompletedTimestamp = Stopwatch.GetTimestamp();
+				if (exceeded)
 				{
 					markExceeded();
 					try
@@ -1114,15 +1131,35 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 					       System.ComponentModel.Win32Exception)
 					{
 					}
-					return;
+					return new QuotaMonitorState(lastScanCompletedTimestamp);
 				}
-				await Task.Delay(_resourceLimits.PollInterval, cancellationToken).ConfigureAwait(false);
+				var scanDuration = Stopwatch.GetElapsedTime(
+					scanStartedTimestamp,
+					lastScanCompletedTimestamp.Value);
+				var delay = CalculateQuotaPollDelay(scanDuration, _resourceLimits.PollInterval);
+				await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 			}
 		}
 		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 		{
 		}
+		return new QuotaMonitorState(lastScanCompletedTimestamp);
 	}
+
+	internal static TimeSpan CalculateQuotaPollDelay(
+		TimeSpan scanDuration,
+		TimeSpan minimumPollInterval)
+	{
+		var adaptiveTicks = scanDuration.Ticks > TimeSpan.MaxValue.Ticks / 10
+			? TimeSpan.MaxValue.Ticks
+			: scanDuration.Ticks * 10;
+		return TimeSpan.FromTicks(Math.Max(minimumPollInterval.Ticks, adaptiveTicks));
+	}
+
+	internal static bool ShouldPerformFinalQuotaScan(
+		TimeSpan? lastScanAge,
+		TimeSpan pollInterval) =>
+		lastScanAge is null || lastScanAge.Value >= pollInterval;
 
 	private bool ExceedsRepositoryQuota(string path)
 	{
@@ -1131,19 +1168,23 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 		{
 			if (!Directory.Exists(path))
 				return false;
-			foreach (var file in Directory.EnumerateFiles(
-				         path,
-				         "*",
-				         new EnumerationOptions
-				         {
-					         RecurseSubdirectories = true,
-					         AttributesToSkip = FileAttributes.ReparsePoint,
-					         IgnoreInaccessible = true
-				         }))
+			var files = new FileSystemEnumerable<long>(
+				path,
+				static (ref FileSystemEntry entry) => entry.Length,
+				new EnumerationOptions
+				{
+					RecurseSubdirectories = true,
+					AttributesToSkip = FileAttributes.ReparsePoint,
+					IgnoreInaccessible = true
+				})
+			{
+				ShouldIncludePredicate = static (ref FileSystemEntry entry) => !entry.IsDirectory
+			};
+			foreach (var length in files)
 			{
 				try
 				{
-					total = checked(total + new FileInfo(file).Length);
+					total = checked(total + length);
 					if (total > _resourceLimits.MaximumRepositoryBytes)
 						return true;
 				}
@@ -1158,16 +1199,20 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 		return false;
 	}
 
-	private static async Task ObserveQuotaMonitorAsync(Task monitor)
+	private static async Task<QuotaMonitorState> ObserveQuotaMonitorAsync(
+		Task<QuotaMonitorState> monitor)
 	{
 		try
 		{
-			await monitor.ConfigureAwait(false);
+			return await monitor.ConfigureAwait(false);
 		}
 		catch (OperationCanceledException)
 		{
+			return default;
 		}
 	}
+
+	private readonly record struct QuotaMonitorState(long? LastScanCompletedTimestamp);
 
 	private static GitCloneResult FailedClone(
 		string localPath,

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -34,6 +34,8 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 	internal const int MaximumProgressFrameCharacters = 4 * 1024;
 	internal const string CacheQuotaDiagnostic =
 		"DPX-GIT-CACHE-QUOTA: Git cache size exceeds the configured limit.";
+	internal const string CacheReserveDiagnostic =
+		"DPX-GIT-CACHE-RESERVE: Git cache destination does not have the required free-space reserve.";
     private readonly string? _gitExecutable;
     private readonly bool _allowFileTransport;
 	private readonly bool _materializeTestClone;
@@ -142,7 +144,7 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 					targetDirectory,
 					repoName,
 					resultRepositoryUrl,
-					CacheQuotaDiagnostic);
+					CacheReserveDiagnostic);
 
             // Note: progress status is set by caller to show localized message
             // We only report dynamic progress (git output with percentages)
@@ -563,7 +565,7 @@ public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 				return false;
 			if (!HasTransferAdmission(RepositoryCacheLayout.GetContainer(repositoryPath)))
 			{
-				progress?.Report(CacheQuotaDiagnostic);
+				progress?.Report(CacheReserveDiagnostic);
 				return false;
 			}
 			await using var baseLock = await RepositoryFileLease.AcquireExclusiveAsync(

--- a/Infrastructure/Git/GitRepositoryService.cs
+++ b/Infrastructure/Git/GitRepositoryService.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
+using System.Security;
 using DevProjex.Infrastructure.Processes;
 using DevProjex.Kernel;
 
@@ -22,17 +24,23 @@ namespace DevProjex.Infrastructure.Git;
 /// - Force operations (-B checkout, --hard reset) are safe for cached copies
 /// - AI assistants: Do NOT change these optimizations without understanding the read-only cache context
 /// </summary>
-public sealed class GitRepositoryService : IGitRepositoryService
+public sealed class GitRepositoryService : IGitRepositoryService, IDisposable
 {
 	internal const string TestFileTransportPolicyVariable =
 		"DEVPROJEX_INTERNAL_TEST_ALLOW_FILE_GIT";
     private const int CommandOutputBufferChars = 64 * 1024;
     private const int CommandErrorBufferChars = 64 * 1024;
-    internal const int MaximumProgressFrameCharacters = 4 * 1024;
+	internal const int MaximumProgressFrameCharacters = 4 * 1024;
+	internal const string CacheQuotaDiagnostic =
+		"DPX-GIT-CACHE-QUOTA: Git cache size exceeds the configured limit.";
     private readonly string? _gitExecutable;
     private readonly bool _allowFileTransport;
 	private readonly bool _materializeTestClone;
 	private readonly bool _retainTestManagedMarker;
+	private readonly GitRepositoryResourceLimits _resourceLimits;
+	private readonly ConcurrentDictionary<string, GitAskPassSession> _authenticationSessions =
+		new(StringComparer.Ordinal);
+	private int _disposed;
 
     public GitRepositoryService()
     {
@@ -43,6 +51,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
 			"1",
 			StringComparison.Ordinal);
 		_materializeTestClone = _allowFileTransport;
+		_resourceLimits = GitRepositoryResourceLimits.Default;
         _ = GitRuntime.VersionDisplay;
         _ = GitRuntime.SshExecutable;
     }
@@ -51,6 +60,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(gitExecutable);
         _gitExecutable = gitExecutable;
+		_resourceLimits = GitRepositoryResourceLimits.Default;
     }
 
     internal GitRepositoryService(bool allowFileTransportForTests)
@@ -61,10 +71,22 @@ public sealed class GitRepositoryService : IGitRepositoryService
 	internal GitRepositoryService(
 		bool allowFileTransportForTests,
 		bool retainTestManagedMarker)
+		: this(
+			allowFileTransportForTests,
+			retainTestManagedMarker,
+			GitRepositoryResourceLimits.Default)
+	{
+	}
+
+	internal GitRepositoryService(
+		bool allowFileTransportForTests,
+		bool retainTestManagedMarker,
+		GitRepositoryResourceLimits resourceLimits)
     {
         _allowFileTransport = allowFileTransportForTests;
 		_materializeTestClone = allowFileTransportForTests;
 		_retainTestManagedMarker = allowFileTransportForTests && retainTestManagedMarker;
+		_resourceLimits = (resourceLimits ?? throw new ArgumentNullException(nameof(resourceLimits))).Validate();
         _ = GitRuntime.VersionDisplay;
         _ = GitRuntime.SshExecutable;
     }
@@ -97,7 +119,7 @@ public sealed class GitRepositoryService : IGitRepositoryService
             url,
             out var cloneUrl,
             out var authentication);
-        var resultRepositoryUrl = RepositoryUrlUtility.ToSafeDisplay(cloneUrl);
+		var resultRepositoryUrl = RepositoryUrlUtility.ToSafeDisplay(url);
         var repoName = RepositoryUrlUtility.GetRepositoryName(resultRepositoryUrl);
 
         try
@@ -114,15 +136,24 @@ public sealed class GitRepositoryService : IGitRepositoryService
                     ErrorMessage: "Clone failed");
             }
 
+			if (!HasTransferAdmission(targetDirectory))
+				return FailedClone(
+					targetDirectory,
+					repoName,
+					resultRepositoryUrl,
+					CacheQuotaDiagnostic);
+
             // Note: progress status is set by caller to show localized message
             // We only report dynamic progress (git output with percentages)
 
             // Git suppresses transfer progress when stderr is redirected. --progress is required
             // here so a long clone cannot look frozen while the external process is still active.
             // SHALLOW CLONE: --depth 1 downloads only 1 commit for speed.
-            using var askPass = authentication is null
-                ? null
-                : GitAskPassSession.Create(authentication);
+			var askPass = authentication is null
+				? null
+				: GetOrCreateAuthenticationSession(
+					RepositoryUrlUtility.ToSafeSourceIdentity(url),
+					authentication);
             var result = await RunGitCommandAsync(
                 null,
 				GitProcessOperation.CloneRepository(
@@ -131,12 +162,15 @@ public sealed class GitRepositoryService : IGitRepositoryService
 					_allowFileTransport),
                 cancellationToken,
                 progress,
-                askPass);
+				askPass,
+				quotaPath: targetDirectory);
 
             if (result.ExitCode != 0)
             {
                 // Parse git error and provide user-friendly message
-                var errorMessage = ParseGitCloneError(result.Error);
+				var errorMessage = result.Error.Contains(CacheQuotaDiagnostic, StringComparison.Ordinal)
+					? CacheQuotaDiagnostic
+					: ParseGitCloneError(result.Error);
 
                 return new GitCloneResult(
                     Success: false,
@@ -148,7 +182,11 @@ public sealed class GitRepositoryService : IGitRepositoryService
                     ErrorMessage: errorMessage);
             }
 
-			GitRemoteIdentityStore.Write(targetDirectory, cloneUrl, _allowFileTransport);
+			GitRemoteIdentityStore.Write(
+				targetDirectory,
+				cloneUrl,
+				url,
+				_allowFileTransport);
 
             // After clone, determine which branch we're on (usually main or master)
             var defaultBranch = await GetDefaultBranchAsync(targetDirectory, cancellationToken);
@@ -317,7 +355,8 @@ public sealed class GitRepositoryService : IGitRepositoryService
 						GitBranchListKind.RemoteHeads,
 						remoteUrl,
 						_allowFileTransport),
-					cancellationToken).ConfigureAwait(false);
+					cancellationToken,
+					askPass: GetAuthenticationSession(repositoryPath)).ConfigureAwait(false);
 
             var seen = new HashSet<string>(StringComparer.Ordinal);
 
@@ -394,6 +433,14 @@ public sealed class GitRepositoryService : IGitRepositoryService
                     }
                 }
             }
+
+			if (!string.IsNullOrWhiteSpace(currentBranch) && seen.Add(currentBranch))
+			{
+				branches.Add(new GitBranch(
+					Name: currentBranch,
+					IsActive: true,
+					IsRemote: false));
+			}
 
             // Sort: active branch first, then alphabetically
             branches.Sort((a, b) =>
@@ -513,6 +560,11 @@ public sealed class GitRepositoryService : IGitRepositoryService
 				.ConfigureAwait(false);
 			if (remoteUrl is null)
 				return false;
+			if (!HasTransferAdmission(RepositoryCacheLayout.GetContainer(repositoryPath)))
+			{
+				progress?.Report(CacheQuotaDiagnostic);
+				return false;
+			}
 			await using var baseLock = await RepositoryFileLease.AcquireExclusiveAsync(
 				RepositoryCacheLayout.GetBaseOperationLockPath(
 					RepositoryCacheLayout.GetContainer(repositoryPath),
@@ -529,7 +581,9 @@ public sealed class GitRepositoryService : IGitRepositoryService
 					remoteUrl,
 					currentBranch,
 					allowFileTransport: _allowFileTransport),
-				cancellationToken);
+				cancellationToken,
+				askPass: GetAuthenticationSession(repositoryPath),
+				quotaPath: RepositoryCacheLayout.GetContainer(repositoryPath));
 
             if (fetchResult.ExitCode != 0)
                 return false;  // Network error or branch doesn't exist
@@ -668,6 +722,8 @@ public sealed class GitRepositoryService : IGitRepositoryService
 				.ConfigureAwait(false);
 			if (remoteUrl is null)
 				return false;
+			if (!HasTransferAdmission(container))
+				return false;
             var setBranches = await RunGitCommandAsync(
                 repositoryPath,
 				GitProcessOperation.ManagedConfigWrite(
@@ -680,7 +736,9 @@ public sealed class GitRepositoryService : IGitRepositoryService
 					remoteUrl,
 					branchName,
 					allowFileTransport: _allowFileTransport),
-                cancellationToken);
+				cancellationToken,
+				askPass: GetAuthenticationSession(repositoryPath),
+				quotaPath: RepositoryCacheLayout.GetContainer(repositoryPath));
             if (setBranches.ExitCode != 0 || fetch.ExitCode != 0)
                 return false;
         }
@@ -849,6 +907,38 @@ public sealed class GitRepositoryService : IGitRepositoryService
 		}
 	}
 
+	private GitAskPassSession GetOrCreateAuthenticationSession(
+		string sourceIdentity,
+		GitCloneAuthentication authentication)
+	{
+		ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+		var identity = RepositoryUrlUtility.GetSourceCacheKey(sourceIdentity);
+		if (identity.Length == 0)
+			throw new InvalidOperationException("The authenticated source identity is invalid.");
+		return _authenticationSessions.GetOrAdd(
+			identity,
+			_ => GitAskPassSession.Create(authentication));
+	}
+
+	private GitAskPassSession? GetAuthenticationSession(string repositoryPath)
+	{
+		if (!GitRemoteIdentityStore.TryReadSourceIdentity(repositoryPath, out var sourceIdentity))
+			return null;
+		var identity = RepositoryUrlUtility.GetSourceCacheKey(sourceIdentity);
+		return identity.Length > 0 && _authenticationSessions.TryGetValue(identity, out var session)
+			? session
+			: null;
+	}
+
+	public void Dispose()
+	{
+		if (Interlocked.Exchange(ref _disposed, 1) != 0)
+			return;
+		foreach (var session in _authenticationSessions.Values)
+			session.Dispose();
+		_authenticationSessions.Clear();
+	}
+
     /// <summary>
     /// Executes a git command asynchronously with proper output capture.
     ///
@@ -858,12 +948,13 @@ public sealed class GitRepositoryService : IGitRepositoryService
     /// - Supports cancellation with process termination
     /// - Uses UTF-8 encoding for international characters
     /// </summary>
-    private async Task<GitCommandResult> RunGitCommandAsync(
+	private async Task<GitCommandResult> RunGitCommandAsync(
         string? workingDirectory,
 		GitProcessOperation operation,
         CancellationToken cancellationToken,
         IProgress<string>? progress = null,
-        GitAskPassSession? askPass = null)
+		GitAskPassSession? askPass = null,
+		string? quotaPath = null)
     {
         // Honor pre-canceled tokens before spawning git. Without this guard a very fast
         // command such as "git --version" can complete before WaitForExitAsync observes
@@ -888,6 +979,15 @@ public sealed class GitRepositoryService : IGitRepositoryService
 
         process.Start();
         process.StandardInput.Close();
+		var quotaExceeded = 0;
+		using var quotaMonitorCancellation = CancellationTokenSource.CreateLinkedTokenSource(operationToken);
+		var quotaMonitor = quotaPath is null
+			? Task.CompletedTask
+			: MonitorRepositoryQuotaAsync(
+				process,
+				quotaPath,
+				() => Interlocked.Exchange(ref quotaExceeded, 1),
+				quotaMonitorCancellation.Token);
 
         var outputPump = GitProcessLinePump.ReadAsync(
             process.StandardOutput,
@@ -903,6 +1003,10 @@ public sealed class GitRepositoryService : IGitRepositoryService
         try
         {
 			await WaitForExitOrTerminateAsync(process, operationToken);
+			quotaMonitorCancellation.Cancel();
+			await ObserveQuotaMonitorAsync(quotaMonitor).ConfigureAwait(false);
+			if (quotaPath is not null && ExceedsRepositoryQuota(quotaPath))
+				Interlocked.Exchange(ref quotaExceeded, 1);
 			var outputCompleted = await GitProcessOutputReader
 				.WaitForCompletionAfterExitAsync(process, outputPump, errorPump)
 				.ConfigureAwait(false);
@@ -912,12 +1016,20 @@ public sealed class GitRepositoryService : IGitRepositoryService
         }
 		catch (OperationCanceledException)
 		{
+			quotaMonitorCancellation.Cancel();
+			await ObserveQuotaMonitorAsync(quotaMonitor).ConfigureAwait(false);
 			await GitProcessOutputReader
 				.ObserveAfterTerminationAsync(process, outputPump, errorPump)
 				.ConfigureAwait(false);
 			if (cancellationToken.IsCancellationRequested)
 				throw;
 			return GitCommandResult.Failed("Git operation exceeded its safety deadline.");
+		}
+
+		if (Volatile.Read(ref quotaExceeded) != 0)
+		{
+			progress?.Report(CacheQuotaDiagnostic);
+			return GitCommandResult.Failed(CacheQuotaDiagnostic);
 		}
 
 		var outputExceeded = outputBuffer.ExceededLimit || errorBuffer.ExceededLimit;
@@ -965,6 +1077,111 @@ public sealed class GitRepositoryService : IGitRepositoryService
             }
         }
     }
+
+	private bool HasTransferAdmission(string destinationPath)
+	{
+		try
+		{
+			return _resourceLimits.GetAvailableFreeSpace(destinationPath) >=
+			       _resourceLimits.FreeSpaceReserveBytes;
+		}
+		catch (Exception exception) when (exception is ArgumentException or IOException or UnauthorizedAccessException or SecurityException or NotSupportedException)
+		{
+			return false;
+		}
+	}
+
+	private async Task MonitorRepositoryQuotaAsync(
+		Process process,
+		string path,
+		Action markExceeded,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			while (!process.HasExited)
+			{
+				if (ExceedsRepositoryQuota(path))
+				{
+					markExceeded();
+					try
+					{
+						process.Kill(entireProcessTree: true);
+					}
+					catch (Exception exception) when (exception is
+					       InvalidOperationException or
+					       NotSupportedException or
+					       System.ComponentModel.Win32Exception)
+					{
+					}
+					return;
+				}
+				await Task.Delay(_resourceLimits.PollInterval, cancellationToken).ConfigureAwait(false);
+			}
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+		}
+	}
+
+	private bool ExceedsRepositoryQuota(string path)
+	{
+		long total = 0;
+		try
+		{
+			if (!Directory.Exists(path))
+				return false;
+			foreach (var file in Directory.EnumerateFiles(
+				         path,
+				         "*",
+				         new EnumerationOptions
+				         {
+					         RecurseSubdirectories = true,
+					         AttributesToSkip = FileAttributes.ReparsePoint,
+					         IgnoreInaccessible = true
+				         }))
+			{
+				try
+				{
+					total = checked(total + new FileInfo(file).Length);
+					if (total > _resourceLimits.MaximumRepositoryBytes)
+						return true;
+				}
+				catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or OverflowException)
+				{
+				}
+			}
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+		{
+		}
+		return false;
+	}
+
+	private static async Task ObserveQuotaMonitorAsync(Task monitor)
+	{
+		try
+		{
+			await monitor.ConfigureAwait(false);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+	}
+
+	private static GitCloneResult FailedClone(
+		string localPath,
+		string repositoryName,
+		string repositoryUrl,
+		string errorMessage) =>
+		new(
+			Success: false,
+			LocalPath: localPath,
+			SourceType: ProjectSourceType.GitClone,
+			DefaultBranch: null,
+			RepositoryName: repositoryName,
+			RepositoryUrl: repositoryUrl,
+			ErrorMessage: errorMessage);
 
     private static string SanitizeProgressFrame(string value)
     {

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -1929,11 +1929,30 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 			var entries = document.Entries
 				.Where(candidate =>
 					!string.Equals(candidate.Identity, identity, StringComparison.Ordinal) &&
-					!ArePathsInSameRepository(candidate.LocalPath, normalizedPath))
+					!ArePathsInSameRepository(candidate.LocalPath, normalizedPath) &&
+					!IsLegacySafeUrlIdentity(candidate, safeUrl, identity))
 				.ToList();
 			entries.Add(entry);
 			WriteIndex(fileSet, entries);
 		}
+	}
+
+	private static bool IsLegacySafeUrlIdentity(
+		RepositoryCacheIndexEntry candidate,
+		string safeUrl,
+		string replacementIdentity)
+	{
+		if (!string.Equals(
+				RepositoryUrlUtility.ToSafeDisplay(candidate.RepositoryUrl),
+				safeUrl,
+				StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		var anonymousIdentity = RepositoryUrlUtility.GetSourceCacheKey(candidate.RepositoryUrl);
+		return !string.Equals(anonymousIdentity, replacementIdentity, StringComparison.Ordinal) &&
+		       string.Equals(candidate.Identity, anonymousIdentity, StringComparison.Ordinal);
 	}
 
 	private RepositoryCacheIndexEntry? FindIndexedRepositoryByIdentity(string identity)
@@ -2748,7 +2767,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 		return new RepositoryCacheIndexDocument(CacheIndexSchemaVersion, entries);
 	}
 
-	private static RepositoryCacheIndexEntry? NormalizeIndexEntryOrNull(
+	private RepositoryCacheIndexEntry? NormalizeIndexEntryOrNull(
 		RepositoryCacheIndexEntry entry,
 		DateTimeOffset maximumAcceptedTimestamp)
 	{
@@ -2757,8 +2776,21 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 			var safeUrl = RepositoryUrlUtility.ToSafeDisplay(entry.RepositoryUrl);
 			if (safeUrl.Length == 0)
 				return null;
+			var identity = entry.Identity;
+			if (!RepositoryUrlUtility.IsCurrentSourceCacheKey(identity))
+			{
+				var identitySource = GitRemoteIdentityStore.TryReadSourceIdentity(
+					entry.LocalPath,
+					out var storedSourceIdentity)
+					? storedSourceIdentity
+					: safeUrl;
+				identity = RepositoryUrlUtility.GetSourceCacheKey(identitySource);
+				if (identity.Length == 0)
+					return null;
+			}
 			return entry with
 			{
+				Identity = identity,
 				RepositoryUrl = safeUrl,
 				LastUsedUtc = entry.LastUsedUtc <= DateTimeOffset.UnixEpoch ||
 				              entry.LastUsedUtc > maximumAcceptedTimestamp

--- a/Infrastructure/Git/RepoCacheService.cs
+++ b/Infrastructure/Git/RepoCacheService.cs
@@ -23,6 +23,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 	private const int MaximumPortablePathComponentBytes = 255;
 	private const int MaximumRepositoryNameUtf8Bytes =
 		MaximumPortablePathComponentBytes - UniquePathSuffixLength - 1;
+	private const int MaximumSynchronousPublicationFileCount = 1024;
 	private const UnixFileMode PrivateUnixDirectoryMode =
 		UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
 	internal const long MaximumCacheIndexBytes = 64L * 1024 * 1024;
@@ -230,14 +231,20 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 					Path.Combine(container, RepositoryCacheLayout.MarkerFileName),
 					contentKind == RepositoryCacheContentKind.Git ? "git" : "zip");
 				Directory.Move(normalizedStagingPath, destination);
+				var approximateSize = CalculateDirectorySizeBounded(
+					container,
+					MaximumSynchronousPublicationFileCount,
+					out var sizeIsComplete);
 				RecordIndexedRepositoryCore(
 					repositoryUrl,
 					destination,
 					branch: null,
 					commitHash: null,
 					RepositoryCacheEntryState.Ready,
-					CalculateDirectorySize(container),
+					approximateSize,
 					contentKind);
+				if (!sizeIsComplete)
+					ScheduleRepositorySizeRefresh(destination);
 			}
 			return destination;
 		}
@@ -250,7 +257,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 
 	public RepositoryCacheIndexEntry? FindIndexedRepository(string repositoryUrl)
 	{
-		var identity = RepositoryUrlUtility.GetComparisonKey(repositoryUrl);
+		var identity = RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl);
 		if (identity.Length == 0)
 			return null;
 
@@ -459,7 +466,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 		string? branch = null,
 		CancellationToken cancellationToken = default)
 	{
-		var identity = RepositoryUrlUtility.GetComparisonKey(repositoryUrl);
+		var identity = RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl);
 		if (identity.Length == 0)
 			return null;
 
@@ -519,7 +526,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 		string repositoryUrl,
 		CancellationToken cancellationToken = default)
 	{
-		var identity = RepositoryUrlUtility.GetComparisonKey(repositoryUrl);
+		var identity = RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl);
 		if (identity.Length == 0)
 			throw new ArgumentException("Repository URL is invalid.", nameof(repositoryUrl));
 
@@ -636,7 +643,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 		string identity;
 		try
 		{
-			identity = RepositoryUrlUtility.GetComparisonKey(repositoryUrl);
+			identity = RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl);
 		}
 		catch
 		{
@@ -1871,8 +1878,7 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 		RepositoryCacheContentKind contentKind)
 	{
 		var safeUrl = RepositoryUrlUtility.ToSafeDisplay(repositoryUrl);
-		var identity = RepositoryUrlUtility.GetComparisonKey(safeUrl);
-		if (identity.Length == 0 || string.IsNullOrWhiteSpace(localPath))
+		if (string.IsNullOrWhiteSpace(localPath))
 			return;
 
 		string normalizedPath;
@@ -1886,6 +1892,14 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 		}
 
 		if (!IsInCache(normalizedPath))
+			return;
+		var identitySource = GitRemoteIdentityStore.TryReadSourceIdentity(
+			normalizedPath,
+			out var storedSourceIdentity)
+			? storedSourceIdentity
+			: safeUrl;
+		var identity = RepositoryUrlUtility.GetSourceCacheKey(identitySource);
+		if (identity.Length == 0)
 			return;
 
 		var fileSet = GetIndexFileSet();
@@ -2444,6 +2458,39 @@ public sealed class RepoCacheService : IRepoCacheService, IDisposable, IAsyncDis
 			foreach (var file in Directory.EnumerateFiles(path, "*", RecursiveCacheEnumeration))
 			{
 				cancellationToken.ThrowIfCancellationRequested();
+				try
+				{
+					total = checked(total + new FileInfo(file).Length);
+				}
+				catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or OverflowException)
+				{
+				}
+			}
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+		}
+		return total;
+	}
+
+	private static long CalculateDirectorySizeBounded(
+		string path,
+		int maximumFileCount,
+		out bool complete)
+	{
+		long total = 0;
+		var fileCount = 0;
+		complete = true;
+		try
+		{
+			foreach (var file in Directory.EnumerateFiles(path, "*", RecursiveCacheEnumeration))
+			{
+				if (++fileCount > maximumFileCount)
+				{
+					complete = false;
+					return 0;
+				}
+
 				try
 				{
 					total = checked(total + new FileInfo(file).Length);

--- a/Infrastructure/Git/ZipDownloadService.cs
+++ b/Infrastructure/Git/ZipDownloadService.cs
@@ -15,10 +15,12 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
     private const int ExtractionProgressReportInterval = 50;
 	private const long MaximumRepositoryMetadataBytes = 64 * 1024;
     private static readonly TimeSpan DefaultHttpTimeout = TimeSpan.FromMinutes(10);
+	private static readonly TimeSpan DefaultBodyProgressTimeout = TimeSpan.FromSeconds(30);
 
     private readonly HttpClient _httpClient;
     private readonly ZipResourceLimits _limits;
     private readonly Func<ZipArchiveEntry, Stream> _openEntryStream;
+	private readonly TimeSpan _bodyProgressTimeout;
     private bool _disposed;
 
     public ZipDownloadService()
@@ -63,6 +65,9 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
         _openEntryStream = openEntryStream ?? throw new ArgumentNullException(nameof(openEntryStream));
         _limits.Validate();
         _httpClient.Timeout = httpTimeout;
+		_bodyProgressTimeout = httpTimeout < DefaultBodyProgressTimeout
+			? httpTimeout
+			: DefaultBodyProgressTimeout;
         _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("DevProjex/1.0");
     }
 
@@ -87,8 +92,23 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
                 ErrorMessage: "Could not determine ZIP download URL");
         }
 
-        var metadataBranch = await TryGetDefaultBranchAsync(owner, repository, cancellationToken)
-            .ConfigureAwait(false);
+		string? metadataBranch;
+		try
+		{
+			metadataBranch = await TryGetDefaultBranchAsync(owner, repository, cancellationToken)
+				.ConfigureAwait(false);
+		}
+		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		{
+			return new GitCloneResult(
+				Success: false,
+				LocalPath: targetDirectory,
+				SourceType: ProjectSourceType.ZipDownload,
+				DefaultBranch: null,
+				RepositoryName: repoName,
+				RepositoryUrl: resultRepositoryUrl,
+				ErrorMessage: "DPX-ZIP-METADATA-TIMEOUT: ZIP metadata request timed out.");
+		}
         var branch = metadataBranch ?? "main";
         var zipUrl = CreateZipUrl(owner, repository, branch);
         var tempZipPath = Path.Combine(Path.GetTempPath(), $"devprojex_{Guid.NewGuid():N}.zip");
@@ -140,9 +160,11 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
                     ReportPercent(progress, 0, ref lastDownloadPercent);
 
                     int bytesRead;
-                    while ((bytesRead = await contentStream
-                               .ReadAsync(buffer.AsMemory(0, StreamBufferSize), cancellationToken)
-                               .ConfigureAwait(false)) > 0)
+					while ((bytesRead = await ReadArchiveBodyAsync(
+					           contentStream,
+					           buffer.AsMemory(0, StreamBufferSize),
+					           cancellationToken)
+					       .ConfigureAwait(false)) > 0)
                     {
                         if (bytesRead > _limits.MaxDownloadedArchiveBytes - totalRead)
                             throw ZipResourceLimits.CreateLimitException(
@@ -244,7 +266,17 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 
         var declaredTotal = ValidateArchiveMetadata(archive, archiveSize);
         EnsureAvailableFreeSpace(targetDirectory, declaredTotal);
-        var extractionPlan = BuildExtractionPlan(archive, targetDirectory);
+		var extractionPlan = BuildExtractionPlan(
+			archive,
+			targetDirectory,
+			out var skippedSymbolicLinks);
+		if (skippedSymbolicLinks > 0)
+		{
+			progress?.Report(
+				skippedSymbolicLinks == 1
+					? "DPX-ZIP-SYMLINK-SKIPPED: 1 symbolic link entry was skipped."
+					: $"DPX-ZIP-SYMLINK-SKIPPED: {skippedSymbolicLinks} symbolic link entries were skipped.");
+		}
         Directory.CreateDirectory(targetDirectory);
 
         var extractionBudget = new ZipExtractionBudget(archiveSize, _limits);
@@ -464,8 +496,10 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 
 	private static IReadOnlyList<ZipExtractionEntry> BuildExtractionPlan(
 		ZipArchive archive,
-		string targetDirectory)
+		string targetDirectory,
+		out int skippedSymbolicLinks)
 	{
+		skippedSymbolicLinks = 0;
 		var planned = new List<ZipExtractionEntry>(archive.Entries.Count);
 		var explicitEntries = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 		var explicitFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -476,6 +510,11 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
 
 		foreach (var entry in archive.Entries)
 		{
+			if (IsSymbolicLinkEntry(entry))
+			{
+				skippedSymbolicLinks++;
+				continue;
+			}
 			var entryPath = entry.FullName;
 			if (!string.IsNullOrEmpty(rootFolder) && StartsWithFolderPrefix(entryPath, rootFolder))
 				entryPath = entryPath[(rootFolder.Length + 1)..];
@@ -628,10 +667,31 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
         return destinationPath;
     }
 
-    private static bool IsDirectoryEntry(ZipArchiveEntry entry)
+	private static bool IsDirectoryEntry(ZipArchiveEntry entry)
         => entry.FullName.EndsWith("/", StringComparison.Ordinal) ||
            entry.FullName.EndsWith("\\", StringComparison.Ordinal) ||
            string.IsNullOrEmpty(entry.Name);
+
+	private static bool IsSymbolicLinkEntry(ZipArchiveEntry entry) =>
+		((uint)entry.ExternalAttributes >> 16 & 0xF000u) == 0xA000u;
+
+	private async ValueTask<int> ReadArchiveBodyAsync(
+		Stream contentStream,
+		Memory<byte> buffer,
+		CancellationToken cancellationToken)
+	{
+		using var progressDeadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		progressDeadline.CancelAfter(_bodyProgressTimeout);
+		try
+		{
+			return await contentStream.ReadAsync(buffer, progressDeadline.Token).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		{
+			throw new IOException(
+				"DPX-ZIP-BODY-TIMEOUT: ZIP archive body made no progress within the configured deadline.");
+		}
+	}
 
     private static bool IsPathWithinDirectory(string path, string directory)
     {
@@ -697,11 +757,10 @@ public sealed class ZipDownloadService : IZipDownloadService, IDisposable
         try
         {
             var fullPath = Path.GetFullPath(targetDirectory);
-            var root = Path.GetPathRoot(fullPath);
-            if (string.IsNullOrEmpty(root))
-                return;
-
-            availableBytes = new DriveInfo(root).AvailableFreeSpace;
+			var root = GitRepositoryResourceLimits.ResolveDestinationDriveRoot(
+				fullPath,
+				DriveInfo.GetDrives().Select(static drive => drive.Name));
+			availableBytes = new DriveInfo(root).AvailableFreeSpace;
         }
         catch (Exception exception) when (
             exception is ArgumentException or

--- a/Kernel/Models/RepositoryUrlUtility.cs
+++ b/Kernel/Models/RepositoryUrlUtility.cs
@@ -155,6 +155,9 @@ public static class RepositoryUrlUtility
 		return SourceCacheIdentity(normalized);
 	}
 
+	public static bool IsCurrentSourceCacheKey(string? identity) =>
+		identity?.StartsWith(SourceCacheIdentityVersionPrefix, StringComparison.Ordinal) == true;
+
 	public static bool AreEquivalent(string? left, string? right)
 	{
 		var leftKey = GetComparisonKey(left);

--- a/Kernel/Models/RepositoryUrlUtility.cs
+++ b/Kernel/Models/RepositoryUrlUtility.cs
@@ -6,6 +6,9 @@ namespace DevProjex.Kernel.Models;
 public static class RepositoryUrlUtility
 {
 	private const string ComparisonIdentityVersionPrefix = "v2:";
+	private const string SourceCacheIdentityVersionPrefix = "v3:";
+	private const string TestFileTransportPolicyVariable =
+		"DEVPROJEX_INTERNAL_TEST_ALLOW_FILE_GIT";
 	private static readonly HashSet<string> CaseInsensitiveRepositoryPathHosts = new(
 		StringComparer.OrdinalIgnoreCase)
 	{
@@ -20,7 +23,13 @@ public static class RepositoryUrlUtility
 		return normalizedUrl.Length > 0;
 	}
 
-	public static string Normalize(string? repositoryUrl)
+	public static string Normalize(string? repositoryUrl) =>
+		Normalize(repositoryUrl, preserveHttpUserName: false);
+
+	public static string ToSafeSourceIdentity(string? repositoryUrl) =>
+		Normalize(repositoryUrl, preserveHttpUserName: true);
+
+	private static string Normalize(string? repositoryUrl, bool preserveHttpUserName)
 	{
 		if (string.IsNullOrWhiteSpace(repositoryUrl))
 			return string.Empty;
@@ -57,7 +66,7 @@ public static class RepositoryUrlUtility
 				Password = string.Empty,
 				Host = uri.Host.ToLowerInvariant()
 			};
-			if (uri.Scheme is "http" or "https")
+			if (!preserveHttpUserName && uri.Scheme is "http" or "https")
 				builder.UserName = string.Empty;
 
 			var sanitizedUri = builder.Uri;
@@ -89,12 +98,12 @@ public static class RepositoryUrlUtility
 				uri.AbsolutePath);
 		}
 		if (uri?.IsFile == true)
-			return BuildVersionedFileSystemKey(uri.LocalPath);
+			return BuildVersionedFileSystemKey(TrimGitSuffix(uri.LocalPath));
 
 		try
 		{
 			if (Path.IsPathFullyQualified(normalized))
-				return BuildVersionedFileSystemKey(normalized);
+				return BuildVersionedFileSystemKey(TrimGitSuffix(normalized));
 		}
 		catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
 		{
@@ -102,6 +111,48 @@ public static class RepositoryUrlUtility
 		}
 
 		return VersionIdentity(TrimGitSuffix(normalized));
+	}
+
+	public static string GetSourceCacheKey(string? repositoryUrl)
+	{
+		var normalized = ToSafeSourceIdentity(repositoryUrl);
+		if (normalized.Length == 0)
+			return string.Empty;
+
+		if (TryParseScpSyntax(normalized, out var scp))
+		{
+			return BuildSourceCacheHostPathKey(
+				"ssh",
+				scp.UserPrefix.TrimEnd('@'),
+				scp.Host,
+				22,
+				scp.Path);
+		}
+
+		if (Uri.TryCreate(normalized, UriKind.Absolute, out var uri) &&
+		    uri.Scheme is "http" or "https" or "ssh" or "git")
+		{
+			return BuildSourceCacheHostPathKey(
+				uri.Scheme.ToLowerInvariant(),
+				GetUserName(uri),
+				uri.Host,
+				GetEffectivePort(uri),
+				uri.AbsolutePath);
+		}
+		if (uri?.IsFile == true)
+			return BuildSourceCacheFileSystemKey(uri.LocalPath);
+
+		try
+		{
+			if (Path.IsPathFullyQualified(normalized))
+				return BuildSourceCacheFileSystemKey(normalized);
+		}
+		catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+		{
+			return string.Empty;
+		}
+
+		return SourceCacheIdentity(normalized);
 	}
 
 	public static bool AreEquivalent(string? left, string? right)
@@ -162,6 +213,21 @@ public static class RepositoryUrlUtility
 
 	public static bool IsSupportedCloneSource(string? repositoryUrl)
 	{
+		try
+		{
+			var localCandidate = repositoryUrl?.Trim();
+			if (!string.IsNullOrEmpty(localCandidate) &&
+			    !localCandidate.StartsWith("file:", StringComparison.OrdinalIgnoreCase) &&
+			    Path.IsPathFullyQualified(localCandidate) &&
+			    Directory.Exists(localCandidate))
+			{
+				return true;
+			}
+		}
+		catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+		{
+		}
+
 		if (!TryNormalize(repositoryUrl, out var normalized) ||
 		    normalized.StartsWith("-", StringComparison.Ordinal))
 		{
@@ -173,7 +239,11 @@ public static class RepositoryUrlUtility
 
 		if (Uri.TryCreate(normalized, UriKind.Absolute, out var uri))
 		{
-			return uri.Scheme is "http" or "https" or "ssh" or "git" or "file";
+			return uri.Scheme is "https" or "ssh" ||
+			       uri.IsFile && string.Equals(
+				       Environment.GetEnvironmentVariable(TestFileTransportPolicyVariable),
+				       "1",
+				       StringComparison.Ordinal);
 		}
 
 		try
@@ -207,15 +277,81 @@ public static class RepositoryUrlUtility
 		return VersionIdentity($"{normalizedHost}{portSuffix}/{normalizedPath.TrimStart('/')}");
 	}
 
+	private static string BuildSourceCacheHostPathKey(
+		string scheme,
+		string user,
+		string host,
+		int port,
+		string path)
+	{
+		var normalizedHost = host.Trim().ToLowerInvariant();
+		var caseInsensitivePath = CaseInsensitiveRepositoryPathHosts.Contains(normalizedHost);
+		var normalizedPath = TrimGitSuffix(
+			NormalizePath(path),
+			StringComparison.OrdinalIgnoreCase);
+		if (caseInsensitivePath)
+			normalizedPath = normalizedPath.ToLowerInvariant();
+		return SourceCacheIdentity(
+			$"{scheme.ToLowerInvariant()}://{user}@{normalizedHost}:{port}/{normalizedPath.TrimStart('/')}");
+	}
+
 	private static string BuildVersionedFileSystemKey(string path)
 	{
-		var normalizedPath = PathUtility.NormalizeForCacheKey(TrimGitSuffix(path));
+		var normalizedPath = PathUtility.NormalizeForCacheKey(path);
 		return VersionIdentity(
 			$"file/{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPath)))}");
 	}
 
+	private static string BuildSourceCacheFileSystemKey(string path)
+	{
+		var normalizedPath = PathUtility.NormalizeForCacheKey(ResolveLocalIdentityPath(path));
+		return SourceCacheIdentity(
+			$"file/{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPath)))}");
+	}
+
+	private static string ResolveLocalIdentityPath(string path)
+	{
+		var fullPath = Path.GetFullPath(path);
+		try
+		{
+			var info = new DirectoryInfo(fullPath);
+			if (info.Exists && info.LinkTarget is not null)
+				return info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? fullPath;
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException)
+		{
+		}
+		return fullPath;
+	}
+
+	private static string GetUserName(Uri uri)
+	{
+		if (string.IsNullOrEmpty(uri.UserInfo))
+			return string.Empty;
+		var separator = uri.UserInfo.IndexOf(':');
+		var encoded = separator >= 0 ? uri.UserInfo[..separator] : uri.UserInfo;
+		return Uri.UnescapeDataString(encoded);
+	}
+
+	private static int GetEffectivePort(Uri uri)
+	{
+		if (!uri.IsDefaultPort)
+			return uri.Port;
+		return uri.Scheme.ToLowerInvariant() switch
+		{
+			"http" => 80,
+			"https" => 443,
+			"ssh" => 22,
+			"git" => 9418,
+			_ => -1
+		};
+	}
+
 	private static string VersionIdentity(string identity) =>
 		$"{ComparisonIdentityVersionPrefix}{identity}";
+
+	private static string SourceCacheIdentity(string identity) =>
+		$"{SourceCacheIdentityVersionPrefix}{identity}";
 
 	private static string GetLastPathSegment(string value)
 	{

--- a/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
@@ -399,9 +399,15 @@ public sealed class GitPrivateHttpsAuthenticationIntegrationTests
 			authorityRequest.CertificateExtensions.Add(new X509KeyUsageExtension(
 				X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
 				true));
-			var authority = authorityRequest.CreateSelfSigned(
+			var authorityGenerator = X509SignatureGenerator.CreateForRSA(
+				authorityKey,
+				RSASignaturePadding.Pkcs1);
+			var authority = authorityRequest.Create(
+				authorityRequest.SubjectName,
+				authorityGenerator,
 				DateTimeOffset.UtcNow.AddMinutes(-5),
-				DateTimeOffset.UtcNow.AddDays(2));
+				DateTimeOffset.UtcNow.AddDays(2),
+				RandomNumberGenerator.GetBytes(16));
 
 			using var serverKey = RSA.Create(2048);
 			var serverRequest = new CertificateRequest(
@@ -421,7 +427,8 @@ public sealed class GitPrivateHttpsAuthenticationIntegrationTests
 			serverRequest.CertificateExtensions.Add(san.Build());
 			var serial = RandomNumberGenerator.GetBytes(16);
 			var publicServer = serverRequest.Create(
-				authority,
+				authority.SubjectName,
+				authorityGenerator,
 				DateTimeOffset.UtcNow.AddMinutes(-5),
 				DateTimeOffset.UtcNow.AddDays(1),
 				serial);

--- a/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
@@ -1,0 +1,454 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace DevProjex.Tests.Integration;
+
+[Collection(GitNetworkTestCollection.Name)]
+public sealed class GitPrivateHttpsAuthenticationIntegrationTests
+{
+	[Fact]
+	public async Task New044_PrivateCloneBranchFetchAndUpdateReuseAskPassSession()
+	{
+		using var temporary = new TemporaryDirectory();
+		var source = temporary.CreateDirectory("source");
+		RunGit(source, "init", "--initial-branch=main");
+		RunGit(source, "config", "user.name", "DevProjex Tests");
+		RunGit(source, "config", "user.email", "tests@devprojex.local");
+		await File.WriteAllTextAsync(
+			Path.Combine(source, "main.txt"),
+			"main\n",
+			TestContext.Current.CancellationToken);
+		RunGit(source, "add", ".");
+		RunGit(source, "commit", "-m", "main");
+		RunGit(source, "checkout", "-b", "private-feature");
+		await File.WriteAllTextAsync(
+			Path.Combine(source, "feature.txt"),
+			"first\n",
+			TestContext.Current.CancellationToken);
+		RunGit(source, "add", ".");
+		RunGit(source, "commit", "-m", "feature");
+		RunGit(source, "checkout", "main");
+		var bare = Path.Combine(temporary.Path, "private.git");
+		RunGit(temporary.Path, "clone", "--bare", source, bare);
+		RunGit(bare, "symbolic-ref", "HEAD", "refs/heads/main");
+		RunGit(bare, "update-server-info");
+
+		await using var server = await AuthenticatedGitHttpsServer.StartAsync(
+			bare,
+			"private-user",
+			"private-password");
+		var caFile = Path.Combine(temporary.Path, "test-ca.pem");
+		await File.WriteAllTextAsync(
+			caFile,
+			server.CertificateAuthority.ExportCertificatePem(),
+			TestContext.Current.CancellationToken);
+		var previousCa = Environment.GetEnvironmentVariable("GIT_SSL_CAINFO");
+		Environment.SetEnvironmentVariable("GIT_SSL_CAINFO", caFile);
+		try
+		{
+			using var service = new GitRepositoryService();
+			var target = Path.Combine(temporary.Path, "managed", RepositoryCacheLayout.BaseDirectoryName);
+			Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+			var authenticatedUrl = server.Url.Replace(
+				"https://",
+				"https://private-user:private-password@",
+				StringComparison.Ordinal);
+			var clone = await service.CloneAsync(
+				authenticatedUrl,
+				target,
+				cancellationToken: TestContext.Current.CancellationToken);
+			Assert.True(
+				clone.Success,
+				$"{clone.ErrorMessage}; authorized requests: {server.AuthorizedRequestCount}; " +
+				$"requests: {server.RequestCount}; server error: {server.LastError}");
+			Assert.DoesNotContain("private-password", clone.RepositoryUrl, StringComparison.Ordinal);
+			Assert.DoesNotContain(
+				"private-password",
+				await service.GetRemoteUrlAsync(target, TestContext.Current.CancellationToken) ?? string.Empty,
+				StringComparison.Ordinal);
+			await File.WriteAllTextAsync(
+				Path.Combine(Path.GetDirectoryName(target)!, RepositoryCacheLayout.MarkerFileName),
+				"git",
+				TestContext.Current.CancellationToken);
+
+			var branches = await service.GetBranchesAsync(target, TestContext.Current.CancellationToken);
+			Assert.True(
+				branches.Any(static branch => branch.Name == "private-feature"),
+				$"Branches: {string.Join(',', branches.Select(static branch => branch.Name))}; " +
+				$"authorized requests: {server.AuthorizedRequestCount}; server: {server.LastBackendResponse}");
+			Assert.True(await service.SwitchBranchAsync(
+				target,
+				"private-feature",
+				cancellationToken: TestContext.Current.CancellationToken));
+
+			RunGit(source, "checkout", "private-feature");
+			await File.AppendAllTextAsync(
+				Path.Combine(source, "feature.txt"),
+				"second\n",
+				TestContext.Current.CancellationToken);
+			RunGit(source, "add", ".");
+			RunGit(source, "commit", "-m", "feature update");
+			RunGit(source, "push", bare, "private-feature");
+			RunGit(bare, "update-server-info");
+
+			Assert.True(await service.PullUpdatesAsync(
+				target,
+				cancellationToken: TestContext.Current.CancellationToken));
+			Assert.Equal(
+				"first\nsecond\n",
+				(await File.ReadAllTextAsync(
+					Path.Combine(target, "feature.txt"),
+					TestContext.Current.CancellationToken)).ReplaceLineEndings("\n"));
+			Assert.True(server.AuthorizedRequestCount >= 3, server.AuthorizedRequestCount.ToString());
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("GIT_SSL_CAINFO", previousCa);
+		}
+	}
+
+	private static void RunGit(string workingDirectory, params string[] arguments)
+	{
+		var startInfo = new ProcessStartInfo(GitRuntime.GitExecutable)
+		{
+			WorkingDirectory = workingDirectory,
+			UseShellExecute = false,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		foreach (var argument in arguments)
+			startInfo.ArgumentList.Add(argument);
+		using var process = Process.Start(startInfo);
+		Assert.NotNull(process);
+		process.StandardInput.Close();
+		var output = process.StandardOutput.ReadToEnd();
+		var error = process.StandardError.ReadToEnd();
+		Assert.True(process.WaitForExit(30_000), "Git fixture command timed out.");
+		Assert.True(process.ExitCode == 0, $"git {string.Join(' ', arguments)} failed: {error}{output}");
+	}
+
+	private sealed class AuthenticatedGitHttpsServer : IAsyncDisposable
+	{
+		private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+		private readonly CancellationTokenSource _shutdown = new();
+		private readonly string _repositoryRoot;
+		private readonly string _expectedAuthorization;
+		private readonly X509Certificate2 _serverCertificate;
+		private readonly Task _serveTask;
+		private int _authorizedRequestCount;
+		private int _requestCount;
+		private string? _lastError;
+		private string? _lastBackendResponse;
+
+		private AuthenticatedGitHttpsServer(
+			string repositoryRoot,
+			string userName,
+			string password,
+			X509Certificate2 certificateAuthority,
+			X509Certificate2 serverCertificate)
+		{
+			_repositoryRoot = Path.GetFullPath(repositoryRoot);
+			_expectedAuthorization = "Basic " + Convert.ToBase64String(
+				Encoding.UTF8.GetBytes($"{userName}:{password}"));
+			CertificateAuthority = certificateAuthority;
+			_serverCertificate = serverCertificate;
+			_listener.Start();
+			var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+			Url = $"https://127.0.0.1:{endpoint.Port}/private.git";
+			_serveTask = ServeAsync();
+		}
+
+		public string Url { get; }
+		public X509Certificate2 CertificateAuthority { get; }
+		public int AuthorizedRequestCount => Volatile.Read(ref _authorizedRequestCount);
+		public int RequestCount => Volatile.Read(ref _requestCount);
+		public string? LastError => Volatile.Read(ref _lastError);
+		public string? LastBackendResponse => Volatile.Read(ref _lastBackendResponse);
+
+		public static Task<AuthenticatedGitHttpsServer> StartAsync(
+			string repositoryRoot,
+			string userName,
+			string password)
+		{
+			var certificates = CreateCertificates();
+			return Task.FromResult(new AuthenticatedGitHttpsServer(
+				repositoryRoot,
+				userName,
+				password,
+				certificates.Authority,
+				certificates.Server));
+		}
+
+		private async Task ServeAsync()
+		{
+			var clients = new List<Task>();
+			try
+			{
+				while (!_shutdown.IsCancellationRequested)
+				{
+					var client = await _listener.AcceptTcpClientAsync(_shutdown.Token);
+					clients.Add(HandleSafelyAsync(client));
+				}
+			}
+			catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+			{
+			}
+			catch (ObjectDisposedException) when (_shutdown.IsCancellationRequested)
+			{
+			}
+			await Task.WhenAll(clients);
+		}
+
+		private async Task HandleSafelyAsync(TcpClient client)
+		{
+			try
+			{
+				await HandleAsync(client);
+			}
+			catch (Exception exception) when (
+				exception is IOException or AuthenticationException && !_shutdown.IsCancellationRequested)
+			{
+				Volatile.Write(ref _lastError, exception.ToString());
+				client.Dispose();
+			}
+		}
+
+		private async Task HandleAsync(TcpClient client)
+		{
+			using (client)
+			await using (var tls = new SslStream(client.GetStream(), leaveInnerStreamOpen: false))
+			{
+				await tls.AuthenticateAsServerAsync(
+					new SslServerAuthenticationOptions
+					{
+						ServerCertificate = _serverCertificate,
+						EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13
+					},
+					_shutdown.Token);
+				var request = await ReadRequestAsync(tls, _shutdown.Token);
+				if (request is null)
+					return;
+				Interlocked.Increment(ref _requestCount);
+				if (!request.Headers.TryGetValue("Authorization", out var authorization) ||
+				    !string.Equals(authorization, _expectedAuthorization, StringComparison.Ordinal))
+				{
+					await WriteResponseAsync(
+						tls,
+						"401 Unauthorized",
+						[],
+						"WWW-Authenticate: Basic realm=\"DevProjex test\"\r\n");
+					return;
+				}
+				Interlocked.Increment(ref _authorizedRequestCount);
+				await RunGitHttpBackendAsync(tls, request, _shutdown.Token);
+			}
+		}
+
+		private async Task RunGitHttpBackendAsync(
+			Stream responseStream,
+			HttpRequest request,
+			CancellationToken cancellationToken)
+		{
+			var targetParts = request.Target.Split('?', 2);
+			var startInfo = new ProcessStartInfo(GitRuntime.GitExecutable)
+			{
+				UseShellExecute = false,
+				RedirectStandardInput = true,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true
+			};
+			startInfo.ArgumentList.Add("http-backend");
+			startInfo.Environment["GIT_PROJECT_ROOT"] = Path.GetDirectoryName(_repositoryRoot)!;
+			startInfo.Environment["GIT_HTTP_EXPORT_ALL"] = "1";
+			startInfo.Environment["PATH_INFO"] = targetParts[0];
+			startInfo.Environment["QUERY_STRING"] = targetParts.Length > 1 ? targetParts[1] : string.Empty;
+			startInfo.Environment["REQUEST_METHOD"] = request.Method;
+			startInfo.Environment["CONTENT_TYPE"] = request.Headers.GetValueOrDefault("Content-Type") ?? string.Empty;
+			startInfo.Environment["CONTENT_LENGTH"] = request.Body.Length.ToString(System.Globalization.CultureInfo.InvariantCulture);
+			using var process = Process.Start(startInfo);
+			Assert.NotNull(process);
+			await process.StandardInput.BaseStream.WriteAsync(request.Body, cancellationToken);
+			process.StandardInput.Close();
+			using var output = new MemoryStream();
+			var outputTask = process.StandardOutput.BaseStream.CopyToAsync(output, cancellationToken);
+			var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+			await process.WaitForExitAsync(cancellationToken);
+			await outputTask;
+			var error = await errorTask;
+			Assert.True(process.ExitCode == 0, error);
+			var bytes = output.ToArray();
+			var separator = FindHeaderSeparator(bytes, out var separatorLength);
+			Assert.True(separator >= 0, "git http-backend returned no CGI header boundary.");
+			var headerText = Encoding.ASCII.GetString(bytes, 0, separator);
+			var responseHeaders = headerText.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+			var status = "200 OK";
+			var forwarded = new StringBuilder();
+			foreach (var header in responseHeaders)
+			{
+				if (header.StartsWith("Status:", StringComparison.OrdinalIgnoreCase))
+					status = header["Status:".Length..].Trim();
+				else
+					forwarded.Append(header).Append("\r\n");
+			}
+			var body = bytes.AsSpan(separator + separatorLength).ToArray();
+			Volatile.Write(
+				ref _lastBackendResponse,
+				headerText + " | " + Encoding.UTF8.GetString(body.AsSpan(0, Math.Min(body.Length, 512))));
+			await WriteResponseAsync(responseStream, status, body, forwarded.ToString());
+		}
+
+		private static async Task<HttpRequest?> ReadRequestAsync(
+			Stream stream,
+			CancellationToken cancellationToken)
+		{
+			using var headerBuffer = new MemoryStream();
+			var one = new byte[1];
+			while (headerBuffer.Length < 64 * 1024)
+			{
+				var read = await stream.ReadAsync(one, cancellationToken);
+				if (read == 0)
+					return null;
+				headerBuffer.WriteByte(one[0]);
+				var bytes = headerBuffer.GetBuffer();
+				var length = (int)headerBuffer.Length;
+				if (length >= 4 && bytes[length - 4] == '\r' && bytes[length - 3] == '\n' &&
+				    bytes[length - 2] == '\r' && bytes[length - 1] == '\n')
+					break;
+			}
+			var headerText = Encoding.ASCII.GetString(headerBuffer.GetBuffer(), 0, (int)headerBuffer.Length);
+			var lines = headerText.Split(["\r\n"], StringSplitOptions.RemoveEmptyEntries);
+			if (lines.Length == 0)
+				return null;
+			var requestLine = lines[0].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+			if (requestLine.Length < 2)
+				return null;
+			var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			foreach (var line in lines.Skip(1))
+			{
+				var colon = line.IndexOf(':');
+				if (colon > 0)
+					headers[line[..colon]] = line[(colon + 1)..].Trim();
+			}
+			var contentLength = headers.TryGetValue("Content-Length", out var value) &&
+			                    int.TryParse(value, out var parsed)
+				? parsed
+				: 0;
+			var body = new byte[contentLength];
+			await stream.ReadExactlyAsync(body, cancellationToken);
+			return new HttpRequest(requestLine[0], requestLine[1], headers, body);
+		}
+
+		private static int FindHeaderSeparator(byte[] bytes, out int length)
+		{
+			for (var index = 0; index <= bytes.Length - 4; index++)
+			{
+				if (bytes[index] == '\r' && bytes[index + 1] == '\n' &&
+				    bytes[index + 2] == '\r' && bytes[index + 3] == '\n')
+				{
+					length = 4;
+					return index;
+				}
+			}
+			for (var index = 0; index <= bytes.Length - 2; index++)
+			{
+				if (bytes[index] == '\n' && bytes[index + 1] == '\n')
+				{
+					length = 2;
+					return index;
+				}
+			}
+			length = 0;
+			return -1;
+		}
+
+		private static async Task WriteResponseAsync(
+			Stream stream,
+			string status,
+			byte[] body,
+			string additionalHeaders = "")
+		{
+			var header = Encoding.ASCII.GetBytes(
+				$"HTTP/1.1 {status}\r\nContent-Length: {body.Length}\r\n" +
+				additionalHeaders +
+				(additionalHeaders.Contains("Content-Type:", StringComparison.OrdinalIgnoreCase)
+					? string.Empty
+					: "Content-Type: application/octet-stream\r\n") +
+				"Connection: close\r\n\r\n");
+			await stream.WriteAsync(header);
+			if (body.Length > 0)
+				await stream.WriteAsync(body);
+			await stream.FlushAsync();
+		}
+
+		private static (X509Certificate2 Authority, X509Certificate2 Server) CreateCertificates()
+		{
+			using var authorityKey = RSA.Create(2048);
+			var authorityRequest = new CertificateRequest(
+				"CN=DevProjex Test CA",
+				authorityKey,
+				HashAlgorithmName.SHA256,
+				RSASignaturePadding.Pkcs1);
+			authorityRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+			authorityRequest.CertificateExtensions.Add(new X509KeyUsageExtension(
+				X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+				true));
+			var authority = authorityRequest.CreateSelfSigned(
+				DateTimeOffset.UtcNow.AddMinutes(-5),
+				DateTimeOffset.UtcNow.AddDays(2));
+
+			using var serverKey = RSA.Create(2048);
+			var serverRequest = new CertificateRequest(
+				"CN=127.0.0.1",
+				serverKey,
+				HashAlgorithmName.SHA256,
+				RSASignaturePadding.Pkcs1);
+			serverRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+			serverRequest.CertificateExtensions.Add(new X509KeyUsageExtension(
+				X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+				true));
+			serverRequest.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+				[new Oid("1.3.6.1.5.5.7.3.1")],
+				true));
+			var san = new SubjectAlternativeNameBuilder();
+			san.AddIpAddress(IPAddress.Loopback);
+			serverRequest.CertificateExtensions.Add(san.Build());
+			var serial = RandomNumberGenerator.GetBytes(16);
+			var publicServer = serverRequest.Create(
+				authority,
+				DateTimeOffset.UtcNow.AddMinutes(-5),
+				DateTimeOffset.UtcNow.AddDays(1),
+				serial);
+			using var ephemeralServer = publicServer.CopyWithPrivateKey(serverKey);
+			var server = X509CertificateLoader.LoadPkcs12(
+				ephemeralServer.Export(X509ContentType.Pfx),
+				password: null,
+				X509KeyStorageFlags.MachineKeySet |
+				X509KeyStorageFlags.Exportable);
+			publicServer.Dispose();
+			return (authority, server);
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			_shutdown.Cancel();
+			_listener.Stop();
+			await _serveTask;
+			_serverCertificate.Dispose();
+			CertificateAuthority.Dispose();
+			_shutdown.Dispose();
+		}
+
+		private sealed record HttpRequest(
+			string Method,
+			string Target,
+			IReadOnlyDictionary<string, string> Headers,
+			byte[] Body);
+	}
+}

--- a/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
@@ -432,14 +432,20 @@ public sealed class GitPrivateHttpsAuthenticationIntegrationTests
 				DateTimeOffset.UtcNow.AddMinutes(-5),
 				DateTimeOffset.UtcNow.AddDays(1),
 				serial);
-			using var ephemeralServer = publicServer.CopyWithPrivateKey(serverKey);
-			var server = X509CertificateLoader.LoadPkcs12(
-				ephemeralServer.Export(X509ContentType.Pfx),
-				password: null,
-				X509KeyStorageFlags.MachineKeySet |
-				X509KeyStorageFlags.Exportable);
+			var ephemeralServer = publicServer.CopyWithPrivateKey(serverKey);
 			publicServer.Dispose();
-			return (authority, server);
+			if (!OperatingSystem.IsWindows())
+				return (authority, ephemeralServer);
+
+			using (ephemeralServer)
+			{
+				var server = X509CertificateLoader.LoadPkcs12(
+					ephemeralServer.Export(X509ContentType.Pfx),
+					password: null,
+					X509KeyStorageFlags.MachineKeySet |
+					X509KeyStorageFlags.Exportable);
+				return (authority, server);
+			}
 		}
 
 		public async ValueTask DisposeAsync()

--- a/Tests/DevProjex.Tests.Integration/GitRemoteSourceHardeningIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitRemoteSourceHardeningIntegrationTests.cs
@@ -1,0 +1,274 @@
+using System.Diagnostics;
+
+namespace DevProjex.Tests.Integration;
+
+[Collection(GitNetworkTestCollection.Name)]
+public sealed class GitRemoteSourceHardeningIntegrationTests
+{
+	[Theory]
+	[InlineData("ssh://alice@git.example.test/team/repo.git", "ssh://bob@git.example.test/team/repo.git")]
+	[InlineData("https://alice@git.example.test/team/repo.git", "https://bob@git.example.test/team/repo.git")]
+	[InlineData("https://git.example.test/team/repo.git", "ssh://git.example.test/team/repo.git")]
+	public void New026_CacheIdentityPreservesUserAndTransport(string left, string right)
+	{
+		Assert.NotEqual(
+			RepositoryUrlUtility.GetSourceCacheKey(left),
+			RepositoryUrlUtility.GetSourceCacheKey(right));
+	}
+
+	[Theory]
+	[InlineData("https://git.example.test/team/repo", "https://GIT.EXAMPLE.TEST/team/repo.git")]
+	[InlineData("ssh://git@git.example.test/team/repo", "git@git.example.test:team/repo.git")]
+	public void New026_RemoteGitSuffixAndEquivalentSshFormsShareIdentity(string left, string right)
+	{
+		Assert.Equal(
+			RepositoryUrlUtility.GetSourceCacheKey(left),
+			RepositoryUrlUtility.GetSourceCacheKey(right));
+	}
+
+	[Fact]
+	public void New027_DistinctLocalGitDirectoriesDoNotShareCacheIdentity()
+	{
+		using var temporary = new TemporaryDirectory();
+		var repository = temporary.CreateDirectory("repo");
+		var bareRepository = temporary.CreateDirectory("repo.git");
+		RunGit(repository, "init", "--initial-branch=main");
+		RunGit(bareRepository, "init", "--bare", "--initial-branch=main");
+
+		var repositoryUrl = new Uri(repository).AbsoluteUri;
+		var bareRepositoryUrl = new Uri(bareRepository).AbsoluteUri;
+		Assert.NotEqual(
+			RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl),
+			RepositoryUrlUtility.GetSourceCacheKey(bareRepositoryUrl));
+
+		using var cache = new TemporaryDirectory();
+		using var service = new RepoCacheService(Path.Combine(cache.Path, "RepoCache"));
+		var first = service.CreateRepositoryDirectory(repositoryUrl);
+		var second = service.CreateRepositoryDirectory(bareRepositoryUrl);
+		service.RecordIndexedRepository(repositoryUrl, first, "main");
+		service.RecordIndexedRepository(bareRepositoryUrl, second, "main");
+		Assert.Equal(2, service.ListIndexedRepositories().Count);
+	}
+
+	[Fact]
+	public void New027_LocalGitSuffixAliasSharesIdentityOnlyWhenItTargetsTheSameDirectory()
+	{
+		using var temporary = new TemporaryDirectory();
+		var repository = temporary.CreateDirectory("repository");
+		RunGit(repository, "init", "--initial-branch=main");
+		var alias = Path.Combine(temporary.Path, "repository.git");
+		try
+		{
+			Directory.CreateSymbolicLink(alias, repository);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException)
+		{
+			Assert.Skip($"Directory symbolic links are unavailable: {exception.GetType().Name}.");
+		}
+
+		Assert.Equal(
+			RepositoryUrlUtility.GetSourceCacheKey(new Uri(repository).AbsoluteUri),
+			RepositoryUrlUtility.GetSourceCacheKey(new Uri(alias).AbsoluteUri));
+	}
+
+	[Theory]
+	[InlineData("http://example.test/team/repo.git")]
+	[InlineData("git://example.test/team/repo.git")]
+	[InlineData("file:///tmp/repo.git")]
+	public void New043_ProductionSourceValidatorRejectsDisallowedTransports(string source)
+	{
+		Assert.False(RepositoryUrlUtility.IsSupportedCloneSource(source));
+	}
+
+	[Fact]
+	public void New045And046_ExplicitNetworkPreservesOnlyTrustedProxyAndCertificateEnvironment()
+	{
+		var names = new[]
+		{
+			"HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "SSL_CERT_FILE", "SSL_CERT_DIR", "GIT_SSL_CAINFO"
+		};
+		var previous = names.ToDictionary(
+			static name => name,
+			static name => Environment.GetEnvironmentVariable(name),
+			StringComparer.OrdinalIgnoreCase);
+		var previousProxyCommand = Environment.GetEnvironmentVariable("GIT_PROXY_COMMAND");
+		try
+		{
+			foreach (var name in names)
+				Environment.SetEnvironmentVariable(name, $"trusted-{name.ToLowerInvariant()}");
+			Environment.SetEnvironmentVariable("GIT_PROXY_COMMAND", "repository-controlled-command");
+
+			using var temporary = new TemporaryDirectory();
+			var operation = GitProcessOperation.CloneRepository(
+				"https://example.test/team/repo.git",
+				Path.Combine(temporary.Path, "clone"));
+			var startInfo = GitProcessStartInfoFactory.Create(null, operation);
+
+			foreach (var name in names)
+				Assert.Equal($"trusted-{name.ToLowerInvariant()}", startInfo.Environment[name]);
+			Assert.False(startInfo.Environment.ContainsKey("GIT_PROXY_COMMAND"));
+			Assert.DoesNotContain("http.proxy=", startInfo.ArgumentList);
+		}
+		finally
+		{
+			foreach (var (name, value) in previous)
+				Environment.SetEnvironmentVariable(name, value);
+			Environment.SetEnvironmentVariable("GIT_PROXY_COMMAND", previousProxyCommand);
+		}
+	}
+
+	[Fact]
+	public async Task New048_ActiveLocalBranchDeletedFromRemoteRemainsVisible()
+	{
+		using var temporary = new TemporaryDirectory();
+		var source = temporary.CreateDirectory("source");
+		RunGit(source, "init", "--initial-branch=main");
+		RunGit(source, "config", "user.name", "DevProjex Tests");
+		RunGit(source, "config", "user.email", "tests@devprojex.local");
+		await File.WriteAllTextAsync(
+			Path.Combine(source, "main.txt"),
+			"main\n",
+			TestContext.Current.CancellationToken);
+		RunGit(source, "add", ".");
+		RunGit(source, "commit", "-m", "main");
+		RunGit(source, "checkout", "-b", "retained-local");
+		await File.WriteAllTextAsync(
+			Path.Combine(source, "branch.txt"),
+			"branch\n",
+			TestContext.Current.CancellationToken);
+		RunGit(source, "add", ".");
+		RunGit(source, "commit", "-m", "branch");
+		var remote = Path.Combine(temporary.Path, "remote.git");
+		RunGit(temporary.Path, "clone", "--bare", source, remote);
+
+		var target = Path.Combine(temporary.Path, "managed", RepositoryCacheLayout.BaseDirectoryName);
+		Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+		var service = new GitRepositoryService(allowFileTransportForTests: true);
+		var clone = await service.CloneAsync(
+			new Uri(remote).AbsoluteUri,
+			target,
+			cancellationToken: TestContext.Current.CancellationToken);
+		Assert.True(clone.Success, clone.ErrorMessage);
+		Assert.Equal("retained-local", await service.GetCurrentBranchAsync(
+			target,
+			TestContext.Current.CancellationToken));
+		RunGit(remote, "update-ref", "-d", "refs/heads/retained-local");
+
+		var branches = await service.GetBranchesAsync(
+			target,
+			TestContext.Current.CancellationToken);
+		var retained = Assert.Single(branches, static branch => branch.Name == "retained-local");
+		Assert.True(retained.IsActive);
+		Assert.False(retained.IsRemote);
+	}
+
+	[Fact]
+	public async Task New047_RealGitCloneIsStoppedWhenCacheQuotaIsExceeded()
+	{
+		using var temporary = new TemporaryDirectory();
+		var source = temporary.CreateDirectory("quota-source");
+		RunGit(source, "init", "--initial-branch=main");
+		RunGit(source, "config", "user.name", "DevProjex Tests");
+		RunGit(source, "config", "user.email", "tests@devprojex.local");
+		var random = new byte[2 * 1024 * 1024];
+		Random.Shared.NextBytes(random);
+		await File.WriteAllBytesAsync(
+			Path.Combine(source, "large.bin"),
+			random,
+			TestContext.Current.CancellationToken);
+		RunGit(source, "add", ".");
+		RunGit(source, "commit", "-m", "large source");
+		var remote = Path.Combine(temporary.Path, "quota-remote.git");
+		RunGit(temporary.Path, "clone", "--bare", source, remote);
+		var progressFrames = new List<string>();
+		var limits = new GitRepositoryResourceLimits
+		{
+			MaximumRepositoryBytes = 64 * 1024,
+			FreeSpaceReserveBytes = 0,
+			PollInterval = TimeSpan.FromMilliseconds(1),
+			AvailableFreeSpace = static _ => long.MaxValue
+		};
+		using var service = new GitRepositoryService(
+			allowFileTransportForTests: true,
+			retainTestManagedMarker: true,
+			limits);
+		var target = Path.Combine(temporary.Path, "quota-target");
+
+		var result = await service.CloneAsync(
+			new Uri(remote).AbsoluteUri,
+			target,
+			new SynchronousProgress(progressFrames.Add),
+			TestContext.Current.CancellationToken);
+
+		Assert.False(result.Success);
+		Assert.Equal(GitRepositoryService.CacheQuotaDiagnostic, result.ErrorMessage);
+		Assert.Contains(GitRepositoryService.CacheQuotaDiagnostic, progressFrames);
+	}
+
+	[Fact]
+	public async Task New047_CloneFailsBeforeStartingWhenDestinationReserveIsUnavailable()
+	{
+		using var temporary = new TemporaryDirectory();
+		var target = Path.Combine(temporary.Path, "reserve-target");
+		var limits = new GitRepositoryResourceLimits
+		{
+			MaximumRepositoryBytes = 1024,
+			FreeSpaceReserveBytes = 1,
+			AvailableFreeSpace = static _ => 0
+		};
+		using var service = new GitRepositoryService(
+			allowFileTransportForTests: true,
+			retainTestManagedMarker: true,
+			limits);
+
+		var result = await service.CloneAsync(
+			new Uri(temporary.Path).AbsoluteUri,
+			target,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.False(result.Success);
+		Assert.Equal(GitRepositoryService.CacheQuotaDiagnostic, result.ErrorMessage);
+		Assert.False(Directory.Exists(target));
+	}
+
+	[Fact]
+	public void New031_FreeSpaceProbeChoosesTheLongestDestinationMount()
+	{
+		using var temporary = new TemporaryDirectory();
+		var targetMount = temporary.CreateDirectory("mounted-cache");
+		var destination = Path.Combine(targetMount, "staging", "repository");
+		var root = Path.GetPathRoot(temporary.Path)!;
+
+		var selected = GitRepositoryResourceLimits.ResolveDestinationDriveRoot(
+			destination,
+			[root, targetMount]);
+
+		Assert.Equal(Path.GetFullPath(targetMount), selected, PathComparer.Default);
+	}
+
+	private static void RunGit(string workingDirectory, params string[] arguments)
+	{
+		var startInfo = new ProcessStartInfo(GitRuntime.GitExecutable)
+		{
+			WorkingDirectory = workingDirectory,
+			UseShellExecute = false,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		foreach (var argument in arguments)
+			startInfo.ArgumentList.Add(argument);
+		using var process = Process.Start(startInfo);
+		Assert.NotNull(process);
+		process.StandardInput.Close();
+		var output = process.StandardOutput.ReadToEnd();
+		var error = process.StandardError.ReadToEnd();
+		Assert.True(process.WaitForExit(30_000), "Git fixture command timed out.");
+		Assert.True(process.ExitCode == 0, $"git {string.Join(' ', arguments)} failed: {error}{output}");
+	}
+
+	private sealed class SynchronousProgress(Action<string> report) : IProgress<string>
+	{
+		public void Report(string value) => report(value);
+	}
+}

--- a/Tests/DevProjex.Tests.Integration/GitRemoteSourceHardeningIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitRemoteSourceHardeningIntegrationTests.cs
@@ -227,7 +227,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 			cancellationToken: TestContext.Current.CancellationToken);
 
 		Assert.False(result.Success);
-		Assert.Equal(GitRepositoryService.CacheQuotaDiagnostic, result.ErrorMessage);
+		Assert.Equal(GitRepositoryService.CacheReserveDiagnostic, result.ErrorMessage);
 		Assert.False(Directory.Exists(target));
 	}
 

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -487,6 +487,9 @@ public sealed class McpServerIntegrationTests
 		RunGit(workspace.Path, "clone", "--quiet", "--bare", source, origin);
 		var repositoryUrl = new Uri(Path.GetFullPath(origin)).AbsoluteUri;
 		var cachePath = Path.Combine(workspace.Path, "repo-cache");
+		using var fileTransportPolicy = new TestEnvironmentVariableScope(
+			"DEVPROJEX_INTERNAL_TEST_ALLOW_FILE_GIT",
+			"1");
 		await using var server = await McpTestServer.StartAsync(
 			localProject,
 			workspace.Path,
@@ -2420,7 +2423,7 @@ public sealed class McpServerIntegrationTests
 
 		Assert.True(localFile.IsError);
 		Assert.Contains(McpErrorCodes.InvalidArguments, Text(localFile), StringComparison.Ordinal);
-		Assert.Contains("outside the configured roots", Text(localFile), StringComparison.Ordinal);
+		Assert.Contains("not a supported Git URL", Text(localFile), StringComparison.Ordinal);
 		Assert.True(queryCredential.IsError);
 		Assert.Contains(McpErrorCodes.InvalidArguments, Text(queryCredential), StringComparison.Ordinal);
 		Assert.Contains("must not contain a query string or fragment", Text(queryCredential), StringComparison.Ordinal);
@@ -2456,6 +2459,9 @@ public sealed class McpServerIntegrationTests
 		RunGit(workspace.Path, "clone", "--quiet", "--bare", source, origin);
 		var repositoryUrl = new Uri(Path.GetFullPath(origin)).AbsoluteUri;
 		var cachePath = Path.Combine(workspace.Path, "repo-cache");
+		using var fileTransportPolicy = new TestEnvironmentVariableScope(
+			"DEVPROJEX_INTERNAL_TEST_ALLOW_FILE_GIT",
+			"1");
 		var git = new CountingGitRepositoryService(
 			new GitRepositoryService(allowFileTransportForTests: true));
 		await using var server = await McpTestServer.StartAsync(
@@ -6657,6 +6663,21 @@ public sealed class McpServerIntegrationTests
 		string ToolName,
 		IReadOnlyDictionary<string, object?> Arguments,
 		IReadOnlyList<string> ExpectedPhases);
+
+	private sealed class TestEnvironmentVariableScope : IDisposable
+	{
+		private readonly string _name;
+		private readonly string? _previousValue;
+
+		public TestEnvironmentVariableScope(string name, string value)
+		{
+			_name = name;
+			_previousValue = Environment.GetEnvironmentVariable(name);
+			Environment.SetEnvironmentVariable(name, value);
+		}
+
+		public void Dispose() => Environment.SetEnvironmentVariable(_name, _previousValue);
+	}
 
 	private sealed class InlineProgress<T> : IProgress<T>
 	{

--- a/Tests/DevProjex.Tests.Integration/ZipRemoteSourceHardeningTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipRemoteSourceHardeningTests.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class ZipRemoteSourceHardeningTests
+{
+	[Fact]
+	public async Task New028_StalledArchiveBodyFailsWithinProgressDeadline()
+	{
+		using var temporary = new TemporaryDirectory();
+		using var service = new ZipDownloadService(
+			new StalledArchiveHandler(),
+			ZipResourceLimits.Default with { FreeSpaceReserveBytes = 0 },
+			TimeSpan.FromMilliseconds(150));
+		using var outerDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+		var stopwatch = Stopwatch.StartNew();
+
+		var result = await service.DownloadAndExtractAsync(
+			"https://github.com/example/repository.git",
+			Path.Combine(temporary.Path, "target"),
+			cancellationToken: outerDeadline.Token);
+
+		Assert.False(result.Success);
+		Assert.Contains("ZIP archive body made no progress", result.ErrorMessage, StringComparison.Ordinal);
+		Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), stopwatch.Elapsed.ToString());
+		Assert.False(outerDeadline.IsCancellationRequested);
+	}
+
+	[Fact]
+	public async Task New030_MetadataTimeoutIsAnOperationFailureInsteadOfCallerCancellation()
+	{
+		using var temporary = new TemporaryDirectory();
+		using var service = new ZipDownloadService(new MetadataTimeoutHandler());
+
+		var result = await service.DownloadAndExtractAsync(
+			"https://github.com/example/repository.git",
+			Path.Combine(temporary.Path, "target"),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.False(result.Success);
+		Assert.Equal("DPX-ZIP-METADATA-TIMEOUT: ZIP metadata request timed out.", result.ErrorMessage);
+	}
+
+	[Fact]
+	public async Task New029_MetadataFallbackReportsTheBranchThatWasActuallyDownloaded()
+	{
+		using var temporary = new TemporaryDirectory();
+		var archive = CreateArchive(("repository-master/app.txt", "master"));
+		using var service = new ZipDownloadService(new MetadataFailureArchiveHandler(archive));
+
+		var result = await service.DownloadAndExtractAsync(
+			"https://github.com/example/repository.git",
+			Path.Combine(temporary.Path, "target"),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.True(result.Success, result.ErrorMessage);
+		Assert.Equal("master", result.DefaultBranch);
+		Assert.Equal("master", File.ReadAllText(Path.Combine(result.LocalPath, "app.txt")));
+	}
+
+	[Fact]
+	public async Task New032_SymbolicLinkArchiveEntriesAreSkippedWithCountedDiagnostic()
+	{
+		using var temporary = new TemporaryDirectory();
+		var archive = CreateArchiveWithSymbolicLink();
+		using var service = new ZipDownloadService(new ArchiveHandler(archive));
+		var progressFrames = new List<string>();
+		var progress = new SynchronousProgress(progressFrames.Add);
+
+		var result = await service.DownloadAndExtractAsync(
+			"https://github.com/example/repository.git",
+			Path.Combine(temporary.Path, "target"),
+			progress,
+			TestContext.Current.CancellationToken);
+
+		Assert.True(result.Success, result.ErrorMessage);
+		Assert.True(File.Exists(Path.Combine(result.LocalPath, "app.txt")));
+		Assert.False(File.Exists(Path.Combine(result.LocalPath, "link.txt")));
+		Assert.Contains(
+			"DPX-ZIP-SYMLINK-SKIPPED: 1 symbolic link entry was skipped.",
+			progressFrames);
+	}
+
+	private static byte[] CreateArchive(params (string Path, string Content)[] files)
+	{
+		using var memory = new MemoryStream();
+		using (var archive = new ZipArchive(memory, ZipArchiveMode.Create, leaveOpen: true))
+		{
+			foreach (var (path, content) in files)
+			{
+				var entry = archive.CreateEntry(path);
+				using var writer = new StreamWriter(entry.Open());
+				writer.Write(content);
+			}
+		}
+		return memory.ToArray();
+	}
+
+	private static byte[] CreateArchiveWithSymbolicLink()
+	{
+		using var memory = new MemoryStream();
+		using (var archive = new ZipArchive(memory, ZipArchiveMode.Create, leaveOpen: true))
+		{
+			var regular = archive.CreateEntry("repository-main/app.txt");
+			using (var writer = new StreamWriter(regular.Open()))
+				writer.Write("content");
+			var link = archive.CreateEntry("repository-main/link.txt");
+			link.ExternalAttributes = unchecked((int)((0xA000u | 0x1FFu) << 16));
+			using var linkWriter = new StreamWriter(link.Open());
+			linkWriter.Write("app.txt");
+		}
+		return memory.ToArray();
+	}
+
+	private sealed class StalledArchiveHandler : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request,
+			CancellationToken cancellationToken)
+		{
+			if (request.RequestUri!.Host == "api.github.com")
+				return Task.FromResult(JsonResponse("{\"default_branch\":\"main\"}"));
+			var content = new StreamContent(new NeverProgressStream());
+			content.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+		}
+	}
+
+	private sealed class MetadataTimeoutHandler : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request,
+			CancellationToken cancellationToken) =>
+			throw new TaskCanceledException("internal timeout");
+	}
+
+	private sealed class MetadataFailureArchiveHandler(byte[] archive) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request,
+			CancellationToken cancellationToken)
+		{
+			if (request.RequestUri!.Host == "api.github.com")
+				return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden));
+			return Task.FromResult(request.RequestUri.AbsolutePath.Contains("/main.zip", StringComparison.Ordinal)
+				? new HttpResponseMessage(HttpStatusCode.NotFound)
+				: BytesResponse(archive));
+		}
+	}
+
+	private sealed class ArchiveHandler(byte[] archive) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request,
+			CancellationToken cancellationToken) =>
+			Task.FromResult(request.RequestUri!.Host == "api.github.com"
+				? JsonResponse("{\"default_branch\":\"main\"}")
+				: BytesResponse(archive));
+	}
+
+	private sealed class NeverProgressStream : Stream
+	{
+		public override bool CanRead => true;
+		public override bool CanSeek => false;
+		public override bool CanWrite => false;
+		public override long Length => throw new NotSupportedException();
+		public override long Position { get => 0; set => throw new NotSupportedException(); }
+		public override void Flush() { }
+		public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+		public override void SetLength(long value) => throw new NotSupportedException();
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+		public override async ValueTask<int> ReadAsync(
+			Memory<byte> buffer,
+			CancellationToken cancellationToken = default)
+		{
+			await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+			return 0;
+		}
+	}
+
+	private sealed class SynchronousProgress(Action<string> report) : IProgress<string>
+	{
+		public void Report(string value) => report(value);
+	}
+
+	private static HttpResponseMessage JsonResponse(string json) =>
+		new(HttpStatusCode.OK) { Content = new StringContent(json) };
+
+	private static HttpResponseMessage BytesResponse(byte[] bytes) =>
+		new(HttpStatusCode.OK) { Content = new ByteArrayContent(bytes) };
+}

--- a/Tests/DevProjex.Tests.Terminal/CliUrlSourceCommandTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/CliUrlSourceCommandTests.cs
@@ -8,6 +8,34 @@ namespace DevProjex.Tests.Terminal;
 public sealed class CliUrlSourceCommandTests
 {
 	[Theory]
+	[InlineData("http://example.test/team/repository.git")]
+	[InlineData("git://example.test/team/repository.git")]
+	[InlineData("file:///tmp/repository.git")]
+	public async Task DisallowedRemoteTransportFailsBeforeGitOrCacheAccess(string source)
+	{
+		using var data = new TemporaryDirectory();
+		var git = new CountingGitRepositoryService();
+		var services = new TerminalServiceFactory(() => data.Path).Create(AppLanguage.En) with
+		{
+			GitRepositoryService = git
+		};
+		var environment = new TestTerminalEnvironment();
+
+		var exitCode = await new TerminalApplication(
+				environment,
+				new TerminalServiceFactory(_ => services))
+			.RunAsync(
+				["analyze", source, "--format", "json"],
+				TestContext.Current.CancellationToken);
+
+		Assert.Equal(CommandLineExitCodes.UsageError, exitCode);
+		Assert.Equal(0, git.CallCount);
+		Assert.Empty(services.RepoCacheService.ListCacheEntriesForManagement().Entries);
+		Assert.Empty(environment.StandardOutput);
+		Assert.Contains("DPX-CLI-GIT-URL-INVALID", environment.StandardError, StringComparison.Ordinal);
+	}
+
+	[Theory]
 	[InlineData(false, true, false)]
 	[InlineData(true, false, false)]
 	[InlineData(true, true, true)]
@@ -120,6 +148,9 @@ public sealed class CliUrlSourceCommandTests
 	[Fact]
 	public async Task LocalUrlSourceClonesReusesCacheSelectsBranchWithoutRecordingRecentHistory()
 	{
+		using var fileTransport = new EnvironmentVariableScope(
+			GitRepositoryService.TestFileTransportPolicyVariable,
+			"1");
 		if (!IsGitAvailable())
 			Assert.Skip("Git is unavailable on this test host.");
 
@@ -194,6 +225,9 @@ public sealed class CliUrlSourceCommandTests
 	[Fact]
 	public async Task UrlSourceFlowsThroughTreeAndExportsUsingTheManagedCache()
 	{
+		using var fileTransport = new EnvironmentVariableScope(
+			GitRepositoryService.TestFileTransportPolicyVariable,
+			"1");
 		if (!IsGitAvailable())
 			Assert.Skip("Git is unavailable on this test host.");
 
@@ -258,6 +292,9 @@ public sealed class CliUrlSourceCommandTests
 	[Fact]
 	public async Task RemoteShallowDiffIsConsistentAcrossCliContentCommands()
 	{
+		using var fileTransport = new EnvironmentVariableScope(
+			GitRepositoryService.TestFileTransportPolicyVariable,
+			"1");
 		if (!IsGitAvailable())
 			Assert.Skip("Git is unavailable on this test host.");
 
@@ -332,6 +369,9 @@ public sealed class CliUrlSourceCommandTests
 	[Fact]
 	public async Task RedirectedUrlCloneProgressNeverContaminatesContextPayloadAndStaysBounded()
 	{
+		using var fileTransport = new EnvironmentVariableScope(
+			GitRepositoryService.TestFileTransportPolicyVariable,
+			"1");
 		if (!IsGitAvailable())
 			Assert.Skip("Git is unavailable on this test host.");
 
@@ -383,6 +423,9 @@ public sealed class CliUrlSourceCommandTests
 	[Fact]
 	public async Task MissingFileRemoteReturnsRuntimeFailureWithoutPayload()
 	{
+		using var fileTransport = new EnvironmentVariableScope(
+			GitRepositoryService.TestFileTransportPolicyVariable,
+			"1");
 		using var workspace = new TemporaryDirectory();
 		using var data = new TemporaryDirectory();
 		var missing = Path.Combine(workspace.Path, "missing.git");
@@ -503,6 +546,21 @@ public sealed class CliUrlSourceCommandTests
 		Assert.True(
 			result.ExitCode == 0,
 			$"git {string.Join(' ', arguments)} failed: {result.StandardOutput}{result.StandardError}");
+	}
+
+	private sealed class EnvironmentVariableScope : IDisposable
+	{
+		private readonly string _name;
+		private readonly string? _previousValue;
+
+		public EnvironmentVariableScope(string name, string value)
+		{
+			_name = name;
+			_previousValue = Environment.GetEnvironmentVariable(name);
+			Environment.SetEnvironmentVariable(name, value);
+		}
+
+		public void Dispose() => Environment.SetEnvironmentVariable(_name, _previousValue);
 	}
 
 	private sealed class BlockingCloneService : IGitRepositoryService

--- a/Tests/DevProjex.Tests.Terminal/RepositoryCacheCatalogTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/RepositoryCacheCatalogTests.cs
@@ -139,7 +139,7 @@ public sealed class RepositoryCacheCatalogTests
 		var catalog = new RepositoryCacheCatalog(git, cache);
 
 		var result = await catalog.FindAsync(
-			"git@github.com:Avazbek22/DevProjex.git",
+			"https://github.com/Avazbek22/DevProjex.git",
 			TestContext.Current.CancellationToken);
 
 		Assert.Equal(RepositoryCacheState.Ready, result.State);

--- a/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs
@@ -1506,6 +1506,9 @@ public sealed class TerminalWorkspaceContractTests
 		var bare = Path.Combine(workspace.Path, "origin.git");
 		Assert.True(TryRunGit(workspace.Path, "clone", "--quiet", "--bare", source, bare));
 		var repositoryUrl = new Uri(bare + Path.DirectorySeparatorChar).AbsoluteUri;
+		using var fileTransportPolicy = new TestEnvironmentVariableScope(
+			"DEVPROJEX_INTERNAL_TEST_ALLOW_FILE_GIT",
+			"1");
 		var services = new TerminalServiceFactory(
 			() => appData.Path,
 			new GitRepositoryService(
@@ -1745,6 +1748,21 @@ public sealed class TerminalWorkspaceContractTests
 		Assert.DoesNotContain("remove this comment", exported, StringComparison.Ordinal);
 		Assert.DoesNotContain($"{Environment.NewLine}{Environment.NewLine}", exported, StringComparison.Ordinal);
 		Assert.DoesNotContain("Console.WriteLine(Token)", exported, StringComparison.Ordinal);
+	}
+
+	private sealed class TestEnvironmentVariableScope : IDisposable
+	{
+		private readonly string _name;
+		private readonly string? _previousValue;
+
+		public TestEnvironmentVariableScope(string name, string value)
+		{
+			_name = name;
+			_previousValue = Environment.GetEnvironmentVariable(name);
+			Environment.SetEnvironmentVariable(name, value);
+		}
+
+		public void Dispose() => Environment.SetEnvironmentVariable(_name, _previousValue);
 	}
 
 	private sealed class SynchronousProgress<T>(Action<T> report) : IProgress<T>

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -7,6 +7,33 @@ public class GitRepositoryServiceUnitTests
 {
     private readonly GitRepositoryService _service = new();
 
+	[Theory]
+	[InlineData(5, 100, 100)]
+	[InlineData(25, 100, 250)]
+	public void New047_QuotaPollDelayBoundsMonitorDutyCycle(
+		int scanMilliseconds,
+		int pollMilliseconds,
+		int expectedMilliseconds)
+	{
+		Assert.Equal(
+			TimeSpan.FromMilliseconds(expectedMilliseconds),
+			GitRepositoryService.CalculateQuotaPollDelay(
+				TimeSpan.FromMilliseconds(scanMilliseconds),
+				TimeSpan.FromMilliseconds(pollMilliseconds)));
+	}
+
+	[Fact]
+	public void New047_FinalQuotaScanRunsOnlyWhenLastObservationIsStale()
+	{
+		var interval = TimeSpan.FromMilliseconds(100);
+
+		Assert.True(GitRepositoryService.ShouldPerformFinalQuotaScan(null, interval));
+		Assert.False(GitRepositoryService.ShouldPerformFinalQuotaScan(
+			TimeSpan.FromMilliseconds(99),
+			interval));
+		Assert.True(GitRepositoryService.ShouldPerformFinalQuotaScan(interval, interval));
+	}
+
     [Fact]
     public void GitCommandsUseNonInteractiveStandardTransports()
     {

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -181,7 +181,7 @@ public class RepoCacheServiceTests : IDisposable
         const string damagedUrl = "https://github.com/example/damaged.git";
         const string missingUrl = "https://github.com/example/missing.git";
         const string missingLegacyUrl = "https://github.com/example/missing-legacy.git";
-        var sharedIdentity = RepositoryUrlUtility.GetComparisonKey(sharedUrl);
+        var sharedIdentity = RepositoryUrlUtility.GetSourceCacheKey(sharedUrl);
         var older = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var newer = older.AddDays(2);
         var newest = older.AddDays(3);
@@ -199,7 +199,7 @@ public class RepoCacheServiceTests : IDisposable
                     200,
                     RepositoryCacheContentKind.Git),
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(damagedUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(damagedUrl),
                     damagedUrl,
                     damagedRepository,
                     "main",
@@ -209,7 +209,7 @@ public class RepoCacheServiceTests : IDisposable
                     300,
                     RepositoryCacheContentKind.Git),
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(missingUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(missingUrl),
                     missingUrl,
                     missingRepository,
                     "main",
@@ -243,7 +243,7 @@ public class RepoCacheServiceTests : IDisposable
                     900,
                     RepositoryCacheContentKind.Git),
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(legacyOnlyUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(legacyOnlyUrl),
                     legacyOnlyUrl,
                     legacyOnlyRepository,
                     "archive",
@@ -253,7 +253,7 @@ public class RepoCacheServiceTests : IDisposable
                     500,
                     RepositoryCacheContentKind.Zip),
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(missingLegacyUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(missingLegacyUrl),
                     missingLegacyUrl,
                     missingLegacyRepository,
                     "main",
@@ -375,7 +375,7 @@ public class RepoCacheServiceTests : IDisposable
 				Entries = new[]
 				{
 					new RepositoryCacheIndexEntry(
-						RepositoryUrlUtility.GetComparisonKey(repositoryUrl),
+						RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl),
 						repositoryUrl,
 						repositoryPath,
 						null,
@@ -418,7 +418,7 @@ public class RepoCacheServiceTests : IDisposable
             _testCacheRoot,
             [
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(repositoryUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl),
                     repositoryUrl,
                     repositoryPath,
                     "main",
@@ -443,7 +443,7 @@ public class RepoCacheServiceTests : IDisposable
         const string repositoryUrl = "https://github.com/example/timestamp.git";
         var corruptPath = _service.CreateRepositoryDirectory(repositoryUrl);
         var validPath = _service.CreateRepositoryDirectory(repositoryUrl);
-        var identity = RepositoryUrlUtility.GetComparisonKey(repositoryUrl);
+        var identity = RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl);
         var validTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1);
         WriteCacheIndex(
             _testCacheRoot,
@@ -486,7 +486,7 @@ public class RepoCacheServiceTests : IDisposable
             _testCacheRoot,
             [
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(firstUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(firstUrl),
                     firstUrl,
                     firstPath,
                     null,
@@ -496,7 +496,7 @@ public class RepoCacheServiceTests : IDisposable
                     long.MaxValue,
                     RepositoryCacheContentKind.Zip),
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(secondUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(secondUrl),
                     secondUrl,
                     secondPath,
                     null,
@@ -620,7 +620,7 @@ public class RepoCacheServiceTests : IDisposable
         Assert.Contains(entries, entry => PathComparer.Default.Equals(entry.LocalPath, currentCachePath));
         Assert.Contains($"\"identity\": \"{legacyIdentity}\"", indexPayload, StringComparison.Ordinal);
         Assert.Contains(
-            $"\"identity\": \"{RepositoryUrlUtility.GetComparisonKey(repositoryUrl)}\"",
+            $"\"identity\": \"{RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl)}\"",
             indexPayload,
             StringComparison.Ordinal);
     }
@@ -647,7 +647,7 @@ public class RepoCacheServiceTests : IDisposable
                     RepositoryCacheEntryState.Ready,
                     ContentKind: RepositoryCacheContentKind.Zip),
                 new RepositoryCacheIndexEntry(
-                    RepositoryUrlUtility.GetComparisonKey(validUrl),
+                    RepositoryUrlUtility.GetSourceCacheKey(validUrl),
                     validUrl,
                     validPath,
                     "main",
@@ -795,7 +795,7 @@ public class RepoCacheServiceTests : IDisposable
 
         var published = _service.PublishRepositoryDirectory(staging, repositoryUrl);
         var indexed = _service.FindIndexedRepository(
-            "git@github.com:user/repository.git");
+            "https://GITHUB.com/user/repository");
 
         Assert.NotNull(indexed);
         Assert.Equal(published, indexed.LocalPath, PathComparer.Default);
@@ -811,7 +811,7 @@ public class RepoCacheServiceTests : IDisposable
 
         _service.RecordIndexedRepository(repositoryUrl, cachePath, "main", "1111111");
         _service.RecordIndexedRepository(
-            "git@github.com:user/repository.git",
+            "https://GITHUB.com/user/repository",
             cachePath,
             "release",
             "2222222");
@@ -976,7 +976,7 @@ public class RepoCacheServiceTests : IDisposable
 					Entries = new[]
 					{
 						new RepositoryCacheIndexEntry(
-							RepositoryUrlUtility.GetComparisonKey(unsafeUrl),
+							RepositoryUrlUtility.GetSourceCacheKey(safeUrl),
 							unsafeUrl,
 							repositoryPath,
 							"main",

--- a/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepoCacheServiceTests.cs
@@ -582,47 +582,114 @@ public class RepoCacheServiceTests : IDisposable
     }
 
     [Fact]
-    public void LegacyRepositoryIdentityRemainsUnchangedAndCoexistsAfterVersionedCacheMiss()
+    public async Task V51VersionedIdentityMigratesInPlaceAndOpensOfflineIdempotently()
     {
         const string repositoryUrl = "https://example.com/Owner/Repo.git";
-        const string legacyIdentity = "example.com/owner/repo";
+        const string scpUrl = "git@example.com:Owner/Repo.git";
         var legacyCachePath = _service.CreateRepositoryDirectory(repositoryUrl);
+        Directory.CreateDirectory(Path.Combine(legacyCachePath, ".git"));
+        File.WriteAllText(
+            Path.Combine(legacyCachePath, ".git", "devprojex.remote-identity"),
+            repositoryUrl + "\n");
+        File.WriteAllText(Path.Combine(legacyCachePath, "README.md"), "cached");
         WriteCacheIndex(
             _testCacheRoot,
             [
                 new RepositoryCacheIndexEntry(
-                    legacyIdentity,
+                    RepositoryUrlUtility.GetComparisonKey(repositoryUrl),
+                    repositoryUrl,
+                    legacyCachePath,
+                    "main",
+                    "0123456789abcdef",
+                    DateTimeOffset.UtcNow,
+                    RepositoryCacheEntryState.Ready,
+                    ContentKind: RepositoryCacheContentKind.Git)
+            ]);
+        var indexPath = Path.Combine(_testCacheRoot, "cache-index.json");
+        var git = new OfflineGitRepositoryService(legacyCachePath, repositoryUrl);
+        var catalog = new RepositoryCacheCatalog(git, _service);
+
+        var indexed = Assert.IsType<RepositoryCacheIndexEntry>(
+            _service.FindIndexedRepository(repositoryUrl));
+        var cached = await catalog.FindAsync(
+            repositoryUrl,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(legacyCachePath, indexed.LocalPath, PathComparer.Default);
+        Assert.Equal(RepositoryCacheState.Ready, cached.State);
+        Assert.Equal(0, git.NetworkOperationCount);
+        Assert.Single(_service.ListIndexedRepositories());
+        Assert.Null(_service.FindIndexedRepository(scpUrl));
+        using (var index = JsonDocument.Parse(File.ReadAllBytes(indexPath)))
+        {
+            var entry = Assert.Single(index.RootElement.GetProperty("entries").EnumerateArray());
+            Assert.Equal(
+                RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl),
+                entry.GetProperty("identity").GetString());
+        }
+        var migratedIndexBytes = File.ReadAllBytes(indexPath);
+
+        Assert.NotNull(_service.FindIndexedRepository(repositoryUrl));
+        Assert.Single(_service.ListIndexedRepositories());
+        Assert.Equal(migratedIndexBytes, File.ReadAllBytes(indexPath));
+    }
+
+    [Fact]
+    public void RecordingUserAwareIdentityRemovesMigratedLegacySafeUrlEntry()
+    {
+        const string repositoryUrl = "https://example.com/owner/repo.git";
+        const string userSourceUrl = "https://alice@example.com/owner/repo.git";
+        var legacyCachePath = _service.CreateRepositoryDirectory(repositoryUrl);
+        Directory.CreateDirectory(Path.Combine(legacyCachePath, ".git"));
+        File.WriteAllText(
+            Path.Combine(legacyCachePath, ".git", "devprojex.remote-identity"),
+            repositoryUrl + "\n");
+        WriteCacheIndex(
+            _testCacheRoot,
+            [
+                new RepositoryCacheIndexEntry(
+                    RepositoryUrlUtility.GetComparisonKey(repositoryUrl),
                     repositoryUrl,
                     legacyCachePath,
                     "main",
                     null,
                     DateTimeOffset.UtcNow,
                     RepositoryCacheEntryState.Ready,
-                    ContentKind: RepositoryCacheContentKind.Zip)
+                    ContentKind: RepositoryCacheContentKind.Git)
             ]);
-        var indexPath = Path.Combine(_testCacheRoot, "cache-index.json");
-        var legacyIndexBytes = File.ReadAllBytes(indexPath);
-
-        Assert.Null(_service.FindIndexedRepository(repositoryUrl));
-        Assert.Equal(legacyIndexBytes, File.ReadAllBytes(indexPath));
-
         var currentCachePath = _service.CreateRepositoryDirectory(repositoryUrl);
-        _service.RecordIndexedRepository(
-            repositoryUrl,
-            currentCachePath,
-            "main");
+        Directory.CreateDirectory(Path.Combine(currentCachePath, ".git"));
+        File.WriteAllText(
+            Path.Combine(currentCachePath, ".git", "devprojex.remote-identity"),
+            repositoryUrl + "\n" + userSourceUrl + "\n");
 
-        var entries = _service.ListIndexedRepositories();
-        var indexPayload = File.ReadAllText(indexPath);
+        _service.RecordIndexedRepository(repositoryUrl, currentCachePath, "main");
 
-        Assert.Equal(2, entries.Count);
-        Assert.Contains(entries, entry => PathComparer.Default.Equals(entry.LocalPath, legacyCachePath));
-        Assert.Contains(entries, entry => PathComparer.Default.Equals(entry.LocalPath, currentCachePath));
-        Assert.Contains($"\"identity\": \"{legacyIdentity}\"", indexPayload, StringComparison.Ordinal);
-        Assert.Contains(
-            $"\"identity\": \"{RepositoryUrlUtility.GetSourceCacheKey(repositoryUrl)}\"",
-            indexPayload,
-            StringComparison.Ordinal);
+        var catalogEntry = Assert.Single(_service.ListIndexedRepositories());
+        var entry = Assert.IsType<RepositoryCacheIndexEntry>(
+            _service.FindIndexedRepository(userSourceUrl));
+        Assert.Equal(currentCachePath, catalogEntry.LocalPath, PathComparer.Default);
+        Assert.Equal(
+            RepositoryUrlUtility.GetSourceCacheKey(userSourceUrl),
+            entry.Identity);
+    }
+
+    [Fact]
+    public void RemoteIdentityStoreMatchesV51SingleLineTransportWithoutCrossingScheme()
+    {
+        const string repositoryUrl = "https://example.com/owner/repo.git";
+        var repositoryPath = _service.CreateRepositoryDirectory(repositoryUrl);
+        Directory.CreateDirectory(Path.Combine(repositoryPath, ".git"));
+        File.WriteAllText(
+            Path.Combine(repositoryPath, ".git", "devprojex.remote-identity"),
+            repositoryUrl + "\n");
+
+        Assert.True(GitRemoteIdentityStore.Matches(
+            repositoryPath,
+            "https://EXAMPLE.com:443/owner/repo"));
+        Assert.False(GitRemoteIdentityStore.Matches(
+            repositoryPath,
+            "git@example.com:owner/repo.git"));
     }
 
     [Fact]

--- a/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryCacheIsolationTests.cs
@@ -180,6 +180,41 @@ public sealed class RepositoryCacheIsolationTests : IDisposable
 	}
 
 	[Fact]
+	public async Task RepositoryPublicationReturnsBeforeCancellableSizeRefreshCompletes()
+	{
+		var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var allowRefresh = new ManualResetEventSlim();
+		var hooks = new RepoCacheTestHooks
+		{
+			BeforeRepositorySizeRefresh = _ =>
+			{
+				refreshStarted.TrySetResult();
+				allowRefresh.Wait(TestContext.Current.CancellationToken);
+			}
+		};
+		var service = CreateService(new FakeWorktreeManager(supported: true), hooks: hooks);
+		try
+		{
+			var staging = service.CreateRepositoryStagingDirectory(RepositoryUrl);
+			for (var index = 0; index <= 1024; index++)
+				File.WriteAllText(Path.Combine(staging, $"file-{index:D4}.txt"), "x");
+
+			var published = service.PublishRepositoryDirectory(staging, RepositoryUrl);
+
+			Assert.True(Directory.Exists(published));
+			Assert.Equal(0, service.FindIndexedRepository(RepositoryUrl)!.ApproximateSizeBytes);
+			await refreshStarted.Task.WaitAsync(
+				BackgroundOperationTimeout,
+				TestContext.Current.CancellationToken);
+		}
+		finally
+		{
+			allowRefresh.Set();
+			await service.DisposeAsync();
+		}
+	}
+
+	[Fact]
 	public async Task GitSessionReturnsBeforeRepositorySizeRefreshAndBackgroundRefreshUpdatesIndex()
 	{
 		var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/Tests/DevProjex.Tests.Unit/RepositoryUrlUtilityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/RepositoryUrlUtilityTests.cs
@@ -13,11 +13,8 @@ public sealed class RepositoryUrlUtilityTests
 
 	[Theory]
 	[InlineData(
-		"https://github.com/owner/DevProjex.git",
-		"git@github.com:owner/DevProjex.git")]
-	[InlineData(
 		"ssh://git@github.com/owner/DevProjex",
-		"https://github.com/owner/DevProjex")]
+		"git@github.com:owner/DevProjex.git")]
 	[InlineData(
 		"https://GITHUB.com/owner/DevProjex?token=secret",
 		"https://github.com/owner/DevProjex#fragment")]
@@ -66,6 +63,10 @@ public sealed class RepositoryUrlUtilityTests
 			"v2:",
 			RepositoryUrlUtility.GetComparisonKey("https://example.com/Owner/Repo.git"),
 			StringComparison.Ordinal);
+		Assert.StartsWith(
+			"v3:",
+			RepositoryUrlUtility.GetSourceCacheKey("https://example.com/Owner/Repo.git"),
+			StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -77,6 +78,17 @@ public sealed class RepositoryUrlUtilityTests
 		Assert.Equal("https://example.com/owner/repo.git", display);
 		Assert.DoesNotContain("super-secret", display, StringComparison.Ordinal);
 		Assert.DoesNotContain("access_token", display, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void SafeSourceIdentityKeepsUserButRemovesPasswordQueryAndFragment()
+	{
+		var identity = RepositoryUrlUtility.ToSafeSourceIdentity(
+			"https:" + "//alice:super-secret@example.com/owner/repo.git?access_token=hidden#fragment");
+
+		Assert.Equal("https://alice@example.com/owner/repo.git", identity);
+		Assert.DoesNotContain("super-secret", identity, StringComparison.Ordinal);
+		Assert.DoesNotContain("access_token", identity, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -130,13 +142,13 @@ public sealed class RepositoryUrlUtilityTests
 	}
 
 	[Fact]
-	public void LocalRepositoryIdentityStillIgnoresGitSuffix()
+	public void DistinctLocalRepositoryPathsDoNotIgnoreGitSuffix()
 	{
 		var repositoryPath = Path.Combine(Path.GetTempPath(), "DevProjex", "LocalIdentity", "repo");
 
-		Assert.True(RepositoryUrlUtility.AreEquivalent(
-			new Uri(repositoryPath).AbsoluteUri,
-			new Uri(repositoryPath + ".git").AbsoluteUri));
+		Assert.NotEqual(
+			RepositoryUrlUtility.GetSourceCacheKey(new Uri(repositoryPath).AbsoluteUri),
+			RepositoryUrlUtility.GetSourceCacheKey(new Uri(repositoryPath + ".git").AbsoluteUri));
 	}
 
 	[Theory]
@@ -154,7 +166,6 @@ public sealed class RepositoryUrlUtilityTests
 	[InlineData("https://example.com/owner/repo.git")]
 	[InlineData("ssh://git@example.com/owner/repo.git")]
 	[InlineData("git@example.com:owner/repo.git")]
-	[InlineData("git://example.com/owner/repo.git")]
 	public void SupportedRemoteCloneSourcesAreAccepted(string source)
 	{
 		Assert.True(RepositoryUrlUtility.IsSupportedCloneSource(source));


### PR DESCRIPTION
## Summary
- separate cache identities by transport and user while preserving canonical remote aliases
- retain HTTPS askpass credentials for branch and update operations within the source session
- enforce Git cache admission/quota checks and bounded publication size accounting
- bound ZIP body reads, report the actual fallback branch, and skip symlink entries
- align source URL validation and document proxy/certificate environment boundaries

## Validation
- targeted Git, ZIP, cache, CLI, adversarial-profile, and documentation contract tests
- Release build of Infrastructure with zero warnings

Target: v5.2