### PR TITLE
feat(dependencies): resolve literal relative specifiers without a compilation config

### DIFF
--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -819,6 +819,9 @@ public sealed class DependencyFactsEngine : IDisposable
 
 	private static string PortableRelative(string root, string path) => Normalize(Path.GetRelativePath(root, path));
 	private static string Normalize(string path) => path.Replace('\\', '/').TrimStart('/');
+	private const string MissingTypeScriptConfigurationReason =
+		"no owning tsconfig.json or jsconfig.json in the manifest";
+
 	private static StringComparer PathComparer => OperatingSystem.IsWindows()
 		? StringComparer.OrdinalIgnoreCase
 		: StringComparer.Ordinal;
@@ -1288,8 +1291,7 @@ public sealed class DependencyFactsEngine : IDisposable
 					import.Reason, []);
 			var scope = FindScope(source.ScopeId);
 			if (scope is null || !scope.HasConfiguration)
-				return Edge(source, import, ResolutionStatus.Unresolved, null,
-					"no owning tsconfig.json or jsconfig.json in the manifest", []);
+				return ResolveTypeScriptImportWithoutConfiguration(source, import);
 			if (ConfigurationFailure(scope) is { } configurationFailure)
 				return Edge(source, import, ResolutionStatus.Unresolved, null, configurationFailure, []);
 			if (FindNearestPackageMap(source) is { ConfigurationState: not DependencyConfigurationState.Valid } packageMap)
@@ -1359,13 +1361,13 @@ public sealed class DependencyFactsEngine : IDisposable
 				"one module target under configured module resolution");
 		}
 
-		private bool SupportsCommonJs(FileFacts source, DependencyScopeDescriptor scope)
+		private bool SupportsCommonJs(FileFacts source, DependencyScopeDescriptor? scope)
 		{
 			var extension = Path.GetExtension(source.Path).ToLowerInvariant();
 			if (extension is ".cjs" or ".cts") return true;
 			if (extension is ".mjs" or ".mts") return false;
 			if (extension is not (".ts" or ".tsx" or ".js" or ".jsx"))
-				return scope.LegacyTypeScriptConfiguration;
+				return scope?.LegacyTypeScriptConfiguration == true;
 			var moduleType = FindNearestPackageMap(source)?.ModuleType;
 			if (string.Equals(moduleType, "commonjs", StringComparison.OrdinalIgnoreCase)) return true;
 			if (string.Equals(moduleType, "module", StringComparison.OrdinalIgnoreCase)) return false;
@@ -1652,6 +1654,96 @@ public sealed class DependencyFactsEngine : IDisposable
 				}
 			}
 			return candidates;
