### PR TITLE
fix(mcp): answer a file-name lookup and name what emptied a selection

### DIFF
--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -216,7 +216,7 @@ internal sealed class DevProjexMcpTools(
 					new McpSelectionNoticeContext(
 						HasPaths: HasItems(paths),
 						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns),
-				HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)))));
+						HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)))));
 		}, cancellationToken);
 
 	[Description(
@@ -807,7 +807,7 @@ internal sealed class DevProjexMcpTools(
 					new McpSelectionNoticeContext(
 						HasPaths: HasItems(paths),
 						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns),
-				HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)))));
+						HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)))));
 		}, cancellationToken);
 
 	[Description(
@@ -1345,14 +1345,15 @@ internal sealed class DevProjexMcpTools(
 
 	private static bool HasItems<T>(IReadOnlyCollection<T>? items) => items is { Count: > 0 };
 
-	// A pattern without '/' can only match a file directly in the project root, because a pattern is
-	// matched against the whole project-relative path. That is the shape a caller types when all
-	// they know is a file name, so an empty result deserves the concrete rewrite rather than the
-	// general rule.
+	// A pattern is matched against the whole project-relative path, and without '/' every remaining
+	// wildcard stays inside one segment, so such a pattern can only match a file directly in the
+	// project root. '**' is the exception: it spans separators even without a trailing '/', so a
+	// pattern carrying it already reaches any depth and must not be offered the same rewrite.
 	private static bool HasRootOnlyPattern(IReadOnlyList<string>? includePatterns) =>
 		includePatterns?.Any(static pattern =>
 			!string.IsNullOrWhiteSpace(pattern) &&
-			!pattern.Contains('/', StringComparison.Ordinal)) == true;
+			!pattern.Contains('/', StringComparison.Ordinal) &&
+			!pattern.Contains("**", StringComparison.Ordinal)) == true;
 
 	// The exclusions argument exists only on servers started with --allow-agent-exclusions;
 	// everywhere else the allowlist rejects it, so a default server keeps the

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -215,7 +215,8 @@ internal sealed class DevProjexMcpTools(
 					includeFilters: true,
 					new McpSelectionNoticeContext(
 						HasPaths: HasItems(paths),
-						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns)))));
+						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns),
+				HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)))));
 		}, cancellationToken);
 
 	[Description(
@@ -799,14 +800,14 @@ internal sealed class DevProjexMcpTools(
 				inspectionBudgetReached
 					? "[Search incomplete] The inspected-text byte budget was reached; additional selected files were not searched and match counts are partial."
 					: null,
-				resultGroupTruncated ? "[Search group truncated at the response character limit.]" : null,
 				resultGroupTruncated ? SearchContentCapNotice : null,
 				SelectionNotices(
 					plan,
 					includeFilters: false,
 					new McpSelectionNoticeContext(
 						HasPaths: HasItems(paths),
-						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns)))));
+						HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns),
+				HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)))));
 		}, cancellationToken);
 
 	[Description(
@@ -859,7 +860,8 @@ internal sealed class DevProjexMcpTools(
 			var configurationData = FormatDependencyConfigurationData(coverage.ConfigurationDiagnostics);
 			var selectionContext = new McpSelectionNoticeContext(
 				HasPaths: false,
-				HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns));
+				HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns),
+				HasRootOnlyPattern: HasRootOnlyPattern(includePatterns));
 			var noRelatedNotice = resolution.Resolved == 0
 				? resolution.Unresolved == 0
 					? "[No related files] in the effective selection."
