### PR TITLE
docs(mcp): name every tool and describe the notices the server sends

### DIFF
--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1249,7 +1249,8 @@ default `10`; both surfaces share the same bounded, deterministic ranking.
 `--max-file-bytes SIZE` is an additive, invocation-only option on `analyze`,
 `tree`, and `export context`. The five MCP selection tools that narrow a file set
 — `get_tree`, `analyze`, `pack_context`, `search_project`, and `related_files` —
-expose the equivalent positive integer `max_file_bytes` parameter. Both surfaces use one Application
+expose the equivalent `max_file_bytes` parameter, as a positive integer or the
+same value written as a numeric string. Both surfaces use one Application
 filter and exclude files strictly larger than the limit without changing profile
 schemas. Existing machine documents add no property; their inventory, byte
 metrics, trees, and content reflect the effective narrowed selection.
@@ -1282,15 +1283,18 @@ effective set in an `exclusions` array and `list_projects` results carry a
 `baseline` object (`git`, `exclusions`, `agentExclusions`); both are required
 on every server — including servers started without the exclusion flags — so
 consumers that pinned the pre-v5.2 output schemas must refresh their copies.
-`get_tree` and `pack_context` responses carry a trusted `[Effective filters]`
-line among their trailing diagnostics, which also include `[Protection]` and,
-for a pinned remote checkout, `[Remote]`; a session receives that pair once and
-then the constant `[Unchanged] filters, protection; see list_projects.` line
-until what it says changes, while an `[Empty selection]` response and any call
-that passed `max_file_bytes` always report the full pair. Every selection tool
-adds an `[Empty selection]` line when nothing survived the filters, and a
-`DPX-MCP-PATH-NOT-FOUND` error for a file the filters hide names the effective
-filters. Glob patterns gain `{a,b}` alternatives; `!` negation and
+`get_tree`, `pack_context`, and `related_files` responses always carry a trusted
+`[Effective filters]` line; the other selection tools carry it only when they
+have to explain themselves. It is never the last line: an `[Empty selection]`
+line can follow it, `[Protection]` comes after that, a pinned remote checkout
+adds `[Remote]`, and a budgeted `pack_context` ends with `[Budget accounting]`.
+A session is told each trusted service line once and then receives the constant
+`[Unchanged] filters, protection; see list_projects.` line until that content
+changes; an `[Empty selection]` response and any call that passed
+`max_file_bytes` report the full set instead. `analyze` reports no protection
+line on any call. Every selection tool adds an `[Empty selection]` line when
+nothing survived the filters, and a `DPX-MCP-PATH-NOT-FOUND` error for a file
+the filters hide names the effective filters. Glob patterns gain `{a,b}` alternatives; `!` negation and
 `[...]` classes, previously matched as literal characters, are rejected with
 `DPX-MCP-INVALID-PATTERN`.
 

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1233,8 +1233,9 @@ and profile text uses localized yes/no values.
 
 `devprojex mcp --allow-remote` is an additive, opt-in startup capability. Without
 the flag, MCP project tools retain the local-only, zero-network contract. With
-the flag, `get_tree`, `analyze`, `pack_context`, `search_project`, and `get_file`
-accept a Git URL in `project` plus an optional URL-only `branch`. RepoCache owns
+the flag, `get_tree`, `analyze`, `pack_context`, `search_project`,
+`related_files`, and `get_file` accept a Git URL in `project` plus an optional
+URL-only `branch`. RepoCache owns
 clone publication and the server pins each resolved checkout until shutdown.
 `list_projects` remains the stable list of configured local roots.
 Remote network URLs use HTTP(S), SSH, Git protocol, or SCP syntax and cannot
@@ -1246,8 +1247,9 @@ The MCP `analyze` tool exposes the matching optional `top_files` parameter with
 default `10`; both surfaces share the same bounded, deterministic ranking.
 
 `--max-file-bytes SIZE` is an additive, invocation-only option on `analyze`,
