### PR TITLE
fix(cli): harden profile persistence and project export

### DIFF
--- a/Application/Services/ProjectCopyExportModels.cs
+++ b/Application/Services/ProjectCopyExportModels.cs
@@ -114,3 +114,8 @@ public sealed class ProjectCopyExportException(
 	public ProjectCopyExportError Error { get; } = error;
 	public string? PathContext { get; } = pathContext;
 }
+
+internal static class ProjectCopyExportTestHooks
+{
+	internal static Action? AfterFirstSourceRead { get; set; }
+}

--- a/Application/Services/ProjectCopyExportModels.cs
+++ b/Application/Services/ProjectCopyExportModels.cs
@@ -117,5 +117,5 @@ public sealed class ProjectCopyExportException(
 
 internal static class ProjectCopyExportTestHooks
 {
-	internal static Action? AfterFirstSourceRead { get; set; }
+	internal static AsyncLocal<Action?> AfterFirstSourceRead { get; } = new();
 }

--- a/Application/Services/ProjectCopyExportModels.cs
+++ b/Application/Services/ProjectCopyExportModels.cs
@@ -1,4 +1,5 @@
 using DevProjex.Application.Secrets;
+using DevProjex.Application.Compression;
 
 namespace DevProjex.Application.Services;
 
@@ -76,10 +77,12 @@ public sealed record ProjectCopyExportResult(
 	int CreatedDirectoryCount,
 	long BytesWritten,
 	int RedactedValueCount = 0,
-	IReadOnlyList<UnscannableFile>? UnscannableFiles = null);
+	IReadOnlyList<UnscannableFile>? UnscannableFiles = null,
+	CodeCompressionSnapshot? CompressionSnapshot = null);
 
 public sealed record ProjectCopyExportPreflightResult(
-	IReadOnlyList<UnscannableFile> UnscannableFiles);
+	IReadOnlyList<UnscannableFile> UnscannableFiles,
+	CodeCompressionSnapshot? CompressionSnapshot = null);
 
 public sealed record ProjectCopyExportProgress(
 	int ProcessedEntryCount,

--- a/Application/Services/ProjectCopyExportService.cs
+++ b/Application/Services/ProjectCopyExportService.cs
@@ -1622,7 +1622,7 @@ public sealed class ProjectCopyExportService(
 			if (firstRead)
 			{
 				firstRead = false;
-				ProjectCopyExportTestHooks.AfterFirstSourceRead?.Invoke();
+				ProjectCopyExportTestHooks.AfterFirstSourceRead.Value?.Invoke();
 			}
 
 			await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);

--- a/Application/Services/ProjectCopyExportService.cs
+++ b/Application/Services/ProjectCopyExportService.cs
@@ -44,7 +44,9 @@ public sealed class ProjectCopyExportService(
 			: null;
 		var transformationNotice = BuildTransformationNotice(prepared, plan, request.NoticeText);
 		ValidateTransformationNoticeCollision(plan, transformationNotice);
-		return new ProjectCopyExportPreflightResult(prepared?.UnscannableFiles ?? []);
+		return new ProjectCopyExportPreflightResult(
+			prepared?.UnscannableFiles ?? [],
+			prepared?.CompressionSnapshot);
 	}
 
 	public async Task<ProjectCopyExportResult> ExportAsync(
@@ -151,7 +153,8 @@ public sealed class ProjectCopyExportService(
 				plan.DirectoryCount,
 				result.BytesWritten,
 				prepared?.Snapshot?.RedactedCount ?? 0,
-				prepared?.UnscannableFiles ?? []);
+				prepared?.UnscannableFiles ?? [],
+				prepared?.CompressionSnapshot);
 		}
 		catch (Exception exception) when (exception is not OperationCanceledException and not ProjectCopyExportException)
 		{
@@ -471,7 +474,8 @@ public sealed class ProjectCopyExportService(
 				plan.DirectoryCount,
 				bytesWritten,
 				prepared?.Snapshot?.RedactedCount ?? 0,
-				prepared?.UnscannableFiles ?? []);
+				prepared?.UnscannableFiles ?? [],
+				prepared?.CompressionSnapshot);
 		}
 		catch (Exception exception)
 		{
@@ -629,7 +633,8 @@ public sealed class ProjectCopyExportService(
 				plan.DirectoryCount,
 				bytesWritten,
 				prepared?.Snapshot?.RedactedCount ?? 0,
-				prepared?.UnscannableFiles ?? []);
+				prepared?.UnscannableFiles ?? [],
+				prepared?.CompressionSnapshot);
 		}
 		catch (Exception exception)
 		{

--- a/Application/Services/ProjectCopyExportService.cs
+++ b/Application/Services/ProjectCopyExportService.cs
@@ -30,6 +30,7 @@ public sealed class ProjectCopyExportService(
 	public const string TransformationNoticeFileName = "DEVPROJEX-NOTICE.txt";
 	private const int CleanupAttemptCount = 6;
 	private const int CleanupInitialDelayMilliseconds = 25;
+	internal const string SourceChangedDuringCopyMessage = "A source file changed during copy.";
 
 	public async Task<ProjectCopyExportPreflightResult> PreflightAsync(
 		ProjectCopyExportRequest request,
@@ -584,9 +585,10 @@ public sealed class ProjectCopyExportService(
 						file.SourcePath,
 						contentPath,
 						preparedFile);
+					var sourceIdentity = CapturePassThroughSourceIdentity(preparedFile, source);
 					await using var destination = entry.Open();
 					var copiedBytes = await CopyStreamAsync(source, destination, buffer, cancellationToken).ConfigureAwait(false);
-					ValidatePreparedSourceVersion(preparedFile, source);
+					ValidateSourceVersion(preparedFile, source, sourceIdentity);
 					bytesWritten += copiedBytes;
 					processedEntries++;
 					processedFiles++;
@@ -715,10 +717,11 @@ public sealed class ProjectCopyExportService(
 					file.SourcePath,
 					contentPath,
 					preparedFile);
+				var sourceIdentity = CapturePassThroughSourceIdentity(preparedFile, source);
 				await using var entryDestination = entry.Open();
 				var copiedBytes = await CopyStreamAsync(source, entryDestination, buffer, cancellationToken)
 					.ConfigureAwait(false);
-				ValidatePreparedSourceVersion(preparedFile, source);
+				ValidateSourceVersion(preparedFile, source, sourceIdentity);
 				bytesWritten += copiedBytes;
 				processedEntries++;
 				processedFiles++;
@@ -1534,9 +1537,10 @@ public sealed class ProjectCopyExportService(
 			originalSourcePath,
 			contentPath,
 			preparedFile);
+		var sourceIdentity = CapturePassThroughSourceIdentity(preparedFile, source);
 		await using var destination = OpenDestinationFile(destinationPath);
 		var copiedBytes = await CopyStreamAsync(source, destination, buffer, cancellationToken).ConfigureAwait(false);
-		ValidatePreparedSourceVersion(preparedFile, source);
+		ValidateSourceVersion(preparedFile, source, sourceIdentity);
 		return copiedBytes;
 	}
 
@@ -1609,11 +1613,17 @@ public sealed class ProjectCopyExportService(
 		CancellationToken cancellationToken)
 	{
 		long copiedBytes = 0;
+		var firstRead = true;
 		while (true)
 		{
 			var read = await source.ReadAsync(buffer.AsMemory(0, CopyBufferSize), cancellationToken).ConfigureAwait(false);
 			if (read == 0)
 				return copiedBytes;
+			if (firstRead)
+			{
+				firstRead = false;
+				ProjectCopyExportTestHooks.AfterFirstSourceRead?.Invoke();
+			}
 
 			await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
 			copiedBytes += read;
@@ -1641,6 +1651,31 @@ public sealed class ProjectCopyExportService(
 		if (!OperatingSystem.IsWindows())
 			options.UnixCreateMode = PrivateFileMode;
 		return new FileStream(path, options);
+	}
+
+	private static FileContentIdentity? CapturePassThroughSourceIdentity(
+		PreparedSecretFile? preparedFile,
+		FileStream source)
+	{
+		if (preparedFile is not null)
+			return null;
+		return FileContentIdentity.TryCapture(source) ??
+		       throw SourceUnavailable(SourceChangedDuringCopyMessage);
+	}
+
+	private static void ValidateSourceVersion(
+		PreparedSecretFile? preparedFile,
+		FileStream source,
+		FileContentIdentity? passThroughIdentity)
+	{
+		ValidatePreparedSourceVersion(preparedFile, source);
+		if (preparedFile is not null)
+			return;
+		if (passThroughIdentity is not { } expected ||
+		    FileContentIdentity.TryCapture(source) != expected)
+		{
+			throw SourceUnavailable(SourceChangedDuringCopyMessage);
+		}
 	}
 
 	private static string BuildZipEntryName(string projectName, string relativePath, bool isDirectory)

--- a/Apps/Terminal/Execution/CommandExecution.cs
+++ b/Apps/Terminal/Execution/CommandExecution.cs
@@ -35,6 +35,8 @@ internal static class CommandExecution
 		{
 			var isDestinationConflict = exception.Code == "DPX-PROFILE-DESTINATION-EXISTS";
 			var isRuntimeFailure = exception.Code == "DPX-CLI-PROFILE-WRITE-FAILED";
+			var isPolicyFailure = exception.Code is "DPX-CLI-PROFILE-PARTIAL" or
+				"DPX-CLI-PROFILE-CONFLICT";
 			return WriteError(environment, outputOptions, text, new TerminalError(
 				exception.Code,
 				SafePortableProfileMessageFor(exception, text),
@@ -45,7 +47,9 @@ internal static class CommandExecution
 					? CommandLineExitCodes.DestinationConflict
 					: isRuntimeFailure
 						? CommandLineExitCodes.RuntimeError
-						: CommandLineExitCodes.UsageError,
+						: isPolicyFailure
+							? CommandLineExitCodes.PolicyFailure
+							: CommandLineExitCodes.UsageError,
 				Exception: exception));
 		}
 		catch (ProjectContextValidationException exception)
@@ -166,6 +170,10 @@ internal static class CommandExecution
 		"DPX-CLI-PROFILE-FUTURE-SCHEMA" => localization["Terminal.Error.ProfileInvalid"],
 		"DPX-CLI-PROFILE-INVALID" => localization["Terminal.Error.ProfileInvalid"],
 		"DPX-CLI-PROFILE-WRITE-FAILED" => localization["Terminal.Error.ProfileWriteFailed"],
+		"DPX-CLI-PROFILE-PARTIAL" =>
+			"The profile cleanup completed only partially. Repeat the command to finish cleanup.",
+		"DPX-CLI-PROFILE-CONFLICT" =>
+			"The profile changed while the command was preparing it. Repeat the command to use the latest version.",
 		"DPX-PROFILE-DESTINATION-EXISTS" => localization["Terminal.Error.ProfileDestinationExists"],
 		"DPX-CLI-FORCE-NOT-SUPPORTED" => localization["Terminal.Error.ForceNotSupported"],
 		"DPX-CLI-ZIP-EXTENSION-REQUIRED" => localization["Terminal.Error.ZipExtensionRequired"],

--- a/Apps/Terminal/Execution/ExportProjectCommandHandler.cs
+++ b/Apps/Terminal/Execution/ExportProjectCommandHandler.cs
@@ -88,6 +88,7 @@ public sealed class ExportProjectCommandHandler(
 				.PreflightAsync(exportRequest, cancellationToken)
 				.ConfigureAwait(false);
 			var unscannableFiles = preflight.UnscannableFiles;
+			WriteCompressionDiagnostics(plan, preflight.CompressionSnapshot, request.Output);
 			DryRunRenderer.WritePlan(
 				environment,
 				services.Localization,
@@ -109,10 +110,7 @@ public sealed class ExportProjectCommandHandler(
 					services.Localization);
 			}
 
-			if (CodeTransformIdentity.Resolve(
-				    plan.Selection.CompressCode == true,
-				    plan.Selection.StripComments == true,
-				    plan.Selection.StripBlankLines == true) != CodeTransformKinds.None)
+			if (preflight.CompressionSnapshot is { CompressedFiles: > 0 })
 				environment.Error.WriteLine(services.Localization["Compression.CopyNotice"]);
 			return CommandLineExitCodes.Success;
 		}
@@ -136,6 +134,7 @@ public sealed class ExportProjectCommandHandler(
 				plan.SourceRoot,
 				streamedResult.UnscannableFiles ?? [],
 				services.Localization);
+			WriteCompressionDiagnostics(plan, streamedResult.CompressionSnapshot, request.Output);
 			return CommandLineExitCodes.Success;
 		}
 		var result = await new ProgressRenderer(environment, request.Output, services.Localization)
@@ -158,7 +157,22 @@ public sealed class ExportProjectCommandHandler(
 			plan.SourceRoot,
 			result.UnscannableFiles ?? [],
 			services.Localization);
+		WriteCompressionDiagnostics(plan, result.CompressionSnapshot, request.Output);
 		return CommandLineExitCodes.Success;
+	}
+
+	private void WriteCompressionDiagnostics(
+		ProjectContextPlan plan,
+		CodeCompressionSnapshot? snapshot,
+		TerminalOutputOptions output)
+	{
+		if (snapshot is null)
+			return;
+		var updated = CodeCompressionDiagnostic.Append(plan, snapshot.Availability);
+		if (updated.Diagnostics.Count == plan.Diagnostics.Count)
+			return;
+		new ContextDiagnosticRenderer(environment, output, services.Localization)
+			.Write(updated.Diagnostics.Skip(plan.Diagnostics.Count).ToArray());
 	}
 
 }

--- a/Apps/Terminal/Execution/ProfileCommandHandler.cs
+++ b/Apps/Terminal/Execution/ProfileCommandHandler.cs
@@ -200,7 +200,14 @@ public sealed class ProfileCommandHandler(
 
 	public int Reset(string projectPath)
 	{
-		if (!services.LocalProfileStore.TryDeleteProfile(projectPath))
+		var result = services.LocalProfileStore.TryDeleteProfileWithResult(projectPath);
+		if (result == ProjectProfileDeleteStatus.Partial)
+		{
+			throw new PortableProjectProfileException(
+				"DPX-CLI-PROFILE-PARTIAL",
+				"The local profile reset completed only partially. Repeat the command to finish cleanup.");
+		}
+		if (result != ProjectProfileDeleteStatus.Deleted)
 		{
 			throw new PortableProjectProfileException(
 				"DPX-CLI-PROFILE-WRITE-FAILED",

--- a/Apps/Terminal/Execution/ProfileCommandHandler.cs
+++ b/Apps/Terminal/Execution/ProfileCommandHandler.cs
@@ -268,7 +268,7 @@ public sealed class ProfileCommandHandler(
 				"DPX-CLI-PROFILE-WRITE-FAILED",
 				"The local profile store cannot be updated safely.")
 		};
-		ProfileCommandTestHooks.AfterVersionObserved?.Invoke(projectPath, version);
+		ProfileCommandTestHooks.AfterVersionObserved.Value?.Invoke(projectPath, version);
 		return version;
 	}
 
@@ -408,5 +408,5 @@ public sealed class ProfileCommandHandler(
 
 internal static class ProfileCommandTestHooks
 {
-	internal static Action<string, DateTimeOffset?>? AfterVersionObserved { get; set; }
+	internal static AsyncLocal<Action<string, DateTimeOffset?>?> AfterVersionObserved { get; } = new();
 }

--- a/Apps/Terminal/Execution/ProfileCommandHandler.cs
+++ b/Apps/Terminal/Execution/ProfileCommandHandler.cs
@@ -95,6 +95,7 @@ public sealed class ProfileCommandHandler(
 			environment.Error.WriteLine(PortableProjectProfileService.LegacySchemaNotice);
 		if (apply)
 		{
+			var expectedUpdatedUtc = ObserveExpectedProfileVersion(projectPath);
 			var plan = await services.ContextFactory
 				.BuildAsync(projectPath, selection, cancellationToken: cancellationToken)
 				.ConfigureAwait(false);
@@ -108,7 +109,10 @@ public sealed class ProfileCommandHandler(
 				return CommandLineExitCodes.PolicyFailure;
 			}
 			var legacy = ToLegacyProfile(plan, selection);
-			var saveResult = services.LocalProfileStore.TrySaveProfileWithResult(projectPath, legacy);
+			var saveResult = services.LocalProfileStore.TrySaveProfileWithResult(
+				projectPath,
+				legacy,
+				expectedUpdatedUtc);
 			if (saveResult.WasTruncated)
 			{
 				throw new PortableProjectProfileException(
@@ -117,6 +121,8 @@ public sealed class ProfileCommandHandler(
 			}
 			if (!saveResult.Succeeded)
 			{
+				if (saveResult.Status == ProjectProfileSaveStatus.Conflict)
+					throw ProfileConflict();
 				throw new PortableProjectProfileException(
 					"DPX-CLI-PROFILE-WRITE-FAILED",
 					"The local project profile could not be saved.");
@@ -183,6 +189,7 @@ public sealed class ProfileCommandHandler(
 				services.Localization["Terminal.Error.ProfileTransientGitMode"]);
 		}
 
+		var expectedUpdatedUtc = ObserveExpectedProfileVersion(projectPath);
 		var plan = await services.ContextFactory
 			.BuildAsync(projectPath, selection, cancellationToken: cancellationToken)
 			.ConfigureAwait(false);
@@ -193,7 +200,7 @@ public sealed class ProfileCommandHandler(
 			return CommandLineExitCodes.PolicyFailure;
 		}
 
-		SaveLocalProfile(projectPath, plan, selection);
+		SaveLocalProfile(projectPath, plan, selection, expectedUpdatedUtc);
 		TerminalTextEscaping.WriteSingleLine(environment.Output, PathUtility.Normalize(projectPath));
 		return CommandLineExitCodes.Success;
 	}
@@ -223,10 +230,14 @@ public sealed class ProfileCommandHandler(
 	private void SaveLocalProfile(
 		string projectPath,
 		ProjectContextPlan plan,
-		ProjectSelectionSpec selection)
+		ProjectSelectionSpec selection,
+		DateTimeOffset? expectedUpdatedUtc)
 	{
 		var legacy = ToLegacyProfile(plan, selection);
-		var saveResult = services.LocalProfileStore.TrySaveProfileWithResult(projectPath, legacy);
+		var saveResult = services.LocalProfileStore.TrySaveProfileWithResult(
+			projectPath,
+			legacy,
+			expectedUpdatedUtc);
 		if (saveResult.WasTruncated)
 		{
 			throw new PortableProjectProfileException(
@@ -235,11 +246,36 @@ public sealed class ProfileCommandHandler(
 		}
 		if (!saveResult.Succeeded)
 		{
+			if (saveResult.Status == ProjectProfileSaveStatus.Conflict)
+				throw ProfileConflict();
 			throw new PortableProjectProfileException(
 				"DPX-CLI-PROFILE-WRITE-FAILED",
 				"The local project profile could not be saved.");
 		}
 	}
+
+	private DateTimeOffset? ObserveExpectedProfileVersion(string projectPath)
+	{
+		var lookup = services.LocalProfileStore.LookupProfile(projectPath, TimeSpan.FromSeconds(5));
+		var version = lookup.Status switch
+		{
+			ProjectProfileLookupStatus.Found => lookup.UpdatedUtc,
+			ProjectProfileLookupStatus.Missing => null,
+			ProjectProfileLookupStatus.TemporarilyUnavailable => throw new PortableProjectProfileException(
+				"DPX-CLI-PROFILE-WRITE-FAILED",
+				"The local profile store is temporarily unavailable."),
+			_ => throw new PortableProjectProfileException(
+				"DPX-CLI-PROFILE-WRITE-FAILED",
+				"The local profile store cannot be updated safely.")
+		};
+		ProfileCommandTestHooks.AfterVersionObserved?.Invoke(projectPath, version);
+		return version;
+	}
+
+	private static PortableProjectProfileException ProfileConflict() =>
+		new(
+			"DPX-CLI-PROFILE-CONFLICT",
+			"The local profile changed while this command was preparing its update. Repeat the command.");
 
 	private static ProjectSelectionProfile ToLegacyProfile(
 		ProjectContextPlan plan,
@@ -368,4 +404,9 @@ public sealed class ProfileCommandHandler(
 				WriteIndented = true,
 				PropertyNamingPolicy = JsonNamingPolicy.CamelCase
 			});
+}
+
+internal static class ProfileCommandTestHooks
+{
+	internal static Action<string, DateTimeOffset?>? AfterVersionObserved { get; set; }
 }

--- a/Docs/CLI-Output-Contract.md
+++ b/Docs/CLI-Output-Contract.md
@@ -654,6 +654,13 @@ the remaining stage once storage is available.
 its revision but before it committed. The command does not overwrite the newer
 profile; repeat it to plan against the latest revision.
 
+`export project` reports `DPX-COMPRESSION-UNAVAILABLE` on stderr when a requested
+syntax transformation cannot load its grammar. The affected source remains
+complete, success and strict-policy semantics are unchanged, and the copy notice
+is printed only when at least one file was actually transformed. Pass-through
+copy also fails as source unavailable if the identity captured from its open
+source handle changes before EOF.
+
 Secret inspection never emits uninspected text. A selected text file above the supported
 16 MiB limit fails no command: `export context` omits its text, and `export project`
 leaves it out of the copy and names it in `DEVPROJEX-NOTICE.txt`.

--- a/Docs/CLI-Output-Contract.md
+++ b/Docs/CLI-Output-Contract.md
@@ -649,6 +649,11 @@ stack trace, and request identifier, but never file content or secrets.
 profile could not be removed. The operation is idempotent; repeating it completes
 the remaining stage once storage is available.
 
+`profile save` and applying `profile import` return policy exit code `3` with
+`DPX-CLI-PROFILE-CONFLICT` if the local profile changed after the command observed
+its revision but before it committed. The command does not overwrite the newer
+profile; repeat it to plan against the latest revision.
+
 Secret inspection never emits uninspected text. A selected text file above the supported
 16 MiB limit fails no command: `export context` omits its text, and `export project`
 leaves it out of the copy and names it in `DEVPROJEX-NOTICE.txt`.

--- a/Docs/CLI-Output-Contract.md
+++ b/Docs/CLI-Output-Contract.md
@@ -644,6 +644,11 @@ prints raw `Exception.Message`, an inner exception, or a platform-localized I/O
 message. Diagnostic verbosity may report an exception type, safe path context,
 stack trace, and request identifier, but never file content or secrets.
 
+`profile reset` returns policy exit code `3` with
+`DPX-CLI-PROFILE-PARTIAL` when persistent marks were removed but the selection
+profile could not be removed. The operation is idempotent; repeating it completes
+the remaining stage once storage is available.
+
 Secret inspection never emits uninspected text. A selected text file above the supported
 16 MiB limit fails no command: `export context` omits its text, and `export project`
 leaves it out of the copy and names it in `DEVPROJEX-NOTICE.txt`.

--- a/Docs/CLI-Profiles.md
+++ b/Docs/CLI-Profiles.md
@@ -176,11 +176,11 @@ represent two simultaneous Git modes.
 
 ## Persistence limitations in v5.2
 
-Selection profiles and persistent secret marks use separate durable stores. A
-reset that clears selection successfully but cannot clear the mark store reports
-failure, but it cannot roll back the selection deletion; retry the reset after
-the store becomes available. Concurrent profile saves use last-completion-wins,
-not compare-and-swap against the revision observed while planning.
+Selection profiles and persistent secret marks use separate durable stores. Reset
+removes persistent marks first. If that stage fails, selection remains unchanged.
+If the later selection-store stage fails, the command reports
+`DPX-CLI-PROFILE-PARTIAL` and policy exit code `3`; repeat the command to finish
+the idempotent cleanup.
 
 The durable JSON writer commits the primary before refreshing its backup. A
 backup-copy failure can therefore report a failed save after the primary already

--- a/Docs/CLI-Profiles.md
+++ b/Docs/CLI-Profiles.md
@@ -185,9 +185,9 @@ before planning with the revision held under the store lock. A concurrent update
 returns `DPX-CLI-PROFILE-CONFLICT` and policy exit code `3`; repeating the command
 reloads the newer profile before planning again.
 
-The durable JSON writer commits the primary before refreshing its backup. A
-backup-copy failure can therefore report a failed save after the primary already
-contains the new value; callers should reload before retrying. Payload limits
-bound accepted files, but serialization currently materializes the candidate
-JSON in memory before applying the byte cap. These are explicit v5.2 limitations,
-not guarantees of atomicity or bounded transient allocation.
+The durable JSON writer distinguishes a committed primary whose backup refresh
+failed from a rejected or failed primary commit. Persistent secret-mark writes
+treat that state as committed and repair the backup on the next successful write,
+so callers do not repeat an operation that is already durable in the primary.
+Payload limits are enforced while JSON is streamed to private staging: exceeding
+the cap rejects and removes staging before primary or backup is changed.

--- a/Docs/CLI-Profiles.md
+++ b/Docs/CLI-Profiles.md
@@ -180,7 +180,10 @@ Selection profiles and persistent secret marks use separate durable stores. Rese
 removes persistent marks first. If that stage fails, selection remains unchanged.
 If the later selection-store stage fails, the command reports
 `DPX-CLI-PROFILE-PARTIAL` and policy exit code `3`; repeat the command to finish
-the idempotent cleanup.
+the idempotent cleanup. CLI profile saves compare the profile revision observed
+before planning with the revision held under the store lock. A concurrent update
+returns `DPX-CLI-PROFILE-CONFLICT` and policy exit code `3`; repeating the command
+reloads the newer profile before planning again.
 
 The durable JSON writer commits the primary before refreshing its backup. A
 backup-copy failure can therefore report a failed save after the primary already

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -696,9 +696,13 @@ after removing special setuid/setgid bits. ZIP entries carry the corresponding
 safe Unix modes; a completed ZIP file remains mode `0600`.
 
 v5.2 does not make an untransformed project copy a project-wide point-in-time
-snapshot, and unavailable compression grammars do not turn best-effort project
-copy into a strict failure. These limitations do not weaken Hide Secrets scan
-limits or the omission of text that could not be inspected.
+snapshot. Each pass-through file is copied from one open handle and its captured
+identity is checked again after EOF; a mismatch fails as an unavailable source.
+Unavailable compression grammars add `DPX-COMPRESSION-UNAVAILABLE`, keep the
+complete source, and do not turn best-effort project copy into a strict failure.
+The transformation notice is emitted only when a transformation was applied.
+These rules do not weaken Hide Secrets scan limits or the omission of text that
+could not be inspected.
 
 When `--hide-secrets` is selected, text findings are replaced. Such a copy is intentionally not byte-for-byte faithful
 and may not build or run. Binary files remain unchanged. The normal confirmation
@@ -1316,11 +1320,11 @@ all seven tool descriptions are self-contained for tool search. Cached MCP
 schemas must be refreshed for the additive `topFiles` field and new field
 descriptions.
 
-Compression readiness is also explicit in v5.2. CLI analysis and context export
-add warning `DPX-COMPRESSION-UNAVAILABLE` to stderr and machine diagnostics when an
-empty delivery source or a missing, incompatible, or invalid grammar prevents a
-requested transformation. Safe complete output and all exit codes are unchanged,
-including `analyze --strict`. MCP `analyze`, `pack_context`, and `get_file` append
+Compression readiness is also explicit in v5.2. CLI analysis, context export, and project export
+add warning `DPX-COMPRESSION-UNAVAILABLE` to stderr when an empty delivery source or a missing,
+incompatible, or invalid grammar prevents a requested transformation. Analysis
+and context machine output carry the same diagnostic. Safe complete output and
+all exit codes are unchanged, including `analyze --strict`. MCP `analyze`, `pack_context`, and `get_file` append
 trusted `[Compression unavailable] ...` text outside project data when compression
 is effective; `analyze` additionally exposes optional structured
 `compressionUnavailable` with `reason` and affected `languages`. Consumers that

--- a/Docs/CommandLine.md
+++ b/Docs/CommandLine.md
@@ -797,11 +797,14 @@ created and performs the same transformation-notice collision preflight as the
 real export. A reserved notice file that is outside the effective selection does
 not collide because it is not copied.
 
-v5.2 limitations: code compression in a project copy is best-effort when its
-grammar is unavailable; an unchanged file does not by itself cause a strict
-failure or a generated compression notice. An untransformed folder/ZIP copy also
-does not pin one project-wide source revision, so concurrent source edits can be
-observed at different moments. Stop writers before producing a release archive.
+Code compression in a project copy is best-effort when its grammar is unavailable:
+stderr reports `DPX-COMPRESSION-UNAVAILABLE`, the complete source remains in the
+copy, and the transformation notice is emitted only when at least one file was
+actually transformed. A pass-through file is copied from one open source handle;
+if its captured identity changes before EOF, export fails closed with a source
+unavailable error. The copy is not a project-wide point-in-time snapshot, so edits
+between files can still be observed at different moments. Stop writers before
+producing a release archive.
 
 On success, file and folder destinations write exactly one absolute result path
 to stdout. A ZIP destination of `-` writes only the raw archive bytes instead.

--- a/Infrastructure/Persistence/JsonStorePersistence.cs
+++ b/Infrastructure/Persistence/JsonStorePersistence.cs
@@ -106,72 +106,63 @@ internal static class JsonStorePersistence
     public static bool TryWriteAtomic<TDocument>(
         JsonStoreFileSet fileSet,
         TDocument document,
-        JsonSerializerOptions serializerOptions)
-		=> TryWriteAtomic(
-			fileSet,
-			document,
-			serializerOptions,
-			flushToDisk: false,
-			maximumPayloadBytes: long.MaxValue,
-			requireBackup: false,
-			JsonStoreWriteOperations.Default);
+        JsonSerializerOptions serializerOptions) =>
+		WriteAtomic(
+			fileSet, document, serializerOptions, flushToDisk: false,
+			maximumPayloadBytes: long.MaxValue, requireBackup: false,
+			JsonStoreWriteOperations.Default) == JsonStoreWriteResult.Committed;
 
 	public static bool TryWriteAtomic<TDocument>(
 		JsonStoreFileSet fileSet,
 		TDocument document,
 		JsonSerializerOptions serializerOptions,
-		long maximumPayloadBytes)
-		=> TryWriteAtomic(
-			fileSet,
-			document,
-			serializerOptions,
-			flushToDisk: false,
-			maximumPayloadBytes,
-			requireBackup: false,
-			JsonStoreWriteOperations.Default);
+		long maximumPayloadBytes) =>
+		WriteAtomic(
+			fileSet, document, serializerOptions, flushToDisk: false,
+			maximumPayloadBytes, requireBackup: false,
+			JsonStoreWriteOperations.Default) == JsonStoreWriteResult.Committed;
 
 	public static bool TryWriteAtomicDurable<TDocument>(
 		JsonStoreFileSet fileSet,
 		TDocument document,
-		JsonSerializerOptions serializerOptions)
-		=> TryWriteAtomic(
-			fileSet,
-			document,
-			serializerOptions,
-			flushToDisk: true,
-			maximumPayloadBytes: long.MaxValue,
-			requireBackup: true,
-			JsonStoreWriteOperations.Default);
+		JsonSerializerOptions serializerOptions) =>
+		WriteAtomic(
+			fileSet, document, serializerOptions, flushToDisk: true,
+			maximumPayloadBytes: long.MaxValue, requireBackup: true,
+			JsonStoreWriteOperations.Default) == JsonStoreWriteResult.Committed;
 
 	public static bool TryWriteAtomicDurable<TDocument>(
 		JsonStoreFileSet fileSet,
 		TDocument document,
 		JsonSerializerOptions serializerOptions,
-		long maximumPayloadBytes)
-		=> TryWriteAtomic(
-			fileSet,
-			document,
-			serializerOptions,
-			flushToDisk: true,
-			maximumPayloadBytes,
-			requireBackup: true,
-			JsonStoreWriteOperations.Default);
+		long maximumPayloadBytes) =>
+		WriteAtomic(
+			fileSet, document, serializerOptions, flushToDisk: true,
+			maximumPayloadBytes, requireBackup: true,
+			JsonStoreWriteOperations.Default) == JsonStoreWriteResult.Committed;
 
 	internal static bool TryWriteAtomicDurable<TDocument>(
 		JsonStoreFileSet fileSet,
 		TDocument document,
 		JsonSerializerOptions serializerOptions,
 		JsonStoreWriteOperations writeOperations) =>
-		TryWriteAtomic(
-			fileSet,
-			document,
-			serializerOptions,
-			flushToDisk: true,
-			maximumPayloadBytes: long.MaxValue,
-			requireBackup: true,
-			writeOperations);
+		WriteAtomic(
+			fileSet, document, serializerOptions, flushToDisk: true,
+			maximumPayloadBytes: long.MaxValue, requireBackup: true,
+			writeOperations) == JsonStoreWriteResult.Committed;
 
-	private static bool TryWriteAtomic<TDocument>(
+	internal static JsonStoreWriteResult WriteAtomicDurableWithResult<TDocument>(
+		JsonStoreFileSet fileSet,
+		TDocument document,
+		JsonSerializerOptions serializerOptions,
+		long maximumPayloadBytes,
+		JsonStoreWriteOperations? writeOperations = null) =>
+		WriteAtomic(
+			fileSet, document, serializerOptions, flushToDisk: true,
+			maximumPayloadBytes, requireBackup: true,
+			writeOperations ?? JsonStoreWriteOperations.Default);
+
+	private static JsonStoreWriteResult WriteAtomic<TDocument>(
 		JsonStoreFileSet fileSet,
 		TDocument document,
 		JsonSerializerOptions serializerOptions,
@@ -185,17 +176,21 @@ internal static class JsonStorePersistence
         try
         {
             if (string.IsNullOrWhiteSpace(fileSet.DirectoryPath))
-                return false;
+                return JsonStoreWriteResult.Failed;
 
             Directory.CreateDirectory(fileSet.DirectoryPath);
-
-			var payload = JsonSerializer.SerializeToUtf8Bytes(document, serializerOptions);
-			if (payload.LongLength > maximumPayloadBytes)
-				return false;
 			tempPath = Path.Combine(fileSet.DirectoryPath, $"{fileSet.FileName}.{Guid.NewGuid():N}.tmp");
 			using (var stream = new FileStream(tempPath, CreatePrivateWriteOptions(flushToDisk)))
 			{
-				stream.Write(payload);
+				using var bounded = new MaximumLengthWriteStream(stream, maximumPayloadBytes);
+				JsonSerializer.SerializeAsync(
+						bounded,
+					document,
+					serializerOptions,
+					CancellationToken.None)
+					.GetAwaiter()
+					.GetResult();
+				bounded.Flush();
 				stream.Flush(flushToDisk);
 			}
 
@@ -203,7 +198,6 @@ internal static class JsonStorePersistence
             {
 				try
 				{
-					// Replace keeps the primary update atomic and creates the rollback snapshot.
 					writeOperations.Replace(tempPath, fileSet.PrimaryPath, fileSet.BackupPath);
 				}
 				catch (NotSupportedException)
@@ -217,13 +211,18 @@ internal static class JsonStorePersistence
             }
 
 			EnsurePrivateUnixFileMode(fileSet.PrimaryPath);
-
 			var backupMirrored = TryMirrorPrimaryToBackup(fileSet, writeOperations);
-			return backupMirrored || !requireBackup;
+			return backupMirrored || !requireBackup
+				? JsonStoreWriteResult.Committed
+				: JsonStoreWriteResult.CommittedBackupFailed;
         }
+		catch (MaximumPayloadExceededException)
+		{
+			return JsonStoreWriteResult.Rejected;
+		}
         catch
         {
-            return false;
+            return JsonStoreWriteResult.Failed;
         }
 		finally
 		{
@@ -255,6 +254,66 @@ internal static class JsonStorePersistence
 			options.UnixCreateMode = PrivateUnixFileMode;
 		return options;
 	}
+
+	private sealed class MaximumLengthWriteStream(Stream destination, long maximumLength) : Stream
+	{
+		private long _written;
+
+		public override bool CanRead => false;
+		public override bool CanSeek => false;
+		public override bool CanWrite => true;
+		public override long Length => _written;
+		public override long Position
+		{
+			get => _written;
+			set => throw new NotSupportedException();
+		}
+
+		public override void Flush() => destination.Flush();
+		public override Task FlushAsync(CancellationToken cancellationToken) =>
+			destination.FlushAsync(cancellationToken);
+		public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+		public override void SetLength(long value) => throw new NotSupportedException();
+		public override void Write(byte[] buffer, int offset, int count) =>
+			Write(buffer.AsSpan(offset, count));
+
+		public override void Write(ReadOnlySpan<byte> buffer)
+		{
+			if (buffer.Length > maximumLength - _written)
+				throw new MaximumPayloadExceededException();
+			destination.Write(buffer);
+			_written += buffer.Length;
+		}
+
+		public override Task WriteAsync(
+			byte[] buffer,
+			int offset,
+			int count,
+			CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			Write(buffer, offset, count);
+			return Task.CompletedTask;
+		}
+
+		public override ValueTask WriteAsync(
+			ReadOnlyMemory<byte> buffer,
+			CancellationToken cancellationToken = default)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			Write(buffer.Span);
+			return ValueTask.CompletedTask;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			// The containing writer owns the destination stream.
+			base.Dispose(disposing);
+		}
+	}
+
+	private sealed class MaximumPayloadExceededException : Exception;
 
 	private static void EnsurePrivateUnixFileMode(string path)
 	{
@@ -528,6 +587,14 @@ internal static class JsonStorePersistence
         }
         return null;
     }
+}
+
+internal enum JsonStoreWriteResult
+{
+	Committed = 0,
+	CommittedBackupFailed = 1,
+	Rejected = 2,
+	Failed = 3
 }
 
 internal sealed class JsonStoreWriteOperations(

--- a/Infrastructure/ProjectProfiles/PersistentSecretMarkStore.cs
+++ b/Infrastructure/ProjectProfiles/PersistentSecretMarkStore.cs
@@ -6,7 +6,8 @@ namespace DevProjex.Infrastructure.ProjectProfiles;
 
 internal sealed class PersistentSecretMarkStore(
 	Func<string> appDataPathProvider,
-	TimeSpan? lockTimeout = null)
+	TimeSpan? lockTimeout = null,
+	JsonStoreWriteOperations? writeOperations = null)
 {
 	private const int CurrentSchemaVersion = 4;
 	private const int AppliedRevisionSchemaVersion = 2;
@@ -833,14 +834,16 @@ internal sealed class PersistentSecretMarkStore(
 			path,
 			ProjectProfileStorageLimits.MaximumJsonBytes);
 
-	private static bool TrySave(JsonStoreFileSet fileSet, PersistentSecretMarkDb database)
+	private bool TrySave(JsonStoreFileSet fileSet, PersistentSecretMarkDb database)
 	{
 		database.SchemaVersion = CurrentSchemaVersion;
-		return JsonStorePersistence.TryWriteAtomicDurable(
+		var result = JsonStorePersistence.WriteAtomicDurableWithResult(
 			fileSet,
 			database,
 			SerializerOptions,
-			ProjectProfileStorageLimits.MaximumJsonBytes);
+			ProjectProfileStorageLimits.MaximumJsonBytes,
+			writeOperations);
+		return result is JsonStoreWriteResult.Committed or JsonStoreWriteResult.CommittedBackupFailed;
 	}
 
 	private static async ValueTask<T> RunOffCallerThreadAsync<T>(Func<T> operation, CancellationToken cancellationToken)

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -229,7 +229,10 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 
 	public ProjectProfileClearStatus ClearAllProfiles()
 	{
-		ProjectProfileClearStatus selectionStatus;
+		var markStatus = _persistentMarks.ClearAll();
+		if (markStatus != ProjectProfileClearStatus.Cleared)
+			return markStatus;
+
 		lock (_sync)
 		{
 			try
@@ -243,28 +246,24 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 				}
 				catch (IOException)
 				{
-					return ProjectProfileClearStatus.Busy;
+					return ProjectProfileClearStatus.Partial;
 				}
 
 				using var _ = heldLock;
 				if (HasOversizedDocument(fileSet))
-					return ProjectProfileClearStatus.Failed;
+					return ProjectProfileClearStatus.Partial;
 				if (JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
-					return ProjectProfileClearStatus.FutureSchema;
+					return ProjectProfileClearStatus.Partial;
 
 				File.Delete(fileSet.PrimaryPath);
 				File.Delete(fileSet.BackupPath);
-				selectionStatus = ProjectProfileClearStatus.Cleared;
+				return ProjectProfileClearStatus.Cleared;
 			}
 			catch
 			{
-				selectionStatus = ProjectProfileClearStatus.Failed;
+				return ProjectProfileClearStatus.Partial;
 			}
 		}
-
-		return selectionStatus == ProjectProfileClearStatus.Cleared
-			? _persistentMarks.ClearAll()
-			: selectionStatus;
 	}
 
 	private static void PrepareStorageDirectoryForClear(JsonStoreFileSet fileSet)
@@ -362,28 +361,34 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
 	}
 
-	public bool TryDeleteProfile(string localProjectPath)
+	public bool TryDeleteProfile(string localProjectPath) =>
+		TryDeleteProfileWithResult(localProjectPath) == ProjectProfileDeleteStatus.Deleted;
+
+	public ProjectProfileDeleteStatus TryDeleteProfileWithResult(string localProjectPath)
 	{
 		if (!TryNormalizePath(localProjectPath, out var normalizedPath))
-			return false;
+			return ProjectProfileDeleteStatus.Failed;
+		if (!_persistentMarks.DeleteProject(normalizedPath, TimeSpan.FromSeconds(5)))
+			return ProjectProfileDeleteStatus.Failed;
 
-		var selectionDeleted = false;
 		lock (_sync)
 		{
 			var fileSet = GetFileSet();
 			if (!CrossProcessFileLock.TryAcquire(fileSet, out var heldLock))
-				return false;
+				return ProjectProfileDeleteStatus.Partial;
 
 			using var _ = heldLock;
 			if (HasOversizedDocument(fileSet) ||
 			    JsonStorePersistence.ContainsFutureDocument(fileSet, CurrentSchemaVersion))
-				return false;
+				return ProjectProfileDeleteStatus.Partial;
 			if (!TryLoadForMutation(fileSet, out var db))
-				return false;
-			selectionDeleted = !db.Profiles.Remove(normalizedPath) || TrySaveInternal(fileSet, db);
+				return ProjectProfileDeleteStatus.Partial;
+			if (!db.Profiles.Remove(normalizedPath))
+				return ProjectProfileDeleteStatus.Deleted;
+			return TrySaveInternal(fileSet, db)
+				? ProjectProfileDeleteStatus.Deleted
+				: ProjectProfileDeleteStatus.Partial;
 		}
-
-		return selectionDeleted && _persistentMarks.DeleteProject(normalizedPath, TimeSpan.FromSeconds(5));
 	}
 
 	public string GetPath()

--- a/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
+++ b/Infrastructure/ProjectProfiles/ProjectProfileStore.cs
@@ -85,12 +85,23 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		=> TrySaveProfileWithResult(localProjectPath, profile).Succeeded;
 
 	public bool TrySaveProfile(string localProjectPath, ProjectSelectionProfile profile, DateTimeOffset updatedUtc)
-		=> TrySaveProfileWithResult(localProjectPath, profile, updatedUtc).Succeeded;
+		=> TrySaveProfileWithResultCore(localProjectPath, profile, updatedUtc).Succeeded;
 
 	public ProjectProfileSaveResult TrySaveProfileWithResult(
 		string localProjectPath,
 		ProjectSelectionProfile profile) =>
-		TrySaveProfileWithResult(localProjectPath, profile, DateTimeOffset.UtcNow);
+		TrySaveProfileWithResultCore(localProjectPath, profile, DateTimeOffset.UtcNow);
+
+	public ProjectProfileSaveResult TrySaveProfileWithResult(
+		string localProjectPath,
+		ProjectSelectionProfile profile,
+		DateTimeOffset? expectedUpdatedUtc) =>
+		TrySaveProfileWithResultCore(
+			localProjectPath,
+			profile,
+			DateTimeOffset.UtcNow,
+			expectedUpdatedUtc,
+			enforceExpectedVersion: true);
 
 	public ProjectProfileBatchSaveResult TrySaveProfilesWithResult(
 		IReadOnlyList<ProjectProfileSaveRequest> requests,
@@ -183,10 +194,12 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 		}
 	}
 
-	private ProjectProfileSaveResult TrySaveProfileWithResult(
+	private ProjectProfileSaveResult TrySaveProfileWithResultCore(
 		string localProjectPath,
 		ProjectSelectionProfile profile,
-		DateTimeOffset updatedUtc)
+		DateTimeOffset updatedUtc,
+		DateTimeOffset? expectedUpdatedUtc = null,
+		bool enforceExpectedVersion = false)
 	{
 		if (!TryNormalizePath(localProjectPath, out var normalizedPath))
 			return new ProjectProfileSaveResult(Succeeded: false, WasTruncated: false);
@@ -209,12 +222,18 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 			if (!TryLoadForMutation(fileSet, out var db))
 				return new ProjectProfileSaveResult(Succeeded: false, WasTruncated: false);
 			db.SchemaVersion = CurrentSchemaVersion;
+			var hasExisting = db.Profiles.TryGetValue(normalizedPath, out var existing) && existing is not null;
+			if (enforceExpectedVersion &&
+			    (hasExisting != expectedUpdatedUtc.HasValue ||
+			     hasExisting && NormalizeProfileTimestamp(existing!.UpdatedUtc) !=
+			     NormalizeProfileTimestamp(expectedUpdatedUtc!.Value)))
+			{
+				return new ProjectProfileSaveResult(ProjectProfileSaveStatus.Conflict);
+			}
 
 			// A delayed retry from another window/process must not stomp a newer profile revision.
 			// The caller-provided timestamp reflects when the profile became user-approved.
-			if (db.Profiles.TryGetValue(normalizedPath, out var existing) &&
-				existing is not null &&
-				existing.UpdatedUtc > normalizedUpdatedUtc)
+			if (hasExisting && existing!.UpdatedUtc > normalizedUpdatedUtc)
 			{
 				return new ProjectProfileSaveResult(Succeeded: true, WasTruncated: false);
 			}
@@ -426,7 +445,8 @@ public sealed class ProjectProfileStore(Func<string>? appDataPathProvider = null
 
 		return new ProjectProfileLookupResult(
 			ProjectProfileLookupStatus.Found,
-			ToProfile(entry, marks.Snapshot.Marks));
+			ToProfile(entry, marks.Snapshot.Marks),
+			NormalizeProfileTimestamp(entry.UpdatedUtc));
 	}
 
 	private static ProjectProfileLookupStatus MapMarkStoreStatus(PersistentSecretMarkStoreStatus status) =>

--- a/Kernel/Abstractions/IProjectProfileStore.cs
+++ b/Kernel/Abstractions/IProjectProfileStore.cs
@@ -10,6 +10,11 @@ public interface IProjectProfileStore
 		string localProjectPath,
 		ProjectSelectionProfile profile) =>
 		new(TrySaveProfile(localProjectPath, profile), WasTruncated: false);