@@ -1278,7 +1280,8 @@ internal sealed class DevProjexMcpTools(
 			plan,
 			new McpSelectionNoticeContext(
 				HasPaths: HasItems(paths),
-				HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns)));
+				HasPatterns: HasItems(includePatterns) || HasItems(excludePatterns),
+				HasRootOnlyPattern: HasRootOnlyPattern(includePatterns)));
 	}
 
 	private string? SelectionNotices(
@@ -1341,6 +1344,15 @@ internal sealed class DevProjexMcpTools(
 	}
 
 	private static bool HasItems<T>(IReadOnlyCollection<T>? items) => items is { Count: > 0 };
+
+	// A pattern without '/' can only match a file directly in the project root, because a pattern is
+	// matched against the whole project-relative path. That is the shape a caller types when all
+	// they know is a file name, so an empty result deserves the concrete rewrite rather than the
+	// general rule.
+	private static bool HasRootOnlyPattern(IReadOnlyList<string>? includePatterns) =>
+		includePatterns?.Any(static pattern =>
+			!string.IsNullOrWhiteSpace(pattern) &&
+			!pattern.Contains('/', StringComparison.Ordinal)) == true;
 
 	// The exclusions argument exists only on servers started with --allow-agent-exclusions;
 	// everywhere else the allowlist rejects it, so a default server keeps the

--- a/Apps/Mcp/McpEffectiveFilters.cs
+++ b/Apps/Mcp/McpEffectiveFilters.cs
@@ -2,9 +2,15 @@ using System.Globalization;
 
 namespace DevProjex.Mcp;
 
+/// <param name="HasRootOnlyPattern">
+/// Whether an include pattern carries no <c>/</c>, so it can only match a file that sits directly
+/// in the project root. It is the shape a caller reaches for when all they know is a file name,
+/// and the one that silently returns nothing.
+/// </param>
 internal readonly record struct McpSelectionNoticeContext(
 	bool HasPaths,
-	bool HasPatterns);
+	bool HasPatterns,
+	bool HasRootOnlyPattern = false);
 
 /// <summary>
 /// The effective-filter footer and, when nothing survived, the explanation of the empty result.
