### PR TITLE
Resolve TypeScript rootDirs imports

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -60,7 +60,8 @@ public sealed record DependencyScopeDescriptor(
 	bool HasConfiguration,
 	string? PythonVersion = null,
 	bool AllowJavaScript = false,
-	IReadOnlyList<string>? TypeScriptModuleSuffixes = null)
+	IReadOnlyList<string>? TypeScriptModuleSuffixes = null,
+	IReadOnlyList<string>? TypeScriptRootDirectories = null)
 {
 	public DependencyConfigurationState ConfigurationState { get; init; } = DependencyConfigurationState.Valid;
 	public string? ConfigurationDiagnostic { get; init; }

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1140,6 +1140,7 @@ public sealed class DependencyFactsEngine : IDisposable
 		private static readonly ConditionalWeakTable<IReadOnlySet<string>, IReadOnlySet<string>> DotNetSimpleNames = new();
 		private readonly string _root;
 		private readonly IReadOnlyDictionary<string, FileFacts> _files;
+		private readonly IReadOnlyDictionary<string, FileFacts> _manifestFiles;
 		private readonly IReadOnlyDictionary<SymbolLookupKey, DeclarationFact[]> _symbolsBySimpleName;
 		private readonly IReadOnlyDictionary<QualifiedSymbolLookupKey, DeclarationFact[]> _symbolsByQualifiedName;
 		private readonly DependencyResolverConfiguration _configuration;
@@ -1166,6 +1167,7 @@ public sealed class DependencyFactsEngine : IDisposable
 			_root = root;
 			_diagnosticsEnabled = DependencyEngineDiagnostics.IsEnabled;
 			_files = files.ToDictionary(static file => file.Path, StringComparer.Ordinal);
+			_manifestFiles = files.ToDictionary(static file => file.Path, PathComparer);
 			DependencyEngineDiagnostics.RecordDictionaryBuild();
 			_symbolsBySimpleName = declarations
 				.GroupBy(static declaration => new SymbolLookupKey(
@@ -1312,7 +1314,14 @@ public sealed class DependencyFactsEngine : IDisposable
 						"extension required for a relative ESM import under node16/nodenext", []);
 				}
 				var directory = Path.GetDirectoryName(Path.Combine(_root, source.Path))!;
-				candidates = ProbeTypeScript(Path.GetFullPath(Path.Combine(directory, physicalSpecifier)), scope, source);
+				var rootDirectoryCandidates = ProbeTypeScriptRootDirectories(
+					directory,
+					physicalSpecifier,
+					scope,
+					source).ToArray();
+				candidates = rootDirectoryCandidates.Length > 0
+					? rootDirectoryCandidates
+					: ProbeTypeScript(Path.GetFullPath(Path.Combine(directory, physicalSpecifier)), scope, source);
 			}
 			else if (import.Specifier.StartsWith("#", StringComparison.Ordinal))
 			{
@@ -1399,8 +1408,8 @@ public sealed class DependencyFactsEngine : IDisposable
 				foreach (var probe in EnumerateTypeScriptProbes(candidate, scope, source, allowDirectoryIndex: true))
 				{
 					var relative = PortableRelative(_root, probe);
-					if (_files.ContainsKey(relative))
-						return [relative];
+					if (TryGetManifestPath(relative, out var manifestPath))
+						return [manifestPath];
 					if (File.Exists(probe))
 						return [];
 				}
@@ -1611,10 +1620,49 @@ public sealed class DependencyFactsEngine : IDisposable
 			foreach (var probe in EnumerateTypeScriptProbes(candidate, scope, source, allowDirectoryIndex))
 			{
 				var relative = PortableRelative(_root, probe);
-				if (_files.ContainsKey(relative))
-					return [relative];
+				if (TryGetManifestPath(relative, out var manifestPath))
+					return [manifestPath];
 			}
 			return [];
+		}
+
+		private IEnumerable<string> ProbeTypeScriptRootDirectories(
+			string sourceDirectory,
+			string physicalSpecifier,
+			DependencyScopeDescriptor scope,
+			FileFacts source)
+		{
+			if (scope.TypeScriptRootDirectories is not { Count: > 0 } rootDirectories)
+				return [];
+			var candidates = new List<string>();
+			foreach (var sourceRoot in rootDirectories)
+			{
+				if (!IsWithin(sourceRoot, sourceDirectory))
+					continue;
+				var virtualCandidate = Path.GetFullPath(Path.Combine(sourceDirectory, physicalSpecifier));
+				if (!IsWithin(sourceRoot, virtualCandidate))
+					continue;
+				var virtualPath = Path.GetRelativePath(sourceRoot, virtualCandidate);
+				foreach (var destinationRoot in rootDirectories)
+				{
+					var destination = Path.GetFullPath(Path.Combine(destinationRoot, virtualPath));
+					if (!IsWithin(destinationRoot, destination))
+						continue;
+					candidates.AddRange(ProbeTypeScript(destination, scope, source));
+				}
+			}
+			return candidates;
+		}
+
+		private bool TryGetManifestPath(string relative, out string manifestPath)
+		{
+			if (_manifestFiles.TryGetValue(relative, out var file))
+			{
+				manifestPath = file.Path;
+				return true;
+			}
+			manifestPath = string.Empty;
+			return false;
 		}
 
 		private IEnumerable<string> EnumerateTypeScriptProbes(

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -105,6 +105,12 @@ When `compilerOptions.moduleSuffixes` is present, every path probe applies its s
 order; an empty suffix is the explicit unsuffixed fallback. Thus `[".ios", ""]` selects `v.ios.ts`
 before `v.ts`. A non-string entry makes the configuration unsupported instead of silently reverting
 to unsuffixed resolution.
+When `compilerOptions.rootDirs` is present, relative imports use the configured directories as one
+virtual tree. A path found under exactly one root resolves normally; paths present under multiple
+roots remain `Ambiguous`. The usual extension, directory-index, and `moduleSuffixes` probe order is
+preserved. Roots are relative to the configuration file that declared them, including through
+`extends`; roots outside the project or escaping it through a symbolic link are ignored and reported
+with a constant configuration diagnostic.
 Conditional package targets distinguish syntax from the source module kind: runtime `import(...)`
 selects the `import` condition even in a `.cts` or `.cjs` file, while literal `require(...)` selects
 the `require` condition. The `node` condition is active only in Node resolution modes, not in bundler

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -23,6 +23,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	internal const string TypeScriptExtendsUnavailableReason = "extended tsconfig is unavailable";
 	internal const string TypeScriptModuleResolutionReason = "tsconfig moduleResolution is not supported";
 	internal const string TypeScriptCustomConditionsReason = "tsconfig customConditions are not supported";
+	internal const string TypeScriptRootDirectoriesOutsideRootReason = "tsconfig rootDirs must stay inside the project root";
 	internal const string ProjectReferenceConditionReason = "project reference condition could not be evaluated safely";
 	internal const string CompileItemMembershipReason = "C# Compile item membership is not supported";
 	internal const string DisableTransitiveProjectReferencesReason = "DisableTransitiveProjectReferences could not be evaluated safely";
@@ -144,7 +145,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			var parsed = await ReadTypeScriptLayerAsync(Path.GetFullPath(configPath), 0, chain).ConfigureAwait(false);
 			return parsed.State == DependencyConfigurationState.Valid
 				? ConfigurationParseResult<TypeScriptConfiguration>.Valid(
-					MaterializeTypeScriptConfiguration(parsed.Value, scopeDirectory))
+					MaterializeTypeScriptConfiguration(parsed.Value, scopeDirectory, root))
 				: ConfigurationParseResult<TypeScriptConfiguration>.Failure(
 					TypeScriptConfiguration.Default,
 					parsed.State,
@@ -316,12 +317,21 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				[],
 				true,
 				AllowJavaScript: parsed.Value.AllowJavaScript,
-				TypeScriptModuleSuffixes: parsed.Value.ModuleSuffixes)
+				TypeScriptModuleSuffixes: parsed.Value.ModuleSuffixes,
+				TypeScriptRootDirectories: parsed.Value.RootDirectories)
 			{
 				ConfigurationState = parsed.State,
 				ConfigurationDiagnostic = parsed.Reason,
 				HasTypeScriptCustomConditions = parsed.Value.HasCustomConditions
 			});