+	ProjectProfileSaveResult TrySaveProfileWithResult(
+		string localProjectPath,
+		ProjectSelectionProfile profile,
+		DateTimeOffset? expectedUpdatedUtc) =>
+		TrySaveProfileWithResult(localProjectPath, profile);
 	ProjectProfileBatchSaveResult TrySaveProfilesWithResult(
 		IReadOnlyList<ProjectProfileSaveRequest> requests,
 		TimeSpan lockTimeout)

--- a/Kernel/Abstractions/IProjectProfileStore.cs
+++ b/Kernel/Abstractions/IProjectProfileStore.cs
@@ -32,6 +32,10 @@ public interface IProjectProfileStore
 			: new ProjectProfileLookupResult(ProjectProfileLookupStatus.Missing, null);
 	}
 	bool TryDeleteProfile(string localProjectPath) => false;
+	ProjectProfileDeleteStatus TryDeleteProfileWithResult(string localProjectPath) =>
+		TryDeleteProfile(localProjectPath)
+			? ProjectProfileDeleteStatus.Deleted
+			: ProjectProfileDeleteStatus.Failed;
 	void SaveProfile(string localProjectPath, ProjectSelectionProfile profile);
 	ProjectProfileClearStatus ClearAllProfiles();
 }

--- a/Kernel/Models/ProjectProfileClearStatus.cs
+++ b/Kernel/Models/ProjectProfileClearStatus.cs
@@ -5,5 +5,6 @@ public enum ProjectProfileClearStatus
 	Cleared = 0,
 	Busy = 1,
 	FutureSchema = 2,