@@ -21,14 +27,21 @@ internal static class McpEffectiveFilters
 {
 	public const string StartupFlags = "--exclude, --unrestricted, --allow-agent-exclusions";
 
+	// Each notice opens with the stage that emptied the selection, as a constant token, so a caller
+	// can tell "narrow your pattern" from "this server hides it" without a second call. The stage is
+	// the proximate one the server can name; overlapping narrowing is reported as the request
+	// argument that was applied, not as a claim about which one removed the last file.
 	private const string PatternSelectionEmptyNotice =
-		"[Empty selection] No file passed the effective filters and the request arguments. " +
-		"Patterns match the whole project-relative path: '*' stays inside one segment, '**/' spans any depth; " +
+		"[Empty selection] stage=patterns. No file matched the request patterns inside the effective " +
+		"filters. Patterns match the whole project-relative path: '*' stays inside one segment, '**/' spans any depth; " +
 		"paths the filters hide never match.";
+	private const string RootOnlyPatternSelectionEmptyNotice =
+		"[Empty selection] stage=patterns. A pattern without '/' matches only a file directly in the " +
+		"project root; prefix it with '**/' to match that name at any depth. Paths the filters hide never match.";
 	private const string PathSelectionEmptyNotice =
-		"[Empty selection] None of the requested paths is in the effective selection; paths the filters hide never match.";
+		"[Empty selection] stage=paths. None of the requested paths is in the effective selection; paths the filters hide never match.";
 	private const string ProjectSelectionEmptyNotice =
-		"[Empty selection] The effective filters leave no file in this project.";
+		"[Empty selection] stage=filters. The effective filters leave no file in this project.";
 
 	public static string Describe(ProjectContextPlan plan)
 	{
@@ -87,7 +100,11 @@ internal static class McpEffectiveFilters
 		McpSelectionNoticeContext request)
 	{
 		if (request.HasPatterns)
-			return PatternSelectionEmptyNotice;
+		{
+			return request.HasRootOnlyPattern
+				? RootOnlyPatternSelectionEmptyNotice
+				: PatternSelectionEmptyNotice;
+		}
 
 		var gitMode = plan.Selection.GitMode ?? GitFilteringMode.None;
 		var isGitNarrowing = gitMode is GitFilteringMode.TrackedFilesOnly or
@@ -98,7 +115,7 @@ internal static class McpEffectiveFilters
 			return PathSelectionEmptyNotice;
 		if (isGitNarrowing)
 		{
-			return $"[Empty selection] Git reports no files for this scope (git: {ProjectSelectionTokens.ToToken(plan.Selection)}).";
+			return $"[Empty selection] stage=git-scope. Git reports no files for this scope (git: {ProjectSelectionTokens.ToToken(plan.Selection)}).";
 		}
 
 		return ProjectSelectionEmptyNotice;

--- a/Apps/Mcp/McpEffectiveFilters.cs
+++ b/Apps/Mcp/McpEffectiveFilters.cs
@@ -32,12 +32,13 @@ internal static class McpEffectiveFilters
 	// the proximate one the server can name; overlapping narrowing is reported as the request
 	// argument that was applied, not as a claim about which one removed the last file.
 	private const string PatternSelectionEmptyNotice =
-		"[Empty selection] stage=patterns. No file matched the request patterns inside the effective " +
-		"filters. Patterns match the whole project-relative path: '*' stays inside one segment, '**/' spans any depth; " +
+		"[Empty selection] stage=patterns. No file passed the effective filters and the request patterns. " +
+		"Patterns match the whole project-relative path: '*' stays inside one segment, '**/' spans any depth; " +
 		"paths the filters hide never match.";
 	private const string RootOnlyPatternSelectionEmptyNotice =
-		"[Empty selection] stage=patterns. A pattern without '/' matches only a file directly in the " +
-		"project root; prefix it with '**/' to match that name at any depth. Paths the filters hide never match.";
+		"[Empty selection] stage=patterns. A pattern with no '/' and no '**' matches only an entry directly " +
+		"in the project root; prefix it with '**/' to match that name at any depth, or append '/**' to select " +
+		"a directory's files. Paths the filters hide never match.";
 	private const string PathSelectionEmptyNotice =
 		"[Empty selection] stage=paths. None of the requested paths is in the effective selection; paths the filters hide never match.";
 	private const string ProjectSelectionEmptyNotice =

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -411,9 +411,9 @@ tool adds an `[Empty selection]` line when no file survived the
 filters and the request arguments. That line opens with the stage that emptied the
 selection as a constant token — `stage=patterns`, `stage=paths`, `stage=git-scope`,
 or `stage=filters` — so a caller can tell a pattern that matched nothing from a
-server that hides the file, without a second call. A pattern without `/` matches
-only a file directly in the project root, and its empty result names the `**/`
-rewrite instead of restating the general rule. `search_project` adds a `[No matches]` line
+server that hides the file, without a second call. A pattern with no `/` and no
+`**` matches only an entry directly in the project root, and its empty result
+names the `**/` and `/**` rewrites instead of restating the general rule. `search_project` adds a `[No matches]` line
 with the searched-file count when the pattern matched nothing, and a
 `DPX-MCP-PATH-NOT-FOUND` error for a filtered file names the effective filters
 and the party able to widen them — the startup line, or a per-call `exclusions`

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -408,7 +408,12 @@ follow it, `[Protection]` comes after that, a pinned remote checkout adds
 `max_file_bytes` is supplied, every tool that accepts it also reports
 `; max_file_bytes: <bytes>` in its effective-filter diagnostics. Every selection
 tool adds an `[Empty selection]` line when no file survived the
-filters and the request arguments, `search_project` adds a `[No matches]` line
+filters and the request arguments. That line opens with the stage that emptied the
+selection as a constant token — `stage=patterns`, `stage=paths`, `stage=git-scope`,
+or `stage=filters` — so a caller can tell a pattern that matched nothing from a
+server that hides the file, without a second call. A pattern without `/` matches
+only a file directly in the project root, and its empty result names the `**/`
+rewrite instead of restating the general rule. `search_project` adds a `[No matches]` line
 with the searched-file count when the pattern matched nothing, and a
 `DPX-MCP-PATH-NOT-FOUND` error for a filtered file names the effective filters
 and the party able to widen them — the startup line, or a per-call `exclusions`
@@ -474,9 +479,9 @@ the final text; only those ranges are excluded from pattern matches. Placeholder
 source text, including an unfinished `DEVPROJEX_REDACTED[` prefix, remains searchable.
 The search is streamed: no intermediate export is written or read. Context windows that overlap or touch
 are emitted once as a merged grep-style group, with `--` between separate groups.
-If the response character limit cuts a group, only matching lines whose complete
+If the search cap below cuts a group, only matching lines whose complete
 prefix, text, and line ending were written count as shown; the remaining count is
-exact and `[Search group truncated at the response character limit.]` marks the partial group.
+exact, and the `[Search truncated]` line names the cap that stopped it.
 
 The match text a `search_project` call returns is capped at 16,000 characters, well
 below the general 50,000-character response limit, because a wide alternation with

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -188,13 +188,26 @@ public sealed class McpServerIntegrationTests
 		var tree = Text(await server.CallAsync("get_tree", rootOnly));
 		Assert.DoesNotContain("Nested.cs", tree, StringComparison.Ordinal);
 		Assert.Contains("[Effective filters] git: gitignore; exclusions: smart-ignore, empty-folders.", tree, StringComparison.Ordinal);
-		Assert.Contains("[Empty selection] stage=patterns. A pattern without '/' matches only a file directly in the project root; prefix it with '**/' to match that name at any depth. Paths the filters hide never match.", tree, StringComparison.Ordinal);
+		Assert.Contains("[Empty selection] stage=patterns. A pattern with no '/' and no '**' matches only an entry directly in the project root; prefix it with '**/' to match that name at any depth, or append '/**' to select a directory's files. Paths the filters hide never match.", tree, StringComparison.Ordinal);
 
-		// A pattern that already spans depth gets the general rule, not the rewrite.
-		var anchored = new Dictionary<string, object?> { ["include_patterns"] = new[] { "**/*.txt" } };
-		var anchoredTree = Text(await server.CallAsync("get_tree", anchored));
-		Assert.Contains("[Empty selection] stage=patterns. No file matched the request patterns inside the effective filters.", anchoredTree, StringComparison.Ordinal);
-		Assert.DoesNotContain("prefix it with", anchoredTree, StringComparison.Ordinal);
+		// A pattern that already spans depth gets the general rule, not the rewrite. '**' spans
+		// separators even without a trailing '/', so carrying it is what decides, not the '/'.
+		foreach (var spanning in new[] { "**/*.txt", "**Absent.cs" })
+		{
+			var spanningTree = Text(await server.CallAsync(
+				"get_tree",
+				new Dictionary<string, object?> { ["include_patterns"] = new[] { spanning } }));
+			Assert.Contains("[Empty selection] stage=patterns. No file passed the effective filters and the request patterns.", spanningTree, StringComparison.Ordinal);
+			Assert.DoesNotContain("prefix it with", spanningTree, StringComparison.Ordinal);
+		}
+
+		// An exclude-only call removed every file rather than failing to match one, so the line
+		// must not claim that nothing matched the request.
+		var excludeOnly = Text(await server.CallAsync(
+			"get_tree",
+			new Dictionary<string, object?> { ["exclude_patterns"] = new[] { "**/*.cs" } }));
+		Assert.Contains("[Empty selection] stage=patterns. No file passed the effective filters and the request patterns.", excludeOnly, StringComparison.Ordinal);
+		Assert.DoesNotContain("prefix it with", excludeOnly, StringComparison.Ordinal);
 
 		var analysis = await server.CallAsync("analyze", rootOnly);
 		Assert.Equal(0, analysis.StructuredContent?.GetProperty("files").GetInt32());

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -182,13 +182,19 @@ public sealed class McpServerIntegrationTests
 		File.WriteAllText(Path.Combine(project, "src", "Nested.cs"), "nested-marker\n");
 		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
 
-		// '*' stays inside one segment, so a root-level pattern misses a nested file: the
-		// empty result carries the rule instead of reading as "no C# files here".
+		// '*' stays inside one segment, so a pattern without '/' misses a nested file: the empty
+		// result names the stage and the rewrite instead of reading as "no C# files here".
 		var rootOnly = new Dictionary<string, object?> { ["include_patterns"] = new[] { "*.cs" } };
 		var tree = Text(await server.CallAsync("get_tree", rootOnly));
 		Assert.DoesNotContain("Nested.cs", tree, StringComparison.Ordinal);
 		Assert.Contains("[Effective filters] git: gitignore; exclusions: smart-ignore, empty-folders.", tree, StringComparison.Ordinal);
-		Assert.Contains("[Empty selection] No file passed the effective filters and the request arguments. Patterns match the whole project-relative path: '*' stays inside one segment, '**/' spans any depth; paths the filters hide never match.", tree, StringComparison.Ordinal);
+		Assert.Contains("[Empty selection] stage=patterns. A pattern without '/' matches only a file directly in the project root; prefix it with '**/' to match that name at any depth. Paths the filters hide never match.", tree, StringComparison.Ordinal);
+
+		// A pattern that already spans depth gets the general rule, not the rewrite.
+		var anchored = new Dictionary<string, object?> { ["include_patterns"] = new[] { "**/*.txt" } };
+		var anchoredTree = Text(await server.CallAsync("get_tree", anchored));
+		Assert.Contains("[Empty selection] stage=patterns. No file matched the request patterns inside the effective filters.", anchoredTree, StringComparison.Ordinal);
+		Assert.DoesNotContain("prefix it with", anchoredTree, StringComparison.Ordinal);
 
 		var analysis = await server.CallAsync("analyze", rootOnly);
 		Assert.Equal(0, analysis.StructuredContent?.GetProperty("files").GetInt32());
@@ -219,7 +225,7 @@ public sealed class McpServerIntegrationTests
 			new Dictionary<string, object?> { ["paths"] = new[] { ".hidden.cs" } });
 		Assert.Equal(0, pathSelection.StructuredContent?.GetProperty("files").GetInt32());
 		Assert.Contains(
-			"[Empty selection] None of the requested paths is in the effective selection; paths the filters hide never match.",
+			"[Empty selection] stage=paths. None of the requested paths is in the effective selection; paths the filters hide never match.",
 			AllText(pathSelection),
 			StringComparison.Ordinal);
 
@@ -244,7 +250,7 @@ public sealed class McpServerIntegrationTests
 			"get_tree",
 			new Dictionary<string, object?> { ["tracked_only"] = true }));
 		Assert.Contains(
-			"[Empty selection] Git reports no files for this scope (git: tracked).",
+			"[Empty selection] stage=git-scope. Git reports no files for this scope (git: tracked).",
 			gitSelection,
 			StringComparison.Ordinal);
 