-`tree`, and `export context`. The four MCP selection tools expose the equivalent
-positive integer `max_file_bytes` parameter. Both surfaces use one Application
+`tree`, and `export context`. The five MCP selection tools that narrow a file set
+— `get_tree`, `analyze`, `pack_context`, `search_project`, and `related_files` —
+expose the equivalent positive integer `max_file_bytes` parameter. Both surfaces use one Application
 filter and exclude files strictly larger than the limit without changing profile
 schemas. Existing machine documents add no property; their inventory, byte
 metrics, trees, and content reflect the effective narrowed selection.
@@ -1255,7 +1257,7 @@ metrics, trees, and content reflect the effective narrowed selection.
 Git-axis v2 is an additive CLI-v1 extension. Direct selection commands accept
 the momentary `staged`, `changes`, and `diff:<REF>..<REF>` tokens. MCP adds the
 persistent server baseline `--git-mode` and the narrowing `git_scope` parameter
-on its four selection tools. Profile schemas remain unchanged and reject
+on the same five selection tools. Profile schemas remain unchanged and reject
 momentary values.
 
 MCP exclusions are a v5.2 extension with one deliberate default change: a
@@ -1270,8 +1272,9 @@ only when a tool does not name an explicit profile.
 `devprojex mcp --unrestricted` is the widest-baseline preset, equivalent to
 `--exclude none --git-mode none` and in conflict with both spelled-out flags.
 `devprojex mcp --allow-agent-exclusions` additionally publishes an `exclusions` array
-parameter on `get_tree`, `analyze`, `pack_context`, `search_project`, and
-`get_file`; the value is the full desired toggle set, an empty array disables
+parameter on the six selection tools (`get_tree`, `analyze`, `pack_context`,
+`search_project`, `related_files`, and `get_file`); the value is the full
+desired toggle set, an empty array disables
 every toggle, and it outranks the server baseline and profile exclusions.
 Without the flag the parameter does not exist in any schema. Redaction toggles
 are not part of the vocabulary on either surface. `analyze` results echo the
@@ -1279,10 +1282,15 @@ effective set in an `exclusions` array and `list_projects` results carry a
 `baseline` object (`git`, `exclusions`, `agentExclusions`); both are required
 on every server — including servers started without the exclusion flags — so
 consumers that pinned the pre-v5.2 output schemas must refresh their copies.
-`get_tree` and `pack_context` responses end with a trusted
-`[Effective filters]` line, every selection tool adds an `[Empty selection]`
-line when nothing survived the filters, and `DPX-MCP-PATH-NOT-FOUND` names the
-effective filters. Glob patterns gain `{a,b}` alternatives; `!` negation and
+`get_tree` and `pack_context` responses carry a trusted `[Effective filters]`
+line among their trailing diagnostics, which also include `[Protection]` and,
+for a pinned remote checkout, `[Remote]`; a session receives that pair once and
+then the constant `[Unchanged] filters, protection; see list_projects.` line
+until what it says changes, while an `[Empty selection]` response and any call
+that passed `max_file_bytes` always report the full pair. Every selection tool
+adds an `[Empty selection]` line when nothing survived the filters, and a
+`DPX-MCP-PATH-NOT-FOUND` error for a file the filters hide names the effective
+filters. Glob patterns gain `{a,b}` alternatives; `!` negation and
 `[...]` classes, previously matched as literal characters, are rejected with
 `DPX-MCP-INVALID-PATTERN`.
 
@@ -1315,7 +1323,7 @@ a fitting depth. Third, uninspected entries in MCP `analyze.topFiles` gain the
 optional `uninspected: true` field, and their estimates use the same character
 base as aggregate `characters` and `tokens`. Fourth, `initialize.instructions`
 now carries workflow, trust-boundary, redaction, limit, and glob guidance, while
