### PR TITLE
fix(mcp): hold the connection payload to a measured budget

### DIFF
--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -511,7 +511,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	        "estimated": {
 	          "type": "object",
 	          "properties": {
-	            "files": { "type": "integer", "description": "Text files." },
+	            "files": { "type": "integer", "description": "Text files with size-based estimates only." },
 	            "characters": { "type": "integer", "description": "Normalized characters." },
 	            "tokens": { "type": "integer" }
 	          },
@@ -551,7 +551,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	      "type": "object",
 	      "description": "Content-protection policy applied to this analysis.",
 	      "properties": {
-	        "secrets": { "type": "string", "const": "always" },
+	        "secrets": { "type": "string", "const": "always", "description": "Mandatory secret-redaction state." },
 	        "privateData": { "type": "string", "enum": ["enabled", "disabled"], "description": "Server-startup redaction state." }
 	      },
 	      "required": ["secrets", "privateData"],

--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -489,7 +489,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	{
 	  "type": "object",
 	  "properties": {
-	    "files": { "type": "integer", "description": "Number of files in the effective selection." },
+	    "files": { "type": "integer", "description": "Files in the effective selection." },
 	    "characters": { "type": "integer", "description": "Rendered characters, including estimates for uninspected text files." },
 	    "tokens": { "type": "integer", "description": "Estimated tokens for the same character total." },
 	    "detail": { "type": "string", "enum": ["full", "compact", "signatures"], "description": "Effective content-detail level used for measurement." },
@@ -500,10 +500,10 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	        "measured": {
 	          "type": "object",
 	          "properties": {
-	            "files": { "type": "integer", "description": "Number of files measured from inspected transformed text." },
-	            "lines": { "type": "integer", "description": "Lines in measured transformed file bodies." },
-	            "characters": { "type": "integer", "description": "Normalized characters in measured transformed file bodies." },
-	            "tokens": { "type": "integer", "description": "Estimated tokens for measured transformed file bodies." }
+	            "files": { "type": "integer" },
+	            "lines": { "type": "integer" },
+	            "characters": { "type": "integer", "description": "Normalized characters." },
+	            "tokens": { "type": "integer", "description": "Estimated tokens." }
 	          },
 	          "required": ["files", "lines", "characters", "tokens"],
 	          "additionalProperties": false
@@ -511,9 +511,9 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	        "estimated": {
 	          "type": "object",
 	          "properties": {
-	            "files": { "type": "integer", "description": "Number of text files represented only by size-based estimates." },
-	            "characters": { "type": "integer", "description": "Estimated normalized characters for those files." },
-	            "tokens": { "type": "integer", "description": "Estimated tokens for those files." }
+	            "files": { "type": "integer", "description": "Text files." },
+	            "characters": { "type": "integer", "description": "Normalized characters." },
+	            "tokens": { "type": "integer" }
 	          },
 	          "required": ["files", "characters", "tokens"],
 	          "additionalProperties": false
@@ -526,11 +526,11 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	      "type": "object",
 	      "description": "Metrics for the canonical pack_context content/text document, including its root and relative-path headings.",
 	      "properties": {
-	        "view": { "type": "string", "const": "content", "description": "Pack view used for document measurement." },
-	        "format": { "type": "string", "const": "text", "description": "Pack format used for document measurement." },
-	        "lines": { "type": "integer", "description": "Rendered document lines." },
-	        "characters": { "type": "integer", "description": "Rendered normalized document characters." },
-	        "tokens": { "type": "integer", "description": "Estimated tokens for the rendered document." },
+	        "view": { "type": "string", "const": "content" },
+	        "format": { "type": "string", "const": "text" },
+	        "lines": { "type": "integer" },
+	        "characters": { "type": "integer", "description": "Normalized characters." },
+	        "tokens": { "type": "integer", "description": "Estimated tokens." },
 	        "estimated": { "type": "boolean", "description": "True when one or more file bodies use size-based estimates or lack text metrics." }
 	      },
 	      "required": ["view", "format", "lines", "characters", "tokens", "estimated"],
@@ -551,8 +551,8 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	      "type": "object",
 	      "description": "Content-protection policy applied to this analysis.",
 	      "properties": {
-	        "secrets": { "type": "string", "const": "always", "description": "Mandatory secret-redaction state." },
-	        "privateData": { "type": "string", "enum": ["enabled", "disabled"], "description": "Server-startup private-data redaction state." }
+	        "secrets": { "type": "string", "const": "always" },
+	        "privateData": { "type": "string", "enum": ["enabled", "disabled"], "description": "Server-startup redaction state." }
 	      },
 	      "required": ["secrets", "privateData"],
 	      "additionalProperties": false
@@ -574,7 +574,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	        "type": "object",
 	        "properties": {
 	          "path": { "type": "string", "description": "Project-relative file path." },
-	          "tokens": { "type": "integer", "description": "Estimated tokens for this file." },
+	          "tokens": { "type": "integer", "description": "Estimated tokens." },
 	          "estimated": { "type": "boolean", "description": "True when this entry uses size-based metrics instead of inspected transformed content." },
 	          "uninspected": { "type": "boolean", "description": "True when bounded secret inspection could not read this file and its metrics are estimated." }
 	        },
@@ -583,7 +583,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	      }
 	    },
 	    "topFilesTruncated": { "type": "boolean", "description": "True when the aggregate top-files character budget omitted remaining entries." },
-	    "topFilesRemaining": { "type": "integer", "minimum": 0, "description": "Number of requested top-file entries omitted by the aggregate character budget." }
+	    "topFilesRemaining": { "type": "integer", "minimum": 0, "description": "Requested top-file entries omitted by the aggregate character budget." }
 	  },
 	  "required": ["files", "characters", "tokens", "detail", "contentMetrics", "documentMetrics", "exclusions", "protection", "topFiles", "topFilesTruncated", "topFilesRemaining"],
 	  "additionalProperties": false

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -265,20 +265,19 @@ open-world.
 ### What a connection costs
 
 Before a client asks anything about a project it has already paid for the tool schemas and the
-server instructions. Measured on 2026-09-11 against the built application:
+server instructions. Measured on 2026-09-11 from the characters a client received:
 
 | Payload | Characters |
 |---|---:|
-| `tools/list` result, default server | 33,981 |
-| `tools/list` result, `--allow-agent-exclusions` | 37,869 |
-| `initialize` result | 1,223 |
-| of which `instructions` | 1,044 |
+| `tools/list` result, default server | 35,176 |
+| `tools/list` result, `--allow-agent-exclusions` | 39,094 |
+| `instructions` | 1,044 |
 
-`analyze` is the largest single tool at 8,325 characters: 4,545 of output schema, 3,076 of input
-schema, and 482 of description. The `exclusions` parameter costs a flat 3,888 characters, 648 on
-each of the six tools that take it. A process test holds both `tools/list` shapes and the
-instructions under explicit ceilings with deliberate headroom, so a new parameter or description
-has to fit a budget rather than grow one silently.
+`analyze` is the largest single tool at 9,219 characters, most of it schema. The `exclusions`
+parameter costs a flat 3,918 characters, 653 on each of the six tools that take it. A process
+test holds the default `tools/list` result and the instructions under ceilings with deliberate
+headroom, and pins the exclusion parameter's cost as an exact difference, so a new parameter or
+description has to fit a budget rather than grow one silently.
 
 | Tool | Parameters | Result and limits |
 |---|---|---|

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -262,6 +262,24 @@ non-idempotent because either may create a stored result with a new session id. 
 closed-world; with it, the six tools that accept `project` Git URLs are annotated
 open-world.
 
+### What a connection costs
+
+Before a client asks anything about a project it has already paid for the tool schemas and the
+server instructions. Measured on 2026-09-11 against the built application:
+
+| Payload | Characters |
+|---|---:|
+| `tools/list` result, default server | 33,981 |
+| `tools/list` result, `--allow-agent-exclusions` | 37,869 |
+| `initialize` result | 1,223 |
+| of which `instructions` | 1,044 |
+
+`analyze` is the largest single tool at 8,325 characters: 4,545 of output schema, 3,076 of input
+schema, and 482 of description. The `exclusions` parameter costs a flat 3,888 characters, 648 on
+each of the six tools that take it. A process test holds both `tools/list` shapes and the
+instructions under explicit ceilings with deliberate headroom, so a new parameter or description
+has to fit a budget rather than grow one silently.
+
 | Tool | Parameters | Result and limits |
 |---|---|---|
 | `list_projects` | none | First-call session inventory: allowed local roots with path, name, type, and profiles, plus the server `baseline`. The profile database is read once per call and `profilesStatus` reports an unavailable bounded read. The baseline reports secret/private-data policy and the optional remote-host allowlist. A project tool accepts either a unique listed name or its absolute path. Remote projects are addressed by URL and are not added to this list. |

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -225,6 +225,7 @@ public sealed class DocumentationAndPackagingContractTests
 		var normalizedSecurity = Regex.Replace(security, @"\s+", " ");
 
 		Assert.Contains("### Service notices repeat only when they change", server, StringComparison.Ordinal);
+		Assert.Contains("### What a connection costs", server, StringComparison.Ordinal);
 		Assert.Contains(
 			"`[Unchanged] filters, protection; see list_projects.`",
 			normalizedServer,

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.ConnectionPayload.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.ConnectionPayload.cs
@@ -1,0 +1,100 @@
+using ModelContextProtocol.Client;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	// Every client pays this on connect, before it asks the server anything about a project, and it
+	// grows with each added parameter and description. The ceilings are deliberate headroom over a
+	// recorded measurement, not the measurement itself: a ceiling with a few characters to spare is
+	// a tripwire for the next honest addition rather than a budget.
+	//
+	// Recorded on 2026-09-11 against the built application: tools/list result 33,981 characters on
+	// a default server and 37,869 on a delegation server, initialize result 1,223 of which
+	// instructions are 1,044. The exclusion parameter costs a flat 3,888 characters.
+	private const int ToolsListResultCeiling = 38_000;
+	private const int ToolsListResultFloor = 30_000;
+	private const int DelegationToolsListResultCeiling = 42_000;
+	private const int DelegationToolsListResultFloor = 34_000;
+	private const int InstructionsCeiling = 1_400;
+	private const int InstructionsFloor = 800;
+
+	[Fact]
+	public async Task RealProcessKeepsTheConnectionPayloadInsideItsBudget()
+	{
+		var (defaultPayload, instructions) = await MeasureConnectionPayloadAsync([]);
+		Assert.InRange(defaultPayload, ToolsListResultFloor, ToolsListResultCeiling);
+		Assert.InRange(instructions.Length, InstructionsFloor, InstructionsCeiling);
+
+		// A delegation server publishes the exclusion parameter on six tools and is the larger
+		// payer, so it carries its own ceiling rather than riding on the default one.
+		var (delegationPayload, delegationInstructions) =
+			await MeasureConnectionPayloadAsync(["--allow-agent-exclusions"]);
+		Assert.InRange(
+			delegationPayload,
+			DelegationToolsListResultFloor,
+			DelegationToolsListResultCeiling);
+		Assert.Equal(instructions, delegationInstructions);
+	}
+
+	private static async Task<(int ToolsListResultCharacters, string Instructions)>
+		MeasureConnectionPayloadAsync(IReadOnlyList<string> additionalArguments)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/App.cs", "internal sealed class App;\n");
+		var (process, client, errorTask, output) =
+			await StartPublishedMcpAsync(workspace, project, additionalArguments);
+		string instructions;
+		int payload;
+		try
+		{
+			instructions = Assert.IsType<string>(client.ServerInstructions);
+			var tools = await client.ListToolsAsync(options: null, TestContext.Current.CancellationToken);
+			Assert.Equal(ExpectedTools, tools.Select(static tool => tool.Name));
+			payload = ReadToolsListResult(output.GetRecordedText()).Length;
+		}
+		finally
+		{
+			process.StandardInput.Close();
+			await client.DisposeAsync();
+		}
+
+		await CompletePublishedMcpAsync(process, errorTask, output);
+		return (payload, instructions);
+	}
+
+	/// <summary>
+	/// The serialized <c>result</c> of the tools/list response exactly as the client received it,
+	/// so the budget measures delivered characters rather than a re-serialization of them.
+	/// </summary>
+	private static string ReadToolsListResult(string recordedSession)
+	{
+		foreach (var line in recordedSession
+			.ReplaceLineEndings("\n")
+			.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+		{
+			JsonDocument document;
+			try
+			{
+				document = JsonDocument.Parse(line);
+			}
+			catch (JsonException)
+			{
+				continue;
+			}
+
+			using (document)
+			{
+				if (document.RootElement.TryGetProperty("result", out var result) &&
+				    result.TryGetProperty("tools", out _))
+				{
+					return result.GetRawText();
+				}
+			}
+		}
+
+		Assert.Fail("The recorded session carries no tools/list result.");
+		return string.Empty;
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.ConnectionPayload.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.ConnectionPayload.cs
@@ -9,15 +9,20 @@ public sealed partial class McpServerProcessTests
 	// recorded measurement, not the measurement itself: a ceiling with a few characters to spare is
 	// a tripwire for the next honest addition rather than a budget.
 	//
-	// Recorded on 2026-09-11 against the built application: tools/list result 33,981 characters on
-	// a default server and 37,869 on a delegation server, initialize result 1,223 of which
-	// instructions are 1,044. The exclusion parameter costs a flat 3,888 characters.
-	private const int ToolsListResultCeiling = 38_000;
-	private const int ToolsListResultFloor = 30_000;
-	private const int DelegationToolsListResultCeiling = 42_000;
-	private const int DelegationToolsListResultFloor = 34_000;
-	private const int InstructionsCeiling = 1_400;
-	private const int InstructionsFloor = 800;
+	// Recorded on 2026-09-11 from the characters the client received: tools/list result 35,176 on a
+	// default server, 39,094 on a delegation server, and 1,044 of instructions.
+	//
+	// The headroom is sized from the additions already planned — one packing parameter and one
+	// symbol-addressed read — not from a round number: roughly two thousand characters each way,
+	// enough for both and far short of a schema-sized addition. A delegation server is the larger
+	// payer, but its excess over a default server is the exclusion parameter and nothing else, so
+	// it is pinned as an exact difference rather than as a second ceiling that could never fire
+	// before the first one.
+	private const int ToolsListResultCeiling = 37_500;
+	private const int ToolsListResultFloor = 33_000;
+	private const int ExclusionsParameterCost = 3_918;
+	private const int InstructionsCeiling = 1_200;
+	private const int InstructionsFloor = 900;
 
 	[Fact]
 	public async Task RealProcessKeepsTheConnectionPayloadInsideItsBudget()
@@ -26,14 +31,12 @@ public sealed partial class McpServerProcessTests
 		Assert.InRange(defaultPayload, ToolsListResultFloor, ToolsListResultCeiling);
 		Assert.InRange(instructions.Length, InstructionsFloor, InstructionsCeiling);
 
-		// A delegation server publishes the exclusion parameter on six tools and is the larger
-		// payer, so it carries its own ceiling rather than riding on the default one.
+		// A delegation server publishes the exclusion parameter on six tools and pays for nothing
+		// else, so the whole difference is that parameter. Pinning it exactly reports a growing
+		// parameter by name instead of waiting for a total to cross a line.
 		var (delegationPayload, delegationInstructions) =
 			await MeasureConnectionPayloadAsync(["--allow-agent-exclusions"]);
-		Assert.InRange(
-			delegationPayload,
-			DelegationToolsListResultFloor,
-			DelegationToolsListResultCeiling);
+		Assert.Equal(ExclusionsParameterCost, delegationPayload - defaultPayload);
 		Assert.Equal(instructions, delegationInstructions);
 	}
 

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -335,7 +335,7 @@ public sealed partial class McpServerProcessTests
 			clientPhase.Token))
 		{
 			var instructions = Assert.IsType<string>(client.ServerInstructions);
-			Assert.InRange(instructions.Length, 600, 1_060);
+			Assert.InRange(instructions.Length, InstructionsFloor, InstructionsCeiling);
 			Assert.Contains("list_projects", instructions, StringComparison.Ordinal);
 			Assert.Contains("pack_context", instructions, StringComparison.Ordinal);
 			Assert.Contains("DEVPROJEX_REDACTED[<category>#<n>]", instructions, StringComparison.Ordinal);


### PR DESCRIPTION
Closes #349.

A client pays for tool schemas and server instructions on every connection, before it asks
anything about a project. Nothing measured that, and the one component that had a bound —
`instructions` — sat sixteen characters under it.

## What it costs

Measured from the characters the client received, not from a re-serialization of them:

| Payload | Characters |
|---|---:|
| `tools/list` result, default server | 35,176 |
| `tools/list` result, `--allow-agent-exclusions` | 39,094 |
| `instructions` | 1,044 |

`analyze` is the largest single tool at 9,219 characters. The `exclusions` parameter costs a
flat 3,918, which is 653 on each of the six tools that take it.

## The budget

`RealProcessKeepsTheConnectionPayloadInsideItsBudget` drives the built application through a
real handshake and reads the recorded `tools/list` result, so it measures delivered characters.

- The default `tools/list` result must stay within 33,000–37,500. The headroom is sized from
  the additions already planned — one packing parameter and one symbol-addressed read — rather
  than rounded: about 2,300 characters, enough for both and far short of a schema-sized
  addition.
- `instructions` must stay within 900–1,200. The previous 600–1,060 left sixteen characters on
  a 1,044-character string, which is a tripwire rather than a budget; 1,200 leaves room for one
  sentence and not for a paragraph.
- A delegation server pays the default payload plus the exclusion parameter and nothing else,
  so its cost is pinned as an exact difference. A second ceiling four thousand characters above
  the first could never fire before it, and the matching floor could only ever fire after it;
  an exact difference names a growing parameter instead of waiting for a total to cross a line.

Both directions are checked by mutation rather than assumed: a 2,560-character description
added to the schema fails the ceiling, and the earlier, looser 38,000 ceiling was re-checked
the same way before it was tightened.

## The schema

Seven nested descriptions in the `analyze` output schema restated their own property name, or
the name plus the parent object's description, and eight more led with that restatement before
the part that carried information. The schema goes from 5,176 to 4,626 characters with no
property, type, constant, enum, minimum, required entry, or `additionalProperties` flag
touched — the two schemas are byte-identical once every `description` is stripped.

Nothing was dropped that a caller needs: every unit, bound, normalization claim,
measured-versus-estimated distinction, optionality claim and cross-field relationship stays.
Two trims were reverted for exactly that reason — `contentMetrics.estimated.files`
shortened to "Text files." reads as the count of all text files rather than the estimated
subset, and removing the mandatory-redaction sentence from `protection.secrets` would have left
the same field documented in the `list_projects` schema and undocumented in this one.

The statement that `get_file` has a batched read form, and the statement that `search_project`
matches content rather than paths, are both untouched; neither lives in the `analyze` surface.

## Local results

`-c Release` on Windows: documentation and payload contract tests 33 passed, 0 failed; the MCP
tool-annotation schema tests 2 passed; `McpServerIntegrationTests` 181 passed, 0 failed, 5
skipped.