+		}
+
+		/// <summary>
+		/// Index files a relative directory specifier may name. This is the same list, in the same
+		/// order, that a configured project probes, so a directory resolved without configuration is
+		/// always a directory a configured project would have resolved too.
+		/// </summary>
+		private static readonly string[] TypeScriptIndexSuffixes =
+			[".ts", ".tsx", ".d.ts", ".js", ".jsx"];
+
+		/// <summary>
+		/// Suffixes that make a sibling file compete with a directory of the same stem. Choosing
+		/// between <c>util.js</c> and <c>util/index.js</c> is what module resolution settings decide,
+		/// so the presence of any of these leaves the specifier unresolved.
+		/// </summary>
+		private static readonly string[] TypeScriptSiblingSuffixes =
+			[".ts", ".tsx", ".d.ts", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"];
+
+		/// <summary>
+		/// Resolution for a file that no <c>tsconfig.json</c> or <c>jsconfig.json</c> owns. Only what
+		/// the specifier literally names can be proven without configuration: a relative path that is
+		/// itself a manifest file, or a relative directory holding exactly one index file and nothing
+		/// that competes with it. Extension substitution, root and path mapping, package resolution,
+		/// and <c>main</c> or <c>types</c> entry points all need configuration and keep the existing
+		/// unresolved reason.
+		/// </summary>
+		private DependencyEdge ResolveTypeScriptImportWithoutConfiguration(FileFacts source, ImportFact import)
+		{
+			if (!IsExplicitRelativeSpecifier(import.Specifier))
+				return MissingTypeScriptConfiguration(source, import);
+			if (FindNearestPackageMap(source) is { ConfigurationState: not DependencyConfigurationState.Valid })
+				return MissingTypeScriptConfiguration(source, import);
+			if (IsRequire(import) && !SupportsCommonJs(source, scope: null))
+				return MissingTypeScriptConfiguration(source, import);
+			var physical = PhysicalModuleSpecifier(import.Specifier);
+			if (physical.Length == 0)
+				return MissingTypeScriptConfiguration(source, import);
+			var directory = Path.GetDirectoryName(Path.Combine(_root, source.Path));
+			if (directory is null)
+				return MissingTypeScriptConfiguration(source, import);
+			var target = Path.GetFullPath(Path.Combine(directory, physical));
+			if (!IsWithin(_root, target))
+				return MissingTypeScriptConfiguration(source, import);
+			var relative = PortableRelative(_root, target);
+			if (TryGetManifestPath(relative, out var named))
+				return Edge(source, import, ResolutionStatus.Resolved, named,
+					"relative specifier names a file in the manifest", [named]);
+			if (SingleTypeScriptDirectoryIndex(relative) is not { } index)
+				return MissingTypeScriptConfiguration(source, import);
+			return Edge(source, import, ResolutionStatus.Resolved, index,
+				"relative specifier names a directory with one index file", [index]);
+		}
+
+		/// <summary>
+		/// A specifier that names a path relative to the importing file. A bare specifier that merely
+		/// starts with a dot, such as <c>.config/app.js</c>, is a package name and is not relative.
+		/// </summary>
+		private static bool IsExplicitRelativeSpecifier(string specifier) =>
+			specifier is "." or ".." ||
+			specifier.StartsWith("./", StringComparison.Ordinal) ||
+			specifier.StartsWith("../", StringComparison.Ordinal);
+
+		private DependencyEdge MissingTypeScriptConfiguration(FileFacts source, ImportFact import) =>
+			Edge(source, import, ResolutionStatus.Unresolved, null,
+				MissingTypeScriptConfigurationReason, []);
+
+		/// <summary>
+		/// The single <c>index.*</c> file directly inside a manifest directory, or
+		/// <see langword="null"/> when the directory owns a <c>package.json</c>, when a sibling file
+		/// of the same stem competes with it, or when it holds none or more than one index file.
+		/// Each of those is a choice only the configuration could make.
+		/// </summary>
+		private string? SingleTypeScriptDirectoryIndex(string relativeDirectory)
+		{
+			if (_configuration.PackageMaps.ContainsKey(relativeDirectory))
+				return null;
+			foreach (var suffix in TypeScriptSiblingSuffixes)
+				if (TryGetManifestPath(relativeDirectory + suffix, out _))
+					return null;
+			var prefix = relativeDirectory is "." or "" ? string.Empty : relativeDirectory + "/";
+			string? single = null;
+			foreach (var suffix in TypeScriptIndexSuffixes)
+			{
+				if (!TryGetManifestPath(prefix + "index" + suffix, out var candidate))
+					continue;
+				if (single is not null)
+					return null;
+				single = candidate;
+			}
+			return single;
 		}
 
 		private bool TryGetManifestPath(string relative, out string manifestPath)
@@ -2004,7 +2096,7 @@ public sealed class DependencyFactsEngine : IDisposable
 				return Edge(source, reference, ResolutionStatus.Unresolved, null,
 					source.LanguageId == LanguageId.CSharp
 						? "no owning .csproj in the manifest"
-						: "no owning tsconfig.json or jsconfig.json in the manifest", []);
+						: MissingTypeScriptConfigurationReason, []);
 			}
 			if (scope is not null && ConfigurationFailure(scope) is { } configurationFailure)
 				return Edge(source, reference, ResolutionStatus.Unresolved, null, configurationFailure, []);

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -131,8 +131,30 @@ and directory probes. A relative directory containing `package.json` stays unres
 When `moduleResolution` is absent, `module: node16` or `module: nodenext` selects the matching
 resolution mode; other module values keep the existing bundler default.
 `node10`/`node` and `baseUrl` are marked legacy under the TypeScript 7 contract.