-all seven tool descriptions are self-contained for tool search. Cached MCP
+all eight tool descriptions are self-contained for tool search. Cached MCP
 schemas must be refreshed for the additive `topFiles` field and new field
 descriptions.
 

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -381,10 +381,13 @@ schema must refresh it.
 Filters are never silent, though an unchanged filter line is reported once per
 session rather than on every response — see
 [Service notices repeat only when they change](#service-notices-repeat-only-when-they-change).
-`get_tree` and `pack_context` end with a trusted
+`get_tree` and `pack_context` carry a trusted
 `[Effective filters] git: ...; exclusions: ...` line naming the Git mode and
 exclusion toggles that shaped the tree and who can widen them: the server
-startup line, or a per-call `exclusions` value on a delegation server. When
+startup line, or a per-call `exclusions` value on a delegation server. It sits
+among the trailing diagnostics rather than last: `[Protection]` follows it, a
+pinned remote checkout adds `[Remote]`, and a budgeted `pack_context` ends with
+`[Budget accounting]`. When
 `max_file_bytes` is supplied, every tool that accepts it also reports
 `; max_file_bytes: <bytes>` in its effective-filter diagnostics. Every selection
 tool adds an `[Empty selection]` line when no file survived the

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -381,13 +381,13 @@ schema must refresh it.
 Filters are never silent, though an unchanged filter line is reported once per
 session rather than on every response — see
 [Service notices repeat only when they change](#service-notices-repeat-only-when-they-change).
-`get_tree` and `pack_context` carry a trusted
+`get_tree`, `pack_context`, and `related_files` carry a trusted
 `[Effective filters] git: ...; exclusions: ...` line naming the Git mode and
 exclusion toggles that shaped the tree and who can widen them: the server
 startup line, or a per-call `exclusions` value on a delegation server. It sits
-among the trailing diagnostics rather than last: `[Protection]` follows it, a
-pinned remote checkout adds `[Remote]`, and a budgeted `pack_context` ends with
-`[Budget accounting]`. When
+among the trailing diagnostics rather than last: an `[Empty selection]` line can
+follow it, `[Protection]` comes after that, a pinned remote checkout adds
+`[Remote]`, and a budgeted `pack_context` ends with `[Budget accounting]`. When
 `max_file_bytes` is supplied, every tool that accepts it also reports
 `; max_file_bytes: <bytes>` in its effective-filter diagnostics. Every selection
 tool adds an `[Empty selection]` line when no file survived the

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ devprojex mcp --root /path/to/project
 
 For Claude Code it's one command: `claude mcp add devprojex -- devprojex mcp --root .`
 
-Eight read-only tools cover the whole workflow: `list_projects`, `get_tree`, `analyze`, `search_project`, `related_files`, `get_file`, `pack_context`, and `read_pack`. `related_files` answers "what does this file actually use, and who uses it" from a static dependency index over up to 16 seed files, so following a thread never widens the selection. Only `pack_context` stores oversized context as a session pack; `read_pack` reads it back in line ranges instead of flooding the agent's context. Long operations report standard MCP progress notifications.
+Eight read-only tools cover the whole workflow: `list_projects`, `get_tree`, `analyze`, `search_project`, `related_files`, `get_file`, `pack_context`, and `read_pack`. `related_files` answers "what does this file actually use, and who uses it" from a static dependency index over up to 16 seed files, so following a thread never widens the selection. `pack_context` and `related_files` store an oversized result as a session pack; `read_pack` reads it back in line ranges instead of flooding the agent's context. Long operations report standard MCP progress notifications.
 
 The server enforces hard security boundaries on top of DevProjex's read-only design:
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ devprojex mcp --root /path/to/project
 
 For Claude Code it's one command: `claude mcp add devprojex -- devprojex mcp --root .`
 
-Seven read-only tools cover the whole workflow: `list_projects`, `get_tree`, `analyze`, `search_project`, `get_file`, `pack_context`, and `read_pack`. Only `pack_context` stores oversized context as a session pack; `read_pack` reads it back in line ranges instead of flooding the agent's context. Long operations report standard MCP progress notifications.
+Eight read-only tools cover the whole workflow: `list_projects`, `get_tree`, `analyze`, `search_project`, `related_files`, `get_file`, `pack_context`, and `read_pack`. `related_files` answers "what does this file actually use, and who uses it" from a static dependency index over up to 16 seed files, so following a thread never widens the selection. Only `pack_context` stores oversized context as a session pack; `read_pack` reads it back in line ranges instead of flooding the agent's context. Long operations report standard MCP progress notifications.
 
 The server enforces hard security boundaries on top of DevProjex's read-only design:
 

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -64,7 +64,8 @@ public sealed class DocumentationAndPackagingContractTests
 		var toolNames = ReadCatalogToolNames(rootPath);
 		var readMe = File.ReadAllText(Path.Combine(rootPath, "README.md"));
 		var contract = File.ReadAllText(Path.Combine(rootPath, "Docs", "CLI-V1-Contract.md"));
-		var enumeration = ParagraphContaining(readMe, "read-only tools cover the whole workflow");
+		var enumeration = FirstSentence(
+			ParagraphContaining(readMe, "read-only tools cover the whole workflow"));
 
 		foreach (var name in toolNames)
 			Assert.Contains($"`{name}`", enumeration, StringComparison.Ordinal);
@@ -1661,6 +1662,10 @@ public sealed class DocumentationAndPackagingContractTests
 			.ToArray();
 		Assert.NotEmpty(names);
 		Assert.Equal(names.Length, names.Distinct(StringComparer.Ordinal).Count());
+
+		// A registration this reader cannot parse must fail loudly rather than lower the count on
+		// both sides of the comparison and let a stale document pass.
+		Assert.Equal(Regex.Matches(catalog, @"Create\(\s*target,").Count, names.Length);
 		return names;
 	}
 
@@ -1672,6 +1677,16 @@ public sealed class DocumentationAndPackagingContractTests
 			.FirstOrDefault(block => block.Contains(marker, StringComparison.Ordinal));
 		Assert.True(paragraph is not null, $"No paragraph contains '{marker}'.");
 		return paragraph!;
+	}
+
+	/// <summary>
+	/// The opening sentence of a paragraph, so that a name mentioned in later prose cannot stand in
+	/// for a name missing from the enumeration itself.
+	/// </summary>
+	private static string FirstSentence(string paragraph)
+	{
+		var end = paragraph.IndexOf(". ", StringComparison.Ordinal);
+		return end < 0 ? paragraph : paragraph[..(end + 1)];
 	}
 
 	private static string CountWord(int value) => value switch

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -58,6 +58,28 @@ public sealed class DocumentationAndPackagingContractTests
 	}
 
 	[Fact]
