### PR TITLE
Normalize test method names

### DIFF
--- a/Tests/DevProjex.Tests.Integration/DependencyCSharpTypeScriptSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyCSharpTypeScriptSemanticsIntegrationTests.cs
@@ -6,7 +6,7 @@ namespace DevProjex.Tests.Integration;
 public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 {
 	[Fact]
-	public async Task New093_UnknownCrossProjectAccessibilityRemainsAmbiguous()
+	public async Task UnknownCrossProjectAccessibilityRemainsAmbiguous()
 	{
 		using var fixture = new TemporaryDirectory();
 		var projectA = fixture.CreateFile(
@@ -32,7 +32,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New094_OnlyPreprocessorDependentReferencesAreHonestlyUnresolved()
+	public async Task OnlyPreprocessorDependentReferencesAreHonestlyUnresolved()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -84,7 +84,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New094_NestedConditionalRegionsRemainBoundedByTheOuterDirective()
+	public async Task NestedConditionalRegionsRemainBoundedByTheOuterDirective()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -124,7 +124,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New094_UnterminatedConditionalRegionDegradesOnlyTheFileTail()
+	public async Task UnterminatedConditionalRegionDegradesOnlyTheFileTail()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -157,7 +157,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New094_RegionAndNullableDirectivesAreNotConditionalRegions()
+	public async Task RegionAndNullableDirectivesAreNotConditionalRegions()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -192,7 +192,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New092_NestedGenericSegmentIsHonestlyUnresolved()
+	public async Task NestedGenericSegmentIsHonestlyUnresolved()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -216,7 +216,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New015_UsingStaticExposesNestedTypes()
+	public async Task UsingStaticExposesNestedTypes()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -240,7 +240,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New059_ExportsFallbackArrayIsHonestlyUnresolved()
+	public async Task ExportsFallbackArrayIsHonestlyUnresolved()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -266,7 +266,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New023_DirectoryPackageMetadataDoesNotFallBackToIndex()
+	public async Task DirectoryPackageMetadataDoesNotFallBackToIndex()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -290,7 +290,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New022_ExcludedPrimaryPathMappingDoesNotSelectFallback()
+	public async Task ExcludedPrimaryPathMappingDoesNotSelectFallback()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -314,7 +314,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New063_CustomConditionsFailClosedOnlyForConditionalPackageMaps()
+	public async Task CustomConditionsFailClosedOnlyForConditionalPackageMaps()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -363,7 +363,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New097_BarePackageImportTargetIsNotProbedAsLocalPath()
+	public async Task BarePackageImportTargetIsNotProbedAsLocalPath()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -388,7 +388,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New061_ModuleNodeNextInfersNodeNextResolution()
+	public async Task ModuleNodeNextInfersNodeNextResolution()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -411,7 +411,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New060_RelativeModuleUrlSuffixUsesPhysicalPath()
+	public async Task RelativeModuleUrlSuffixUsesPhysicalPath()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -436,7 +436,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New052_OrdinaryCSharpTypePositionsProduceReferences()
+	public async Task OrdinaryCSharpTypePositionsProduceReferences()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -486,7 +486,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New014_RelativeAliasTargetFallsBackToLexicalNamespace()
+	public async Task RelativeAliasTargetFallsBackToLexicalNamespace()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -508,7 +508,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New096_PackageExportsRejectTargetsOutsidePackage()
+	public async Task PackageExportsRejectTargetsOutsidePackage()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -534,7 +534,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New095_RequireParameterDoesNotCreateModuleImport()
+	public async Task RequireParameterDoesNotCreateModuleImport()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -559,7 +559,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New091_TupleElementNamesAreNotTypeReferences()
+	public async Task TupleElementNamesAreNotTypeReferences()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -582,7 +582,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New090_UnknownQualifiedTypeIsNotExternalByItsLastName()
+	public async Task UnknownQualifiedTypeIsNotExternalByItsLastName()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -605,7 +605,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New058_JsxSpecifierProbesTsxSource()
+	public async Task JsxSpecifierProbesTsxSource()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -627,7 +627,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New056_GlobalNamespaceTypePrecedesImportedTypeAtTopLevel()
+	public async Task GlobalNamespaceTypePrecedesImportedTypeAtTopLevel()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -650,7 +650,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New055_AttributeShortNameFallbackRunsAfterVisibilityFiltering()
+	public async Task AttributeShortNameFallbackRunsAfterVisibilityFiltering()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -671,7 +671,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New054_ExactPackageExportDoesNotProbeDirectoryIndex()
+	public async Task ExactPackageExportDoesNotProbeDirectoryIndex()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -696,7 +696,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New053_DynamicImportInCommonJsRequiresRelativeExtension()
+	public async Task DynamicImportInCommonJsRequiresRelativeExtension()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -722,7 +722,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New021_NodeConditionIsActiveForNodeNextButNotBundler()
+	public async Task NodeConditionIsActiveForNodeNextButNotBundler()
 	{
 		using var fixture = new TemporaryDirectory();
 		var bundlerConfig = fixture.CreateFile(
@@ -760,7 +760,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New020_InactiveUnknownPackageConditionDoesNotBlockDefault()
+	public async Task InactiveUnknownPackageConditionDoesNotBlockDefault()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -785,7 +785,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New019_PackageWildcardPrefersLongestStaticPrefix()
+	public async Task PackageWildcardPrefersLongestStaticPrefix()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -811,7 +811,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New018_MultilineGenericReferenceUsesTokenCoordinates()
+	public async Task MultilineGenericReferenceUsesTokenCoordinates()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -833,7 +833,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New017_NonAsciiIdentifierStartIsExtractedAsTypeReference()
+	public async Task NonAsciiIdentifierStartIsExtractedAsTypeReference()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -853,7 +853,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New016_GenericUsingAliasPreservesContainerAndArgumentReferences()
+	public async Task GenericUsingAliasPreservesContainerAndArgumentReferences()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -878,7 +878,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New013_QualifiedNameUsesLexicalNamespaceBeforeGlobalNamespace()
+	public async Task QualifiedNameUsesLexicalNamespaceBeforeGlobalNamespace()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -905,7 +905,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New012_NestedBlockNamespacesComposeTheirQualifiedName()
+	public async Task NestedBlockNamespacesComposeTheirQualifiedName()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -934,7 +934,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New011_TupleCommasDoNotIncreaseConstructedGenericArity()
+	public async Task TupleCommasDoNotIncreaseConstructedGenericArity()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -957,7 +957,7 @@ public sealed class DependencyCSharpTypeScriptSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New010_DynamicImportAttributesPreserveEveryImportFact()
+	public async Task DynamicImportAttributesPreserveEveryImportFact()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(

--- a/Tests/DevProjex.Tests.Integration/DependencyPythonAndConfigurationSemanticsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyPythonAndConfigurationSemanticsIntegrationTests.cs
@@ -7,7 +7,7 @@ namespace DevProjex.Tests.Integration;
 public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 {
 	[Fact]
-	public async Task New025_DottedImportsBindTheTopLevelNameUnlessAliased()
+	public async Task DottedImportsBindTheTopLevelNameUnlessAliased()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -27,7 +27,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New057_ReExportDoesNotTreatAnOrdinaryModuleAsAPackage()
+	public async Task ReExportDoesNotTreatAnOrdinaryModuleAsAPackage()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -50,7 +50,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New067_PyProjectDependenciesUseTomlArrayBoundaries()
+	public async Task PyProjectDependenciesUseTomlArrayBoundaries()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -80,7 +80,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	[Theory]
 	[InlineData("[project]\nname = \"unterminated")]
 	[InlineData("[project]\ndependencies = [\n  \"requests\",")]
-	public async Task New068_InvalidPyProjectTomlIsCorrupt(string content)
+	public async Task InvalidPyProjectTomlIsCorrupt(string content)
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", content);
@@ -100,7 +100,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New069_NamedDirectUrlDependencyRetainsItsDistributionName()
+	public async Task NamedDirectUrlDependencyRetainsItsDistributionName()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -120,7 +120,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New069_BareDirectUrlDoesNotInventAPackageName()
+	public async Task BareDirectUrlDoesNotInventAPackageName()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -136,7 +136,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New070_NestedPyProjectDoesNotChangeUnownedRootFiles()
+	public async Task NestedPyProjectDoesNotChangeUnownedRootFiles()
 	{
 		using var fixture = new TemporaryDirectory();
 		var module = fixture.CreateFile("module.py", "VALUE = 1");
@@ -162,7 +162,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New071_ModuleFileBlocksDottedChildResolution()
+	public async Task ModuleFileBlocksDottedChildResolution()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -182,7 +182,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New071_RegularPackageBlocksChildrenFromAnotherRoot()
+	public async Task RegularPackageBlocksChildrenFromAnotherRoot()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -202,7 +202,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New072_LastUnconditionalReExportBindingWins()
+	public async Task LastUnconditionalReExportBindingWins()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -224,7 +224,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New072_ConditionalReExportDoesNotClaimOneTarget()
+	public async Task ConditionalReExportDoesNotClaimOneTarget()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -249,7 +249,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New073_DocstringAndLocalAllAssignmentsDoNotSetModulePolicy()
+	public async Task DocstringAndLocalAllAssignmentsDoNotSetModulePolicy()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -277,7 +277,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New073_ModuleLevelDynamicAllRemainsExplicitlyUnresolved()
+	public async Task ModuleLevelDynamicAllRemainsExplicitlyUnresolved()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -299,7 +299,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New024_ModuleAssignmentsHaveAnExplicitResolutionLimitation()
+	public async Task ModuleAssignmentsHaveAnExplicitResolutionLimitation()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -319,7 +319,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New074_WildcardReExportHasAnExplicitResolutionLimitation()
+	public async Task WildcardReExportHasAnExplicitResolutionLimitation()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");
@@ -340,7 +340,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New064_EqualRootConfigurationsFailClosedAsAmbiguousOwnership()
+	public async Task EqualRootConfigurationsFailClosedAsAmbiguousOwnership()
 	{
 		using var fixture = new TemporaryDirectory();
 		var pyproject = fixture.CreateFile(
@@ -363,7 +363,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New065_StaticCompileItemsFailClosedWithoutEvaluatingMsBuild()
+	public async Task StaticCompileItemsFailClosedWithoutEvaluatingMsBuild()
 	{
 		using var fixture = new TemporaryDirectory();
 		var project = fixture.CreateFile(
@@ -386,7 +386,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New066_FilteredOwningConfigurationHasAnExplicitMissingReason()
+	public async Task FilteredOwningConfigurationHasAnExplicitMissingReason()
 	{
 		using var fixture = new TemporaryDirectory();
 		fixture.CreateFile("Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
@@ -466,7 +466,7 @@ public sealed class DependencyPythonAndConfigurationSemanticsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New078_TransientGrammarResolutionFailureIsRetried()
+	public async Task TransientGrammarResolutionFailureIsRetried()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile("pyproject.toml", "[project]\nname = \"fixture\"");

--- a/Tests/DevProjex.Tests.Integration/DependencyTypeScriptRootDirsIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyTypeScriptRootDirsIntegrationTests.cs
@@ -6,7 +6,7 @@ namespace DevProjex.Tests.Integration;
 public sealed class DependencyTypeScriptRootDirsIntegrationTests
 {
 	[Fact]
-	public async Task New062_RootDirsResolveTheSameVirtualRelativePath()
+	public async Task RootDirsResolveTheSameVirtualRelativePath()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -29,7 +29,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_RootDirsReportEveryManifestCandidateAsAmbiguous()
+	public async Task RootDirsReportEveryManifestCandidateAsAmbiguous()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -53,7 +53,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_RootDirsDoNotExposeTargetsOutsideTheManifest()
+	public async Task RootDirsDoNotExposeTargetsOutsideTheManifest()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -77,7 +77,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_RootDirsChangeReresolvesWithoutReparsingSources()
+	public async Task RootDirsChangeReresolvesWithoutReparsingSources()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -112,7 +112,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_WindowsSeparatorsAndFileSystemCaseResolveRootDirs()
+	public async Task WindowsSeparatorsAndFileSystemCaseResolveRootDirs()
 	{
 		if (!OperatingSystem.IsWindows())
 			Assert.Skip("Windows path identity is required for this assertion.");
@@ -136,7 +136,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_UnsafeRootDirsAreIgnoredWithoutInvalidatingTheScope()
+	public async Task UnsafeRootDirsAreIgnoredWithoutInvalidatingTheScope()
 	{
 		using var fixture = new TemporaryDirectory();
 		using var outside = new TemporaryDirectory();
@@ -160,7 +160,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_RootDirsUseInheritedOriginModuleSuffixesAndDirectoryIndexes()
+	public async Task RootDirsUseInheritedOriginModuleSuffixesAndDirectoryIndexes()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(
@@ -185,7 +185,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_RootDirectorySymlinkOutsideTheProjectIsIgnored()
+	public async Task RootDirectorySymlinkOutsideTheProjectIsIgnored()
 	{
 		using var fixture = new TemporaryDirectory();
 		using var outside = new TemporaryDirectory();
@@ -217,7 +217,7 @@ public sealed class DependencyTypeScriptRootDirsIntegrationTests
 	}
 
 	[Fact]
-	public async Task New062_NonStringRootDirectoryMakesConfigurationUnsupported()
+	public async Task NonStringRootDirectoryMakesConfigurationUnsupported()
 	{
 		using var fixture = new TemporaryDirectory();
 		var config = fixture.CreateFile(

--- a/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitPrivateHttpsAuthenticationIntegrationTests.cs
@@ -13,7 +13,7 @@ namespace DevProjex.Tests.Integration;
 public sealed class GitPrivateHttpsAuthenticationIntegrationTests
 {
 	[Fact]
-	public async Task New044_PrivateCloneBranchFetchAndUpdateReuseAskPassSession()
+	public async Task PrivateCloneBranchFetchAndUpdateReuseAskPassSession()
 	{
 		using var temporary = new TemporaryDirectory();
 		var source = temporary.CreateDirectory("source");

--- a/Tests/DevProjex.Tests.Integration/GitRemoteSourceHardeningIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/GitRemoteSourceHardeningIntegrationTests.cs
@@ -9,7 +9,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	[InlineData("ssh://alice@git.example.test/team/repo.git", "ssh://bob@git.example.test/team/repo.git")]
 	[InlineData("https://alice@git.example.test/team/repo.git", "https://bob@git.example.test/team/repo.git")]
 	[InlineData("https://git.example.test/team/repo.git", "ssh://git.example.test/team/repo.git")]
-	public void New026_CacheIdentityPreservesUserAndTransport(string left, string right)
+	public void CacheIdentityPreservesUserAndTransport(string left, string right)
 	{
 		Assert.NotEqual(
 			RepositoryUrlUtility.GetSourceCacheKey(left),
@@ -19,7 +19,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	[Theory]
 	[InlineData("https://git.example.test/team/repo", "https://GIT.EXAMPLE.TEST/team/repo.git")]
 	[InlineData("ssh://git@git.example.test/team/repo", "git@git.example.test:team/repo.git")]
-	public void New026_RemoteGitSuffixAndEquivalentSshFormsShareIdentity(string left, string right)
+	public void RemoteGitSuffixAndEquivalentSshFormsShareIdentity(string left, string right)
 	{
 		Assert.Equal(
 			RepositoryUrlUtility.GetSourceCacheKey(left),
@@ -27,7 +27,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	}
 
 	[Fact]
-	public void New027_DistinctLocalGitDirectoriesDoNotShareCacheIdentity()
+	public void DistinctLocalGitDirectoriesDoNotShareCacheIdentity()
 	{
 		using var temporary = new TemporaryDirectory();
 		var repository = temporary.CreateDirectory("repo");
@@ -51,7 +51,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	}
 
 	[Fact]
-	public void New027_LocalGitSuffixAliasSharesIdentityOnlyWhenItTargetsTheSameDirectory()
+	public void LocalGitSuffixAliasSharesIdentityOnlyWhenItTargetsTheSameDirectory()
 	{
 		using var temporary = new TemporaryDirectory();
 		var repository = temporary.CreateDirectory("repository");
@@ -75,13 +75,13 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	[InlineData("http://example.test/team/repo.git")]
 	[InlineData("git://example.test/team/repo.git")]
 	[InlineData("file:///tmp/repo.git")]
-	public void New043_ProductionSourceValidatorRejectsDisallowedTransports(string source)
+	public void ProductionSourceValidatorRejectsDisallowedTransports(string source)
 	{
 		Assert.False(RepositoryUrlUtility.IsSupportedCloneSource(source));
 	}
 
 	[Fact]
-	public void New045And046_ExplicitNetworkPreservesOnlyTrustedProxyAndCertificateEnvironment()
+	public void ExplicitNetworkPreservesOnlyTrustedProxyAndCertificateEnvironment()
 	{
 		var names = new[]
 		{
@@ -118,7 +118,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	}
 
 	[Fact]
-	public async Task New048_ActiveLocalBranchDeletedFromRemoteRemainsVisible()
+	public async Task ActiveLocalBranchDeletedFromRemoteRemainsVisible()
 	{
 		using var temporary = new TemporaryDirectory();
 		var source = temporary.CreateDirectory("source");
@@ -163,7 +163,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	}
 
 	[Fact]
-	public async Task New047_RealGitCloneIsStoppedWhenCacheQuotaIsExceeded()
+	public async Task RealGitCloneIsStoppedWhenCacheQuotaIsExceeded()
 	{
 		using var temporary = new TemporaryDirectory();
 		var source = temporary.CreateDirectory("quota-source");
@@ -206,7 +206,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	}
 
 	[Fact]
-	public async Task New047_CloneFailsBeforeStartingWhenDestinationReserveIsUnavailable()
+	public async Task CloneFailsBeforeStartingWhenDestinationReserveIsUnavailable()
 	{
 		using var temporary = new TemporaryDirectory();
 		var target = Path.Combine(temporary.Path, "reserve-target");
@@ -232,7 +232,7 @@ public sealed class GitRemoteSourceHardeningIntegrationTests
 	}
 
 	[Fact]
-	public void New031_FreeSpaceProbeChoosesTheLongestDestinationMount()
+	public void FreeSpaceProbeChoosesTheLongestDestinationMount()
 	{
 		using var temporary = new TemporaryDirectory();
 		var targetMount = temporary.CreateDirectory("mounted-cache");

--- a/Tests/DevProjex.Tests.Integration/ZipRemoteSourceHardeningTests.cs
+++ b/Tests/DevProjex.Tests.Integration/ZipRemoteSourceHardeningTests.cs
@@ -8,7 +8,7 @@ namespace DevProjex.Tests.Integration;
 public sealed class ZipRemoteSourceHardeningTests
 {
 	[Fact]
-	public async Task New028_StalledArchiveBodyFailsWithinProgressDeadline()
+	public async Task StalledArchiveBodyFailsWithinProgressDeadline()
 	{
 		using var temporary = new TemporaryDirectory();
 		using var service = new ZipDownloadService(
@@ -30,7 +30,7 @@ public sealed class ZipRemoteSourceHardeningTests
 	}
 
 	[Fact]
-	public async Task New030_MetadataTimeoutIsAnOperationFailureInsteadOfCallerCancellation()
+	public async Task MetadataTimeoutIsAnOperationFailureInsteadOfCallerCancellation()
 	{
 		using var temporary = new TemporaryDirectory();
 		using var service = new ZipDownloadService(new MetadataTimeoutHandler());
@@ -45,7 +45,7 @@ public sealed class ZipRemoteSourceHardeningTests
 	}
 
 	[Fact]
-	public async Task New029_MetadataFallbackReportsTheBranchThatWasActuallyDownloaded()
+	public async Task MetadataFallbackReportsTheBranchThatWasActuallyDownloaded()
 	{
 		using var temporary = new TemporaryDirectory();
 		var archive = CreateArchive(("repository-master/app.txt", "master"));
@@ -62,7 +62,7 @@ public sealed class ZipRemoteSourceHardeningTests
 	}
 
 	[Fact]
-	public async Task New032_SymbolicLinkArchiveEntriesAreSkippedWithCountedDiagnostic()
+	public async Task SymbolicLinkArchiveEntriesAreSkippedWithCountedDiagnostic()
 	{
 		using var temporary = new TemporaryDirectory();
 		var archive = CreateArchiveWithSymbolicLink();

--- a/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitRepositoryServiceUnitTests.cs
@@ -10,7 +10,7 @@ public class GitRepositoryServiceUnitTests
 	[Theory]
 	[InlineData(5, 100, 100)]
 	[InlineData(25, 100, 250)]
-	public void New047_QuotaPollDelayBoundsMonitorDutyCycle(
+	public void QuotaPollDelayBoundsMonitorDutyCycle(
 		int scanMilliseconds,
 		int pollMilliseconds,
 		int expectedMilliseconds)
@@ -23,7 +23,7 @@ public class GitRepositoryServiceUnitTests
 	}
 
 	[Fact]
-	public void New047_FinalQuotaScanRunsOnlyWhenLastObservationIsStale()
+	public void FinalQuotaScanRunsOnlyWhenLastObservationIsStale()
 	{
 		var interval = TimeSpan.FromMilliseconds(100);
 


### PR DESCRIPTION
## Summary

- remove legacy prefixes from behavior-focused test names
- preserve test bodies, assertions, and fixtures

## Validation

- targeted integration test classes pass
- targeted unit test class passes