-DevProjex never guesses a `dist` to `src` mapping without configuration, and module references without
-an owning `tsconfig.json` or `jsconfig.json` stay unresolved.
+DevProjex never guesses a `dist` to `src` mapping without configuration.
+
+Without an owning `tsconfig.json` or `jsconfig.json`, one narrow capability applies to module
+specifiers. A literal relative specifier, one that starts with `./` or `../`, is resolved when it
+names a file already in the allowed manifest with the exact extension it wrote, such as
+`./util.mjs`, `../lib/x.js`, or `./x.ts`. A relative specifier that names a directory resolves to
+that directory's index file when the manifest holds exactly one of `index.ts`, `index.tsx`,
+`index.d.ts`, `index.js`, and `index.jsx` there. That is the same index list, in the same order,
+that a configured project probes, so an unconfigured project never resolves a directory a
+configured project would refuse.
+
+The directory rule withdraws wherever the answer would depend on configuration: a directory that
+owns a `package.json` stays unresolved because `main` and `types` are not emulated, a directory
+whose stem also names a sibling module such as `util.js` beside `util/index.js` stays unresolved
+because module resolution settings decide that order, and two index files in one directory stay
+unresolved. A `require(...)` call keeps its CommonJS-context rule, and an invalid `package.json`
+above the importing file suppresses resolution exactly as it does with configuration. Everything
+else keeps the reason `no owning tsconfig.json or jsconfig.json in the manifest`: an extensionless
+specifier that names no such directory, a `.js` specifier whose only counterpart is a `.ts` file,
+a path that leaves the project root, a bare specifier including one that merely begins with a dot
+such as `.config/app.js`, a `#imports` specifier, and every form of `paths`, `rootDirs`,
+`moduleSuffixes`, or `package.json` `exports` resolution. This path reads the manifest and the
+package-map boundary only; it substitutes no extension, so it cannot change what a configured
+project resolves.
 
 TypeScript configuration supports a bounded `extends` chain when every value is one explicit relative
 path inside the project root. At most eight inheritance edges are followed; cycles, arrays, package or

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -875,6 +875,195 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task WithoutCompilationConfiguration_ALiteralRelativeSpecifierNamingAManifestFileResolves()
+	{
+		using var fixture = new TemporaryDirectory();
+		var helper = fixture.CreateFile("lib/helper.mjs", "export const helper = 1;");
+		var typed = fixture.CreateFile("lib/typed.ts", "export const typed = 1;");
+		var plain = fixture.CreateFile("plain.js", "export const plain = 1;");
+		var reexport = fixture.CreateFile("lib/reexport.js", "export { typed } from './typed.ts';");
+		var entry = fixture.CreateFile("app/entry.js", """
+			import { helper } from '../lib/helper.mjs';
+			import { typed } from '../lib/typed.ts';
+			import { plain } from '../plain.js';
+			const lazy = await import('../plain.js');
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[helper, typed, plain, reexport, entry],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.All(
+			new[] { "../lib/helper.mjs", "../lib/typed.ts", "../plain.js" },
+			reference => Assert.Contains(
+				result.Edges, edge => edge.Source == "app/entry.js" &&
+					edge.Reference == reference &&
+					edge.Status == ResolutionStatus.Resolved &&
+					edge.Reasons.Contains("relative specifier names a file in the manifest")));
+		// Re-export and dynamic import reach the same rule as a static import.
+		Assert.Contains(result.Edges, edge => edge.Source == "lib/reexport.js" &&
+			edge.Reference == "./typed.ts" && edge.Status == ResolutionStatus.Resolved &&
+			edge.Target == "lib/typed.ts");
+		Assert.Contains(result.Edges, edge => edge.Source == "app/entry.js" &&
+			edge.Reference == "../plain.js" && edge.Target == "plain.js");
+	}
+
+	[Fact]
+	public async Task WithoutCompilationConfiguration_ADirectoryResolvesOnlyWhenOneIndexFileIsUncontested()
+	{
+		using var fixture = new TemporaryDirectory();
+		var single = fixture.CreateFile("single/index.ts", "export const single = 1;");
+		var declaration = fixture.CreateFile("typings/index.d.ts", "export declare const typed: number;");
+		var firstOfTwo = fixture.CreateFile("both/index.ts", "export const both = 1;");
+		var secondOfTwo = fixture.CreateFile("both/index.js", "export const both = 1;");
+		var siblingFile = fixture.CreateFile("util.js", "export const util = 1;");
+		var siblingIndex = fixture.CreateFile("util/index.js", "export const util = 2;");
+		var packaged = fixture.CreateFile("pkg/package.json", "{ \"main\": \"./dist/entry.js\" }");
+		var packagedIndex = fixture.CreateFile("pkg/index.js", "export const pkg = 1;");
+		var entry = fixture.CreateFile("entry.js", """
+			import { single } from './single';
+			import { typed } from './typings';
+			import { both } from './both';
+			import { util } from './util';
+			import { pkg } from './pkg';
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[single, declaration, firstOfTwo, secondOfTwo, siblingFile, siblingIndex, packaged, packagedIndex, entry],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.All(
+			new[]
+			{
+				("./single", "single/index.ts"),
+				("./typings", "typings/index.d.ts")
+			},
+			expected => Assert.Contains(
+				result.Edges, edge => edge.Source == "entry.js" &&
+					edge.Reference == expected.Item1 &&
+					edge.Status == ResolutionStatus.Resolved &&
+					edge.Target == expected.Item2 &&
+					edge.Reasons.Contains("relative specifier names a directory with one index file")));
+		// Two index files, a sibling module of the same stem, and a directory that owns
+		// package.json are all choices only the configuration could make.
+		Assert.All(
+			new[] { "./both", "./util", "./pkg" },
+			reference => Assert.Contains(
+				result.Edges, edge => edge.Source == "entry.js" &&
+					edge.Reference == reference &&
+					edge.Status == ResolutionStatus.Unresolved &&
+					edge.Target is null &&
+					edge.Reasons.Contains("no owning tsconfig.json or jsconfig.json in the manifest")));
+	}
+
+	[Fact]
+	public async Task WithoutCompilationConfiguration_NothingBeyondTheLiteralNameIsGuessed()
+	{
+		using var fixture = new TemporaryDirectory();
+		var source = fixture.CreateFile("src/value.ts", "export const value = 1;");
+		var built = fixture.CreateFile("dist/value.js", "export const value = 1;");
+		var dotted = fixture.CreateFile(".config/app.js", "export const app = 1;");
+		var entry = fixture.CreateFile("src/entry.ts", """
+			import { value } from './value';
+			import { built } from '../dist/value.mjs';
+			import { app } from '.config/app.js';
+			import { lodash } from 'lodash';
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[source, built, dotted, entry],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// No extension substitution, no counterpart file, no bare specifier that merely starts
+		// with a dot, and no package name.
+		Assert.All(
+			new[] { "./value", "../dist/value.mjs", ".config/app.js", "lodash" },
+			reference => Assert.Contains(
+				result.Edges, edge => edge.Source == "src/entry.ts" &&
+					edge.Reference == reference &&
+					edge.Status == ResolutionStatus.Unresolved &&
+					edge.Target is null &&
+					edge.Reasons.Contains("no owning tsconfig.json or jsconfig.json in the manifest")));
+	}
+
+	[Fact]
+	public async Task WithoutCompilationConfiguration_RequireKeepsItsCommonJsContextRule()
+	{
+		using var fixture = new TemporaryDirectory();
+		var package = fixture.CreateFile("package.json", "{ \"type\": \"module\" }");
+		var target = fixture.CreateFile("value.js", "module.exports = 1;");
+		var moduleSource = fixture.CreateFile("main.mjs", "const value = require('./value.js');");
+		var commonJsSource = fixture.CreateFile("worker.cjs", "const value = require('./value.js');");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[package, target, moduleSource, commonJsSource],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(result.Edges, edge => edge.Source == "worker.cjs" &&
+			edge.Reference == "./value.js" && edge.Status == ResolutionStatus.Resolved &&
+			edge.Target == "value.js");
+		Assert.Contains(result.Edges, edge => edge.Source == "main.mjs" &&
+			edge.Reference == "./value.js" && edge.Status == ResolutionStatus.Unresolved &&
+			edge.Target is null &&
+			edge.Reasons.Contains("no owning tsconfig.json or jsconfig.json in the manifest"));
+	}
+
+	[Fact]
+	public async Task WithoutOwningConfiguration_AFileOutsideEveryConfigResolvesAcrossScopes()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("packages/web/tsconfig.json", "{ }");
+		var owned = fixture.CreateFile("packages/web/src/app.ts", "export const app = 1;");
+		var unowned = fixture.CreateFile(
+			"tools/build.js",
+			"import { app } from '../packages/web/src/app.ts';");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, owned, unowned],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// The tsconfig owns packages/web only, so tools/build.js has no owning configuration
+		// and the edge it produces crosses into the configured scope.
+		Assert.Contains(result.Edges, edge => edge.Source == "tools/build.js" &&
+			edge.Reference == "../packages/web/src/app.ts" &&
+			edge.Status == ResolutionStatus.Resolved &&
+			edge.Target == "packages/web/src/app.ts" && edge.CrossScope);
+	}
+
+	[Fact]
+	public async Task WithCompilationConfiguration_TheCounterpartProbeStillOutranksTheLiteralFile()
+	{
+		using var fixture = new TemporaryDirectory();
+		var config = fixture.CreateFile("tsconfig.json", "{ }");
+		var typed = fixture.CreateFile("value.ts", "export const value = 1;");
+		var literal = fixture.CreateFile("value.js", "export const value = 2;");
+		var entry = fixture.CreateFile("entry.ts", "import { value } from './value.js';");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[config, typed, literal, entry],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// With configuration the .ts counterpart wins over the literally named .js file;
+		// the no-configuration rule would have taken value.js instead.
+		Assert.Contains(result.Edges, edge => edge.Source == "entry.ts" &&
+			edge.Reference == "./value.js" && edge.Status == ResolutionStatus.Resolved &&
+			edge.Target == "value.ts" &&
+			edge.Reasons.Contains("one module target under configured module resolution"));
+	}
+
+	[Fact]
 	public async Task PythonFacts_ResolveRelativeImportsAndClassifyKnownStdlibOnly()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Terminal/DependencyFactsDocumentationContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DependencyFactsDocumentationContractTests.cs
@@ -17,6 +17,11 @@ public sealed class DependencyFactsDocumentationContractTests
 		Assert.Contains("**Ambiguous**", dependencies, StringComparison.Ordinal);
 		Assert.Contains("Merely failing to find a name in the manifest never", dependencies, StringComparison.Ordinal);
 		Assert.Contains("2 Mi characters", dependencies, StringComparison.Ordinal);
+		Assert.Contains(
+			"Without an owning `tsconfig.json` or `jsconfig.json`, one narrow capability applies",
+			dependencies,
+			StringComparison.Ordinal);
+		Assert.Contains("exactly one of `index.ts`", dependencies, StringComparison.Ordinal);
 		Assert.Contains("related_files.path", mcp, StringComparison.Ordinal);
 		Assert.Contains("[Facts coverage]", mcp, StringComparison.Ordinal);
 		Assert.Contains("devprojex related <PATH>", commandLine, StringComparison.Ordinal);


### PR DESCRIPTION
Closes part 1 of #340.

## What changes

A JavaScript or TypeScript file that no `tsconfig.json` or `jsconfig.json` owns resolved no module
specifier at all, so an ordinary Node project had an almost empty dependency graph and `related_files`,
`focus` and the graph weight in ranking had nothing to work with. Two cases can be proven from the
allowed manifest alone, and only those two now resolve:

- a literal relative specifier (`./` or `../`) that names a manifest file with the exact extension it
  wrote: `./util.mjs`, `../lib/x.js`, `./x.ts`;
- a relative specifier naming a directory that holds exactly one of `index.ts`, `index.tsx`,
  `index.d.ts`, `index.js`, `index.jsx`.

## What deliberately stays unresolved

The directory rule withdraws wherever the answer would depend on configuration:

- the directory owns a `package.json` — `main` and `types` are not emulated;
- a sibling module of the same stem exists, such as `util.js` beside `util/index.js` — module
  resolution settings decide that order, and picking either would be a guess;
- the directory holds two index files.

`require(...)` keeps its CommonJS-context rule, and an invalid `package.json` above the importing file
suppresses resolution exactly as it does with configuration. Extension substitution, `paths`,
`rootDirs`, `moduleSuffixes`, package `exports`, bare specifiers (including one that merely starts with
a dot, such as `.config/app.js`), and paths leaving the project root all keep the existing reason
`no owning tsconfig.json or jsconfig.json in the manifest`.

The index list is exactly the list a configured project already probes, and the rule requires a unique
match where a configured project takes the first hit, so the unconfigured behaviour is a strict subset:
adding a `tsconfig.json` can never delete an edge this path produced.

## Frozen ranking evaluation

Run against the registered three-repository corpus at the branch base, compared cell by cell with a
baseline run of the unmodified base:

- regressions: 0; improvements: 0; every cell byte-identical.
- `candidateFiles` unchanged (devprojex 2299, repomix 951, flask 212).

No cell moves because all three registered corpora are covered by configuration — repomix ships a
root `tsconfig.json`, flask is Python, devprojex is C# — so the evaluation is insensitive to this
capability by construction. The behavioural proof is in the integration tests, four of which fail on
the unmodified engine.

## Validation

- six integration tests over the no-configuration path: literal file, re-export and dynamic import,
  directory index including `index.d.ts`, the three withdrawal cases, the `require` rule, and a
  monorepo file outside every config producing a cross-scope edge;
- two invariance controls: a configured project where the `.ts` counterpart must still outrank the
  literally named `.js` file, and the pre-existing test that pins the unresolved reason;
- targeted dependency and ranking suites in the unit, integration and terminal projects;
- documentation contract extended to pin the new paragraph.