+	public void PublishedDocumentationNamesEveryMcpToolAndTheirCount()
+	{
+		var rootPath = FindRepositoryRoot();
+		var toolNames = ReadCatalogToolNames(rootPath);
+		var readMe = File.ReadAllText(Path.Combine(rootPath, "README.md"));
+		var contract = File.ReadAllText(Path.Combine(rootPath, "Docs", "CLI-V1-Contract.md"));
+		var enumeration = ParagraphContaining(readMe, "read-only tools cover the whole workflow");
+
+		foreach (var name in toolNames)
+			Assert.Contains($"`{name}`", enumeration, StringComparison.Ordinal);
+
+		Assert.Contains(
+			$"{CountWord(toolNames.Length)} read-only tools",
+			enumeration,
+			StringComparison.Ordinal);
+		Assert.Contains(
+			$"all {CountWord(toolNames.Length).ToLowerInvariant()} tool descriptions",
+			contract,
+			StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public void GitSafetyProfilesAndFilterRefusalRemainDocumented()
 	{
 		var rootPath = FindRepositoryRoot();
@@ -1622,4 +1644,50 @@ public sealed class DocumentationAndPackagingContractTests
 
 	private static string FindRepositoryRoot()
 		=> PublishedApplicationLocator.FindRepositoryRoot();
+
+	/// <summary>
+	/// The tool names the MCP catalog registers, read from its source so that adding a tool is
+	/// what makes the documentation assertions fail.
+	/// </summary>
+	private static string[] ReadCatalogToolNames(string rootPath)
+	{
+		var catalog = File.ReadAllText(
+			Path.Combine(rootPath, "Apps", "Mcp", "DevProjexMcpToolCatalog.cs"));
+		var names = Regex
+			.Matches(
+				catalog,
+				@"Create\(\s*target,\s*nameof\(DevProjexMcpTools\.\w+\),\s*""(?<name>[a-z_]+)""")
+			.Select(match => match.Groups["name"].Value)
+			.ToArray();
+		Assert.NotEmpty(names);
+		Assert.Equal(names.Length, names.Distinct(StringComparer.Ordinal).Count());
+		return names;
+	}
+
+	private static string ParagraphContaining(string document, string marker)
+	{
+		var paragraph = document
+			.ReplaceLineEndings("\n")
+			.Split("\n\n", StringSplitOptions.RemoveEmptyEntries)
+			.FirstOrDefault(block => block.Contains(marker, StringComparison.Ordinal));
+		Assert.True(paragraph is not null, $"No paragraph contains '{marker}'.");
+		return paragraph!;
+	}
+
+	private static string CountWord(int value) => value switch
+	{
+		1 => "One",
+		2 => "Two",
+		3 => "Three",
+		4 => "Four",
+		5 => "Five",
+		6 => "Six",
+		7 => "Seven",
+		8 => "Eight",
+		9 => "Nine",
+		10 => "Ten",
+		11 => "Eleven",
+		12 => "Twelve",
+		_ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+	};
 }


### PR DESCRIPTION
Closes #350.

## The tool count

The catalog registers eight tools. Five published statements disagreed with it, and three of
them disagreed with another statement in the same document:

- `README.md` said "Seven read-only tools" and named seven, omitting `related_files` entirely.
- `Docs/CLI-V1-Contract.md` counted "all seven tool descriptions".
- Its remote-source paragraph listed five tools that accept a Git URL; `Docs/McpServer.md`
  already said six, and the catalog marks six `openWorld`.
- Its `--allow-agent-exclusions` paragraph listed five tools; the reference table in the same
  file lists six, and the catalog appends the exclusions fragment to six input schemas.
- Its `max_file_bytes` and `git_scope` paragraphs said "four selection tools"; both properties
  appear in five input schemas, and the reference table in the same file says five.

The readme also credited only `pack_context` with storing an oversized result. `related_files`
stores one too, which is why `read_pack.pack_id` is documented as "returned by `pack_context` or
`related_files`".

## The trusted notices

`Docs/CLI-V1-Contract.md` said `get_tree` and `pack_context` responses *end with* the trusted
`[Effective filters]` line, that *every* `DPX-MCP-PATH-NOT-FOUND` names the effective filters,
and said nothing about the continuation line. Each part was wrong:

- The line is never last. `SelectionNotices` emits continuation, filters, empty selection,
  protection, remote in that fixed order, and a budgeted `pack_context` appends
  `[Budget accounting]` after all of them.
- Three tools carry the line unconditionally — `get_tree`, `pack_context` and `related_files`
  all pass `includeFilters: true`. The other selection tools carry it only when they have to
  explain themselves.
- A session is told a trusted service line once and then receives
  `[Unchanged] filters, protection; see list_projects.` until its content changes; an
  `[Empty selection]` response and any call that passed `max_file_bytes` report the full set.
- `analyze` reports no protection line on any call, so the earlier "pair" wording would have
  been wrong in the other direction.
- Only a path the filters hide reports the effective filters in its not-found error. Six other
  throw sites do not. `Docs/McpServer.md` already scoped this correctly; the contract did not.

`Docs/McpServer.md` repeated the same "end with" claim and is corrected with it.

## The contract test

`PublishedDocumentationNamesEveryMcpToolAndTheirCount` reads the tool names from the catalog
source, then requires the readme's opening enumeration sentence to name every one of them and
to use the matching count word, and requires the version contract to use the same word.

It is checked by mutation rather than assumed:

- A ninth registration added to the catalog fails the test.
- Removing a name from the readme enumeration fails the test, including when the name still
  appears in later prose in the same paragraph — the first version of this check passed that
  case, so the check now reads the opening sentence rather than the whole paragraph.
- A registration the reader cannot parse fails the test instead of lowering both sides of the
  count, which would have let a stale document pass.

## Local results

Documentation contract tests, `-c Release` on Windows: 34 passed, 0 failed.

## Not covered

The continuation line names "filters, protection" even in a session that was never sent a
protection line, because `analyze` opts out of it and the memo treats an absent line as
delivered. That is server behaviour, not a documentation defect, and it is left alone here.