+			if (parsed.Value.HasIgnoredRootDirectories)
+			{
+				diagnostics.Add(new DependencyConfigurationDiagnostic(
+					PortableRelative(root, configPath),
+					DependencyConfigurationState.UnsupportedSemantics,
+					TypeScriptRootDirectoriesOutsideRootReason,
+					[scopeId]));
+			}
 		}
 
 		foreach (var configPath in pythonConfigFiles)
@@ -541,6 +551,18 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			var moduleSuffixes = hasModuleSuffixes
 				? moduleSuffixesElement.EnumerateArray().Select(static item => item.GetString()!).ToArray()
 				: null;
+			var hasRootDirectories = options.TryGetProperty("rootDirs", out var rootDirectoriesElement);
+			if (hasRootDirectories &&
+			    (rootDirectoriesElement.ValueKind != JsonValueKind.Array ||
+			     rootDirectoriesElement.EnumerateArray().Any(static item => item.ValueKind != JsonValueKind.String)))
+			{
+				return TypeScriptLayerFailure(
+					DependencyConfigurationState.UnsupportedSemantics,
+					"tsconfig compilerOptions.rootDirs must be an array of strings");
+			}
+			var rootDirectories = hasRootDirectories
+				? rootDirectoriesElement.EnumerateArray().Select(static item => item.GetString()!).ToArray()
+				: null;
 			var paths = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
 			var hasPaths = options.TryGetProperty("paths", out var mappings);
 			if (hasPaths && mappings.ValueKind != JsonValueKind.Object)