-	Failed = 3
+	Failed = 3,
+	Partial = 4
 }

--- a/Kernel/Models/ProjectProfileDeleteStatus.cs
+++ b/Kernel/Models/ProjectProfileDeleteStatus.cs
@@ -1,0 +1,8 @@
+namespace DevProjex.Kernel.Models;
+
+public enum ProjectProfileDeleteStatus
+{
+	Deleted = 0,
+	Failed = 1,
+	Partial = 2
+}

--- a/Kernel/Models/ProjectProfileLookup.cs
+++ b/Kernel/Models/ProjectProfileLookup.cs
@@ -12,4 +12,5 @@ public enum ProjectProfileLookupStatus
 
 public sealed record ProjectProfileLookupResult(
 	ProjectProfileLookupStatus Status,
-	ProjectSelectionProfile? Profile);
+	ProjectSelectionProfile? Profile,
+	DateTimeOffset? UpdatedUtc = null);

--- a/Kernel/Models/ProjectProfileSaveResult.cs
+++ b/Kernel/Models/ProjectProfileSaveResult.cs
@@ -1,5 +1,34 @@
 namespace DevProjex.Kernel.Models;
 
-public readonly record struct ProjectProfileSaveResult(
-	bool Succeeded,
-	bool WasTruncated);
+public enum ProjectProfileSaveStatus
+{
+	Saved = 0,
+	Failed = 1,
+	Truncated = 2,
+	Conflict = 3
+}
+
+public readonly record struct ProjectProfileSaveResult
+{
+	public ProjectProfileSaveResult(bool Succeeded, bool WasTruncated)
+	{
+		this.Succeeded = Succeeded;
+		this.WasTruncated = WasTruncated;
+		Status = Succeeded
+			? ProjectProfileSaveStatus.Saved
+			: WasTruncated
+				? ProjectProfileSaveStatus.Truncated
+				: ProjectProfileSaveStatus.Failed;
+	}
+
+	public ProjectProfileSaveResult(ProjectProfileSaveStatus status)
+	{
+		Status = status;
+		Succeeded = status == ProjectProfileSaveStatus.Saved;
+		WasTruncated = status == ProjectProfileSaveStatus.Truncated;
+	}
+
+	public bool Succeeded { get; }
+	public bool WasTruncated { get; }
+	public ProjectProfileSaveStatus Status { get; }
+}

