### PR TITLE
fix(mcp): preserve portable schemas and connection boundaries

### DIFF
--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -141,7 +141,6 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 		    "exclusions": {
 		      "type": "array",
 		      "maxItems": {{ProjectSelectionTokens.Exclusions.Count}},
-		      "uniqueItems": true,
 		      "items": { "type": "string", "enum": [{{tokens}}] },
 		      "description": "Full desired set of built-in exclusion toggles. An empty array turns every toggle off (widest scan); omit the parameter to keep the server baseline — analyze echoes the effective set. Overrides the server baseline and any profile exclusions for this call. Tokens match case-insensitively; duplicates are rejected. hidden-* follow the platform hidden attribute; on Unix-like systems dot-named entries belong to the dot-* toggles."
 		    }
@@ -353,12 +352,12 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	    {{ProjectProperty}},
 	    {{BranchProperty}},
 	    {{ProfileProperty}}{{(agentExclusions ? ExclusionsPropertyFragment() : "")}},
-	    "path": { "type": "string", "minLength": 1, "description": "Existing file path inside the effective project selection. Markdown-escaped names copied from the default get_tree format are accepted ('\\_'-style ASCII punctuation); use get_tree with format=text to copy unescaped names." },
+	    "path": { "type": "string", "minLength": 1, "description": "Single-file form. Exactly one of path or requests is required; supplying both is rejected before file access. The path must name an existing file inside the effective project selection. Markdown-escaped names copied from the default get_tree format are accepted ('\\_'-style ASCII punctuation); use get_tree with format=text to copy unescaped names." },
 	    "requests": {
 	      "type": "array",
 	      "minItems": 1,
 	      "maxItems": 8,
-	      "description": "Batch form: up to eight file requests and sixteen ranges total. Mutually exclusive with path and its range arguments.",
+	      "description": "Batch form: up to eight file requests and sixteen ranges total. Exactly one of requests or path is required; supplying both is rejected before file access. Single-file range arguments cannot be combined with requests.",
 	      "items": {
 	        "type": "object",
 	        "properties": {
@@ -387,10 +386,6 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	    "end_line": { "description": "Last 1-based line of the returned text after replacements, inclusive; integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] },
 	    "start_column": { "description": "First 1-based Unicode character within start_line; use the continuation value returned for a long line.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] }
 	  },
-	  "oneOf": [
-	    { "required": ["path"], "not": { "required": ["requests"] } },
-	    { "required": ["requests"], "not": { "required": ["path"] } }
-	  ],
 	  "additionalProperties": false
 	}
 	""";
@@ -405,7 +400,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	      "description": "One seed path, or up to 16 seed paths, inside the effective project selection.",
 	      "oneOf": [
 	        { "type": "string", "minLength": 1, "maxLength": 4096 },
-	        { "type": "array", "minItems": 1, "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 4096 } }
+	        { "type": "array", "minItems": 1, "maxItems": 16, "items": { "type": "string", "minLength": 1, "maxLength": 4096 } }
 	      ]
 	    },
 	    "direction": { "type": "string", "enum": ["dependencies", "dependents", "both"], "default": "both", "description": "Static relationship direction: dependencies are files the seed references, dependents are files that reference the seed, both returns both sections." },

--- a/Docs/HideSecrets.md
+++ b/Docs/HideSecrets.md
@@ -118,6 +118,16 @@ URIs on RFC 2606 documentation hosts (`example.com`, `example.net`,
 TLDs) are not redacted. `localhost` is intentionally still inspected because
 development credentials can be real secrets.
 
+A connection-string match requires one complete region of at least two
+`key=value` pairs and an existing connection signal such as `Server`, `Host`, or
+`Database`. ADO.NET regions use semicolons, JDBC and URI query regions use
+ampersands, and libpq keyword/value regions use single spaces. A region may start
+at the beginning of a line, inside a quoted host-language literal, at a JDBC or
+URI anchor, or after one of the already protected HTTP header names: `Cookie`,
+`Set-Cookie`, `Authorization`, and `Proxy-Authorization`. Other header-like or
+call-expression text does not open a region. Unquoted call punctuation invalidates
+the whole region, and a password replacement cannot extend beyond its region.
+
 Structured value boundaries follow the recognized file format instead of one shared delimiter
 rule. Dotenv comments begin only outside quotes; ADO.NET pairs use semicolons while JDBC query
 parameters use ampersands; JSON property names are decoded and sensitive arrays are visited by

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -614,7 +614,8 @@ glob metacharacters have meaning only in the pattern parameters.
 ### Batch `get_file`
 
 Use `requests` when several source excerpts are already known; use `search_project`
-when their locations are not known. `path` and `requests` are mutually exclusive.
+when their locations are not known. Exactly one of `path` or `requests` is required;
+supplying both or neither returns `DPX-MCP-INVALID-ARGUMENTS` before any file is read.
 The batch contains one to eight records, each shaped as
 `{"path":"src/App.cs","ranges":[{"start_line":10,"end_line":30}]}`. A call
 contains at most sixteen ranges in total. Each range is inclusive, starts at line

--- a/Infrastructure/Secrets/SmartSecretsDetector.cs
+++ b/Infrastructure/Secrets/SmartSecretsDetector.cs
@@ -679,82 +679,397 @@ internal static class StructuredSecretDetector
 			CheckpointPeriodically(ref checkpointCounter, budget, cancellationToken);
 			if (!LooksLikeConnectionString(line))
 				continue;
-			var queryStyle = Contains(line, "jdbc:");
 
-			var position = 0;
-			while (position < line.Length)
+			var regionSearchStart = 0;
+			while (TryFindConnectionRegion(line, ref regionSearchStart, out var region))
 			{
-				var equals = line[position..].IndexOf('=');
-				if (equals < 0)
-					break;
-				equals += position;
-				var keyStart = equals - 1;
-				while (keyStart >= 0 && IsConnectionKeyCharacter(line[keyStart]))
-					keyStart--;
-				keyStart++;
-				var key = line[keyStart..equals].Trim();
-				if (key.Equals("password", StringComparison.OrdinalIgnoreCase) ||
-				    key.Equals("pwd", StringComparison.OrdinalIgnoreCase))
-				{
-					var value = FindConnectionValue(line, equals + 1, queryStyle);
-					AddFinding(
-						content,
-						lineStart + value.Start,
-						value.Length,
-						"connection-password",
-						ConnectionPasswordOrder,
-						findings);
-					position = Math.Max(equals + 1, value.End + 1);
-					continue;
-				}
-
-				position = equals + 1;
+				AddConnectionPasswords(content, line, lineStart, region, findings);
+				CheckpointPeriodically(ref checkpointCounter, budget, cancellationToken);
 			}
 		}
 	}
 
-	private static TextSpan FindConnectionValue(ReadOnlySpan<char> line, int start, bool queryStyle)
+	private static bool TryFindConnectionRegion(
+		ReadOnlySpan<char> line,
+		ref int searchStart,
+		out ConnectionRegion region)
 	{
-		while (start < line.Length && char.IsWhiteSpace(line[start]))
-			start++;
-		if (start >= line.Length)
-			return new TextSpan(start, 0);
-
-		if (TryGetConnectionQuoteToken(line[start..], out var quoteToken))
+		if (searchStart == 0)
 		{
-			start += quoteToken.Length;
-			var quotedEnd = start;
-			while (quotedEnd < line.Length)
+			var first = IndexOfFirstNonWhitespace(line);
+			if (first >= 0 &&
+			    (TryCreateConnectionRegion(line, first, line.Length, out region) ||
+			     TryGetHttpHeaderConnectionStart(line, first, out var headerStart) &&
+			     TryCreateConnectionRegion(line, headerStart, line.Length, out region)))
 			{
-				if (!line[quotedEnd..].StartsWith(quoteToken, StringComparison.Ordinal))
-				{
-					quotedEnd++;
-					continue;
-				}
-				var nextQuote = quotedEnd + quoteToken.Length;
-				if (nextQuote < line.Length &&
-				    line[nextQuote..].StartsWith(quoteToken, StringComparison.Ordinal))
-				{
-					quotedEnd = nextQuote + quoteToken.Length;
-					continue;
-				}
-				break;
+				searchStart = region.End + 1;
+				return true;
 			}
-			return new TextSpan(start, quotedEnd - start);
 		}
 
-		var endDelimiter = queryStyle ? '&' : ';';
-		var end = start;
-		while (end < line.Length)
+		var position = Math.Max(0, searchStart);
+		while (position < line.Length)
 		{
-			if (line[end] == endDelimiter &&
-			    (queryStyle || !IsXmlEntityTerminator(line, start, end)))
+			var relativeQuote = line[position..].IndexOfAny('\'', '"');
+			if (relativeQuote < 0)
+				break;
+			var quote = position + relativeQuote;
+			if (IsBackslashEscaped(line, quote) ||
+			    !TryFindHostLiteralEnd(line, quote, out var literalEnd))
+			{
+				position = quote + 1;
+				continue;
+			}
+
+			if (TryCreateConnectionRegion(line, quote + 1, literalEnd, out region))
+			{
+				searchStart = literalEnd + 1;
+				return true;
+			}
+			position = literalEnd + 1;
+		}
+
+		region = default;
+		searchStart = line.Length;
+		return false;
+	}
+
+	private static bool TryGetHttpHeaderConnectionStart(
+		ReadOnlySpan<char> line,
+		int first,
+		out int regionStart)
+	{
+		regionStart = 0;
+		var relativeColon = line[first..].IndexOf(':');
+		if (relativeColon <= 0)
+			return false;
+		var colon = first + relativeColon;
+		var name = line[first..colon];
+		if (!IsSecretHttpHeader(name) || colon + 1 >= line.Length || line[colon + 1] != ' ')
+			return false;
+
+		regionStart = colon + 2;
+		while (regionStart < line.Length && line[regionStart] == ' ')
+			regionStart++;
+		return regionStart < line.Length;
+	}
+
+	private static bool IsSecretHttpHeader(ReadOnlySpan<char> name) =>
+		name.Equals("Cookie", StringComparison.OrdinalIgnoreCase) ||
+		name.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase) ||
+		name.Equals("Authorization", StringComparison.OrdinalIgnoreCase) ||
+		name.Equals("Proxy-Authorization", StringComparison.OrdinalIgnoreCase);
+
+	private static bool TryFindHostLiteralEnd(
+		ReadOnlySpan<char> line,
+		int openingQuote,
+		out int literalEnd)
+	{
+		var quote = line[openingQuote];
+		for (var position = openingQuote + 1; position < line.Length; position++)
+		{
+			if (line[position] == quote && !IsBackslashEscaped(line, position))
+			{
+				literalEnd = position;
+				return true;
+			}
+		}
+		literalEnd = 0;
+		return false;
+	}
+
+	private static bool IsBackslashEscaped(ReadOnlySpan<char> value, int position)
+	{
+		var slashCount = 0;
+		for (var index = position - 1; index >= 0 && value[index] == '\\'; index--)
+			slashCount++;
+		return (slashCount & 1) != 0;
+	}
+
+	private static bool TryCreateConnectionRegion(
+		ReadOnlySpan<char> line,
+		int candidateStart,
+		int candidateEnd,
+		out ConnectionRegion region)
+	{
+		region = default;
+		if (candidateStart >= candidateEnd)
+			return false;
+
+		var candidate = line[candidateStart..candidateEnd];
+		var anchorSignal = false;
+		var pairStart = candidateStart;
+		var style = ConnectionPairStyle.AdoNet;
+		if (candidate.StartsWith("jdbc:", StringComparison.OrdinalIgnoreCase))
+		{
+			var query = candidate.IndexOf('?');
+			if (query < 0 || !IsConnectionUriPrefix(candidate[..query]))
+				return false;
+			pairStart += query + 1;
+			style = ConnectionPairStyle.Query;
+			anchorSignal = true;
+		}
+		else if (TryGetConnectionUriQueryStart(candidate, out var relativePairStart))
+		{
+			pairStart += relativePairStart;
+			style = ConnectionPairStyle.Query;
+		}
+		else if (TryValidateConnectionPairs(
+			         line,
+			         pairStart,
+			         candidateEnd,
+			         ConnectionPairStyle.AdoNet,
+			         anchorSignal: false))
+		{
+			region = new ConnectionRegion(pairStart, candidateEnd, ConnectionPairStyle.AdoNet);
+			return true;
+		}
+		else
+		{
+			style = ConnectionPairStyle.LibPq;
+		}
+
+		if (!TryValidateConnectionPairs(line, pairStart, candidateEnd, style, anchorSignal))
+			return false;
+
+		region = new ConnectionRegion(pairStart, candidateEnd, style);
+		return true;
+	}
+
+	private static bool TryGetConnectionUriQueryStart(
+		ReadOnlySpan<char> candidate,
+		out int pairStart)
+	{
+		pairStart = 0;
+		var scheme = candidate.IndexOf("://", StringComparison.Ordinal);
+		if (scheme <= 0)
+			return false;
+		for (var index = 0; index < scheme; index++)
+		{
+			if (!(char.IsAsciiLetterOrDigit(candidate[index]) || candidate[index] is '+' or '-' or '.'))
+				return false;
+		}
+		var query = candidate.IndexOf('?');
+		if (query < scheme + 3 || !IsConnectionUriPrefix(candidate[..query]))
+			return false;
+		pairStart = query + 1;
+		return true;
+	}
+
+	private static bool IsConnectionUriPrefix(ReadOnlySpan<char> prefix)
+	{
+		foreach (var character in prefix)
+		{
+			if (char.IsWhiteSpace(character) || character is '"' or '\'' or '(' or ')' or '[' or ']' or '{' or '}' or ',' or ';' or '&' or '=')
+				return false;
+		}
+		return true;
+	}
+
+	private static bool TryValidateConnectionPairs(
+		ReadOnlySpan<char> line,
+		int start,
+		int end,
+		ConnectionPairStyle style,
+		bool anchorSignal)
+	{
+		var pairCount = 0;
+		var hasSignal = anchorSignal;
+		var position = start;
+		while (position < end)
+		{
+			if (style is not ConnectionPairStyle.LibPq)
+			{
+				while (position < end && char.IsWhiteSpace(line[position]))
+					position++;
+				if (position == end)
+					break;
+			}
+
+			if (!TryReadConnectionPair(line, position, end, style, out var pair))
+				return false;
+			pairCount++;
+			hasSignal |= IsConnectionSignalKey(line[pair.KeyStart..pair.KeyEnd]);
+			position = pair.Next;
+			if (position == end)
+				break;
+			if (line[position] != GetConnectionSeparator(style))
+				return false;
+			position++;
+			if (position == end)
+				break;
+			if (style == ConnectionPairStyle.LibPq && line[position] == ' ')
+				return false;
+		}
+		return pairCount >= 2 && hasSignal;
+	}
+
+	private static bool TryReadConnectionPair(
+		ReadOnlySpan<char> line,
+		int start,
+		int end,
+		ConnectionPairStyle style,
+		out ConnectionPair pair)
+	{
+		pair = default;
+		var equals = start;
+		while (equals < end && line[equals] != '=')
+		{
+			if (line[equals] == GetConnectionSeparator(style))
+				return false;
+			equals++;
+		}
+		if (equals == end)
+			return false;
+
+		var keyStart = start;
+		var keyEnd = equals;
+		while (keyStart < keyEnd && char.IsWhiteSpace(line[keyStart]))
+			keyStart++;
+		while (keyEnd > keyStart && char.IsWhiteSpace(line[keyEnd - 1]))
+			keyEnd--;
+		if (keyStart == keyEnd)
+			return false;
+		for (var index = keyStart; index < keyEnd; index++)
+		{
+			if (!IsConnectionKeyCharacter(line[index]) ||
+			    style == ConnectionPairStyle.LibPq && char.IsWhiteSpace(line[index]))
+			{
+				return false;
+			}
+		}
+
+		var valueStart = equals + 1;
+		if (style is not ConnectionPairStyle.LibPq)
+		{
+			while (valueStart < end && char.IsWhiteSpace(line[valueStart]))
+				valueStart++;
+		}
+		if (!TryReadConnectionValue(line, valueStart, end, style, out var value, out var next))
+			return false;
+
+		pair = new ConnectionPair(keyStart, keyEnd, value.Start, value.End, next);
+		return true;
+	}
+
+	private static bool TryReadConnectionValue(
+		ReadOnlySpan<char> line,
+		int start,
+		int end,
+		ConnectionPairStyle style,
+		out TextSpan value,
+		out int next)
+	{
+		value = default;
+		next = start;
+		if (start > end)
+			return false;
+
+		if (start < end && TryGetConnectionQuoteToken(line[start..end], out var quoteToken))
+		{
+			var contentStart = start + quoteToken.Length;
+			var position = contentStart;
+			while (position <= end - quoteToken.Length)
+			{
+				if (!line[position..end].StartsWith(quoteToken, StringComparison.Ordinal))
+				{
+					position++;
+					continue;
+				}
+				var afterQuote = position + quoteToken.Length;
+				if (afterQuote <= end - quoteToken.Length &&
+				    line[afterQuote..end].StartsWith(quoteToken, StringComparison.Ordinal))
+				{
+					position = afterQuote + quoteToken.Length;
+					continue;
+				}
+
+				next = afterQuote;
+				while (next < end && char.IsWhiteSpace(line[next]) && style is not ConnectionPairStyle.LibPq)
+					next++;
+				if (next < end && line[next] != GetConnectionSeparator(style))
+					return false;
+				value = new TextSpan(contentStart, position - contentStart);
+				return true;
+			}
+			return false;
+		}
+
+		var separator = GetConnectionSeparator(style);
+		var valueEnd = start;
+		while (valueEnd < end)
+		{
+			var character = line[valueEnd];
+			if (character == separator &&
+			    (style != ConnectionPairStyle.AdoNet || !IsXmlEntityTerminator(line, start, valueEnd)))
 			{
 				break;
 			}
-			end++;
+			if (style == ConnectionPairStyle.LibPq && character == '\\' && valueEnd + 1 < end)
+			{
+				valueEnd += 2;
+				continue;
+			}
+			if (IsDisallowedConnectionValueCharacter(character, style))
+				return false;
+			valueEnd++;
 		}
-		return TrimEnd(line, start, end);
+		next = valueEnd;
+		value = TrimEnd(line, start, valueEnd);
+		return true;
+	}
+
+	private static bool IsDisallowedConnectionValueCharacter(
+		char character,
+		ConnectionPairStyle style) =>
+		character is '(' or ')' or '[' or ']' or '{' or '}' or ',' or '\'' or '"' ||
+		style == ConnectionPairStyle.Query && (char.IsWhiteSpace(character) || character == '#');
+
+	private static char GetConnectionSeparator(ConnectionPairStyle style) => style switch
+	{
+		ConnectionPairStyle.AdoNet => ';',
+		ConnectionPairStyle.Query => '&',
+		ConnectionPairStyle.LibPq => ' ',
+		_ => throw new ArgumentOutOfRangeException(nameof(style))
+	};
+
+	private static void AddConnectionPasswords(
+		ReadOnlySpan<char> content,
+		ReadOnlySpan<char> line,
+		int lineStart,
+		ConnectionRegion region,
+		ICollection<DetectedSecret> matches)
+	{
+		var position = region.Start;
+		while (position < region.End)
+		{
+			if (region.Style is not ConnectionPairStyle.LibPq)
+			{
+				while (position < region.End && char.IsWhiteSpace(line[position]))
+					position++;
+				if (position == region.End)
+					break;
+			}
+
+			if (!TryReadConnectionPair(line, position, region.End, region.Style, out var pair))
+				return;
+			var key = line[pair.KeyStart..pair.KeyEnd];
+			if (key.Equals("password", StringComparison.OrdinalIgnoreCase) ||
+			    key.Equals("pwd", StringComparison.OrdinalIgnoreCase))
+			{
+				AddFinding(
+					content,
+					lineStart + pair.ValueStart,
+					pair.ValueEnd - pair.ValueStart,
+					"connection-password",
+					ConnectionPasswordOrder,
+					matches);
+			}
+			position = pair.Next;
+			if (position >= region.End)
+				break;
+			position++;
+		}
 	}
 
 	private static bool TryGetConnectionQuoteToken(ReadOnlySpan<char> value, out string quoteToken)
@@ -838,6 +1153,15 @@ internal static class StructuredSecretDetector
 		}
 		return assignmentCount >= 2 && hasConnectionSignal;
 	}
+
+	private static bool IsConnectionSignalKey(ReadOnlySpan<char> key) =>
+		key.Equals("host", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("server", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("data source", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("database", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("initial catalog", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("user id", StringComparison.OrdinalIgnoreCase) ||
+		key.Equals("username", StringComparison.OrdinalIgnoreCase);
 
 	private static void DetectEnvironmentAssignments(
 		ReadOnlySpan<char> content,
@@ -1879,6 +2203,25 @@ internal static class StructuredSecretDetector
 	private readonly record struct TextSpan(int Start, int Length)
 	{
 		public int End => Start + Length;
+	}
+
+	private readonly record struct ConnectionPair(
+		int KeyStart,
+		int KeyEnd,
+		int ValueStart,
+		int ValueEnd,
+		int Next);
+
+	private readonly record struct ConnectionRegion(
+		int Start,
+		int End,
+		ConnectionPairStyle Style);
+
+	private enum ConnectionPairStyle : byte
+	{
+		AdoNet,
+		Query,
+		LibPq
 	}
 
 	private readonly record struct XmlAttributeSpan(

--- a/Infrastructure/Secrets/SmartSecretsDetector.cs
+++ b/Infrastructure/Secrets/SmartSecretsDetector.cs
@@ -14,7 +14,7 @@ public sealed class SmartSecretsDetector(
 	ISecretDetector providerDetector,
 	SmartIgnoreService smartIgnore) : ISecretDetector
 {
-	internal const string StructuredRulesVersion = "smart-secrets-v5";
+	internal const string StructuredRulesVersion = "smart-secrets-v6";
 
 	public string RulesIdentity =>
 		$"{providerDetector.RulesIdentity}:{StructuredRulesVersion}";

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1523,7 +1523,7 @@ public sealed class McpServerIntegrationTests
 			Assert.Equal(
 				ProjectSelectionTokens.Exclusions.Count,
 				published.GetProperty("maxItems").GetInt32());
-			Assert.True(published.GetProperty("uniqueItems").GetBoolean());
+			Assert.False(published.TryGetProperty("uniqueItems", out _));
 			var propertyNames = schema.GetProperty("properties").EnumerateObject().Select(static property => property.Name).ToArray();
 			var globAnchor = Array.IndexOf(propertyNames, "exclude_patterns");
 			var profileAnchor = Array.IndexOf(propertyNames, "profile");
@@ -1643,7 +1643,8 @@ public sealed class McpServerIntegrationTests
 			Assert.Contains("exclusions", Text(leaked), StringComparison.Ordinal);
 		}
 
-		// The published schema declares uniqueItems, and case-variant repeats count too.
+		// Runtime validation rejects case-variant repeats even though the portable schema subset
+		// does not advertise a uniqueness keyword.
 		var duplicated = await delegatedServer.CallAsync(
 			"get_tree",
 			new Dictionary<string, object?> { ["exclusions"] = new[] { "dot-files", "DOT-FILES" } });
@@ -1976,7 +1977,16 @@ public sealed class McpServerIntegrationTests
 		Assert.Equal(
 			McpGetFileRequestSet.MaximumRanges,
 			batchRequests.GetProperty("items").GetProperty("properties").GetProperty("ranges").GetProperty("maxItems").GetInt32());
-		Assert.Equal(2, getFileSchema.GetProperty("oneOf").GetArrayLength());
+		Assert.False(getFileSchema.TryGetProperty("oneOf", out _));
+		Assert.False(getFileSchema.TryGetProperty("not", out _));
+		Assert.Contains(
+			"Exactly one of path or requests is required",
+			getFileSchema.GetProperty("properties").GetProperty("path").GetProperty("description").GetString(),
+			StringComparison.Ordinal);
+		Assert.Contains(
+			"Exactly one of requests or path is required",
+			batchRequests.GetProperty("description").GetString(),
+			StringComparison.Ordinal);
 		var searchBoolean = tools.Single(static tool => tool.Name == "search_project")
 			.ProtocolTool.InputSchema.GetProperty("properties").GetProperty("ignore_case");
 		Assert.Equal(2, searchBoolean.GetProperty("oneOf").GetArrayLength());
@@ -2124,6 +2134,56 @@ public sealed class McpServerIntegrationTests
 				var items = patterns.GetProperty("items");
 				Assert.Equal(1, items.GetProperty("minLength").GetInt32());
 				Assert.Equal(512, items.GetProperty("maxLength").GetInt32());
+			}
+		}
+	}
+
+	[Fact]
+	public async Task PublishedInputSchemasUseThePortableKeywordSubset()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		await using var server = await McpTestServer.StartAsync(
+			project,
+			workspace.Path,
+			agentExclusions: true);
+
+		var tools = await server.Client.ListToolsAsync(
+			options: null,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(ExpectedTools, tools.Select(static tool => tool.Name));
+		foreach (var tool in tools)
+			AssertPortableKeywords(tool.Name, tool.ProtocolTool.InputSchema);
+	}
+
+	private static void AssertPortableKeywords(string toolName, JsonElement schema)
+	{
+		string[] allowed =
+		[
+			"type", "properties", "required", "description", "enum", "items",
+			"minItems", "maxItems", "minimum", "maximum", "minLength", "maxLength",
+			"pattern", "additionalProperties", "oneOf", "default"
+		];
+
+		foreach (var property in schema.EnumerateObject())
+		{
+			Assert.True(
+				allowed.Contains(property.Name, StringComparer.Ordinal),
+				$"{toolName}: unsupported schema keyword '{property.Name}'.");
+			if (property.NameEquals("properties"))
+			{
+				foreach (var parameter in property.Value.EnumerateObject())
+					AssertPortableKeywords(toolName, parameter.Value);
+			}
+			else if (property.NameEquals("items") && property.Value.ValueKind == JsonValueKind.Object)
+			{
+				AssertPortableKeywords(toolName, property.Value);
+			}
+			else if (property.NameEquals("oneOf"))
+			{
+				foreach (var alternative in property.Value.EnumerateArray())
+					AssertPortableKeywords(toolName, alternative);
 			}
 		}
 	}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -26,6 +26,83 @@ public sealed partial class McpServerProcessTests
 	private const string PrivateEmail = "alice.smith" + "@company.io";
 	private const string PrivatePath = "/home/alice-smith/DevProjexMcpProcessProbe/project";
 
+	[Fact]
+	public async Task RealProcessListsEveryCatalogToolAndRejectsMissingOrConflictingFileSelectors()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/Anchor.cs", "anchor\n");
+		var startInfo = new ProcessStartInfo("dotnet")
+		{
+			UseShellExecute = false,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			CreateNoWindow = true,
+			WorkingDirectory = project
+		};
+		startInfo.ArgumentList.Add(PublishedApplicationLocator.FindApplicationAssembly());
+		startInfo.ArgumentList.Add("mcp");
+		startInfo.ArgumentList.Add("--root");
+		startInfo.ArgumentList.Add(project);
+		startInfo.Environment["DEVPROJEX_INTERNAL_DATA_ROOT"] = workspace.CreateDirectory("data");
+
+		using var process = Process.Start(startInfo) ??
+		                    throw new InvalidOperationException("MCP process did not start.");
+		var standardErrorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+		using var clientPhase = CancellationTokenSource.CreateLinkedTokenSource(
+			TestContext.Current.CancellationToken);
+		clientPhase.CancelAfter(TimeSpan.FromMinutes(2));
+		await using (var client = await McpClient.CreateAsync(
+			new StreamClientTransport(process.StandardInput.BaseStream, process.StandardOutput.BaseStream),
+			clientOptions: null,
+			loggerFactory: null,
+			clientPhase.Token))
+		{
+			var tools = await client.ListToolsAsync(options: null, clientPhase.Token);
+			Assert.Equal(8, tools.Count);
+			Assert.Equal(ExpectedTools, tools.Select(static tool => tool.Name));
+
+			var missing = await client.CallToolAsync(
+				"get_file",
+				new Dictionary<string, object?>(),
+				progress: null,
+				options: null,
+				clientPhase.Token);
+			Assert.True(missing.IsError);
+			Assert.StartsWith(
+				McpErrorCodes.InvalidArguments,
+				Assert.IsType<TextContentBlock>(Assert.Single(missing.Content)).Text,
+				StringComparison.Ordinal);
+
+			var conflicting = await client.CallToolAsync(
+				"get_file",
+				new Dictionary<string, object?>
+				{
+					["path"] = "Anchor.cs",
+					["requests"] = new object[]
+					{
+						new { path = "Anchor.cs", ranges = new[] { new { start_line = 1, end_line = 1 } } }
+					}
+				},
+				progress: null,
+				options: null,
+				clientPhase.Token);
+			Assert.True(conflicting.IsError);
+			Assert.StartsWith(
+				McpErrorCodes.InvalidArguments,
+				Assert.IsType<TextContentBlock>(Assert.Single(conflicting.Content)).Text,
+				StringComparison.Ordinal);
+		}
+
+		process.StandardInput.Close();
+		await process.WaitForExitAsync(TestContext.Current.CancellationToken)
+			.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+		var standardError = await standardErrorTask;
+		Assert.Equal(0, process.ExitCode);
+		Assert.True(string.IsNullOrWhiteSpace(standardError), $"Unexpected stderr: {standardError}");
+	}
+
 	[Theory]
 	[InlineData("none")]
 	[InlineData("off")]

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsConnectionValueGrammarTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsConnectionValueGrammarTests.cs
@@ -1,0 +1,154 @@
+using DevProjex.Application.Secrets;
+using DevProjex.Infrastructure.Secrets;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class SmartSecretsConnectionValueGrammarTests
+{
+	// Pair and quoting rules follow the ADO.NET, JDBC URL, libpq, and HTTP field grammars.
+	// Sources: https://learn.microsoft.com/dotnet/framework/data/adonet/connection-strings
+	//          https://docs.oracle.com/javase/8/docs/api/java/sql/DriverManager.html
+	//          https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+	//          https://www.rfc-editor.org/rfc/rfc9110#section-5
+	public static TheoryData<string, string> AcceptedRegions => new()
+	{
+		{ "Server=db;User ID=sa;Password=Admin123!;Database=app", "Admin123!" },
+		{ "Host=db;Username=admin;Password=Admin123!;Database=app", "Admin123!" },
+		{ "jdbc:postgresql://db/app?user=admin&password=short&ssl=true", "short" },
+		{ "postgresql://db/app?username=admin&password=query-password&ssl=true", "query-password" },
+		{ "Server=db;User ID=sa;Password=ab&cd;Database=app", "ab&cd" },
+		{ "Server=db;User ID=sa;Password=\"ab\"\"cd\";Database=app", "ab\"\"cd" },
+		{ "Server=db;User ID=sa;Password='ab;cd';Database=app", "ab;cd" },
+		{ "Server=db;User ID=sa;Password=ab=cd;Database=app", "ab=cd" },
+		{ "{\"Connection\":\"Server=db;Password=ab&cd;Database=app\"}", "ab&cd" },
+		{ "const string value = \"Server=db;Password=ab&cd;Database=app\";", "ab&cd" },
+		{ "<add value=\"Server=db;Password=ab&amp;cd;Database=app\" />", "ab&amp;cd" },
+		{ "host=localhost port=5432 dbname=app user=postgres password=Admin123!", "Admin123!" },
+		{ "Cookie: Server=db; Password=cookie-password", "cookie-password" },
+		{ "  cOoKiE: Server=db; Password=header-password", "header-password" },
+		{ "Server=db;User ID=sa;Password='päss;🔐'", "päss;🔐" },
+		{ "safe\r\nServer=db;User ID=sa;Password=line-password;Database=app\r\nsafe", "line-password" }
+	};
+
+	[Theory]
+	[MemberData(nameof(AcceptedRegions))]
+	public void CompletePairRegionsExposeOnlyThePasswordValue(string content, string expected)
+	{
+		AssertExactCoverage(content, Match(content), expected);
+	}
+
+	public static TheoryData<string> RejectedRegions => new()
+	{
+		{ "return BasicAuth(username=username, password=password)" },
+		{ "return BasicAuth(username=auth[0], password=auth[1])" },
+		{ "password=self._password" },
+		{ "password=kwargs.get(\"password\")" },
+		{ "password=os.environ[\"PW\"]" },
+		{ "password=config.password" },
+		{ "Connect(host = host, password = password);" },
+		{ "connect({ host = host, password = password });" },
+		{ "Cookie: str = \"value\"" },
+		{ "Cookie: name=value" },
+		{ "Foo: Server=db; Password=x" },
+		{ "Server=db" },
+		{ "Password=x" },
+		{ "jdbc:postgresql://db/app?user=admin&ssl=true" },
+		{ "host=localhost  password=Admin123!" },
+		{ "Server=db;Password=;Database=app" }
+	};
+
+	[Theory]
+	[MemberData(nameof(RejectedRegions))]
+	public void TextOutsideACompletePairRegionRemainsUnchanged(string content)
+	{
+		Assert.Empty(Match(content));
+	}
+
+	[Theory]
+	[InlineData("Cookie")]
+	[InlineData("Set-Cookie")]
+	[InlineData("Authorization")]
+	[InlineData("Proxy-Authorization")]
+	public void ExistingProtectedHeaderNamesMayOpenACompletePairRegion(string header)
+	{
+		var content = $"{header}: Server=db; Password=header-password";
+
+		AssertExactCoverage(content, Match(content), "header-password");
+	}
+
+	[Theory]
+	[InlineData("return BasicAuth(username=username, password=password)")]
+	[InlineData("return BasicAuth(username=auth[0], password=auth[1])")]
+	public void PythonCallTextRemainsByteForByteUnchanged(string content)
+	{
+		var matches = SmartSecretsDetectorTests.Detector.Detect(
+			"httpx/_client.py",
+			content,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(content, Apply(content, matches));
+	}
+
+	[Fact(Timeout = 5_000)]
+	public void LongCompleteRegionAtTheInspectionBoundaryKeepsExactCoverage()
+	{
+		var password = string.Create(2 * 1024 * 1024, 0, static (buffer, _) =>
+		{
+			for (var index = 0; index < buffer.Length; index++)
+				buffer[index] = (index & 1) == 0 ? 'a' : 'B';
+		});
+		var content = $"Server=db;User ID=sa;Password={password};Database=app";
+
+		AssertExactCoverage(content, Match(content), password);
+	}
+
+	private static DetectedSecret[] Match(string content) =>
+		StructuredSecretDetector.Detect(
+			"settings.txt",
+			content,
+			SmartSecretStack.None,
+			TestContext.Current.CancellationToken)
+		.Where(static match => match.RuleId == "connection-password")
+		.OrderBy(static match => match.Start)
+		.ToArray();
+
+	private static string Apply(string content, IReadOnlyList<DetectedSecret> matches)
+	{
+		var result = content;
+		foreach (var match in matches.OrderByDescending(static match => match.Start))
+		{
+			result = string.Concat(
+				result.AsSpan(0, match.Start),
+				$"DEVPROJEX_REDACTED[{match.RuleId}#1]",
+				result.AsSpan(match.Start + match.Length));
+		}
+		return result;
+	}
+
+	private static void AssertExactCoverage(
+		string content,
+		IReadOnlyList<DetectedSecret> matches,
+		params string[] expectedValues)
+	{
+		var expectedCoverage = new bool[content.Length];
+		var searchStart = 0;
+		foreach (var expectedValue in expectedValues)
+		{
+			var start = content.IndexOf(expectedValue, searchStart, StringComparison.Ordinal);
+			Assert.True(start >= 0, $"Expected value '{expectedValue}' was not present after offset {searchStart}.");
+			for (var index = start; index < start + expectedValue.Length; index++)
+				expectedCoverage[index] = true;
+			searchStart = start + expectedValue.Length;
+		}
+
+		var actualCoverage = new bool[content.Length];
+		foreach (var match in matches)
+		{
+			Assert.Equal(match.Value, content.Substring(match.Start, match.Length));
+			for (var index = match.Start; index < match.Start + match.Length; index++)
+				actualCoverage[index] = true;
+		}
+
+		Assert.Equal(expectedCoverage, actualCoverage);
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/SmartSecretsDetectorTests.cs
@@ -8,9 +8,9 @@ public sealed class SmartSecretsDetectorTests
 	internal static readonly SmartSecretsDetector Detector = CreateDetector();
 
 	[Fact]
-	public void RulesIdentity_UsesVersionFiveForStructuredCacheInvalidation()
+	public void RulesIdentity_UsesVersionSixForStructuredCacheInvalidation()
 	{
-		Assert.EndsWith(":smart-secrets-v5", Detector.RulesIdentity, StringComparison.Ordinal);
+		Assert.EndsWith(":smart-secrets-v6", Detector.RulesIdentity, StringComparison.Ordinal);
 	}
 
 	[Theory]


### PR DESCRIPTION
## Summary
- keep published MCP input schemas within the portable keyword subset while enforcing get_file selector rules before file access
- require complete connection pair regions before masking password values in source text
- preserve exact support for ADO.NET, JDBC, URI query, libpq, host-language literals, and protected HTTP headers

## Validation
- targeted MCP integration and real-process checks
- targeted Smart Secrets parser and regression checks
- default BenchmarkDotNet detector runs on clean, accepted, and rejected corpora