@@ -573,6 +595,11 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 						hasPaths ? new TypeScriptPathMappings(Path.GetDirectoryName(configPath)!, paths) : null),
 					new OptionalConfigurationValue<bool>(hasAllowJavaScript, allowJavaScript),
 					new OptionalConfigurationValue<IReadOnlyList<string>>(hasModuleSuffixes, moduleSuffixes),
+					new OptionalConfigurationValue<TypeScriptRootDirectories>(
+						hasRootDirectories,
+						hasRootDirectories
+							? new TypeScriptRootDirectories(Path.GetDirectoryName(configPath)!, rootDirectories!)
+							: null),
 					new OptionalConfigurationValue<bool>(hasCustomConditions, usesCustomConditions)));
 		}
 		catch (JsonException)
@@ -667,11 +694,13 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			child.Paths.IsSpecified ? child.Paths : inherited.Paths,
 			child.AllowJavaScript.IsSpecified ? child.AllowJavaScript : inherited.AllowJavaScript,
 			child.ModuleSuffixes.IsSpecified ? child.ModuleSuffixes : inherited.ModuleSuffixes,
+			child.RootDirectories.IsSpecified ? child.RootDirectories : inherited.RootDirectories,
 			child.CustomConditions.IsSpecified ? child.CustomConditions : inherited.CustomConditions);
 