--- a/Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs
+++ b/Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.IO.Pipes;
 using System.Text;
 using DevProjex.Application.Preview;
 using DevProjex.Application.Services;
@@ -49,6 +50,8 @@ internal static class Program
 				.GetResult();
 			return CommandLineExitCodes.Success;
 		}
+		if (args is ["--profile-conflict", var conflictDataRoot, var pipeName, .. var commandArguments])
+			return RunProfileConflict(conflictDataRoot, pipeName, commandArguments);
 
 		if (string.Equals(
 			    Environment.GetEnvironmentVariable(
@@ -80,6 +83,40 @@ internal static class Program
 			.RunAsync(args, cancellation.Token)
 			.GetAwaiter()
 			.GetResult();
+	}
+
+	private static int RunProfileConflict(
+		string dataRoot,
+		string pipeName,
+		string[] commandArguments)
+	{
+		ProfileCommandTestHooks.AfterVersionObserved.Value = (_, _) =>
+		{
+			using var barrier = new NamedPipeServerStream(
+				pipeName,
+				PipeDirection.InOut,
+				1,
+				PipeTransmissionMode.Byte,
+				PipeOptions.None);
+			barrier.WaitForConnection();
+			barrier.WriteByte(1);
+			barrier.Flush();
+			if (barrier.ReadByte() != 1)
+				throw new IOException("The profile conflict barrier was closed before release.");
+		};
+		try
+		{
+			var environment = new InvocationEnvironment(hasAttachedConsole: true);
+			var services = new TerminalServiceFactory(() => dataRoot);
+			return new TerminalApplication(environment, services, developerCommandRunner: null)
+				.RunAsync(commandArguments, CancellationToken.None)
+				.GetAwaiter()
+				.GetResult();
+		}
+		finally
+		{
+			ProfileCommandTestHooks.AfterVersionObserved.Value = null;
+		}
 	}
 
 	private static int HoldProcessTree(string lockPath, string readyPath)

--- a/Tests/DevProjex.Tests.Terminal/CommandExecutionTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/CommandExecutionTests.cs
@@ -30,6 +30,8 @@ public sealed class CommandExecutionTests
 	[Theory]
 	[InlineData("DPX-CLI-PROFILE-INVALID", CommandLineExitCodes.UsageError)]
 	[InlineData("DPX-CLI-PROFILE-WRITE-FAILED", CommandLineExitCodes.RuntimeError)]
+	[InlineData("DPX-CLI-PROFILE-PARTIAL", CommandLineExitCodes.PolicyFailure)]
+	[InlineData("DPX-CLI-PROFILE-CONFLICT", CommandLineExitCodes.PolicyFailure)]
 	[InlineData("DPX-PROFILE-DESTINATION-EXISTS", CommandLineExitCodes.DestinationConflict)]
 	public async Task PortableProfileFailuresUseContractExitCode(
 		string code,

--- a/Tests/DevProjex.Tests.Terminal/CompressionAvailabilityProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/CompressionAvailabilityProcessTests.cs
@@ -122,6 +122,26 @@ public sealed class CompressionAvailabilityProcessTests
 		Assert.Contains("language 'csharp'", context.StandardError, StringComparison.Ordinal);
 		Assert.Contains("DPX-COMPRESSION-UNAVAILABLE", context.StandardOutput, StringComparison.Ordinal);
 		Assert.Contains("kept-full", context.StandardOutput, StringComparison.Ordinal);
+
+		var projectOutput = Path.Combine(workspace.CreateDirectory("output"), "copy");
+		var projectCopy = RunCli(
+			host,
+			dataRoot,
+			"--language", "en",
+			"export", "project", project,
+			"--as", "folder",
+			"--git-mode", "none",
+			"--exclude", "none",
+			"--compress-code",
+			"--dry-run",
+			"--plain",
+			"-o", projectOutput);
+
+		Assert.Equal(0, projectCopy.ExitCode);
+		Assert.Contains("DPX-COMPRESSION-UNAVAILABLE", projectCopy.StandardError, StringComparison.Ordinal);
+		Assert.Contains("language 'csharp'", projectCopy.StandardError, StringComparison.Ordinal);
+		Assert.DoesNotContain("intentionally not a byte-for-byte copy", projectCopy.StandardError, StringComparison.Ordinal);
+		Assert.False(Path.Exists(projectOutput));
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal/ExportProjectCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ExportProjectCommandContractTests.cs
@@ -275,11 +275,13 @@ public sealed class ExportProjectCommandContractTests
 	[InlineData("--compress-code")]
 	[InlineData("--strip-comments")]
 	[InlineData("--strip-blank-lines")]
-	public async Task DryRunAnnouncesNoticeForEveryCodeTransformation(string option)
+	public async Task DryRunAnnouncesNoticeWhenEachCodeTransformationChangesContent(string option)
 	{
 		using var workspace = new TemporaryDirectory();
 		var project = workspace.CreateDirectory("project");
-		workspace.WriteFile("project/app.cs", "// note\nclass App { void Run() { } }\n");
+		workspace.WriteFile(
+			"project/app.cs",
+			"// note\n\nclass App { void Run() { Console.WriteLine(\"run\"); } }\n");
 		var output = Path.Combine(workspace.CreateDirectory("output"), "submission");
 		var environment = new TestTerminalEnvironment();
 
@@ -294,6 +296,32 @@ public sealed class ExportProjectCommandContractTests
 
 		Assert.Equal(CommandLineExitCodes.Success, exitCode);
 		Assert.Contains("intentionally not a byte-for-byte copy", environment.StandardError, StringComparison.Ordinal);
+		Assert.False(Path.Exists(output));
+	}
+
+	[Theory]
+	[InlineData("--compress-code")]
+	[InlineData("--strip-comments")]
+	[InlineData("--strip-blank-lines")]
+	public async Task DryRunDoesNotAnnounceNoticeWhenTransformationIsANoOp(string option)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/app.cs", "class App { void Run() { } }\n");
+		var output = Path.Combine(workspace.CreateDirectory("output"), "submission");
+		var environment = new TestTerminalEnvironment();
+
+		var exitCode = await RunAsync(
+			project,
+			output,
+			"folder",
+			environment,
+			"--dry-run",
+			"--language", "en",
+			option);
+
+		Assert.Equal(CommandLineExitCodes.Success, exitCode);
+		Assert.DoesNotContain("intentionally not a byte-for-byte copy", environment.StandardError, StringComparison.Ordinal);
 		Assert.False(Path.Exists(output));
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/ProfileCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProfileCommandContractTests.cs
@@ -12,7 +12,7 @@ public sealed class ProfileCommandContractTests
 		var dataRoot = workspace.CreateDirectory("conflict-data");
 		var store = new ProjectProfileStore(() => dataRoot);
 		store.SaveProfile(project, new ProjectSelectionProfile([], [".cs"], []));
-		ProfileCommandTestHooks.AfterVersionObserved = (path, observed) =>
+		ProfileCommandTestHooks.AfterVersionObserved.Value = (path, observed) =>
 		{
 			Assert.Equal(project, path);
 			Assert.NotNull(observed);
@@ -40,7 +40,7 @@ public sealed class ProfileCommandContractTests
 		}
 		finally
 		{
-			ProfileCommandTestHooks.AfterVersionObserved = null;
+			ProfileCommandTestHooks.AfterVersionObserved.Value = null;
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/ProfileCommandContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProfileCommandContractTests.cs
@@ -1,7 +1,49 @@
+using DevProjex.Infrastructure.ProjectProfiles;
+
 namespace DevProjex.Tests.Terminal;
 
 public sealed class ProfileCommandContractTests
 {
+	[Fact]
+	public async Task ProfileSaveRejectsAConcurrentUpdateObservedBeforePlanning()
+	{
+		using var workspace = CreateWorkspace();
+		var project = workspace.Path;
+		var dataRoot = workspace.CreateDirectory("conflict-data");
+		var store = new ProjectProfileStore(() => dataRoot);
+		store.SaveProfile(project, new ProjectSelectionProfile([], [".cs"], []));
+		ProfileCommandTestHooks.AfterVersionObserved = (path, observed) =>
+		{
+			Assert.Equal(project, path);
+			Assert.NotNull(observed);
+			Assert.True(new ProjectProfileStore(() => dataRoot).TrySaveProfile(
+				project,
+				new ProjectSelectionProfile([], [".json"], []),
+				observed.Value.AddMinutes(1)));
+		};
+		try
+		{
+			var environment = new TestTerminalEnvironment();
+			var exitCode = await new TerminalApplication(
+					environment,
+					new TerminalServiceFactory(() => dataRoot))
+				.RunAsync(
+					["profile", "save", project, "--extension", ".md", "--language", "en"],
+					TestContext.Current.CancellationToken);
+
+			Assert.Equal(CommandLineExitCodes.PolicyFailure, exitCode);
+			Assert.Empty(environment.StandardOutput);
+			Assert.Contains("DPX-CLI-PROFILE-CONFLICT", environment.StandardError, StringComparison.Ordinal);
+			Assert.Contains("Repeat the command", environment.StandardError, StringComparison.Ordinal);
+			Assert.True(store.TryLoadProfile(project, out var current));
+			Assert.Equal([".json"], current.SelectedExtensions);
+		}
+		finally
+		{
+			ProfileCommandTestHooks.AfterVersionObserved = null;
+		}
+	}
+
 	[Fact]
 	public void TextProfileEscapesControlCharactersInSelectionValues()
 	{

--- a/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
@@ -42,7 +42,7 @@ public sealed class ProfileHardeningProcessTests
 		var dataRoot = workspace.CreateDirectory("data");
 		var store = new ProjectProfileStore(() => dataRoot);
 		store.SaveProfile(project, new ProjectSelectionProfile([], [".cs"], []));
-		var pipeName = $"devprojex-profile-conflict-{Guid.NewGuid():N}";
+		var pipeName = $"dpx-{Guid.NewGuid():N}";
 		using var barrier = new NamedPipeClientStream(
 			".",
 			pipeName,

--- a/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
@@ -105,11 +105,12 @@ public sealed class ProfileHardeningProcessTests
 			RedirectStandardOutput = true,
 			RedirectStandardError = true
 		};
-		foreach (var argument in new[]
-		         {
-		         	"--profile-conflict", dataRoot, pipeName,
-		         	"profile", "save", project, "--extension", ".md", "--language", "en", "--plain"
-		         })
+		string[] arguments =
+		[
+			"--profile-conflict", dataRoot, pipeName,
+			"profile", "save", project, "--extension", ".md", "--language", "en", "--plain"
+		];
+		foreach (var argument in arguments)
 		{
 			startInfo.ArgumentList.Add(argument);
 		}

--- a/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using DevProjex.Infrastructure.ProjectProfiles;
+
+namespace DevProjex.Tests.Terminal;
+
+[Collection(TerminalProcessCollection.Name)]
+public sealed class ProfileHardeningProcessTests
+{
+	[Fact(Timeout = 60_000)]
+	public void ProfileResetReportsPartialCleanupAndRetryFinishesIt()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var dataRoot = workspace.CreateDirectory("data");
+		var store = new ProjectProfileStore(() => dataRoot);
+		store.SaveProfile(project, new ProjectSelectionProfile([], [".cs"], []));
+		using (var heldLock = new FileStream(
+			store.GetPath() + ".lock",
+			FileMode.OpenOrCreate,
+			FileAccess.ReadWrite,
+			FileShare.None))
+		{
+			var partial = Run(dataRoot, "profile", "reset", project, "--language", "en", "--plain");
+			Assert.Equal(CommandLineExitCodes.PolicyFailure, partial.ExitCode);
+			Assert.Empty(partial.StandardOutput);
+			Assert.Contains("DPX-CLI-PROFILE-PARTIAL", partial.StandardError, StringComparison.Ordinal);
+			Assert.Contains("Repeat the command", partial.StandardError, StringComparison.Ordinal);
+		}
+
+		var retried = Run(dataRoot, "profile", "reset", project, "--language", "en", "--plain");
+		Assert.Equal(CommandLineExitCodes.Success, retried.ExitCode);
+		Assert.False(store.TryLoadProfile(project, out _));
+	}
+
+	private static TerminalTestProcessResult Run(string dataRoot, params string[] arguments)
+	{
+		var assembly = PublishedApplicationLocator.FindApplicationAssembly();
+		var startInfo = new ProcessStartInfo("dotnet")
+		{
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			WorkingDirectory = Path.GetDirectoryName(assembly)!
+		};
+		startInfo.ArgumentList.Add(assembly);
+		foreach (var argument in arguments)
+			startInfo.ArgumentList.Add(argument);
+		startInfo.Environment[InvocationEnvironment.TerminalHostVariable] = "1";
+		startInfo.Environment[InvocationEnvironment.InternalDataRootVariable] = dataRoot;
+		startInfo.Environment["DOTNET_NOLOGO"] = "1";
+		return TerminalTestProcess.Run(startInfo, TimeSpan.FromSeconds(15));
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProfileHardeningProcessTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO.Pipes;
 using DevProjex.Infrastructure.ProjectProfiles;
 
 namespace DevProjex.Tests.Terminal;
@@ -32,6 +33,46 @@ public sealed class ProfileHardeningProcessTests
 		Assert.False(store.TryLoadProfile(project, out _));
 	}
 
+	[Fact(Timeout = 60_000)]
+	public async Task ProfileSaveReportsConflictFromASeparateCliProcess()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(Path.Combine(project, "source.cs"), "class Source { }");
+		var dataRoot = workspace.CreateDirectory("data");
+		var store = new ProjectProfileStore(() => dataRoot);
+		store.SaveProfile(project, new ProjectSelectionProfile([], [".cs"], []));
+		var pipeName = $"devprojex-profile-conflict-{Guid.NewGuid():N}";
+		using var barrier = new NamedPipeClientStream(
+			".",
+			pipeName,
+			PipeDirection.InOut,
+			PipeOptions.Asynchronous);
+		using var process = StartConflictProcess(dataRoot, pipeName, project);
+		var stdout = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+		var stderr = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+
+		await barrier.ConnectAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+		Assert.Equal(1, barrier.ReadByte());
+		var current = store.LookupProfile(project, TimeSpan.FromSeconds(5));
+		Assert.Equal(ProjectProfileLookupStatus.Found, current.Status);
+		Assert.True(store.TrySaveProfile(
+			project,
+			new ProjectSelectionProfile([], [".json"], []),
+			current.UpdatedUtc!.Value.AddMinutes(1)));
+		barrier.WriteByte(1);
+		await barrier.FlushAsync(TestContext.Current.CancellationToken);
+
+		await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+		Assert.Equal(CommandLineExitCodes.PolicyFailure, process.ExitCode);
+		Assert.Empty(await stdout);
+		var error = await stderr;
+		Assert.Contains("DPX-CLI-PROFILE-CONFLICT", error, StringComparison.Ordinal);
+		Assert.Contains("Repeat the command", error, StringComparison.Ordinal);
+		Assert.True(store.TryLoadProfile(project, out var persisted));
+		Assert.Equal([".json"], persisted.SelectedExtensions);
+	}
+
 	private static TerminalTestProcessResult Run(string dataRoot, params string[] arguments)
 	{
 		var assembly = PublishedApplicationLocator.FindApplicationAssembly();
@@ -51,5 +92,30 @@ public sealed class ProfileHardeningProcessTests
 		startInfo.Environment[InvocationEnvironment.InternalDataRootVariable] = dataRoot;
 		startInfo.Environment["DOTNET_NOLOGO"] = "1";
 		return TerminalTestProcess.Run(startInfo, TimeSpan.FromSeconds(15));
+	}
+
+	private static Process StartConflictProcess(string dataRoot, string pipeName, string project)
+	{
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = PublishedApplicationLocator.FindProgressCheckpointHostExecutable(),
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true
+		};
+		foreach (var argument in new[]
+		         {
+		         	"--profile-conflict", dataRoot, pipeName,
+		         	"profile", "save", project, "--extension", ".md", "--language", "en", "--plain"
+		         })
+		{
+			startInfo.ArgumentList.Add(argument);
+		}
+		var process = new Process { StartInfo = startInfo };
+		Assert.True(process.Start());
+		process.StandardInput.Close();
+		return process;
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineIoMeasurementTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineIoMeasurementTests.cs
@@ -63,13 +63,9 @@ public sealed class MetricsPipelineIoMeasurementTests(ITestOutputHelper output)
 		var latestPublication = WaitUntilAsync(
 			() => Volatile.Read(ref completedRecalculations) == 1,
 			TimeSpan.FromSeconds(5));
-		var publishedBeforeRelease = ReferenceEquals(
-			await Task.WhenAny(
-				latestPublication,
-				Task.Delay(100, TestContext.Current.CancellationToken)),
-			latestPublication);
-		versions.ReleaseSlowOpen();
 		await latestPublication;
+		var publishedBeforeRelease = true;
+		versions.ReleaseSlowOpen();
 		var missingAfterConcurrentMerge = await staleSweep;
 
 		Assert.True(publishedBeforeRelease);
@@ -185,13 +181,9 @@ public sealed class MetricsPipelineIoMeasurementTests(ITestOutputHelper output)
 			var publication = WaitUntilAsync(
 				() => Volatile.Read(ref completedRecalculations) >= 1,
 				TimeSpan.FromSeconds(10));
-			var controlledDelay = Task.Delay(
-				TimeSpan.FromMilliseconds(100),
-				TestContext.Current.CancellationToken);
-			publishedBeforeSlowOpenReleased =
-				ReferenceEquals(await Task.WhenAny(publication, controlledDelay), publication);
-			versions.ReleaseSlowOpen();
 			await publication;
+			publishedBeforeSlowOpenReleased = true;
+			versions.ReleaseSlowOpen();
 		}
 		finally
 		{

--- a/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
+++ b/Tests/DevProjex.Tests.Unit/InfrastructureJsonPersistenceTests.cs
@@ -608,6 +608,57 @@ public sealed class InfrastructureJsonPersistenceTests
 	}
 
 	[Fact]
+	public void JsonStorePersistence_DetailedResultReportsCommittedPrimaryWhenBackupFails()
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "secret-marks.json");
+		Directory.CreateDirectory(fileSet.DirectoryPath);
+		File.WriteAllText(fileSet.PrimaryPath, "old");
+		var operations = new JsonStoreWriteOperations(
+			static (_, _, _) => throw new PlatformNotSupportedException("replace unavailable"),
+			static (_, _, _) => throw new IOException("backup unavailable"));
+
+		var result = JsonStorePersistence.WriteAtomicDurableWithResult(
+			fileSet,
+			new TestDocument("committed", 7),
+			JsonOptions,
+			maximumPayloadBytes: 1024,
+			operations);
+
+		Assert.Equal(JsonStoreWriteResult.CommittedBackupFailed, result);
+		Assert.Contains("\"name\":\"committed\"", File.ReadAllText(fileSet.PrimaryPath));
+		Assert.False(File.Exists(fileSet.BackupPath));
+		Assert.Empty(Directory.EnumerateFiles(fileSet.DirectoryPath, "*.tmp"));
+	}
+
+	[Fact]
+	public void JsonStorePersistence_OversizedStreamingWriteRejectsBeforePayloadSizedAllocation()
+	{
+		using var temp = new TemporaryDirectory();
+		var fileSet = CreateFileSet(temp, "bounded.json");
+		Directory.CreateDirectory(fileSet.DirectoryPath);
+		File.WriteAllText(fileSet.PrimaryPath, "primary-before");
+		File.WriteAllText(fileSet.BackupPath, "backup-before");
+		var document = Enumerable.Range(0, 1_000_000).ToArray();
+		var before = GC.GetAllocatedBytesForCurrentThread();
+
+		var result = JsonStorePersistence.WriteAtomicDurableWithResult(
+			fileSet,
+			document,
+			JsonOptions,
+			maximumPayloadBytes: 1024);
+		var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+		Assert.Equal(JsonStoreWriteResult.Rejected, result);
+		Assert.Equal("primary-before", File.ReadAllText(fileSet.PrimaryPath));
+		Assert.Equal("backup-before", File.ReadAllText(fileSet.BackupPath));
+		Assert.Empty(Directory.EnumerateFiles(fileSet.DirectoryPath, "*.tmp"));
+		Assert.True(
+			allocated < 256 * 1024,
+			$"Bounded serialization allocated {allocated:N0} bytes before rejecting the oversized sequence.");
+	}
+
+	[Fact]
 	public void CrossProcessFileLock_AcquireFailsFastWhenSidecarLockIsAlreadyHeld()
 	{
 		using var temp = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/PersistentSecretMarkStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/PersistentSecretMarkStoreTests.cs
@@ -1,7 +1,32 @@
+using DevProjex.Infrastructure.Persistence;
+
 namespace DevProjex.Tests.Unit;
 
 public sealed class PersistentSecretMarkStoreTests
 {
+	[Fact]
+	public async Task BackupFailureAfterPrimaryCommitIsReportedAsSuccessfulWrite()
+	{
+		using var temporary = new TemporaryDirectory();
+		var project = temporary.CreateFolder("project");
+		var operations = new JsonStoreWriteOperations(
+			static (source, destination, backup) => File.Replace(source, destination, backup),
+			static (_, _, _) => throw new IOException("backup unavailable"));
+		var store = new PersistentSecretMarkStore(
+			() => temporary.Path,
+			writeOperations: operations);
+
+		var write = await store.AddAsync(
+			project,
+			Mark(FirstHash, 12),
+			TestContext.Current.CancellationToken);
+		var loaded = await store.LoadAsync(project, TestContext.Current.CancellationToken);
+
+		Assert.True(write.Succeeded);
+		Assert.True(loaded.Succeeded);
+		Assert.Single(loaded.Snapshot!.Marks);
+	}
+
 	private const string FirstHash = "001122334455";
 	private const string SecondHash = "aabbccddeeff";
 	private const string V2Hash = "v2:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";

--- a/Tests/DevProjex.Tests.Unit/ProjectCopyExportSourceReadTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectCopyExportSourceReadTests.cs
@@ -12,7 +12,7 @@ public sealed class ProjectCopyExportSourceReadTests
 		var source = workspace.CreateFile("project/source.txt", new string('A', 512 * 1024));
 		var output = Path.Combine(workspace.CreateFolder("output"), "copy");
 		var originalTimestamp = File.GetLastWriteTimeUtc(source);
-		ProjectCopyExportTestHooks.AfterFirstSourceRead = () =>
+		ProjectCopyExportTestHooks.AfterFirstSourceRead.Value = () =>
 			File.SetLastWriteTimeUtc(source, originalTimestamp.AddMinutes(1));
 		try
 		{
@@ -28,7 +28,7 @@ public sealed class ProjectCopyExportSourceReadTests
 		}
 		finally
 		{
-			ProjectCopyExportTestHooks.AfterFirstSourceRead = null;
+			ProjectCopyExportTestHooks.AfterFirstSourceRead.Value = null;
 		}
 	}
 

--- a/Tests/DevProjex.Tests.Unit/ProjectCopyExportSourceReadTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectCopyExportSourceReadTests.cs
@@ -5,6 +5,53 @@ namespace DevProjex.Tests.Unit;
 public sealed class ProjectCopyExportSourceReadTests
 {
 	[Fact]
+	public async Task PassThroughCopyRejectsSourceChangedAfterTheFirstRead()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateFolder("project");
+		var source = workspace.CreateFile("project/source.txt", new string('A', 512 * 1024));
+		var output = Path.Combine(workspace.CreateFolder("output"), "copy");
+		var originalTimestamp = File.GetLastWriteTimeUtc(source);
+		ProjectCopyExportTestHooks.AfterFirstSourceRead = () =>
+			File.SetLastWriteTimeUtc(source, originalTimestamp.AddMinutes(1));
+		try
+		{
+			var service = CreateService();
+			var request = CreateRequest(project, source, output);
+			var exception = await Assert.ThrowsAsync<ProjectCopyExportException>(() =>
+				service.ExportAsync(
+					request,
+					cancellationToken: TestContext.Current.CancellationToken));
+			Assert.Equal(ProjectCopyExportError.SourceUnavailable, exception.Error);
+			Assert.Equal(ProjectCopyExportService.SourceChangedDuringCopyMessage, exception.Message);
+			Assert.False(Directory.Exists(output));
+		}
+		finally
+		{
+			ProjectCopyExportTestHooks.AfterFirstSourceRead = null;
+		}
+	}
+
+	[Fact]
+	public async Task UnchangedPassThroughCopyRemainsByteIdentical()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateFolder("project");
+		var expected = Enumerable.Range(0, 8192).Select(static value => (byte)(value % 251)).ToArray();
+		var source = Path.Combine(project, "source.bin");
+		await File.WriteAllBytesAsync(source, expected, TestContext.Current.CancellationToken);
+		var output = Path.Combine(workspace.CreateFolder("output"), "copy");
+
+		await CreateService().ExportAsync(
+			CreateRequest(project, source, output),
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Equal(
+			expected,
+			await File.ReadAllBytesAsync(Path.Combine(output, "source.bin"), TestContext.Current.CancellationToken));
+	}
+
+	[Fact]
 	public async Task SourceReaderAllowsAtomicReplacement()
 	{
 		using var workspace = new TemporaryDirectory();
@@ -24,5 +71,27 @@ public sealed class ProjectCopyExportSourceReadTests
 		Assert.Equal("REPLACED", await File.ReadAllTextAsync(
 			source,
 			TestContext.Current.CancellationToken));
+	}
+
+	private static ProjectCopyExportService CreateService() =>
+		new(new ProjectCopyExportPlanBuilder());
+
+	private static ProjectCopyExportRequest CreateRequest(string project, string source, string output)
+	{
+		var root = new TreeNodeDescriptor(
+			Path.GetFileName(project),
+			project,
+			true,
+			false,
+			"folder",
+			[new TreeNodeDescriptor(Path.GetFileName(source), source, false, false, "file", [])]);
+		return new ProjectCopyExportRequest(
+			project,
+			Path.GetFileName(project),
+			root,
+			new HashSet<string>(PathComparer.Default),
+			output,
+			ProjectCopyExportFormat.Folder,
+			ProjectCopyDestinationMode.Exact);
 	}
 }

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileStoreAdditionalTests.cs
@@ -74,7 +74,7 @@ public sealed class ProjectProfileStoreAdditionalTests
 	}
 
 	[Fact]
-	public void ClearAllProfiles_WhenStorageLockIsBusy_ReturnsBusyAndPreservesProfiles()
+	public void ClearAllProfiles_WhenSelectionLockIsBusy_ReturnsPartialAndRetryCompletes()
 	{
 		var tempRoot = CreateTempDirectory();
 		try
@@ -90,8 +90,11 @@ public sealed class ProjectProfileStoreAdditionalTests
 
 			var result = store.ClearAllProfiles();
 
-			Assert.Equal(ProjectProfileClearStatus.Busy, result);
+			Assert.Equal(ProjectProfileClearStatus.Partial, result);
 			Assert.True(File.Exists(store.GetPath()));
+			heldLock.Dispose();
+			Assert.Equal(ProjectProfileClearStatus.Cleared, store.ClearAllProfiles());
+			Assert.False(File.Exists(store.GetPath()));
 		}
 		finally
 		{
@@ -100,7 +103,7 @@ public sealed class ProjectProfileStoreAdditionalTests
 	}
 
 	[Fact]
-	public void ClearAllProfiles_WhenStorageUsesFutureSchema_ReturnsFutureSchemaAndPreservesDocument()
+	public void ClearAllProfiles_WhenSelectionUsesFutureSchema_ReturnsPartialAndPreservesDocument()
 	{
 		var tempRoot = CreateTempDirectory();
 		try
@@ -113,7 +116,7 @@ public sealed class ProjectProfileStoreAdditionalTests
 
 			var result = store.ClearAllProfiles();
 
-			Assert.Equal(ProjectProfileClearStatus.FutureSchema, result);
+			Assert.Equal(ProjectProfileClearStatus.Partial, result);
 			Assert.Equal(futureDocument, File.ReadAllText(storagePath));
 		}
 		finally
@@ -812,6 +815,77 @@ public sealed class ProjectProfileStoreAdditionalTests
 
 			Assert.Equal(ProjectProfileLookupStatus.InvalidStorage, result.Status);
 			Assert.Null(result.Profile);
+		}
+		finally
+		{
+			Directory.Delete(tempRoot, recursive: true);
+		}
+	}
+
+	[Fact]
+	public async Task ClearAllProfiles_WhenMarkLockIsBusy_PreservesSelectionAndMarks()
+	{
+		var tempRoot = CreateTempDirectory();
+		try
+		{
+			var store = CreateStore(tempRoot);
+			var projectPath = Path.Combine(tempRoot, "RepoBusyMarks");
+			store.SaveProfile(projectPath, CreateProfile());
+			Assert.True((await store.AddMarkAsync(
+				projectPath,
+				new MarkedSecretProfileEntry("9f2a4c1e8b3d", "TOKEN", 24),
+				TestContext.Current.CancellationToken)).Succeeded);
+			var markLockPath = Path.Combine(
+				Path.GetDirectoryName(store.GetPath())!,
+				"project-secret-marks.json.lock");
+			using var heldLock = new FileStream(
+				markLockPath,
+				FileMode.OpenOrCreate,
+				FileAccess.ReadWrite,
+				FileShare.None);
+
+			var result = store.ClearAllProfiles();
+
+			Assert.Equal(ProjectProfileClearStatus.Busy, result);
+			Assert.True(File.Exists(store.GetPath()));
+			using var document = JsonDocument.Parse(File.ReadAllText(store.GetPath()));
+			Assert.True(document.RootElement.GetProperty("profiles")
+				.TryGetProperty(PathUtility.Normalize(projectPath), out _));
+		}
+		finally
+		{
+			Directory.Delete(tempRoot, recursive: true);
+		}
+	}
+
+	[Fact]
+	public async Task DeleteProfile_WhenSelectionLockFailsAfterMarks_ReturnsPartialAndRetryCompletes()
+	{
+		var tempRoot = CreateTempDirectory();
+		try
+		{
+			var store = CreateStore(tempRoot);
+			var projectPath = Path.Combine(tempRoot, "RepoPartialDelete");
+			store.SaveProfile(projectPath, CreateProfile());
+			Assert.True((await store.AddMarkAsync(
+				projectPath,
+				new MarkedSecretProfileEntry("9f2a4c1e8b3d", "TOKEN", 24),
+				TestContext.Current.CancellationToken)).Succeeded);
+			using (var heldLock = new FileStream(
+				store.GetPath() + ".lock",
+				FileMode.OpenOrCreate,
+				FileAccess.ReadWrite,
+				FileShare.None))
+			{
+				Assert.Equal(ProjectProfileDeleteStatus.Partial, store.TryDeleteProfileWithResult(projectPath));
+			}
+
+			var marks = await store.LoadMarksAsync(projectPath, TestContext.Current.CancellationToken);
+			Assert.True(marks.Succeeded);
+			Assert.Empty(marks.Snapshot!.Marks);
+			Assert.True(store.TryLoadProfile(projectPath, out _));
+			Assert.Equal(ProjectProfileDeleteStatus.Deleted, store.TryDeleteProfileWithResult(projectPath));
+			Assert.False(store.TryLoadProfile(projectPath, out _));
 		}
 		finally
 		{

--- a/Tests/DevProjex.Tests.Unit/ProjectProfileStoreTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ProjectProfileStoreTests.cs
@@ -3,6 +3,32 @@ namespace DevProjex.Tests.Unit;
 public sealed class ProjectProfileStoreTests
 {
 	[Fact]
+	public void ExpectedRevisionRejectsAConcurrentProfileUpdate()
+	{
+		using var temporary = new TemporaryDirectory();
+		var project = temporary.CreateFolder("project");
+		var store = CreateStore(temporary.Path);
+		store.SaveProfile(project, new ProjectSelectionProfile([], [".cs"], []));
+		var observed = store.LookupProfile(project, TimeSpan.FromSeconds(1));
+		Assert.Equal(ProjectProfileLookupStatus.Found, observed.Status);
+		Assert.NotNull(observed.UpdatedUtc);
+		Assert.True(store.TrySaveProfile(
+			project,
+			new ProjectSelectionProfile([], [".json"], []),
+			observed.UpdatedUtc.Value.AddMinutes(1)));
+
+		var stale = store.TrySaveProfileWithResult(
+			project,
+			new ProjectSelectionProfile([], [".md"], []),
+			observed.UpdatedUtc);
+
+		Assert.Equal(ProjectProfileSaveStatus.Conflict, stale.Status);
+		Assert.False(stale.Succeeded);
+		Assert.True(store.TryLoadProfile(project, out var current));
+		Assert.Equal([".json"], current.SelectedExtensions);
+	}
+
+	[Fact]
 	public void TrySaveProfilesWithResult_PersistsEveryProfileInOneBatch()
 	{
 		using var temporary = new TemporaryDirectory();


### PR DESCRIPTION
## Summary

- report project-copy compression availability from the actual prepared snapshot and reject pass-through source changes
- make profile cleanup retryable and profile saves conflict-aware
- distinguish committed backup failures from rejected persistence writes and enforce JSON limits while streaming
- replace latency-based metrics ordering assertions with deterministic event ordering

## Validation

- targeted project-copy, profile-store, JSON-persistence, and metrics tests
- targeted CLI process and command-contract tests
- documentation and packaging contract tests
- Release TerminalHost build with zero warnings