@@ -252,7 +258,7 @@ public sealed class McpServerIntegrationTests
 		await using var emptyServer = await McpTestServer.StartAsync(emptyProject, workspace.Path);
 		var projectSelection = Text(await emptyServer.CallAsync("get_tree"));
 		Assert.Contains(
-			"[Empty selection] The effective filters leave no file in this project.",
+			"[Empty selection] stage=filters. The effective filters leave no file in this project.",
 			projectSelection,
 			StringComparison.Ordinal);
 	}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.FileLookup.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.FileLookup.cs
@@ -1,0 +1,71 @@
+using ModelContextProtocol.Client;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	/// <summary>
+	/// The two things a caller does when they know a name and not a path: list one directory, and
+	/// look the name up. Both are driven through a real server process, because the value of the
+	/// second is the trusted line a caller reads when the lookup returns nothing.
+	/// </summary>
+	[Fact]
+	public async Task RealProcessListsOneSubdirectoryAndAnswersAFileNameLookup()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		workspace.WriteFile("project/src/models/Target.cs", "internal sealed class Target;\n");
+		workspace.WriteFile("project/src/models/Neighbour.cs", "internal sealed class Neighbour;\n");
+		workspace.WriteFile("project/src/Elsewhere.cs", "internal sealed class Elsewhere;\n");
+		workspace.WriteFile("project/RootLevel.cs", "internal sealed class RootLevel;\n");
+		var (process, client, errorTask, output) = await StartPublishedMcpAsync(workspace, project, []);
+		try
+		{
+			// One call lists exactly the requested subdirectory.
+			var subdirectory = await CallTreeAsync(client, "paths", ["src/models"]);
+			Assert.Contains("Target.cs", subdirectory, StringComparison.Ordinal);
+			Assert.Contains("Neighbour.cs", subdirectory, StringComparison.Ordinal);
+			Assert.DoesNotContain("Elsewhere.cs", subdirectory, StringComparison.Ordinal);
+			Assert.DoesNotContain("RootLevel.cs", subdirectory, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Empty selection]", subdirectory, StringComparison.Ordinal);
+
+			// The shape a caller reaches for with only a name returns nothing, and says what to
+			// send instead rather than restating the glob rule.
+			var bareName = await CallTreeAsync(client, "include_patterns", ["Target.cs"]);
+			Assert.DoesNotContain("Target.cs\n", bareName, StringComparison.Ordinal);
+			Assert.Contains("[Empty selection] stage=patterns.", bareName, StringComparison.Ordinal);
+			Assert.Contains(
+				"prefix it with '**/' to match that name at any depth",
+				bareName,
+				StringComparison.Ordinal);
+
+			// The rewrite the line names finds the file.
+			var rewritten = await CallTreeAsync(client, "include_patterns", ["**/Target.cs"]);
+			Assert.Contains("Target.cs", rewritten, StringComparison.Ordinal);
+			Assert.DoesNotContain("Neighbour.cs", rewritten, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Empty selection]", rewritten, StringComparison.Ordinal);
+		}
+		finally
+		{
+			process.StandardInput.Close();
+			await client.DisposeAsync();
+		}
+
+		await CompletePublishedMcpAsync(process, errorTask, output);
+	}
+
+	private static async Task<string> CallTreeAsync(
+		McpClient client,
+		string argument,
+		string[] values)
+	{
+		var result = await client.CallToolAsync(
+			"get_tree",
+			new Dictionary<string, object?> { [argument] = values },
+			progress: null,
+			options: null,
+			TestContext.Current.CancellationToken);
+		Assert.NotEqual(true, result.IsError);
+		return AllProcessText(result);
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchAccounting.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchAccounting.cs
@@ -155,7 +155,10 @@ public sealed partial class McpServerProcessTests
 		Assert.True(
 			shown + additional == 200,
 			$"shown={shown}, additional={additional}\n{text[^Math.Min(text.Length, 2_000)..]}");
-		Assert.Contains("[Search group truncated at the response character limit.]", text, StringComparison.Ordinal);
+		// One condition, one notice, naming the cap that actually stopped the output.
+		Assert.Contains("[Search truncated]", text, StringComparison.Ordinal);
+		Assert.DoesNotContain("response character limit", text, StringComparison.Ordinal);
+		Assert.Single(Regex.Matches(text, @"\[Search truncated\]"));
 		Assert.Contains("😀", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("\uD83D</untrusted-data-", text, StringComparison.Ordinal);
 	}


### PR DESCRIPTION
Part of #346.

Three ergonomics defects, each measured against this repository through a real server process
before anything was changed.

## One notice per condition

`search_project` emitted two trusted notices on the same flag, and the first named the response
character limit:

```
[Search group truncated at the response character limit.]
[Search truncated] The returned text reached the 16000-character search cap. Narrow the pattern,
add paths or include_patterns, or lower context_lines.
```

The flag is set where a match group hits `MaximumSearchContentCharacters`, which is the
16,000-character cap on returned match text, not a response-size limit. One statement sets the
flag, so the two lines could never diverge. The first is removed; the second already names the
limit that fired and what to do about it. `Docs/McpServer.md` repeated the wrong limit name in
its own prose and is corrected with it.

## A file-name lookup answers instead of returning nothing

Measured on this tip, of six natural spellings of "find the file called
`RepositoryUrlUtility.cs`" through `get_tree`, three return an empty tree:

| form | result |
|---|---|
| `include_patterns: ["RepositoryUrlUtility.cs"]` | empty |
| `include_patterns: ["**/RepositoryUrlUtility.cs"]` | found |
| `include_patterns: ["*RepositoryUrlUtility*"]` | empty |
| `include_patterns: ["Kernel/Models/RepositoryUrlUtility.cs"]` | found |
| `include_patterns: ["RepositoryUrlUtility"]` | empty |
| `include_patterns: ["**/*Repository*"]` | found, 43 files |

The three that fail are the ones a caller reaches for when a name is all they have. `paths`
already lists one subdirectory in a single call, so that half of the ergonomics gap does not
exist.

Making a slash-free pattern match at any depth would change the documented meaning of a glob —
that it is matched against the whole project-relative path — on six tools and on the command
line. The empty answer now carries the rewrite instead: a pattern with no `/` and no `**`
matches only an entry directly in the project root, so the line names both `**/name` and
`name/**`.

## An empty selection names the stage

An empty result said the selection was empty without saying what emptied it. Each
`[Empty selection]` line now opens with a constant token: `stage=patterns`, `stage=paths`,
`stage=git-scope`, or `stage=filters`. No project-controlled text enters the trusted area; the
Git line continues to carry only its selection enum token.

The token names the request argument the server applied, not a claim about which stage removed
the last file. Distinguishing overlapping narrowing — a Git scope and patterns that could each
have emptied the result — would need the planner to report per-stage counts, which this change
does not add. `max_depth` is not among the tokens because it truncates a rendered tree rather
than emptying a selection.

## Coverage

`RealProcessListsOneSubdirectoryAndAnswersAFileNameLookup` drives a real server process: one
call lists exactly one subdirectory, a bare file name returns an empty tree whose trusted line
names the rewrite, and the named rewrite finds the file.

`EmptySelectionsAndEmptySearchesExplainThemselves` pins each stage token, and pins that a
pattern which already spans depth gets the general line rather than the rewrite — for `**/*.txt`
and for `**Absent.cs`, because `**` spans separators even without a trailing `/`. It also pins
that an exclude-only call, where every file matched and the request removed them, is not told
that nothing matched.

`RealProcessBoundsASearchGroupAtTheContentCap` now asserts one truncation notice, that it names
the cap rather than the response limit, and that it appears exactly once.

## Behaviour that did not change

Responses to non-empty tree calls and to searches that do not hit the cap are unchanged: the
new context member is read only inside the empty-selection branch, and the removed notice was
gated on the cap flag.

## Local results

`-c Release` on Windows: `McpServerIntegrationTests` 181 passed, 0 failed, 5 skipped;
`McpServerProcessTests` with the documentation contracts 93 passed, 0 failed, 1 skipped.