-	private static TypeScriptConfiguration MaterializeTypeScriptConfiguration(
+	private TypeScriptConfiguration MaterializeTypeScriptConfiguration(
 		TypeScriptConfigurationLayer layer,
-		string scopeDirectory)
+		string scopeDirectory,
+		string projectRoot)
 	{
 		var moduleResolution = layer.ModuleResolution.IsSpecified
 			? layer.ModuleResolution.Value ?? "bundler"
@@ -694,6 +723,35 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var legacy = moduleResolution.Equals("node10", StringComparison.OrdinalIgnoreCase) ||
 		             moduleResolution.Equals("node", StringComparison.OrdinalIgnoreCase) ||
 		             layer.BaseUrl.IsSpecified;
+		var rootDirectories = new List<string>();
+		var hasIgnoredRootDirectories = false;
+		if (layer.RootDirectories.Value is { } configuredRoots)
+		{
+			foreach (var value in configuredRoots.Values)
+			{
+				string candidate;
+				try
+				{
+					candidate = ResolveTypeScriptOptionDirectory(
+						configuredRoots.DeclaringDirectory,
+						NormalizeTypeScriptOptionPath(value));
+				}
+				catch (Exception exception) when (
+					exception is ArgumentException or NotSupportedException or PathTooLongException)
+				{
+					hasIgnoredRootDirectories = true;
+					continue;
+				}
+				if (IsNetworkPath(candidate) || !IsWithin(projectRoot, candidate) ||
+				    !_pathMetadata.TryResolveContainedPath(projectRoot, candidate, out _))
+				{
+					hasIgnoredRootDirectories = true;
+					continue;
+				}
+				if (!rootDirectories.Contains(candidate, PathComparer))
+					rootDirectories.Add(candidate);
+			}
+		}
 		return new TypeScriptConfiguration(
 			moduleResolution,
 			legacy,
@@ -702,8 +760,14 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			layer.ModuleSuffixes.IsSpecified
 				? layer.ModuleSuffixes.Value ?? []
 				: [""],
-			layer.CustomConditions.IsSpecified && layer.CustomConditions.Value);
+			layer.CustomConditions.IsSpecified && layer.CustomConditions.Value,
+			rootDirectories,
+			hasIgnoredRootDirectories);
 	}
+
+	private static string NormalizeTypeScriptOptionPath(string value) => value
+		.Replace('/', Path.DirectorySeparatorChar)
+		.Replace('\\', Path.DirectorySeparatorChar);
 
 	private static string ResolveTypeScriptOptionDirectory(string declaringDirectory, string? relative) =>
 		string.IsNullOrEmpty(relative)
@@ -1108,7 +1172,9 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		IReadOnlyDictionary<string, IReadOnlyList<string>> Paths,
 		bool AllowJavaScript,
 		IReadOnlyList<string> ModuleSuffixes,
-		bool HasCustomConditions)
+		bool HasCustomConditions,
+		IReadOnlyList<string> RootDirectories,
+		bool HasIgnoredRootDirectories)
 	{
 		public static readonly TypeScriptConfiguration Default = new(
 			"bundler",
@@ -1116,6 +1182,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			new Dictionary<string, IReadOnlyList<string>>(),
 			false,
 			[""],
+			false,
+			[],
 			false);
 	}
 
@@ -1127,6 +1195,10 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		string DeclaringDirectory,
 		IReadOnlyDictionary<string, IReadOnlyList<string>> Values);
 
+	private sealed record TypeScriptRootDirectories(
+		string DeclaringDirectory,
+		IReadOnlyList<string> Values);
+
 	private sealed record TypeScriptConfigurationLayer(
 		string? Extends,
 		OptionalConfigurationValue<string> ModuleResolution,
@@ -1135,10 +1207,12 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		OptionalConfigurationValue<TypeScriptPathMappings> Paths,
 		OptionalConfigurationValue<bool> AllowJavaScript,
 		OptionalConfigurationValue<IReadOnlyList<string>> ModuleSuffixes,
+		OptionalConfigurationValue<TypeScriptRootDirectories> RootDirectories,
 		OptionalConfigurationValue<bool> CustomConditions)
 	{
 		public static readonly TypeScriptConfigurationLayer Empty = new(
 			null,
+			default,
 			default,
 			default,
 			default,

--- a/Tests/DevProjex.Tests.Integration/DependencyTypeScriptRootDirsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyTypeScriptRootDirsIntegrationTests.cs
@@ -1,0 +1,240 @@
+using DevProjex.Application.Dependencies;
+using DevProjex.Infrastructure.Dependencies;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed class DependencyTypeScriptRootDirsIntegrationTests
+{
+	[Fact]
+	public async Task New062_RootDirsResolveTheSameVirtualRelativePath()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"src\",\"generated\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "import { value } from './types'; export { value };\n");
+		var target = fixture.CreateFile("generated/types.ts", "export const value = 1;\n");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, candidate =>
+			candidate.Source == "src/view.ts" && candidate.Reference == "./types");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("generated/types.ts", edge.Target);
+		Assert.Equal(["generated/types.ts"], edge.Candidates);
+	}
+
+	[Fact]
+	public async Task New062_RootDirsReportEveryManifestCandidateAsAmbiguous()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"src\",\"generated\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "import { value } from './types'; export { value };\n");
+		var sourceTarget = fixture.CreateFile("src/types.ts", "export const value = 1;\n");
+		var generatedTarget = fixture.CreateFile("generated/types.ts", "export const value = 2;\n");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, sourceTarget, generatedTarget],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, candidate =>
+			candidate.Source == "src/view.ts" && candidate.Reference == "./types");
+		Assert.Equal(ResolutionStatus.Ambiguous, edge.Status);
+		Assert.Null(edge.Target);
+		Assert.Equal(["generated/types.ts", "src/types.ts"], edge.Candidates);
+	}
+
+	[Fact]
+	public async Task New062_RootDirsDoNotExposeTargetsOutsideTheManifest()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"src\",\"generated\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "import { value } from './types'; export { value };\n");
+		var omitted = fixture.CreateFile("generated/types.ts", "export const value = 1;\n");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, candidate =>
+			candidate.Source == "src/view.ts" && candidate.Reference == "./types");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+		Assert.Null(edge.Target);
+		Assert.Empty(edge.Candidates);
+		Assert.DoesNotContain(omitted, string.Join("\n", edge.Reasons), StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public async Task New062_RootDirsChangeReresolvesWithoutReparsingSources()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"src\",\"first\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "import { value } from './types'; export { value };\n");
+		var firstTarget = fixture.CreateFile("first/types.ts", "export const value = 1;\n");
+		var secondTarget = fixture.CreateFile("second/types.ts", "export const value = 2;\n");
+		var manifest = new[] { config, source, firstTarget, secondTarget };
+		using var engine = CreateEngine();
+
+		var first = await engine.IndexAsync(
+			fixture.Path,
+			manifest,
+			cancellationToken: TestContext.Current.CancellationToken);
+		var parseCount = engine.ParseCount;
+		Assert.Contains(first.Edges, edge => edge.Source == "src/view.ts" && edge.Target == "first/types.ts");
+
+		File.WriteAllText(
+			config,
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"src\",\"second\"]}}");
+		File.SetLastWriteTimeUtc(config, DateTime.UtcNow.AddSeconds(2));
+		var second = await engine.IndexAsync(
+			fixture.Path,
+			manifest,
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal(parseCount, engine.ParseCount);
+		Assert.False(second.Metrics.ResolutionCacheHit);
+		Assert.Contains(second.Edges, edge => edge.Source == "src/view.ts" && edge.Target == "second/types.ts");
+		Assert.DoesNotContain(second.Edges, edge => edge.Source == "src/view.ts" && edge.Target == "first/types.ts");
+	}
+
+	[Fact]
+	public async Task New062_WindowsSeparatorsAndFileSystemCaseResolveRootDirs()
+	{
+		if (!OperatingSystem.IsWindows())
+			Assert.Skip("Windows path identity is required for this assertion.");
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\".\\\\SRC\",\".\\\\GENERATED\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "import { value } from './types'; export { value };\n");
+		var target = fixture.CreateFile("generated/types.ts", "export const value = 1;\n");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, candidate =>
+			candidate.Source == "src/view.ts" && candidate.Reference == "./types");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("generated/types.ts", edge.Target);
+	}
+
+	[Fact]
+	public async Task New062_UnsafeRootDirsAreIgnoredWithoutInvalidatingTheScope()
+	{
+		using var fixture = new TemporaryDirectory();
+		using var outside = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"src\",\"../outside\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "import { value } from './types'; export { value };\n");
+		var target = fixture.CreateFile("src/types.ts", "export const value = 1;\n");
+
+		var configuration = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config, source, target],
+			TestContext.Current.CancellationToken);
+
+		var scope = Assert.Single(configuration.Scopes, candidate => candidate.HasConfiguration);
+		Assert.Equal(DependencyConfigurationState.Valid, scope.ConfigurationState);
+		Assert.Equal([Path.Combine(fixture.Path, "src")], scope.TypeScriptRootDirectories);
+		var diagnostic = Assert.Single(configuration.ConfigurationDiagnostics);
+		Assert.Equal(DependencyConfigurationState.UnsupportedSemantics, diagnostic.State);
+		Assert.Equal(FileDependencyConfigurationProvider.TypeScriptRootDirectoriesOutsideRootReason, diagnostic.Reason);
+	}
+
+	[Fact]
+	public async Task New062_RootDirsUseInheritedOriginModuleSuffixesAndDirectoryIndexes()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"app/tsconfig.json",
+			"{\"extends\":\"../configs/base.json\"}");
+		fixture.CreateFile(
+			"configs/base.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\",\"rootDirs\":[\"../app/src\",\"../generated\"],\"moduleSuffixes\":[\".native\",\"\"]}}");
+		var source = fixture.CreateFile("app/src/view.ts", "import { value } from './types'; export { value };\n");
+		var target = fixture.CreateFile("generated/types/index.native.ts", "export const value = 1;\n");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, source, target],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(result.Edges, candidate =>
+			candidate.Source == "app/src/view.ts" && candidate.Reference == "./types");
+		Assert.Equal(ResolutionStatus.Resolved, edge.Status);
+		Assert.Equal("generated/types/index.native.ts", edge.Target);
+	}
+
+	[Fact]
+	public async Task New062_RootDirectorySymlinkOutsideTheProjectIsIgnored()
+	{
+		using var fixture = new TemporaryDirectory();
+		using var outside = new TemporaryDirectory();
+		var link = Path.Combine(fixture.Path, "linked");
+		try
+		{
+			Directory.CreateSymbolicLink(link, outside.Path);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException or IOException or NotSupportedException)
+		{
+			Assert.Skip("Directory symbolic links are unavailable on this host.");
+		}
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"rootDirs\":[\"src\",\"linked\"]}}");
+		var source = fixture.CreateFile("src/view.ts", "export const value = 1;\n");
+
+		var configuration = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config, source],
+			TestContext.Current.CancellationToken);
+
+		var scope = Assert.Single(configuration.Scopes, candidate => candidate.HasConfiguration);
+		Assert.Equal(DependencyConfigurationState.Valid, scope.ConfigurationState);
+		Assert.Equal([Path.Combine(fixture.Path, "src")], scope.TypeScriptRootDirectories);
+		Assert.Equal(
+			FileDependencyConfigurationProvider.TypeScriptRootDirectoriesOutsideRootReason,
+			Assert.Single(configuration.ConfigurationDiagnostics).Reason);
+	}
+
+	[Fact]
+	public async Task New062_NonStringRootDirectoryMakesConfigurationUnsupported()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile(
+			"tsconfig.json",
+			"{\"compilerOptions\":{\"rootDirs\":[\"src\",42]}}");
+
+		var configuration = await new FileDependencyConfigurationProvider().ReadAsync(
+			fixture.Path,
+			[config],
+			TestContext.Current.CancellationToken);
+
+		var diagnostic = Assert.Single(configuration.ConfigurationDiagnostics);
+		Assert.Equal(DependencyConfigurationState.UnsupportedSemantics, diagnostic.State);
+		Assert.Equal("tsconfig compilerOptions.rootDirs must be an array of strings", diagnostic.Reason);
+	}
+
+	private static DependencyFactsEngine CreateEngine() => new(
+		new TreeSitterDependencyFactExtractor(),
+		new FileDependencyConfigurationProvider());
+}


### PR DESCRIPTION
## Summary
- model inherited TypeScript rootDirs in dependency configuration and resolver fingerprints
- resolve virtual relative imports with existing probe order and manifest confinement
- reject root directories that escape the project boundary and document the behavior

## Validation
- targeted rootDirs integration tests
- targeted adjacent dependency configuration and TypeScript semantics tests
- frozen RankingEval cells unchanged