### PR TITLE
MCP caller surface: truthful continuation, name lookups, neighbourhood packing, symbol addressing

### DIFF
--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -50,7 +50,15 @@ public enum DependencyDirection
 	Both
 }
 
-public sealed record SourceSite(string File, int Line, string Evidence);
+public sealed record SourceSite(string File, int Line, string Evidence)
+{
+	/// <summary>
+	/// Last line of the declaration this site names, or -1 when the extractor did not report one.
+	/// <see cref="Line"/> and this bound together are what let a caller say which declaration a
+	/// line belongs to without parsing the file again.
+	/// </summary>
+	public int EndLine { get; init; } = -1;
+}
 
 public sealed record TypeParameterScope(string Name, int StartIndex, int EndIndex);
 

--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -248,6 +248,21 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	}
 	""";
 
+	private static string ExpandRelatedProperty =>
+		$$"""
+	"expand_related": {
+	  "description": "Also pack the statically resolved neighbours of the given seed files, in one call instead of a related_files round trip. Expansion only narrows: a neighbour outside the effective filters, the Git scope, or paths never enters. Only resolved edges travel. Stops at {{McpRelatedExpansion.MaximumExpandedFiles}} files and says so.",
+	  "type": "object",
+	  "properties": {
+	    "seeds": { "type": "array", "minItems": 1, "maxItems": {{McpRelatedExpansion.MaximumSeeds}}, "items": { "type": "string" }, "description": "Project-relative files already inside the effective selection; directories and globs are rejected." },
+	    "hops": { "type": "integer", "minimum": {{McpRelatedExpansion.MinimumHops}}, "maximum": {{McpRelatedExpansion.MaximumHops}}, "default": {{McpRelatedExpansion.MinimumHops}}, "description": "How many edges out from each seed to follow." },
+	    "direction": { "type": "string", "enum": ["dependencies", "dependents", "both"], "default": "both", "description": "Which way to follow edges; same meaning as related_files.direction." }
+	  },
+	  "required": ["seeds"],
+	  "additionalProperties": false
+	}
+	""";
+
 	private const string MaxFileBytesProperty = """
 	"max_file_bytes": {
 	  "description": "Exclude otherwise selected files strictly larger than this byte count; integer or numeric string.",
@@ -330,6 +345,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	    {{FocusProperty}},
 	    {{MaximumTokensProperty}},
 	    {{MaxFileBytesProperty}},
+	    {{ExpandRelatedProperty}},
 	    "view": { "type": "string", "enum": ["tree", "content", "tree-content"], "default": "tree-content", "description": "Pack view: tree includes structure only, content includes files only, tree-content includes both." },
 	    "format": { "type": "string", "enum": ["text", "markdown", "json", "xml"], "default": "markdown", "description": "Pack format: markdown or text for readable output; json or xml for structured output." }
 	  },

--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -428,7 +428,8 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	    },
 	    "start_line": { "description": "First 1-based line of the returned text after replacements; integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] },
 	    "end_line": { "description": "Last 1-based line of the returned text after replacements, inclusive; integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] },
-	    "start_column": { "description": "First 1-based Unicode character within start_line; use the continuation value returned for a long line.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] }
+	    "start_column": { "description": "First 1-based Unicode character within start_line; use the continuation value returned for a long line.", "oneOf": [ { "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] },
+	    "symbol": { "type": "string", "minLength": 1, "maxLength": 512, "description": "Read the lines that declare this symbol instead of a line range, with path. Takes a qualified name, or a simple name that is unique in the file; search_project names the declaration each hit sits inside. Cannot be combined with start_line, end_line, or start_column. A name matching several declarations, no declaration, or a file none were extracted from returns DPX-MCP-INVALID-ARGUMENTS." }
 	  },
 	  "additionalProperties": false
 	}

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -26,6 +26,16 @@ internal sealed class DevProjexMcpTools(
 	// context budget in one unpredictable call. The cap bounds that, and the totals line
 	// tells the caller how much it did not get.
 	private const int MaximumSearchContentCharacters = 16_000;
+	// Asking for a file by name is the one request the selection vocabulary answers in a form a
+	// caller rarely guesses: a bare name is root-only, and paths selects what already exists at
+	// the depth it names. Both roads end in an empty or misleading answer, so the two tools that
+	// tolerate them point at the form that works. The pointer is a constant; nothing the caller
+	// sent reaches it.
+	private const string NameSearchNotice =
+		"[Name search] File names and paths are matched only by include_patterns: prefix a bare name " +
+		"with '**/' to find it at any depth, or append '/**' to a directory to select its files. " +
+		"search_project matches file content, and paths selects a path that already exists.";
+	private const int MaximumNameSearchExtensionLength = 8;
 	private const string SearchContentCapNotice =
 		"[Search truncated] The returned text reached the 16000-character search cap. " +
 		"Narrow the pattern, add paths or include_patterns, or lower context_lines.";
@@ -215,6 +225,7 @@ internal sealed class DevProjexMcpTools(
 				McpSpotlight.Wrap(treeWriter.Text),
 				treeTruncationNotice,
 				McpTrustedDiagnosticFormatter.FormatWarnings(plan),
+				FormatNameSearchNotice(plan, paths),
 				SelectionNotices(
 					plan,
 					includeFilters: true,
@@ -890,6 +901,7 @@ internal sealed class DevProjexMcpTools(
 				FormatUnscannableNotice(searched.UnscannableFiles, UnscannableResultKind.Search),
 				McpTrustedDiagnosticFormatter.FormatWarnings(plan),
 				noMatches,
+				FormatNameSearchNotice(plan, paths, pattern, totalMatches),
 				additionalMatchesNotice,
 				searchTotalsNotice,
 				inspectionBudgetReached
@@ -2247,6 +2259,67 @@ internal sealed class DevProjexMcpTools(
 					: $" seeds={item.Seeds.ToString(CultureInfo.InvariantCulture)}"))
 			.ToArray();
 		return notices.Length == 0 ? null : string.Join('\n', notices);
+	}
+
+	/// <summary>
+	/// Points at the form that finds a file by name when this call asked for one in the only way
+	/// the tool tolerates: a requested path that the effective tree does not hold.
+	/// </summary>
+	private static string? FormatNameSearchNotice(
+		ProjectContextPlan plan,
+		IReadOnlyList<string>? paths) =>
+		McpTrustedDiagnosticFormatter.ReportsMissingSelectedPath(plan) && HasBareNamePath(paths)
+			? NameSearchNotice
+			: null;
+
+	/// <summary>
+	/// The search form of the same pointer. A content pattern that searched files and found
+	/// nothing while reading like a file name was almost certainly aimed at one, and this tool
+	/// never matches a path. A selection that held no file to search explains itself through
+	/// <c>[Empty selection]</c> instead, and is left alone.
+	/// </summary>
+	private static string? FormatNameSearchNotice(
+		ProjectContextPlan plan,
+		IReadOnlyList<string>? paths,
+		string pattern,
+		int totalMatches) =>
+		(McpTrustedDiagnosticFormatter.ReportsMissingSelectedPath(plan) && HasBareNamePath(paths)) ||
+		(totalMatches == 0 && plan.IncludedFiles.Count > 0 && LooksLikeANameSearch(pattern))
+			? NameSearchNotice
+			: null;
+
+	/// <summary>
+	/// A requested path with no separator names one entry directly in the project root, so a
+	/// caller who meant "this name, wherever it lives" gets nothing from it.
+	/// </summary>
+	private static bool HasBareNamePath(IReadOnlyList<string>? paths) =>
+		paths?.Any(static path =>
+			!string.IsNullOrWhiteSpace(path) &&
+			!path.Contains('/', StringComparison.Ordinal) &&
+			!path.Contains('\\', StringComparison.Ordinal)) == true;
+
+	/// <summary>
+	/// Whether a pattern that matched no content reads as a file name or path: it carries a path
+	/// separator, or it ends in what looks like an extension, with or without the regex escape
+	/// and the end anchor a caller would write around it. Both are syntactic, both are computed
+	/// only for a response that already found nothing, and neither reaches the response text.
+	/// </summary>
+	private static bool LooksLikeANameSearch(string pattern)
+	{
+		if (string.IsNullOrWhiteSpace(pattern))
+			return false;
+		if (pattern.Contains('/', StringComparison.Ordinal))
+			return true;
+
+		var end = pattern.Length;
+		if (pattern[end - 1] == '$')
+			end--;
+		var start = end;
+		while (start > 0 && char.IsAsciiLetterOrDigit(pattern[start - 1]))
+			start--;
+		return end - start is > 0 and <= MaximumNameSearchExtensionLength &&
+			start > 0 &&
+			pattern[start - 1] == '.';
 	}
 
 	private static IReadOnlyList<string>? ParsePaths(McpJsonArguments arguments) =>

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -74,7 +74,7 @@ internal sealed class DevProjexMcpTools(
 	private readonly IReadOnlySet<string> packArgumentNames = Allowed(agentExclusions,
 		"project", "branch", "paths", "include_patterns", "exclude_patterns", "profile", "view",
 		"format", "detail", "detail_by_pattern", "tracked_only", "git_scope", "rank", "focus",
-		"max_tokens", "max_file_bytes");
+		"max_tokens", "max_file_bytes", McpRelatedExpansion.ParameterName);
 	private readonly IReadOnlySet<string> searchArgumentNames = Allowed(agentExclusions,
 		"project", "branch", "pattern", "paths", "include_patterns", "exclude_patterns", "context_lines",
 		"ignore_case", "max_results", "tracked_only", "git_scope", "max_file_bytes");
@@ -481,7 +481,7 @@ internal sealed class DevProjexMcpTools(
 		}, cancellationToken);
 
 	[Description(
-		"Builds multi-file project context. Use it after get_tree, search_project, or analyze; use get_file instead for one file. Returns inline untrusted project data, or pack_id plus a preview when output exceeds 50,000 characters; page that result with read_pack. Values: detail=full|compact|signatures; view=tree|content|tree-content; format=markdown|text|json|xml; rank=importance; git_scope=staged|changes|diff:<ref>..<ref>. focus requires rank=importance and seeds graph-hop ordering without widening selection; max_tokens applies greedy content admission and reports heuristic token estimates, not tokenizer counts. detail_by_pattern overrides detail per file; entries apply in order and the last matching entry wins, so list general globs before specific ones.")]
+		"Builds multi-file project context. Use it after get_tree, search_project, or analyze; use get_file instead for one file. Returns inline untrusted project data, or pack_id plus a preview when output exceeds 50,000 characters; page that result with read_pack. Values: detail=full|compact|signatures; view=tree|content|tree-content; format=markdown|text|json|xml; rank=importance; git_scope=staged|changes|diff:<ref>..<ref>. expand_related also packs the resolved dependency neighbours of its seeds and only narrows. focus requires rank=importance; max_tokens applies greedy content admission and reports heuristic token estimates, not tokenizer counts. detail_by_pattern overrides detail per file; the last matching entry wins, so list general globs first.")]
 	public Task<CallToolResult> PackContext(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>
@@ -522,6 +522,7 @@ internal sealed class DevProjexMcpTools(
 					$"{McpErrorCodes.InvalidArguments}: {McpDetailOverrides.ParameterName} is valid only when " +
 					"pack_context includes file content.");
 			}
+			var expansionRequest = McpRelatedExpansion.Parse(arguments);
 			var selection = await BuildSelectionAsync(
 					arguments,
 					cancellationToken,
@@ -530,6 +531,29 @@ internal sealed class DevProjexMcpTools(
 						format is ProjectContextDocumentFormat.Json or ProjectContextDocumentFormat.Xml)
 				.ConfigureAwait(false);
 			var plan = selection.Plan;
+			// Expansion runs against the plan the filters produced and can only remove from it, so
+			// a neighbour outside the effective selection has no way in. It also runs before focus
+			// is resolved, which is what makes a focus seed the expansion did not admit fail with
+			// the same error any unselected path gets.
+			var expansionResult = expansionRequest is null
+				? null
+				: await McpRelatedExpansion.ExpandAsync(
+						Projects.DependencyFactsEngine,
+						plan,
+						Projects.ResolveRequestedFiles(plan, expansionRequest.Seeds, cancellationToken)
+							.Select(seed => McpProjectService.ToRelative(plan.SourceRoot, seed))
+							.ToArray(),
+						expansionRequest,
+						operationProgress.MeasureFacts("Indexing dependency facts", 2, 8),
+						cancellationToken)
+					.ConfigureAwait(false);
+			if (expansionResult is not null)
+			{
+				plan = await Projects
+					.NarrowSelectionAsync(plan, expansionResult.RelativePaths, cancellationToken)
+					.ConfigureAwait(false);
+			}
+
 			var selectedFileCount = plan.IncludedFiles.Count;
 			var focusSeeds = focus is null
 				? null
@@ -539,6 +563,7 @@ internal sealed class DevProjexMcpTools(
 			// A pack is the answer many agents read instead of get_tree, so it carries the same
 			// effective-filters footer next to its tree.
 			var trustedPlanWarnings = CombineTrustedNotices(
+				FormatExpansionNotice(expansionResult),
 				McpTrustedDiagnosticFormatter.FormatWarnings(plan),
 				SelectionNotices(plan, includeFilters: true, selection.NoticeContext));
 			operationProgress.Milestone(
@@ -2320,6 +2345,26 @@ internal sealed class DevProjexMcpTools(
 		return end - start is > 0 and <= MaximumNameSearchExtensionLength &&
 			start > 0 &&
 			pattern[start - 1] == '.';
+	}
+
+	/// <summary>
+	/// Reports what the expansion added, in counts and one constant. The paths themselves are in
+	/// the untrusted block with the rest of the pack, as every project path is.
+	/// </summary>
+	private static string? FormatExpansionNotice(McpRelatedExpansionResult? expansion)
+	{
+		if (expansion is null)
+			return null;
+		var reported =
+			$"[Expanded] seeds={expansion.SeedCount.ToString(CultureInfo.InvariantCulture)} · " +
+			$"hop1=+{expansion.FirstHopCount.ToString(CultureInfo.InvariantCulture)} · " +
+			$"hop2=+{expansion.SecondHopCount.ToString(CultureInfo.InvariantCulture)} · " +
+			$"seeds-without-facts={expansion.SeedsWithoutFacts.ToString(CultureInfo.InvariantCulture)}";
+		return expansion.LimitReached
+			? $"{reported}; stopped at the " +
+			  $"{McpRelatedExpansion.MaximumExpandedFiles.ToString(CultureInfo.InvariantCulture)}-file " +
+			  "expansion limit, so the neighbourhood is incomplete."
+			: $"{reported}.";
 	}
 
 	private static IReadOnlyList<string>? ParsePaths(McpJsonArguments arguments) =>

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -858,6 +858,7 @@ internal sealed class DevProjexMcpTools(
 			var responseLimitReached = false;
 			var resultGroupTruncated = false;
 			var inspectedFiles = new List<string>(plan.IncludedFiles.Count);
+			var writtenHits = new List<McpSearchHit>();
 			long inspectedBytes = 0;
 			foreach (var path in plan.IncludedFiles)
 			{
@@ -887,15 +888,20 @@ internal sealed class DevProjexMcpTools(
 					if (responseLimitReached)
 						return ValueTask.CompletedTask;
 
+					var relative = McpProjectService.ToRelative(plan.SourceRoot, file.Path);
 					foreach (var match in scan.Matches)
 					{
 						var appended = AppendSearchResult(
 							output,
-							McpProjectService.ToRelative(plan.SourceRoot, file.Path),
+							relative,
 							file.Content,
 							match,
 							MaximumSearchContentCharacters);
 						shownMatches += appended.WrittenMatches;
+						// Only the lines that reached the caller are worth naming; a match the cap
+						// dropped is not in the response to be annotated.
+						foreach (var line in match.MatchLineNumbers.Take(appended.WrittenMatches))
+							writtenHits.Add(new McpSearchHit(relative, file.Path, line));
 						if (appended.Truncated)
 						{
 							responseLimitReached = true;
@@ -906,6 +912,14 @@ internal sealed class DevProjexMcpTools(
 					return ValueTask.CompletedTask;
 				},
 				cancellationToken).ConfigureAwait(false);
+			// A response the character cap already cut has no room to spend on naming, and the
+			// caller's next move there is to narrow the pattern rather than to read a symbol.
+			var symbols = resultGroupTruncated
+				? McpSearchSymbolResult.None
+				: await McpSearchSymbols
+					.ResolveAsync(Projects.DependencyFactsEngine, plan, writtenHits, cancellationToken)
+					.ConfigureAwait(false);
+			AppendEnclosingDeclarations(output, symbols);
 			var additionalMatchesNotice = totalMatches > shownMatches
 				? $"[{totalMatches - shownMatches} additional matches not shown; narrow the pattern or filters.]"
 				: null;
@@ -926,6 +940,7 @@ internal sealed class DevProjexMcpTools(
 				FormatUnscannableNotice(searched.UnscannableFiles, UnscannableResultKind.Search),
 				McpTrustedDiagnosticFormatter.FormatWarnings(plan),
 				noMatches,
+				FormatSymbolCoverageNotice(symbols),
 				FormatNameSearchNotice(plan, paths, pattern, totalMatches),
 				additionalMatchesNotice,
 				searchTotalsNotice,
@@ -2284,6 +2299,45 @@ internal sealed class DevProjexMcpTools(
 					: $" seeds={item.Seeds.ToString(CultureInfo.InvariantCulture)}"))
 			.ToArray();
 		return notices.Length == 0 ? null : string.Join('\n', notices);
+	}
+
+	/// <summary>
+	/// Writes the declaration each shown hit sits inside, inside the untrusted block, because a
+	/// declaration name is text this project wrote.
+	/// </summary>
+	private static void AppendEnclosingDeclarations(StringBuilder output, McpSearchSymbolResult symbols)
+	{
+		if (symbols.Lines.Count == 0)
+			return;
+		if (output.Length > 0)
+			output.AppendLine();
+		output.AppendLine(McpSearchSymbols.SectionHeading);
+		foreach (var line in symbols.Lines)
+		{
+			// The naming shares the search character cap rather than adding to it, so turning it
+			// on cannot make any response larger than the published bound.
+			if (output.Length + line.Length >= MaximumSearchContentCharacters)
+				break;
+			output.AppendLine(line);
+		}
+	}
+
+	/// <summary>
+	/// Reports how far the naming reached, in counts alone, so a caller can tell "this hit is in no
+	/// declaration" from "this file was never parsed".
+	/// </summary>
+	private static string? FormatSymbolCoverageNotice(McpSearchSymbolResult symbols)
+	{
+		if (symbols.AnnotatedHits == 0 && symbols.FilesWithoutDeclarations == 0 && symbols.FilesBeyondTheLimit == 0)
+			return null;
+		var reported =
+			$"[Symbols] annotated={symbols.AnnotatedHits.ToString(CultureInfo.InvariantCulture)} · " +
+			$"files-without-declarations={symbols.FilesWithoutDeclarations.ToString(CultureInfo.InvariantCulture)}";
+		return symbols.FilesBeyondTheLimit > 0
+			? $"{reported} · files-past-the-" +
+			  $"{McpSearchSymbols.MaximumAnnotatedFiles.ToString(CultureInfo.InvariantCulture)}-file " +
+			  $"naming limit={symbols.FilesBeyondTheLimit.ToString(CultureInfo.InvariantCulture)}."
+			: $"{reported}.";
 	}
 
 	/// <summary>

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -82,7 +82,8 @@ internal sealed class DevProjexMcpTools(
 		"project", "branch", "path", "direction", "include_patterns", "exclude_patterns", "profile",
 		"tracked_only", "git_scope", "max_file_bytes");
 	private readonly IReadOnlySet<string> getFileArgumentNames = Allowed(agentExclusions,
-		"project", "branch", "profile", "path", "requests", "start_line", "end_line", "start_column");
+		"project", "branch", "profile", "path", "requests", "start_line", "end_line", "start_column",
+		"symbol");
 	private McpProjectService Projects => projectService.Value;
 
 	[Description(
@@ -1077,6 +1078,15 @@ internal sealed class DevProjexMcpTools(
 			var start = arguments.OptionalInteger("start_line", 1, int.MaxValue);
 			var end = arguments.OptionalInteger("end_line", 1, int.MaxValue);
 			var startColumn = arguments.OptionalInteger("start_column", 1, int.MaxValue);
+			var symbol = arguments.OptionalString("symbol");
+			if (symbol is not null && (start is not null || end is not null || startColumn is not null))
+			{
+				throw new McpToolException(
+					McpErrorCodes.InvalidArguments,
+					$"{McpErrorCodes.InvalidArguments}: 'symbol' addresses a declaration and cannot be " +
+					"combined with start_line, end_line, or start_column.");
+			}
+
 			ValidateLineRange(start, end);
 			var plan = await Projects.BuildPlanAsync(
 				arguments.OptionalString("project"),
@@ -1092,6 +1102,20 @@ internal sealed class DevProjexMcpTools(
 				includeOutputMetrics: false,
 				exclusions: ParseExclusionsArgument(arguments)).ConfigureAwait(false);
 			var file = Projects.ResolveFile(plan, requestedPath);
+			if (symbol is not null)
+			{
+				var located = await McpSearchSymbols
+					.ResolveSymbolAsync(
+						Projects.DependencyFactsEngine,
+						plan,
+						McpProjectService.ToRelative(plan.SourceRoot, file),
+						file,
+						symbol,
+						cancellationToken)
+					.ConfigureAwait(false);
+				(start, end) = ResolveSymbolRange(located);
+			}
+
 			TransformedTextFile? transformed = null;
 			await using var inspected = await Projects.ConsumeSearchTextAsync(
 					plan with { IncludedFiles = [file] },
@@ -2300,6 +2324,31 @@ internal sealed class DevProjexMcpTools(
 			.ToArray();
 		return notices.Length == 0 ? null : string.Join('\n', notices);
 	}
+
+	/// <summary>
+	/// Turns a symbol lookup into the line range to read, or into the error that says why there is
+	/// none. An ambiguous name reports how many declarations answered to it and asks for a
+	/// qualified name; it never names them, because a declaration name is project text and the
+	/// error text is outside the untrusted block.
+	/// </summary>
+	private static (int? Start, int? End) ResolveSymbolRange(McpSymbolLookup located) =>
+		located.Status switch
+		{
+			McpSymbolLookupStatus.Resolved => (located.StartLine, located.EndLine),
+			McpSymbolLookupStatus.Ambiguous => throw new McpToolException(
+				McpErrorCodes.InvalidArguments,
+				$"{McpErrorCodes.InvalidArguments}: 'symbol' matches " +
+				$"{located.CandidateCount.ToString(CultureInfo.InvariantCulture)} declarations in this " +
+				"file; pass the qualified name, or read the file and choose a line range."),
+			McpSymbolLookupStatus.Unsupported => throw new McpToolException(
+				McpErrorCodes.InvalidArguments,
+				$"{McpErrorCodes.InvalidArguments}: 'symbol' is not supported for this file, because no " +
+				"declarations were extracted from it; pass start_line and end_line instead."),
+			_ => throw new McpToolException(
+				McpErrorCodes.InvalidArguments,
+				$"{McpErrorCodes.InvalidArguments}: 'symbol' matches no declaration in this file; " +
+				"search_project names the declaration each hit sits inside.")
+		};
 
 	/// <summary>
 	/// Writes the declaration each shown hit sits inside, inside the untrusted block, because a

--- a/Apps/Mcp/McpProjectService.cs
+++ b/Apps/Mcp/McpProjectService.cs
@@ -972,6 +972,35 @@ internal sealed class McpProjectService(
 		}
 	}
 
+	/// <summary>
+	/// Narrows a plan to a subset of the files it already holds. Every path must come from the
+	/// plan itself, so this can only remove: it is how a request that computes its own subset
+	/// stays inside the effective selection instead of being trusted to.
+	/// </summary>
+	public async Task<ProjectContextPlan> NarrowSelectionAsync(
+		ProjectContextPlan plan,
+		IReadOnlyCollection<string> relativePaths,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(plan);
+		ArgumentNullException.ThrowIfNull(relativePaths);
+		if (relativePaths.Count == 0)
+		{
+			return await services.Planner
+				.ReprojectEmptySelectionAsync(plan, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		var gitMode = plan.Selection.GitMode ?? GitFilteringMode.None;
+		return GitScopeSelection.IsMomentary(gitMode)
+			? await services.Planner
+				.ReprojectSelectionAsync(plan, relativePaths, StringComparer.Ordinal, cancellationToken)
+				.ConfigureAwait(false)
+			: await services.Planner
+				.ReprojectSelectionAsync(plan, relativePaths, cancellationToken)
+				.ConfigureAwait(false);
+	}
+
 	public IReadOnlyList<string> ResolveRequestedFiles(
 		ProjectContextPlan plan,
 		IReadOnlyList<string> paths,

--- a/Apps/Mcp/McpRelatedExpansion.cs
+++ b/Apps/Mcp/McpRelatedExpansion.cs
@@ -1,0 +1,207 @@
+using System.Globalization;
+
+namespace DevProjex.Mcp;
+
+/// <summary>
+/// Reads <c>expand_related</c> and resolves the neighbourhood it names, so one call can pack a
+/// file together with the files it statically depends on or that depend on it.
+/// </summary>
+/// <remarks>
+/// Expansion is computed over the dependency index built from the plan's own included files, so
+/// every path it can reach was already admissible. It therefore narrows a selection to the seeds
+/// and their resolved neighbours and can never add a file the effective filters, the Git scope,
+/// or the project root kept out. Only <see cref="ResolutionStatus.Resolved"/> edges travel: an
+/// ambiguous or unresolved reference names a file the engine would not commit to, and following
+/// it would put a guess in the pack.
+/// </remarks>
+internal static class McpRelatedExpansion
+{
+	public const string ParameterName = "expand_related";
+	public const int MaximumSeeds = 16;
+	public const int MinimumHops = 1;
+	public const int MaximumHops = 2;
+
+	/// <summary>
+	/// A neighbourhood is not bounded by its hop count: one widely imported file can reach most of
+	/// a repository in two hops. This constant is the only bound on the expanded set, and the
+	/// response says so on every call where it decided the answer.
+	/// </summary>
+	public const int MaximumExpandedFiles = 400;
+
+	public static McpRelatedExpansionRequest? Parse(McpJsonArguments arguments)
+	{
+		ArgumentNullException.ThrowIfNull(arguments);
+		if (!arguments.TryGetElement(ParameterName, out var element))
+			return null;
+		if (element.ValueKind != JsonValueKind.Object)
+			throw Invalid("must be an object with 'seeds' and optional 'hops' and 'direction'");
+		ValidatePropertyNames(element);
+		return new McpRelatedExpansionRequest(ReadSeeds(element), ReadHops(element), ReadDirection(element));
+	}
+
+	/// <summary>
+	/// Walks the requested hops outward from the seeds and returns the union in pack order: the
+	/// seeds as the caller gave them, then each hop in ordinal path order. The traversal stops at
+	/// <see cref="MaximumExpandedFiles"/>, and reports that it did.
+	/// </summary>
+	public static async Task<McpRelatedExpansionResult> ExpandAsync(
+		DependencyFactsEngine engine,
+		ProjectContextPlan plan,
+		IReadOnlyList<string> relativeSeeds,
+		McpRelatedExpansionRequest request,
+		IProgress<DependencyIndexProgress>? progress,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(engine);
+		ArgumentNullException.ThrowIfNull(plan);
+		ArgumentNullException.ThrowIfNull(relativeSeeds);
+		ArgumentNullException.ThrowIfNull(request);
+
+		var admitted = new List<string>(relativeSeeds.Count);
+		var seen = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var seed in relativeSeeds)
+		{
+			if (seen.Add(seed))
+				admitted.Add(seed);
+		}
+
+		var seedCount = admitted.Count;
+		var hopCounts = new int[MaximumHops];
+		var seedsWithoutFacts = 0;
+		var limitReached = false;
+		IReadOnlyList<string> frontier = admitted.ToArray();
+
+		for (var hop = 0; hop < request.Hops && frontier.Count > 0 && !limitReached; hop++)
+		{
+			var related = await engine.FindRelatedAsync(
+					plan.SourceRoot,
+					plan.IncludedFiles,
+					frontier,
+					request.Direction,
+					hop == 0 ? progress : null,
+					cancellationToken)
+				.ConfigureAwait(false);
+			if (hop == 0)
+			{
+				seedsWithoutFacts = related.Seeds.Count(static seed => seed.NoFactsReason is not null);
+			}
+
+			// Ordinal order makes the admitted prefix of a hop deterministic, which is what keeps
+			// the limit from turning into an arbitrary choice between neighbours.
+			var candidates = new SortedSet<string>(StringComparer.Ordinal);
+			foreach (var seed in related.Seeds)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				foreach (var neighbour in seed.Dependencies.Concat(seed.Dependents))
+				{
+					if (neighbour.Status == ResolutionStatus.Resolved &&
+					    !seen.Contains(neighbour.Path) &&
+					    related.Index.FileByPath.ContainsKey(neighbour.Path))
+					{
+						candidates.Add(neighbour.Path);
+					}
+				}
+			}
+
+			var reached = new List<string>(candidates.Count);
+			foreach (var path in candidates)
+			{
+				if (admitted.Count >= MaximumExpandedFiles)
+				{
+					limitReached = true;
+					break;
+				}
+
+				seen.Add(path);
+				admitted.Add(path);
+				reached.Add(path);
+			}
+
+			hopCounts[hop] = reached.Count;
+			frontier = reached;
+		}
+
+		return new McpRelatedExpansionResult(
+			admitted,
+			seedCount,
+			hopCounts[0],
+			hopCounts[1],
+			seedsWithoutFacts,
+			limitReached);
+	}
+
+	private static IReadOnlyList<string> ReadSeeds(JsonElement element)
+	{
+		if (!element.TryGetProperty("seeds", out var seeds) || seeds.ValueKind != JsonValueKind.Array)
+			throw Invalid("'seeds' must be a non-empty array of project-relative file paths");
+		if (seeds.GetArrayLength() == 0)
+			throw Invalid("'seeds' must contain at least one file");
+		if (seeds.GetArrayLength() > MaximumSeeds)
+			throw Invalid($"'seeds' accepts at most {MaximumSeeds.ToString(CultureInfo.InvariantCulture)} files");
+
+		var values = new List<string>(seeds.GetArrayLength());
+		foreach (var seed in seeds.EnumerateArray())
+		{
+			if (seed.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(seed.GetString()))
+				throw Invalid("every entry of 'seeds' must be a non-empty string");
+			values.Add(seed.GetString()!);
+		}
+		return values;
+	}
+
+	private static int ReadHops(JsonElement element)
+	{
+		if (!element.TryGetProperty("hops", out var hops))
+			return MinimumHops;
+		if (hops.ValueKind != JsonValueKind.Number ||
+		    !hops.TryGetInt32(out var value) ||
+		    value < MinimumHops ||
+		    value > MaximumHops)
+		{
+			throw Invalid(
+				$"'hops' must be {MinimumHops.ToString(CultureInfo.InvariantCulture)} or " +
+				$"{MaximumHops.ToString(CultureInfo.InvariantCulture)}");
+		}
+		return value;
+	}
+
+	private static DependencyDirection ReadDirection(JsonElement element)
+	{
+		if (!element.TryGetProperty("direction", out var direction))
+			return DependencyDirection.Both;
+		return direction.ValueKind == JsonValueKind.String
+			? direction.GetString() switch
+			{
+				"dependencies" => DependencyDirection.Dependencies,
+				"dependents" => DependencyDirection.Dependents,
+				"both" => DependencyDirection.Both,
+				_ => throw Invalid("'direction' must be dependencies, dependents, or both")
+			}
+			: throw Invalid("'direction' must be dependencies, dependents, or both");
+	}
+
+	private static void ValidatePropertyNames(JsonElement element)
+	{
+		foreach (var property in element.EnumerateObject())
+		{
+			if (property.Name is not ("seeds" or "hops" or "direction"))
+				throw Invalid($"'{property.Name}' is not a recognized property");
+		}
+	}
+
+	private static McpToolException Invalid(string reason) =>
+		new(McpErrorCodes.InvalidArguments, $"{McpErrorCodes.InvalidArguments}: '{ParameterName}' {reason}.");
+}
+
+internal sealed record McpRelatedExpansionRequest(
+	IReadOnlyList<string> Seeds,
+	int Hops,
+	DependencyDirection Direction);
+
+internal sealed record McpRelatedExpansionResult(
+	IReadOnlyList<string> RelativePaths,
+	int SeedCount,
+	int FirstHopCount,
+	int SecondHopCount,
+	int SeedsWithoutFacts,
+	bool LimitReached);

--- a/Apps/Mcp/McpSearchSymbols.cs
+++ b/Apps/Mcp/McpSearchSymbols.cs
@@ -126,7 +126,101 @@ internal static class McpSearchSymbols
 			skippedFiles);
 	}
 
+	/// <summary>
+	/// Turns a declaration name into the lines that declare it, so a caller can read a symbol
+	/// without first learning where it lives.
+	/// </summary>
+	/// <remarks>
+	/// A fully qualified name wins outright. Otherwise the last segment of each declared name is
+	/// compared, and a name that matches more than one declaration is reported as ambiguous rather
+	/// than resolved to whichever came first: choosing silently would return the wrong code with
+	/// nothing in the response to say so.
+	/// </remarks>
+	public static async Task<McpSymbolLookup> ResolveSymbolAsync(
+		DependencyFactsEngine engine,
+		ProjectContextPlan plan,
+		string relativePath,
+		string fullPath,
+		string symbol,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(engine);
+		ArgumentNullException.ThrowIfNull(plan);
+		ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+
+		var index = await engine
+			.IndexAsync(plan.SourceRoot, [fullPath], progress: null, cancellationToken)
+			.ConfigureAwait(false);
+		if (!index.FileByPath.TryGetValue(relativePath, out var facts) ||
+		    facts.Status != DependencyFileStatus.Supported)
+		{
+			return McpSymbolLookup.Unsupported;
+		}
+
+		var spans = new List<DeclarationSpan>();
+		foreach (var declaration in facts.Declarations)
+		{
+			foreach (var site in declaration.DeclarationSites)
+			{
+				if (site.EndLine >= site.Line &&
+				    string.Equals(site.File, relativePath, StringComparison.Ordinal))
+				{
+					spans.Add(new DeclarationSpan(site.Line, site.EndLine, declaration.Identity.QualifiedName));
+				}
+			}
+		}
+
+		if (spans.Count == 0)
+			return McpSymbolLookup.Unsupported;
+
+		var qualified = spans
+			.Where(span => string.Equals(span.Name, symbol, StringComparison.Ordinal))
+			.ToArray();
+		if (qualified.Length == 1)
+			return McpSymbolLookup.Found(qualified[0].Start, qualified[0].End);
+		if (qualified.Length > 1)
+			return McpSymbolLookup.Ambiguous(qualified.Length);
+
+		var simple = spans.Where(span => LastSegment(span.Name).Equals(symbol, StringComparison.Ordinal)).ToArray();
+		return simple.Length switch
+		{
+			1 => McpSymbolLookup.Found(simple[0].Start, simple[0].End),
+			> 1 => McpSymbolLookup.Ambiguous(simple.Length),
+			_ => McpSymbolLookup.Unknown
+		};
+	}
+
+	private static ReadOnlySpan<char> LastSegment(string name)
+	{
+		var separator = name.AsSpan().LastIndexOfAny('.', '#', '/');
+		return separator >= 0 ? name.AsSpan(separator + 1) : name.AsSpan();
+	}
+
 	private sealed record DeclarationSpan(int Start, int End, string Name);
+}
+
+internal enum McpSymbolLookupStatus
+{
+	Resolved,
+	Unknown,
+	Ambiguous,
+	Unsupported
+}
+
+internal readonly record struct McpSymbolLookup(
+	McpSymbolLookupStatus Status,
+	int StartLine,
+	int EndLine,
+	int CandidateCount)
+{
+	public static readonly McpSymbolLookup Unknown = new(McpSymbolLookupStatus.Unknown, 0, 0, 0);
+	public static readonly McpSymbolLookup Unsupported = new(McpSymbolLookupStatus.Unsupported, 0, 0, 0);
+
+	public static McpSymbolLookup Found(int startLine, int endLine) =>
+		new(McpSymbolLookupStatus.Resolved, startLine, endLine, 1);
+
+	public static McpSymbolLookup Ambiguous(int candidates) =>
+		new(McpSymbolLookupStatus.Ambiguous, 0, 0, candidates);
 }
 
 internal readonly record struct McpSearchHit(string RelativePath, string FullPath, int Line);

--- a/Apps/Mcp/McpSearchSymbols.cs
+++ b/Apps/Mcp/McpSearchSymbols.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+
+namespace DevProjex.Mcp;
+
+/// <summary>
+/// Names the declaration each search hit sits inside, so a reader can go from a hit to the thing
+/// that contains it without guessing a line range and reading twice.
+/// </summary>
+/// <remarks>
+/// Declarations come from the dependency index built over the files that actually produced hits:
+/// one bounded parse per such file, never one per hit, and never over the whole selection. A
+/// declaration name is project text, so it is written inside the untrusted block together with the
+/// match lines it describes; only the counts leave that block.
+///
+/// Hit lines are lines of the transformed text the tool returns, and the index parses the file on
+/// disk. Redaction replaces a secret with a placeholder on the same line and adds no lines, so the
+/// two agree on line numbers, which is the only coordinate this needs.
+/// </remarks>
+internal static class McpSearchSymbols
+{
+	public const string SectionHeading = "Enclosing declarations:";
+
+	/// <summary>
+	/// A search can touch many files, and every one of them would be a parse. Hits beyond this many
+	/// distinct files are left unannotated and counted, rather than turning a search into an index.
+	/// </summary>
+	public const int MaximumAnnotatedFiles = 64;
+
+	public static async Task<McpSearchSymbolResult> ResolveAsync(
+		DependencyFactsEngine engine,
+		ProjectContextPlan plan,
+		IReadOnlyList<McpSearchHit> hits,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(engine);
+		ArgumentNullException.ThrowIfNull(plan);
+		ArgumentNullException.ThrowIfNull(hits);
+		if (hits.Count == 0)
+			return McpSearchSymbolResult.None;
+
+		var files = new List<McpSearchHit>();
+		var seen = new HashSet<string>(StringComparer.Ordinal);
+		var skippedFiles = 0;
+		foreach (var hit in hits)
+		{
+			if (!seen.Add(hit.RelativePath))
+				continue;
+			if (files.Count >= MaximumAnnotatedFiles)
+			{
+				skippedFiles++;
+				continue;
+			}
+
+			files.Add(hit);
+		}
+
+		var index = await engine.IndexAsync(
+				plan.SourceRoot,
+				files.Select(static file => file.FullPath).ToArray(),
+				progress: null,
+				cancellationToken)
+			.ConfigureAwait(false);
+
+		var spansByFile = new Dictionary<string, List<DeclarationSpan>>(StringComparer.Ordinal);
+		foreach (var file in files)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (!index.FileByPath.TryGetValue(file.RelativePath, out var facts))
+				continue;
+
+			var spans = new List<DeclarationSpan>();
+			foreach (var declaration in facts.Declarations)
+			{
+				foreach (var site in declaration.DeclarationSites)
+				{
+					// A site without an end line comes from an extractor that reports none, and a
+					// one-line guess would claim containment it cannot know.
+					if (site.EndLine >= site.Line &&
+					    string.Equals(site.File, file.RelativePath, StringComparison.Ordinal))
+					{
+						spans.Add(new DeclarationSpan(site.Line, site.EndLine, declaration.Identity.QualifiedName));
+					}
+				}
+			}
+
+			if (spans.Count > 0)
+				spansByFile[file.RelativePath] = spans;
+		}
+
+		var lines = new List<string>();
+		var annotated = 0;
+		var unannotatedFiles = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var hit in hits)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (!spansByFile.TryGetValue(hit.RelativePath, out var spans))
+			{
+				unannotatedFiles.Add(hit.RelativePath);
+				continue;
+			}
+
+			// The innermost declaration is the narrowest one that still contains the line.
+			DeclarationSpan? best = null;
+			foreach (var span in spans)
+			{
+				if (hit.Line < span.Start || hit.Line > span.End)
+					continue;
+				if (best is null || span.End - span.Start < best.End - best.Start)
+					best = span;
+			}
+
+			if (best is null || string.IsNullOrEmpty(best.Name))
+			{
+				unannotatedFiles.Add(hit.RelativePath);
+				continue;
+			}
+
+			lines.Add($"{hit.RelativePath}:{hit.Line.ToString(CultureInfo.InvariantCulture)}: {best.Name}");
+			annotated++;
+		}
+
+		return new McpSearchSymbolResult(
+			lines,
+			annotated,
+			unannotatedFiles.Count,
+			skippedFiles);
+	}
+
+	private sealed record DeclarationSpan(int Start, int End, string Name);
+}
+
+internal readonly record struct McpSearchHit(string RelativePath, string FullPath, int Line);
+
+internal sealed record McpSearchSymbolResult(
+	IReadOnlyList<string> Lines,
+	int AnnotatedHits,
+	int FilesWithoutDeclarations,
+	int FilesBeyondTheLimit)
+{
+	public static readonly McpSearchSymbolResult None = new([], 0, 0, 0);
+}

--- a/Apps/Mcp/McpServiceNoticeMemo.cs
+++ b/Apps/Mcp/McpServiceNoticeMemo.cs
@@ -4,7 +4,8 @@ namespace DevProjex.Mcp;
 /// The trusted filter and protection lines describe server state, not the call. Repeating them
 /// on every response is a fixed tax that grows with exactly the workload the server is good at:
 /// many small, precise reads. This memo keeps one delivery per session per notice content, and
-/// replaces the repeat with a constant pointer back to <c>list_projects</c>.
+/// replaces the repeat with a constant pointer back to <c>list_projects</c> that names exactly
+/// the lines the response withheld.
 /// </summary>
 /// <remarks>
 /// Omission must be provable, so a line counts as delivered only after it is found in the text
@@ -15,10 +16,17 @@ namespace DevProjex.Mcp;
 internal sealed class McpServiceNoticeMemo
 {
 	/// <summary>
-	/// Never longer than the shortest set it can replace, so a response cannot grow by omitting
-	/// a notice. Its meaning is spelled out once in the server instructions.
+	/// Stands in for both lines on a response that would have carried both. Never longer than the
+	/// shortest set it can replace, so a response cannot grow by omitting a notice. The meaning of
+	/// the marker is spelled out once in the server instructions.
 	/// </summary>
 	public const string ContinuationNotice = "[Unchanged] filters, protection; see list_projects.";
+
+	/// <summary>Stands in for the effective-filters line alone, on a response that carries no protection line.</summary>
+	public const string FiltersContinuationNotice = "[Unchanged] filters; see list_projects.";
+
+	/// <summary>Stands in for the protection line alone, on a response that carries no effective-filters line.</summary>
+	public const string ProtectionContinuationNotice = "[Unchanged] protection; see list_projects.";
 
 	private readonly Lock gate = new();
 	private string? deliveredIdentity;
@@ -54,7 +62,7 @@ internal sealed class McpServiceNoticeMemo
 				IsDelivered(filters, deliveredFilters) &&
 				IsDelivered(protection, deliveredProtection);
 			if (!alwaysSend && alreadyDelivered)
-				return new McpServiceNotices(null, null, ContinuationNotice);
+				return new McpServiceNotices(null, null, Continuation(filters, protection));
 
 			pendingIdentity = identity;
 			pendingFilters = filters ?? pendingFilters;
@@ -112,6 +120,21 @@ internal sealed class McpServiceNoticeMemo
 
 	private static bool IsDelivered(string? current, string? delivered) =>
 		current is null || string.Equals(current, delivered, StringComparison.Ordinal);
+
+	/// <summary>
+	/// Names the lines this response is actually withholding. A tool that reports no protection
+	/// line is not suppressing one, so naming it would credit the session with a report it never
+	/// received; the same holds for the effective-filters line. A caller reaches this only once
+	/// every line it does carry has already been delivered unchanged, and a response carrying
+	/// neither line never gets here at all.
+	/// </summary>
+	private static string Continuation(string? filters, string? protection) =>
+		(filters, protection) switch
+		{
+			(null, _) => ProtectionContinuationNotice,
+			(_, null) => FiltersContinuationNotice,
+			_ => ContinuationNotice
+		};
 }
 
 internal readonly record struct McpServiceNotices(

--- a/Apps/Mcp/McpTrustedDiagnosticFormatter.cs
+++ b/Apps/Mcp/McpTrustedDiagnosticFormatter.cs
@@ -14,6 +14,19 @@ internal static class McpTrustedDiagnosticFormatter
 		return FormatWarnings(plan.Diagnostics);
 	}
 
+	/// <summary>
+	/// Whether the plan reported a requested path the effective tree does not hold. Tools that
+	/// tolerate a missing path answer over the rest of the selection, so this warning is the only
+	/// signal that part of the request selected nothing.
+	/// </summary>
+	public static bool ReportsMissingSelectedPath(ProjectContextPlan plan)
+	{
+		ArgumentNullException.ThrowIfNull(plan);
+		return plan.Diagnostics.Any(static diagnostic =>
+			diagnostic.Severity == ContextDiagnosticSeverity.Warning &&
+			string.Equals(diagnostic.Code, MissingSelectedPathCode, StringComparison.Ordinal));
+	}
+
 	internal static string? FormatWarnings(IReadOnlyList<ContextDiagnostic> diagnostics)
 	{
 		ArgumentNullException.ThrowIfNull(diagnostics);

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1318,7 +1318,13 @@ truncation trailers are trusted text outside the untrusted-data block.
 recognize Markdown-escaped names copied from the default tree format;
 `max_file_bytes` appears in effective-filter diagnostics when supplied; and
 wrong-case path diagnostics are platform-independent and name the spelling
-listed by `get_tree`.
+listed by `get_tree`. A constant `[Name search]` line names the form that finds a
+file by name: `search_project` adds it when it searched at least one file, matched
+nothing, and the pattern carries a `/` or ends in something shaped like an
+extension, and `get_tree` adds it when a `paths` entry with no separator was not
+present in the effective tree. It states a fact about one call and is never
+memoised; searches that matched, ordinary content patterns, and already-empty
+selections are byte-identical to v5.2 without it.
 
 MCP `get_tree.format` is an additive input with `markdown` as its compact default.
 The existing `text`, `json`, and `xml` tree serializers are available explicitly;

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1297,11 +1297,13 @@ consumers that pinned the pre-v5.2 output schemas must refresh their copies.
 have to explain themselves. It is never the last line: an `[Empty selection]`
 line can follow it, `[Protection]` comes after that, a pinned remote checkout
 adds `[Remote]`, and a budgeted `pack_context` ends with `[Budget accounting]`.
-A session is told each trusted service line once and then receives the constant
-`[Unchanged] filters, protection; see list_projects.` line until that content
-changes; an `[Empty selection]` response and any call that passed
+A session is told each trusted service line once and then receives a constant
+`[Unchanged] ...; see list_projects.` line naming exactly the lines that
+response withheld -- `filters, protection`, `filters`, or `protection` -- until
+that content changes; an `[Empty selection]` response and any call that passed
 `max_file_bytes` report the full set instead. `analyze` reports no protection
-line on any call. Every selection tool adds an `[Empty selection]` line when
+line on any call, so no `analyze` response names one as unchanged, and the tools
+that report no effective-filters line name only the protection line. Every selection tool adds an `[Empty selection]` line when
 nothing survived the filters, and a `DPX-MCP-PATH-NOT-FOUND` error for a file
 the filters hide names the effective filters. Glob patterns gain `{a,b}` alternatives; `!` negation and
 `[...]` classes, previously matched as literal characters, are rejected with

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1326,6 +1326,17 @@ present in the effective tree. It states a fact about one call and is never
 memoised; searches that matched, ordinary content patterns, and already-empty
 selections are byte-identical to v5.2 without it.
 
+MCP `pack_context` gains the optional object input `expand_related`
+(`seeds`, `hops`, `direction`), which packs the seeds together with their
+statically resolved dependency neighbours in one call. It only narrows: the
+neighbourhood is computed over the dependency index built from the plan's own
+included files, so no value can admit a file the effective filters, the Git scope,
+or the project root kept out, and an excluded file never bridges two hops. A seed
+that is not a selected file returns the existing `DPX-MCP-PATH-NOT-FOUND`. The
+expansion stops at 400 files and reports the constant that stopped it. Every call
+that expanded carries a trusted `[Expanded]` line of counts. Without the parameter,
+`pack_context` responses are byte-identical.
+
 MCP `get_tree.format` is an additive input with `markdown` as its compact default.
 The existing `text`, `json`, and `xml` tree serializers are available explicitly;
 structured output that cannot fit the 2,000-line response limit fails with an

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1337,6 +1337,16 @@ expansion stops at 400 files and reports the constant that stopped it. Every cal
 that expanded carries a trusted `[Expanded]` line of counts. Without the parameter,
 `pack_context` responses are byte-identical.
 
+MCP `search_project` names the declaration each shown hit sits inside. It takes no
+input: after the match lines, inside the same untrusted block, the response lists
+`path:line: Name` under `Enclosing declarations:`, and one trusted
+`[Symbols] annotated=N · files-without-declarations=K.` line reports coverage in
+counts. Names come from the dependency index over the files that produced hits, one
+bounded parse per such file. Naming shares the 16,000-character search cap rather
+than adding to it, and a response that cap already cut carries none, so no response
+grows past the bound it already had. Match lines, group separators, the match and
+file counters, and the additional-matches contract are unchanged.
+
 MCP `get_tree.format` is an additive input with `markdown` as its compact default.
 The existing `text`, `json`, and `xml` tree serializers are available explicitly;
 structured output that cannot fit the 2,000-line response limit fails with an

--- a/Docs/CLI-V1-Contract.md
+++ b/Docs/CLI-V1-Contract.md
@@ -1347,6 +1347,14 @@ than adding to it, and a response that cap already cut carries none, so no respo
 grows past the bound it already had. Match lines, group separators, the match and
 file counters, and the additional-matches contract are unchanged.
 
+MCP `get_file` gains the optional `symbol` input, used beside `path` in place of a
+line range, returning the lines that declare it. It accepts a qualified name or a
+simple name unique in the file, cannot be combined with `start_line`, `end_line`,
+or `start_column`, and returns `DPX-MCP-INVALID-ARGUMENTS` for a name matching
+several declarations (reporting the count, never the names), a name matching none,
+and a file no declarations were extracted from. Without it every `get_file`
+response is byte-identical, and the batch `requests` form is unchanged.
+
 MCP `get_tree.format` is an additive input with `markdown` as its compact default.
 The existing `text`, `json`, and `xml` tree serializers are available explicitly;
 structured output that cannot fit the 2,000-line response limit fails with an

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -359,6 +359,54 @@ affected snapshot. Changing only `related_files` seeds or `direction` does not;
 those are projections over the same immutable index. This is an optimization,
 not a strict filesystem snapshot mode, and no strict cache switch is offered.
 
+### `pack_context.expand_related`
+
+`expand_related` packs the seeds together with their statically resolved
+neighbours, so the documented `search_project` to `related_files` to
+`pack_context` sequence becomes one call. It takes `seeds` (1 to 16
+project-relative files), `hops` (1 or 2, default 1), and `direction`
+(`dependencies`, `dependents`, or `both`, default `both`, the same enum
+`related_files.direction` uses). `related_files` keeps its own purpose: it shows
+evidence, resolution status, and candidate lists, and lets a reader choose
+neighbours by hand.
+
+**Expansion only ever narrows.** The neighbourhood is computed over the dependency
+index built from the plan's own included files, which is the set the baseline,
+profile, exclusions, Git scope, `tracked_only`, `paths`, the glob parameters, and
+`max_file_bytes` already produced. A file those filters keep out is not in the
+index, so no value of `expand_related` can reach it, and an excluded file cannot
+act as a bridge: if the only route from a seed to a second-hop file runs through a
+file the filters hid, that second-hop file is not packed. Only `Resolved` edges
+travel; an `Ambiguous` or `Unresolved` reference names a file the engine would not
+commit to, and following it would put a guess in the pack.
+
+A seed must be a file inside the effective selection. A directory, a glob, or a
+path the filters hide returns the existing `DPX-MCP-PATH-NOT-FOUND` error naming
+the effective filters, which is the same answer any other unselected path gets.
+
+Two hops do not bound the result: one widely imported file can reach most of a
+repository. The expansion therefore stops at 400 files, counting the seeds, and
+takes each hop in ordinal path order so the admitted prefix is deterministic rather
+than an arbitrary choice between neighbours.
+
+Every call that expanded reports one trusted line of counts and constants:
+
+```text
+[Expanded] seeds=1 · hop1=+11 · hop2=+0 · seeds-without-facts=0.
+```
+
+and, when the limit decided the answer, `; stopped at the 400-file expansion
+limit, so the neighbourhood is incomplete.` The paths themselves stay in the
+untrusted block with the rest of the pack, as every project path does.
+
+Expansion selects the candidate set; it does not order it. Without `rank` the pack
+keeps canonical path order, and with `rank` the existing ranking orders what
+expansion admitted. To put particular files first under a binding `max_tokens`,
+combine `expand_related` with `rank` and `focus`: a `focus` seed the expansion
+admitted is ranked first as usual, and one it did not admit is a path outside the
+selection and returns `DPX-MCP-PATH-NOT-FOUND`. Without `expand_related` every
+response is byte-identical to a server without it.
+
 ## Result Contract
 
 Only `list_projects` and `analyze` declare an MCP `outputSchema`. Their

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -515,8 +515,8 @@ filters]` line.
 
 Only the repetition of unchanged trusted lines changes. Lines that state a fact
 about one call — `[Remote] commit=`, `[Resolution]`, `[Facts coverage]`,
-`[Search scope]`, `[Budget accounting]`, `[Search totals]`, search and tree
-truncation notices, and every `[Warning ...]` — are computed and sent for every
+`[Search scope]`, `[Budget accounting]`, `[Search totals]`, `[Name search]`,
+search and tree truncation notices, and every `[Warning ...]` — are computed and sent for every
 call as before, and the untrusted-data wrapper around project text is never
 affected.
 
@@ -766,10 +766,27 @@ classes (`[...]`) are rejected with `DPX-MCP-INVALID-PATTERN` rather than
 matched literally, because a silently empty result reads as "no such files".
 `paths` contains existing project-relative files or directories for `get_tree`,
 `analyze`, `pack_context`, and `search_project`. Its entries are literal paths;
-glob metacharacters have meaning only in the pattern parameters. Every array
+glob metacharacters have meaning only in the pattern parameters. A `paths` entry
+carrying no separator therefore names one entry directly in the project root, and
+matches nothing when a file of that name lives deeper. Every array
 parameter requires a JSON array: a bare string where an array is expected returns
 `DPX-MCP-INVALID-ARGUMENTS` naming the argument, for example
 `'paths' must be an array of strings.`, instead of a partial or empty result.
+
+### Finding a file by name
+
+`include_patterns` is the only parameter that matches a file by its name. Content
+search never matches a path, and `paths` selects a path that already exists at the
+depth it names, so both answer a name lookup with nothing useful. Two responses
+therefore carry the constant `[Name search]` line, which names the form that
+works: `search_project` when it searched at least one file, found no match, and
+the pattern carries a `/` or ends in something shaped like an extension; and
+`get_tree` when a `paths` entry with no separator was not present in the effective
+tree. The line is a constant — the pattern and the paths a caller sent never reach
+it — and neither `analyze` nor `pack_context` needs it, because a missing `paths`
+entry there is a `DPX-MCP-PATH-NOT-FOUND` error rather than a partial answer. A
+search that found matches, a search whose pattern reads as ordinary content, and a
+selection that was already empty are all unchanged.
 
 ### Batch `get_file`
 

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -869,6 +869,27 @@ any response larger than the bound it already had. The match lines, the `--` gro
 separators, the match and file counters, and the "N additional matches" contract are
 unchanged.
 
+### Reading a declaration by name
+
+`get_file` accepts `symbol` beside `path` in place of a line range, and returns the
+lines that declare it. It takes a qualified name, or a simple name that is unique
+in that file; the last segment is compared when the qualified form does not match.
+It is the other half of the naming `search_project` does: a hit tells you the
+declaration, and `symbol` reads it without a line arithmetic step in between.
+
+`symbol` cannot be combined with `start_line`, `end_line`, or `start_column`, and
+that combination is rejected before the file is read. Three cases return
+`DPX-MCP-INVALID-ARGUMENTS` rather than a guess: a name matching more than one
+declaration, which reports how many and asks for the qualified form; a name
+matching none; and a file no declarations were extracted from, which is how an
+unsupported language answers. None of these echoes a declaration name, because the
+error text sits outside the untrusted block and a declaration name is project text.
+
+The range is the declaration the index reports, so its granularity is the same as
+the naming on search hits: for C# that is the enclosing type rather than the
+enclosing member. Without `symbol`, every `get_file` response is byte-identical,
+and the batch `requests` form is untouched.
+
 ### Batch `get_file`
 
 Use `requests` when several source excerpts are already known; use `search_project`

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -836,6 +836,39 @@ entry there is a `DPX-MCP-PATH-NOT-FOUND` error rather than a partial answer. A
 search that found matches, a search whose pattern reads as ordinary content, and a
 selection that was already empty are all unchanged.
 
+### Search hits name the declaration that contains them
+
+`search_project` names the declaration each shown hit sits inside. There is no
+parameter for it: a hit without the thing that contains it is what made callers
+guess a line range and read twice. After the match lines, inside the same
+untrusted block, the response carries:
+
+```text
+Enclosing declarations:
+src/App.cs:5: P.App
+```
+
+A declaration name is text this project wrote, so it stays inside the untrusted
+block with the match lines it describes. Only counts leave it, as one trusted
+line: `[Symbols] annotated=N · files-without-declarations=K.`, which
+distinguishes a hit that sits in no declaration from a file that was never
+parsed, plus a `files-past-the-64-file naming limit=` term when a search touched
+more files than the naming bound allows.
+
+The names come from the dependency index built over the files that actually
+produced hits: one bounded parse per such file, never one per hit, and never over
+the whole selection. Granularity is whatever that index declares, which for C# is
+the enclosing type rather than the enclosing member. Hit lines are lines of the
+transformed text the tool returns and the index parses the file on disk; redaction
+replaces a secret with a placeholder on the same line and adds no lines, so the
+two agree on the only coordinate this uses.
+
+Naming shares the 16,000-character search cap rather than adding to it, and a
+response the cap already cut carries no naming at all, so turning it on cannot make
+any response larger than the bound it already had. The match lines, the `--` group
+separators, the match and file counters, and the "N additional matches" contract are
+unchanged.
+
 ### Batch `get_file`
 
 Use `requests` when several source excerpts are already known; use `search_project`

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -475,10 +475,21 @@ The `[Effective filters]` and `[Protection]` lines describe server state, not th
 call, so a session receives them once and then only when what they say changes.
 The change signal is the state the lines are made of: the project, the profile,
 the effective exclusion set, the Git mode, and the protection policy. A response
-that withholds them carries the constant
-`[Unchanged] filters, protection; see list_projects.` instead, which is never
-longer than the shortest set it can replace, so no response grows by omitting a
-notice.
+that withholds them carries a constant pointer instead, and the pointer names
+exactly the lines that response withheld:
+`[Unchanged] filters, protection; see list_projects.` when it would have carried
+both, `[Unchanged] filters; see list_projects.` or
+`[Unchanged] protection; see list_projects.` when it would have carried one. Each
+is never longer than the shortest set it can replace, so no response grows by
+omitting a notice.
+
+A tool that never reports one of the lines is not withholding it, so the pointer
+never names it. `analyze` reports no protection line on any call, and no response
+in a session of `analyze` calls says a protection line is unchanged.
+`search_project` and `get_file` report no effective-filters line while the
+selection is not empty, so what they withhold is the protection line alone and
+that is all their pointer names. A session is never told that a line it was never
+sent has not changed.
 
 Omission has to be provable. When the project cannot be identified, when either
 line would say something this session has not been told for that project, or when

--- a/Docs/Ranking.md
+++ b/Docs/Ranking.md
@@ -133,6 +133,15 @@ complete. It cannot add a seed, dependency, intermediate node, or any other file
 excluded by paths, globs, profiles, Git scope, submodule boundaries, exclusions,
 or the file-size limit. GUI and TUI remain human-ordered surfaces and do not use it.
 
+`expand_related` and `focus` act on different things and compose. Expansion changes
+the candidate set inside the effective selection S: it narrows S to the seeds plus
+their resolved neighbours, and because the dependency index is built from S itself,
+it can only remove from S, never add to it. Focus changes nothing about the set; it
+orders what the set already holds. So a file enters a pack only if the filters
+admitted it, expansion kept it, and the budget had room for it, in that order, and
+the frozen `directed-from-seed` result stands: expansion is that workflow expressed
+as one call, not a new ranking signal.
+
 The dependency facts are indexed once and build the same numeric, deduplicated
 resolved non-self graph used by importance PageRank. Only when focus is present,
 the reverse adjacency is built and a deterministic multi-source BFS treats the

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -17,7 +17,8 @@ internal sealed record DependencySyntaxCapture(
 	string? ContainingDeclaration = null,
 	DependencyImportSyntax? ImportSyntax = null,
 	int CapturedNameStartIndex = -1,
-	string? Evidence = null);
+	string? Evidence = null,
+	int EndLine = -1);
 
 internal sealed record DependencyImportSyntax(
 	string Specifier,
@@ -59,7 +60,10 @@ internal interface IDependencyLanguageAdapter
 internal abstract partial class DependencyLanguageAdapter : IDependencyLanguageAdapter
 {
 	protected static SourceSite Site(DependencyExtractionContext context, DependencySyntaxCapture capture) =>
-		new(context.RelativePath, capture.Line, capture.Evidence ?? OneLine(capture.Text));
+		new(context.RelativePath, capture.Line, capture.Evidence ?? OneLine(capture.Text))
+		{
+			EndLine = capture.EndLine
+		};
 
 	protected static string OneLine(string value)
 	{

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -692,7 +692,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 			containingDeclaration,
 			importSyntax,
 			capturedNameStartIndex,
-			evidence);
+			evidence,
+			checked((int)node.EndPosition.Row + 1));
 
 	private static string? FindContainingDeclaration(
 		Node node,

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1963,7 +1963,7 @@ public sealed partial class McpServerIntegrationTests
 			["read_pack"] = ["pack_id", "start_line", "end_line", "start_column"],
 			["search_project"] = ["project", "branch", "pattern", "paths", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "context_lines", "ignore_case", "max_results"],
 			["related_files"] = ["project", "branch", "path", "direction", "include_patterns", "exclude_patterns", "profile", "tracked_only", "git_scope", "max_file_bytes"],
-			["get_file"] = ["project", "branch", "profile", "path", "requests", "start_line", "end_line", "start_column"]
+			["get_file"] = ["project", "branch", "profile", "path", "requests", "start_line", "end_line", "start_column", "symbol"]
 		};
 		foreach (var tool in tools)
 		{

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -1959,7 +1959,7 @@ public sealed partial class McpServerIntegrationTests
 			["list_projects"] = [],
 			["get_tree"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "max_depth", "format"],
 			["analyze"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "profile", "detail", "detail_by_pattern", "tracked_only", "git_scope", "top_files", "max_file_bytes", "max_tokens", "rank", "focus"],
-			["pack_context"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "profile", "detail", "detail_by_pattern", "tracked_only", "git_scope", "rank", "focus", "max_tokens", "max_file_bytes", "view", "format"],
+			["pack_context"] = ["project", "branch", "paths", "include_patterns", "exclude_patterns", "profile", "detail", "detail_by_pattern", "tracked_only", "git_scope", "rank", "focus", "max_tokens", "max_file_bytes", "expand_related", "view", "format"],
 			["read_pack"] = ["pack_id", "start_line", "end_line", "start_column"],
 			["search_project"] = ["project", "branch", "pattern", "paths", "include_patterns", "exclude_patterns", "tracked_only", "git_scope", "max_file_bytes", "context_lines", "ignore_case", "max_results"],
 			["related_files"] = ["project", "branch", "path", "direction", "include_patterns", "exclude_patterns", "profile", "tracked_only", "git_scope", "max_file_bytes"],

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -214,6 +214,16 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("[Search truncated]", server, StringComparison.Ordinal);
 		Assert.Contains("16,000 characters", normalized, StringComparison.Ordinal);
 		Assert.Contains("### Finding a file by name", server, StringComparison.Ordinal);
+		Assert.Contains(
+			"### Search hits name the declaration that contains them",
+			server,
+			StringComparison.Ordinal);
+		Assert.Contains("Enclosing declarations:", server, StringComparison.Ordinal);
+		Assert.Contains(
+			"[Symbols] annotated=N · files-without-declarations=K.",
+			server,
+			StringComparison.Ordinal);
+		Assert.Contains("There is no parameter for it", normalized, StringComparison.Ordinal);
 		Assert.Contains("### `pack_context.expand_related`", server, StringComparison.Ordinal);
 		Assert.Contains("**Expansion only ever narrows.**", server, StringComparison.Ordinal);
 		Assert.Contains(

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -214,6 +214,13 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("[Search truncated]", server, StringComparison.Ordinal);
 		Assert.Contains("16,000 characters", normalized, StringComparison.Ordinal);
 		Assert.Contains("### Finding a file by name", server, StringComparison.Ordinal);
+		Assert.Contains("### `pack_context.expand_related`", server, StringComparison.Ordinal);
+		Assert.Contains("**Expansion only ever narrows.**", server, StringComparison.Ordinal);
+		Assert.Contains(
+			"[Expanded] seeds=1 · hop1=+11 · hop2=+0 · seeds-without-facts=0.",
+			server,
+			StringComparison.Ordinal);
+		Assert.Contains("stops at 400 files", normalized, StringComparison.Ordinal);
 		Assert.Contains(
 			"`include_patterns` is the only parameter that matches a file by its name",
 			normalized,

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -224,6 +224,11 @@ public sealed class DocumentationAndPackagingContractTests
 			server,
 			StringComparison.Ordinal);
 		Assert.Contains("There is no parameter for it", normalized, StringComparison.Ordinal);
+		Assert.Contains("### Reading a declaration by name", server, StringComparison.Ordinal);
+		Assert.Contains(
+			"`symbol` cannot be combined with `start_line`, `end_line`, or `start_column`",
+			normalized,
+			StringComparison.Ordinal);
 		Assert.Contains("### `pack_context.expand_related`", server, StringComparison.Ordinal);
 		Assert.Contains("**Expansion only ever narrows.**", server, StringComparison.Ordinal);
 		Assert.Contains(

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -230,6 +230,22 @@ public sealed class DocumentationAndPackagingContractTests
 			"`[Unchanged] filters, protection; see list_projects.`",
 			normalizedServer,
 			StringComparison.Ordinal);
+		Assert.Contains(
+			"`[Unchanged] filters; see list_projects.`",
+			normalizedServer,
+			StringComparison.Ordinal);
+		Assert.Contains(
+			"`[Unchanged] protection; see list_projects.`",
+			normalizedServer,
+			StringComparison.Ordinal);
+		Assert.Contains(
+			"the pointer names exactly the lines that response withheld",
+			normalizedServer,
+			StringComparison.Ordinal);
+		Assert.Contains(
+			"A session is never told that a line it was never sent has not changed",
+			normalizedServer,
+			StringComparison.Ordinal);
 		Assert.Contains("Omission has to be provable", normalizedServer, StringComparison.Ordinal);
 		Assert.Contains(
 			"any call that passed `max_file_bytes`",

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -213,6 +213,12 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("[Search totals] matches=N · files=M", server, StringComparison.Ordinal);
 		Assert.Contains("[Search truncated]", server, StringComparison.Ordinal);
 		Assert.Contains("16,000 characters", normalized, StringComparison.Ordinal);
+		Assert.Contains("### Finding a file by name", server, StringComparison.Ordinal);
+		Assert.Contains(
+			"`include_patterns` is the only parameter that matches a file by its name",
+			normalized,
+			StringComparison.Ordinal);
+		Assert.Contains("the constant `[Name search]` line", normalized, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.NameSearch.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.NameSearch.cs
@@ -1,0 +1,128 @@
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	private const string NameSearchNotice =
+		"[Name search] File names and paths are matched only by include_patterns: prefix a bare name " +
+		"with '**/' to find it at any depth, or append '/**' to a directory to select its files. " +
+		"search_project matches file content, and paths selects a path that already exists.";
+
+	[Fact]
+	public async Task RealProcessAnswersEveryNaturalFileNameSearchWithAResultOrTheFormToType()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartNameSearchProjectAsync(workspace);
+		{
+			// The eight forms a caller reaches for to answer "where is the file named App.cs".
+			// The project holds src/App.cs and src/deep/App.cs and no App.cs in its root.
+			var contentWithName = await SearchAsync(server, "App.cs");
+			var contentWithPathRegex = await SearchAsync(server, "src/.*App.*\\.cs$");
+			var bareName = await TreeAsync(server, "include_patterns", ["App.cs"]);
+			var starsWithoutSlash = await TreeAsync(server, "include_patterns", ["*App*"]);
+			var spanningName = await TreeAsync(server, "include_patterns", ["**/App.cs"]);
+			var spanningStars = await TreeAsync(server, "include_patterns", ["**/*App*"]);
+			var pathBareName = await TreeAsync(server, "paths", ["App.cs"]);
+			var pathDirectory = await TreeAsync(server, "paths", ["src"]);
+
+			// Content search never matches a name, and now says so and names the form that does.
+			foreach (var text in new[] { contentWithName, contentWithPathRegex })
+			{
+				Assert.Contains("[No matches]", text, StringComparison.Ordinal);
+				Assert.Contains(NameSearchNotice, text, StringComparison.Ordinal);
+			}
+
+			// A pattern with no '/' and no '**' is root-only, which is the documented rule; the
+			// empty result already names the rewrite that reaches any depth.
+			foreach (var text in new[] { bareName, starsWithoutSlash })
+			{
+				Assert.Contains("[Empty selection] stage=patterns.", text, StringComparison.Ordinal);
+				Assert.Contains(
+					"prefix it with '**/' to match that name at any depth",
+					text,
+					StringComparison.Ordinal);
+			}
+
+			// The two spanning forms answer with the files themselves and gain nothing.
+			foreach (var text in new[] { spanningName, spanningStars })
+			{
+				Assert.Contains("App.cs", text, StringComparison.Ordinal);
+				Assert.Contains("deep", text, StringComparison.Ordinal);
+				Assert.DoesNotContain("Helper.cs", text, StringComparison.Ordinal);
+				Assert.DoesNotContain("[Name search]", text, StringComparison.Ordinal);
+				Assert.DoesNotContain("[Empty selection]", text, StringComparison.Ordinal);
+			}
+
+			// paths selects paths that already exist, so a bare name that lives deeper misses. The
+			// response kept its warning and now also names the form that finds the file.
+			Assert.Contains("[Warning DPX-SELECTION-PATH-MISSING]", pathBareName, StringComparison.Ordinal);
+			Assert.Contains(NameSearchNotice, pathBareName, StringComparison.Ordinal);
+
+			// A directory in paths already works and is left alone.
+			Assert.Contains("Helper.cs", pathDirectory, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Name search]", pathDirectory, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Warning DPX-SELECTION-PATH-MISSING]", pathDirectory, StringComparison.Ordinal);
+		}
+	}
+
+	[Fact]
+	public async Task RealProcessLeavesAContentSearchThatSimplyFoundNothingUnchanged()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartNameSearchProjectAsync(workspace);
+		{
+			var found = await SearchAsync(server, "sealed");
+			var missed = await SearchAsync(server, "absentphrase");
+
+			// A pattern that carries neither a separator nor an extension is a content search that
+			// found nothing, and it keeps the response it has always had.
+			Assert.Contains("[No matches]", missed, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Name search]", missed, StringComparison.Ordinal);
+
+			// A search that found something never carries the pointer either.
+			Assert.Contains("src/App.cs:", found, StringComparison.Ordinal);
+			Assert.DoesNotContain("[No matches]", found, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Name search]", found, StringComparison.Ordinal);
+
+			// A selection that held no file to search already explains itself, and is left alone
+			// even though the pattern reads like a file name.
+			var nothingSelected = AllProcessText(await CallAsync(
+				server,
+				"search_project",
+				new Dictionary<string, object?>
+				{
+					["pattern"] = "App.cs",
+					["context_lines"] = 0,
+					["include_patterns"] = new[] { "**/*.nothing" }
+				}));
+			Assert.Contains("[Empty selection] stage=patterns.", nothingSelected, StringComparison.Ordinal);
+			Assert.DoesNotContain("[No matches]", nothingSelected, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Name search]", nothingSelected, StringComparison.Ordinal);
+		}
+	}
+
+	private static async ValueTask<ActualMcpProcess> StartNameSearchProjectAsync(
+		TemporaryDirectory workspace)
+	{
+		var project = workspace.CreateDirectory("name-search-project");
+		workspace.WriteFile("name-search-project/Readme.md", "# Notes\n");
+		workspace.WriteFile("name-search-project/src/App.cs", "namespace P;\n\npublic sealed class App;\n");
+		workspace.WriteFile("name-search-project/src/Helper.cs", "namespace P;\n\npublic sealed class Helper;\n");
+		workspace.WriteFile("name-search-project/src/deep/App.cs", "namespace P.Deep;\n\npublic sealed class App;\n");
+		return await ActualMcpProcess.StartAsync(project, workspace.CreateDirectory("data"));
+	}
+
+	private static async ValueTask<string> SearchAsync(ActualMcpProcess server, string pattern) =>
+		AllProcessText(await CallAsync(
+			server,
+			"search_project",
+			new Dictionary<string, object?> { ["pattern"] = pattern, ["context_lines"] = 0 }));
+
+	private static async ValueTask<string> TreeAsync(
+		ActualMcpProcess server,
+		string argument,
+		string[] values) =>
+		AllProcessText(await CallAsync(
+			server,
+			"get_tree",
+			new Dictionary<string, object?> { ["format"] = "text", [argument] = values }));
+}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RelatedExpansion.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.RelatedExpansion.cs
@@ -1,0 +1,195 @@
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	[Fact]
+	public async Task RealProcessPacksASeedWithItsResolvedNeighbourhoodInOneCall()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartExpansionProjectAsync(workspace);
+
+		var oneHop = await PackAsync(server, Expansion(["src/a.ts"], hops: 1, direction: "dependencies"));
+		var twoHops = await PackAsync(server, Expansion(["src/a.ts"], hops: 2, direction: "dependencies"));
+
+		// One hop reaches what the seed imports and stops there.
+		Assert.Contains(
+			"[Expanded] seeds=1 · hop1=+1 · hop2=+0 · seeds-without-facts=0.",
+			oneHop,
+			StringComparison.Ordinal);
+		Assert.Contains("export const a", oneHop, StringComparison.Ordinal);
+		Assert.Contains("export const b", oneHop, StringComparison.Ordinal);
+		Assert.DoesNotContain("export const c", oneHop, StringComparison.Ordinal);
+		Assert.DoesNotContain("export const unrelated", oneHop, StringComparison.Ordinal);
+
+		// Two hops reach the whole chain, and still nothing outside it.
+		Assert.Contains(
+			"[Expanded] seeds=1 · hop1=+1 · hop2=+1 · seeds-without-facts=0.",
+			twoHops,
+			StringComparison.Ordinal);
+		Assert.Contains("export const c", twoHops, StringComparison.Ordinal);
+		Assert.DoesNotContain("export const unrelated", twoHops, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessExpansionNeverReachesOutsideTheEffectiveSelection()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartExpansionProjectAsync(workspace);
+
+		var arguments = Expansion(["src/a.ts"], hops: 2, direction: "dependencies");
+		arguments["exclude_patterns"] = new[] { "**/b.ts" };
+		var excludedIntermediate = await PackAsync(server, arguments);
+
+		// b.ts is outside the effective selection, so the edge into it does not exist for the
+		// expansion and c.ts is never linked through it. An excluded file cannot be a bridge.
+		Assert.Contains(
+			"[Expanded] seeds=1 · hop1=+0 · hop2=+0 · seeds-without-facts=0.",
+			excludedIntermediate,
+			StringComparison.Ordinal);
+		Assert.Contains("export const a", excludedIntermediate, StringComparison.Ordinal);
+		Assert.DoesNotContain("export const b", excludedIntermediate, StringComparison.Ordinal);
+		Assert.DoesNotContain("export const c", excludedIntermediate, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessExpansionComposesWithFocusAndRejectsASeedItDidNotAdmit()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartExpansionProjectAsync(workspace);
+
+		var admitted = Expansion(["src/a.ts"], hops: 2, direction: "dependencies");
+		admitted["rank"] = "importance";
+		admitted["max_tokens"] = 20_000;
+		admitted["focus"] = new[] { "src/c.ts" };
+		var withFocus = await PackAsync(server, admitted);
+
+		var rejected = Expansion(["src/a.ts"], hops: 2, direction: "dependencies");
+		rejected["rank"] = "importance";
+		rejected["max_tokens"] = 20_000;
+		rejected["focus"] = new[] { "src/unrelated.ts" };
+		var focusOutside = await CallAsync(server, "pack_context", rejected);
+
+		// A focus seed the expansion admitted is ordinary focus ranking.
+		Assert.Contains("export const c", withFocus, StringComparison.Ordinal);
+		Assert.Contains("[Expanded] seeds=1", withFocus, StringComparison.Ordinal);
+
+		// One the expansion did not admit is simply a path outside the selection, and gets the
+		// error every unselected path gets, naming the filters that decided it.
+		Assert.True(focusOutside.IsError);
+		var failure = AllProcessText(focusOutside);
+		Assert.Contains("DPX-MCP-PATH-NOT-FOUND", failure, StringComparison.Ordinal);
+		Assert.Contains("exclusions:", failure, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessRejectsAnExpansionSeedThatIsNotASelectedFile()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartExpansionProjectAsync(workspace);
+
+		var directorySeed = await CallAsync(
+			server,
+			"pack_context",
+			Expansion(["src"], hops: 1, direction: "both"));
+		var absentSeed = await CallAsync(
+			server,
+			"pack_context",
+			Expansion(["src/missing.ts"], hops: 1, direction: "both"));
+		var badHops = await CallAsync(
+			server,
+			"pack_context",
+			Expansion(["src/a.ts"], hops: 3, direction: "both"));
+
+		Assert.True(directorySeed.IsError);
+		Assert.True(absentSeed.IsError);
+		Assert.True(badHops.IsError);
+		Assert.Contains(
+			"'expand_related' 'hops' must be 1 or 2.",
+			AllProcessText(badHops),
+			StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessLeavesAPackWithoutExpansionExactlyAsItWas()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartExpansionProjectAsync(workspace);
+
+		var plain = await PackAsync(
+			server,
+			new Dictionary<string, object?> { ["view"] = "content", ["format"] = "text" });
+
+		// Every file the filters admit, and not one word about expansion.
+		Assert.Contains("export const a", plain, StringComparison.Ordinal);
+		Assert.Contains("export const unrelated", plain, StringComparison.Ordinal);
+		Assert.DoesNotContain("[Expanded]", plain, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessStopsAnExpansionAtItsPublishedFileLimit()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("expansion-limit-project");
+		workspace.WriteFile(
+			"expansion-limit-project/tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}\n");
+		workspace.WriteFile("expansion-limit-project/src/hub.ts", "export const hub = 1;\n");
+		for (var index = 0; index < 460; index++)
+		{
+			workspace.WriteFile(
+				$"expansion-limit-project/src/leaf-{index:D4}.ts",
+				$"import {{ hub }} from './hub.js'; export const leaf{index} = hub;\n");
+		}
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		var arguments = Expansion(["src/hub.ts"], hops: 1, direction: "dependents");
+		arguments["view"] = "tree";
+		var packed = await PackAsync(server, arguments);
+
+		// 460 dependents cannot all be packed, and the response names the constant that stopped it
+		// rather than quietly returning a prefix.
+		Assert.Contains("[Expanded] seeds=1 · hop1=+399", packed, StringComparison.Ordinal);
+		Assert.Contains(
+			"stopped at the 400-file expansion limit, so the neighbourhood is incomplete.",
+			packed,
+			StringComparison.Ordinal);
+	}
+
+	private static Dictionary<string, object?> Expansion(string[] seeds, int hops, string direction) =>
+		new()
+		{
+			["view"] = "content",
+			["format"] = "text",
+			["expand_related"] = new Dictionary<string, object?>
+			{
+				["seeds"] = seeds,
+				["hops"] = hops,
+				["direction"] = direction
+			}
+		};
+
+	private static async ValueTask<string> PackAsync(
+		ActualMcpProcess server,
+		Dictionary<string, object?> arguments) =>
+		AllProcessText(await CallAsync(server, "pack_context", arguments));
+
+	private static async ValueTask<ActualMcpProcess> StartExpansionProjectAsync(
+		TemporaryDirectory workspace)
+	{
+		var project = workspace.CreateDirectory("expansion-project");
+		workspace.WriteFile(
+			"expansion-project/tsconfig.json",
+			"{\"compilerOptions\":{\"moduleResolution\":\"bundler\"}}\n");
+		workspace.WriteFile(
+			"expansion-project/src/a.ts",
+			"import { b } from './b.js';\nexport const a = b;\n");
+		workspace.WriteFile(
+			"expansion-project/src/b.ts",
+			"import { c } from './c.js';\nexport const b = c;\n");
+		workspace.WriteFile("expansion-project/src/c.ts", "export const c = 1;\n");
+		workspace.WriteFile("expansion-project/src/unrelated.ts", "export const unrelated = 2;\n");
+		return await ActualMcpProcess.StartAsync(project, workspace.CreateDirectory("data"));
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchSymbols.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchSymbols.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	[Fact]
+	public async Task RealProcessNamesTheDeclarationEachSearchHitSitsInsideWithoutBeingAsked()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("symbol-project");
+		workspace.WriteFile(
+			"symbol-project/src/App.cs",
+			"namespace P;\n\npublic sealed class App\n{\n\tpublic int Run() => 1;\n}\n");
+		workspace.WriteFile(
+			"symbol-project/src/Helper.cs",
+			"namespace P;\n\npublic sealed class Helper\n{\n\tpublic int Assist() => 2;\n}\n");
+		workspace.WriteFile("symbol-project/README.md", "# Notes\n\nmarker line\n");
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		// No flag is passed: naming is what the tool does.
+		var code = AllProcessText(await CallAsync(
+			server,
+			"search_project",
+			new Dictionary<string, object?> { ["pattern"] = "=> [0-9]", ["context_lines"] = 0 }));
+
+		Assert.Contains("src/App.cs:5:", code, StringComparison.Ordinal);
+		Assert.Contains("src/Helper.cs:5:", code, StringComparison.Ordinal);
+		Assert.Contains("Enclosing declarations:", code, StringComparison.Ordinal);
+		Assert.Contains("src/App.cs:5: P.App", code, StringComparison.Ordinal);
+		Assert.Contains("src/Helper.cs:5: P.Helper", code, StringComparison.Ordinal);
+		Assert.Contains("[Symbols] annotated=2 · files-without-declarations=0.", code, StringComparison.Ordinal);
+
+		// A declaration name is project text, so it stays inside the untrusted block with the match
+		// lines, and only the counts are trusted.
+		var untrustedEnd = code.LastIndexOf("</untrusted-data-", StringComparison.Ordinal);
+		Assert.True(untrustedEnd > 0);
+		Assert.True(
+			code.IndexOf("src/App.cs:5: P.App", StringComparison.Ordinal) < untrustedEnd,
+			"The declaration name must not be reported outside the untrusted block.");
+		Assert.True(code.IndexOf("[Symbols]", StringComparison.Ordinal) > untrustedEnd);
+	}
+
+	[Fact]
+	public async Task RealProcessCountsAHitInAFileThatDeclaresNothingInsteadOfNamingIt()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("prose-project");
+		workspace.WriteFile("prose-project/README.md", "# Notes\n\nmarker line\n");
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		var prose = AllProcessText(await CallAsync(
+			server,
+			"search_project",
+			new Dictionary<string, object?> { ["pattern"] = "marker", ["context_lines"] = 0 }));
+
+		Assert.Contains("README.md:3:marker line", prose, StringComparison.Ordinal);
+		Assert.DoesNotContain("Enclosing declarations:", prose, StringComparison.Ordinal);
+		Assert.Contains("[Symbols] annotated=0 · files-without-declarations=1.", prose, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessSpendsNoResponseCharactersOnNamingWhenTheSearchCapAlreadyFired()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("wide-symbol-project");
+		for (var file = 0; file < 40; file++)
+		{
+			var lines = new StringBuilder();
+			lines.Append("namespace P;\n\npublic sealed class Wide");
+			lines.Append(file.ToString("D2", CultureInfo.InvariantCulture));
+			lines.Append("\n{\n");
+			for (var member = 0; member < 20; member++)
+			{
+				// Long enough that twenty of them in forty files cannot fit the search cap.
+				lines.Append("\tpublic string Needle");
+				lines.Append(member.ToString("D2", CultureInfo.InvariantCulture));
+				lines.Append("() => \"");
+				lines.Append(new string('p', 280));
+				lines.Append("\";\n");
+			}
+
+			lines.Append("}\n");
+			workspace.WriteFile(
+				$"wide-symbol-project/src/Wide{file:D2}.cs",
+				lines.ToString());
+		}
+
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		var wide = AllProcessText(await CallAsync(
+			server,
+			"search_project",
+			new Dictionary<string, object?>
+			{
+				["pattern"] = "public string Needle",
+				["context_lines"] = 3,
+				["max_results"] = 200
+			}));
+
+		// The cap fired, so the response says so and carries no naming at all: turning naming on
+		// cannot push a capped response past the size it already had.
+		Assert.Contains("[Search truncated]", wide, StringComparison.Ordinal);
+		Assert.DoesNotContain("Enclosing declarations:", wide, StringComparison.Ordinal);
+		Assert.DoesNotContain("[Symbols]", wide, StringComparison.Ordinal);
+		Assert.True(wide.Length <= 18_000, $"Capped search returned {wide.Length} characters.");
+	}
+}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.ServiceNotices.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.ServiceNotices.cs
@@ -5,6 +5,8 @@ namespace DevProjex.Tests.Terminal;
 public sealed partial class McpServerProcessTests
 {
 	private const string UnchangedServiceNotice = "[Unchanged] filters, protection; see list_projects.";
+	private const string UnchangedFiltersServiceNotice = "[Unchanged] filters; see list_projects.";
+	private const string UnchangedProtectionServiceNotice = "[Unchanged] protection; see list_projects.";
 
 	[Fact]
 	public async Task RealProcessSendsServiceNoticesOnceWhileTheyKeepSayingTheSameThing()
@@ -39,17 +41,24 @@ public sealed partial class McpServerProcessTests
 		Assert.Equal(10, texts.Count);
 		Assert.Single(texts, static text => text.Contains("[Effective filters]", StringComparison.Ordinal));
 		Assert.Single(texts, static text => text.Contains("[Protection]", StringComparison.Ordinal));
+		Assert.Equal(8, texts.Count(HasContinuation));
+		// Two of the eight are tree calls, which carry both lines. The six content reads carry no
+		// filters line at all, so their continuation names only the line they actually withheld.
 		Assert.Equal(
-			8,
+			2,
 			texts.Count(static text => text.Contains(UnchangedServiceNotice, StringComparison.Ordinal)));
+		Assert.Equal(
+			6,
+			texts.Count(static text =>
+				text.Contains(UnchangedProtectionServiceNotice, StringComparison.Ordinal)));
 		// list_projects is the orientation call and always answers with the whole baseline.
-		Assert.DoesNotContain(UnchangedServiceNotice, texts[0], StringComparison.Ordinal);
+		Assert.False(HasContinuation(texts[0]));
 		Assert.Contains("\"exclusions\"", texts[0], StringComparison.Ordinal);
 		Assert.Contains("\"protection\"", texts[0], StringComparison.Ordinal);
 		// The first response that carries them carries both in full.
 		Assert.Contains("[Effective filters]", texts[1], StringComparison.Ordinal);
 		Assert.Contains("[Protection]", texts[1], StringComparison.Ordinal);
-		Assert.DoesNotContain(UnchangedServiceNotice, texts[1], StringComparison.Ordinal);
+		Assert.False(HasContinuation(texts[1]));
 	}
 
 	[Fact]
@@ -100,7 +109,7 @@ public sealed partial class McpServerProcessTests
 		Assert.Single(texts, static text => text.Contains("[Effective filters]", StringComparison.Ordinal));
 		Assert.Single(texts, static text => text.Contains("[Protection]", StringComparison.Ordinal));
 		Assert.Contains("[Effective filters]", texts[0], StringComparison.Ordinal);
-		Assert.DoesNotContain(UnchangedServiceNotice, texts[0], StringComparison.Ordinal);
+		Assert.False(HasContinuation(texts[0]));
 		Assert.Equal(
 			3,
 			texts.Count(static text => text.Contains(UnchangedServiceNotice, StringComparison.Ordinal)));
@@ -186,9 +195,9 @@ public sealed partial class McpServerProcessTests
 			"get_file",
 			new Dictionary<string, object?> { ["path"] = "src/Alpha.ts" }));
 
-		Assert.Contains(UnchangedServiceNotice, firstResponse, StringComparison.Ordinal);
+		Assert.Contains(UnchangedProtectionServiceNotice, firstResponse, StringComparison.Ordinal);
 		Assert.Contains("[Protection]", freshResponse, StringComparison.Ordinal);
-		Assert.DoesNotContain(UnchangedServiceNotice, freshResponse, StringComparison.Ordinal);
+		Assert.False(HasContinuation(freshResponse));
 	}
 
 	[Fact]
@@ -214,7 +223,7 @@ public sealed partial class McpServerProcessTests
 		// A response that has to explain why it is empty always names the filters that emptied it.
 		Assert.Contains("[Empty selection]", empty, StringComparison.Ordinal);
 		Assert.Contains("[Effective filters]", empty, StringComparison.Ordinal);
-		Assert.DoesNotContain(UnchangedServiceNotice, empty, StringComparison.Ordinal);
+		Assert.False(HasContinuation(empty));
 	}
 
 	[Fact]
@@ -249,7 +258,7 @@ public sealed partial class McpServerProcessTests
 
 		Assert.Contains("Related-files result stored as", stored, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Protection]", stored, StringComparison.Ordinal);
-		Assert.DoesNotContain(UnchangedServiceNotice, next, StringComparison.Ordinal);
+		Assert.False(HasContinuation(next));
 		Assert.Contains("[Effective filters]", next, StringComparison.Ordinal);
 		Assert.Contains("[Protection]", next, StringComparison.Ordinal);
 	}
@@ -274,9 +283,119 @@ public sealed partial class McpServerProcessTests
 			new Dictionary<string, object?> { ["path"] = "src/Alpha.ts" }));
 
 		Assert.True(failed.IsError);
-		Assert.DoesNotContain(UnchangedServiceNotice, next, StringComparison.Ordinal);
+		Assert.False(HasContinuation(next));
 		Assert.Contains("[Protection]", next, StringComparison.Ordinal);
 	}
+
+	[Fact]
+	public async Task RealProcessNeverReportsAnUnchangedProtectionLineInAnAnalyzeOnlySession()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("analyze-only-project");
+		workspace.WriteFile("analyze-only-project/src/Alpha.ts", "export const alpha = 1\n");
+		workspace.WriteFile("analyze-only-project/src/Beta.ts", "export const beta = 2\n");
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		var texts = new List<string>();
+		for (var call = 0; call < 4; call++)
+		{
+			texts.Add(AllProcessText(await CallAsync(
+				server,
+				"analyze",
+				new Dictionary<string, object?>())));
+		}
+
+		// analyze reports no protection line on any call, so no response of this session may say a
+		// protection line is unchanged: the session has never carried one.
+		Assert.Equal(4, texts.Count);
+		Assert.All(
+			texts,
+			static text => Assert.DoesNotContain("[Protection]", text, StringComparison.Ordinal));
+		Assert.All(texts, static text => Assert.False(HasContinuation(text)));
+	}
+
+	[Fact]
+	public async Task RealProcessNamesOnlyTheProtectionLineWhenTheSessionNeverCarriedFilters()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("reads-only-project");
+		workspace.WriteFile("reads-only-project/src/Alpha.ts", "export const alpha = 1\n");
+		workspace.WriteFile("reads-only-project/src/Beta.ts", "export const beta = 2\n");
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		// Neither tool reports an effective-filters line on a selection that is not empty, so this
+		// session never carries one.
+		var first = AllProcessText(await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/Alpha.ts" }));
+		var second = AllProcessText(await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/Beta.ts" }));
+		var third = AllProcessText(await CallAsync(
+			server,
+			"search_project",
+			new Dictionary<string, object?> { ["pattern"] = "alpha", ["context_lines"] = 0 }));
+
+		Assert.Contains("[Protection]", first, StringComparison.Ordinal);
+		Assert.DoesNotContain("[Effective filters]", first, StringComparison.Ordinal);
+		Assert.False(HasContinuation(first));
+
+		foreach (var text in new[] { second, third })
+		{
+			Assert.Contains(UnchangedProtectionServiceNotice, text, StringComparison.Ordinal);
+			Assert.DoesNotContain(UnchangedServiceNotice, text, StringComparison.Ordinal);
+			Assert.DoesNotContain(UnchangedFiltersServiceNotice, text, StringComparison.Ordinal);
+			Assert.DoesNotContain("[Effective filters]", text, StringComparison.Ordinal);
+		}
+	}
+
+	[Fact]
+	public async Task RealProcessNamesTheLinesEachResponseActuallyWithholds()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("mixed-project");
+		workspace.WriteFile("mixed-project/src/Alpha.ts", "export const alpha = 1\n");
+		await using var server = await ActualMcpProcess.StartAsync(
+			project,
+			workspace.CreateDirectory("data"));
+
+		var tree = AllProcessText(await CallAsync(
+			server,
+			"get_tree",
+			new Dictionary<string, object?> { ["format"] = "text" }));
+		var read = AllProcessText(await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/Alpha.ts" }));
+		var repeatedTree = AllProcessText(await CallAsync(
+			server,
+			"get_tree",
+			new Dictionary<string, object?> { ["format"] = "text" }));
+
+		// The tree carries both lines, so it is the one response that can withhold both later.
+		Assert.Contains("[Effective filters]", tree, StringComparison.Ordinal);
+		Assert.Contains("[Protection]", tree, StringComparison.Ordinal);
+		Assert.False(HasContinuation(tree));
+
+		// The read would have carried only a protection line, so that is all it can stand in for,
+		// even though the session has by now reported an effective-filters line as well.
+		Assert.Contains(UnchangedProtectionServiceNotice, read, StringComparison.Ordinal);
+		Assert.DoesNotContain(UnchangedServiceNotice, read, StringComparison.Ordinal);
+
+		Assert.Contains(UnchangedServiceNotice, repeatedTree, StringComparison.Ordinal);
+		Assert.DoesNotContain(UnchangedProtectionServiceNotice, repeatedTree, StringComparison.Ordinal);
+	}
+
+	private static bool HasContinuation(string text) =>
+		text.Contains(UnchangedServiceNotice, StringComparison.Ordinal) ||
+		text.Contains(UnchangedFiltersServiceNotice, StringComparison.Ordinal) ||
+		text.Contains(UnchangedProtectionServiceNotice, StringComparison.Ordinal);
 
 	private static ValueTask<CallToolResult> CallAsync(
 		ActualMcpProcess server,

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SymbolReads.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SymbolReads.cs
@@ -1,0 +1,115 @@
+namespace DevProjex.Tests.Terminal;
+
+public sealed partial class McpServerProcessTests
+{
+	[Fact]
+	public async Task RealProcessReadsADeclarationByNameInsteadOfAGuessedLineRange()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartSymbolReadProjectAsync(workspace);
+
+		var qualified = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/App.cs", ["symbol"] = "P.App" });
+		var simple = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/App.cs", ["symbol"] = "App" });
+
+		var qualifiedText = AllProcessText(qualified);
+		Assert.NotEqual(true, qualified.IsError);
+		Assert.Contains("public sealed class App", qualifiedText, StringComparison.Ordinal);
+		Assert.Contains("public int Run()", qualifiedText, StringComparison.Ordinal);
+		// The declaration ends where it ends: the trailing file content is not part of it.
+		Assert.DoesNotContain("public sealed class Sibling", qualifiedText, StringComparison.Ordinal);
+
+		// A simple name that is unique in the file resolves to the same declaration.
+		Assert.NotEqual(true, simple.IsError);
+		Assert.Contains("public sealed class App", AllProcessText(simple), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessRefusesASymbolItCannotResolveToExactlyOneDeclaration()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartSymbolReadProjectAsync(workspace);
+
+		var unknown = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/App.cs", ["symbol"] = "NoSuchThing" });
+		var withRange = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?>
+			{
+				["path"] = "src/App.cs",
+				["symbol"] = "P.App",
+				["start_line"] = 1
+			});
+		var prose = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "README.md", ["symbol"] = "Notes" });
+
+		Assert.True(unknown.IsError);
+		Assert.Contains(
+			"'symbol' matches no declaration in this file",
+			AllProcessText(unknown),
+			StringComparison.Ordinal);
+
+		Assert.True(withRange.IsError);
+		Assert.Contains(
+			"cannot be combined with start_line, end_line, or start_column",
+			AllProcessText(withRange),
+			StringComparison.Ordinal);
+
+		Assert.True(prose.IsError);
+		Assert.Contains(
+			"'symbol' is not supported for this file",
+			AllProcessText(prose),
+			StringComparison.Ordinal);
+
+		// The refusals report what happened in codes and counts and never echo a declaration name.
+		foreach (var failure in new[] { unknown, withRange, prose })
+			Assert.DoesNotContain("public sealed class", AllProcessText(failure), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task RealProcessLeavesALineAddressedReadExactlyAsItWas()
+	{
+		using var workspace = new TemporaryDirectory();
+		await using var server = await StartSymbolReadProjectAsync(workspace);
+
+		var byLines = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?>
+			{
+				["path"] = "src/App.cs",
+				["start_line"] = 3,
+				["end_line"] = 6
+			});
+		var whole = await CallAsync(
+			server,
+			"get_file",
+			new Dictionary<string, object?> { ["path"] = "src/App.cs" });
+
+		Assert.NotEqual(true, byLines.IsError);
+		Assert.NotEqual(true, whole.IsError);
+		Assert.Contains("public sealed class App", AllProcessText(byLines), StringComparison.Ordinal);
+		Assert.Contains("public sealed class Sibling", AllProcessText(whole), StringComparison.Ordinal);
+	}
+
+	private static async ValueTask<ActualMcpProcess> StartSymbolReadProjectAsync(
+		TemporaryDirectory workspace)
+	{
+		var project = workspace.CreateDirectory("symbol-read-project");
+		workspace.WriteFile(
+			"symbol-read-project/src/App.cs",
+			"namespace P;\n\npublic sealed class App\n{\n\tpublic int Run() => 1;\n}\n\npublic sealed class Sibling\n{\n\tpublic int Assist() => 2;\n}\n");
+		workspace.WriteFile("symbol-read-project/README.md", "# Notes\n\nmarker line\n");
+		return await ActualMcpProcess.StartAsync(project, workspace.CreateDirectory("data"));
+	}
+}

--- a/Tests/DevProjex.Tests.Unit/McpServiceNoticeMemoTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpServiceNoticeMemoTests.cs
@@ -1,0 +1,82 @@
+using DevProjex.Mcp;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class McpServiceNoticeMemoTests
+{
+	private const string Project = "project";
+	private const string Filters = "[Effective filters] git: gitignore; exclusions: smart-ignore.";
+	private const string Protection = "[Protection] secrets=always · private-data=disabled.";
+
+	[Fact]
+	public void AContinuationNamesBothLinesOnlyWhenTheResponseWithholdsBoth()
+	{
+		var memo = new McpServiceNoticeMemo();
+		Deliver(memo, Filters, Protection);
+
+		var repeated = memo.Prepare(Project, Filters, Protection, alwaysSend: false);
+
+		Assert.Null(repeated.Filters);
+		Assert.Null(repeated.Protection);
+		Assert.Equal(McpServiceNoticeMemo.ContinuationNotice, repeated.Continuation);
+	}
+
+	[Fact]
+	public void AResponseThatCarriesNoFiltersLineNamesOnlyTheProtectionLine()
+	{
+		var memo = new McpServiceNoticeMemo();
+		Deliver(memo, Filters, Protection);
+
+		var protectionOnly = memo.Prepare(Project, filters: null, Protection, alwaysSend: false);
+
+		Assert.Equal(McpServiceNoticeMemo.ProtectionContinuationNotice, protectionOnly.Continuation);
+	}
+
+	[Fact]
+	public void AResponseThatCarriesNoProtectionLineNamesOnlyTheFiltersLine()
+	{
+		var memo = new McpServiceNoticeMemo();
+		Deliver(memo, Filters, Protection);
+
+		var filtersOnly = memo.Prepare(Project, Filters, protection: null, alwaysSend: false);
+
+		Assert.Equal(McpServiceNoticeMemo.FiltersContinuationNotice, filtersOnly.Continuation);
+	}
+
+	[Fact]
+	public void ASessionThatOnlyEverReportedProtectionNeverClaimsAnUnchangedFiltersLine()
+	{
+		var memo = new McpServiceNoticeMemo();
+
+		var first = memo.Prepare(Project, filters: null, Protection, alwaysSend: false);
+		Assert.Null(first.Continuation);
+		Assert.Equal(Protection, first.Protection);
+		memo.CommitDelivered(Protection);
+
+		var second = memo.Prepare(Project, filters: null, Protection, alwaysSend: false);
+		Assert.Equal(McpServiceNoticeMemo.ProtectionContinuationNotice, second.Continuation);
+
+		// The filters line was never reported, so the first response that would carry one sends it
+		// in full rather than pointing back at something the session never saw.
+		var withFilters = memo.Prepare(Project, Filters, Protection, alwaysSend: false);
+		Assert.Equal(Filters, withFilters.Filters);
+		Assert.Equal(Protection, withFilters.Protection);
+		Assert.Null(withFilters.Continuation);
+	}
+
+	[Fact]
+	public void EveryContinuationStaysShorterThanTheShortestSetItReplaces()
+	{
+		Assert.True(McpServiceNoticeMemo.ContinuationNotice.Length < Filters.Length + Protection.Length);
+		Assert.True(McpServiceNoticeMemo.FiltersContinuationNotice.Length < Filters.Length);
+		Assert.True(McpServiceNoticeMemo.ProtectionContinuationNotice.Length < Protection.Length);
+	}
+
+	private static void Deliver(McpServiceNoticeMemo memo, string filters, string protection)
+	{
+		var initial = memo.Prepare(Project, filters, protection, alwaysSend: false);
+		Assert.Equal(filters, initial.Filters);
+		Assert.Equal(protection, initial.Protection);
+		memo.CommitDelivered(filters + "\n" + protection);
+	}
+}


### PR DESCRIPTION
Four changes to the MCP caller surface, on one branch into `v5.2`. Each task is one
commit, except the last, which is two because its two halves are ordered.

| Commit | Task |
|---|---|
| `e7cd75a4` | Notice continuation names only what it withholds — #359 |
| `3ea12a05` | A file-name lookup is answered or redirected — remainder of #346 |
| `3e5f239b` | `pack_context.expand_related` — #309 |
| `f4746609` | Search hits name their enclosing declaration — #314, first half |
| `2e93ebee` | `get_file.symbol` — #314, second half |

## `e7cd75a4` — the continuation names only the lines it withholds

**The reported tool is not the one that fails.** #359 names `analyze`. `analyze`
passes `includeFilters: false` *and* `includeProtection: false`, so the notice
builder returns nothing for both lines and the memo exits at its first guard. A
session of only `analyze` calls carries no continuation at all, and the issue's own
acceptance test passes unmodified against the unfixed code. That test is included
anyway, as a guard.

The cause the issue identifies is real, and fires mirrored. `search_project` and
`get_file` pass `includeFilters: false, includeProtection: true`, so they report no
effective-filters line while the selection is not empty. The second such call in a
session answered `[Unchanged] filters, protection` after a session that had carried
protection alone — a false claim, in the region a caller is told to believe without
checking, about the redaction posture.

The memo keeps its all-or-nothing gate, so the first response after any change
still re-sends the full set, and gains two constants for the single-line cases. The
continuation is now chosen from the lines *this response would have carried*, which
is exactly what it stands in for. Each constant stays shorter than the line it
replaces, so the published bound that no response grows by omitting a notice still
holds; a unit test pins all three lengths, including the filters-only form that no
tool reaches today but that the memo would otherwise get wrong.

**On the existing tests.** Four of the five process tests fail against the unfixed
binary and pass against the fixed one; this was verified by reverting the one-line
behaviour change and rebuilding. The exact count assertion in
`RealProcessSendsServiceNoticesOnceWhileTheyKeepSayingTheSameThing` is **kept**, not
relaxed: eight of ten responses still withhold their lines, and the test now also
pins the split into two both-line and six protection-only continuations. One
assertion changed vocabulary — the `get_file` response in
`RealProcessStartsEverySessionWithTheFullServiceNotices` now names the protection
line alone — because that is the contract the issue asks to change.

## `3ea12a05` — a name lookup is answered, or told what to type

**Measured before designing, against the real server over stdio**, on a project
holding `src/App.cs` and `src/deep/App.cs` and no `App.cs` in its root:

| Form | Result |
|---|---|
| `search_project` with a bare file name | empty, no remedy named |
| `search_project` with a path-shaped regex | empty, no remedy named |
| `get_tree include_patterns ["App.cs"]` | empty, already names the rewrite |
| `get_tree include_patterns ["*App*"]` | empty, already names the rewrite |
| `get_tree include_patterns ["**/App.cs"]` | both files |
| `get_tree include_patterns ["**/*App*"]` | both files |
| `get_tree paths ["App.cs"]` | the whole tree, warned to "refresh paths" |
| `get_tree paths ["src"]` | the subtree |

`*App*` is the trap. A single star compiles to a class that cannot cross a
separator, so a pattern with no separator and no double star is root-only however
many stars it carries — and the empty-selection notice already classifies it
correctly and names the rewrite that spans depth. **The shared glob semantics are
unchanged**: the compiled patterns, the six tool schemas and the command line that
publish them, and the responses of every form that already worked are
byte-identical.

What changes is the two forms that taught the caller nothing. Both now carry one
constant naming the parameter that matches a name and the two rewrites that reach
depth. `search_project` adds it when it searched at least one file, matched nothing,
and the pattern carries a separator or ends in something shaped like an extension.
`get_tree` adds it when a requested path with no separator was not in the effective
tree — the only case where a path that selected nothing still answers. `analyze` and
`pack_context` need neither: a missing path there is an error, not a partial answer.

The line is a constant. The caller's pattern and paths are reduced to two booleans
and never reach the response. A search that matched, a pattern that reads as
ordinary content, and a selection that was already empty and already explained are
left exactly as they were.

**On the optional second part.** Stage attribution in the empty-selection notice is
already delivered on this base: `stage=patterns`, `stage=paths`, `stage=git-scope`
and `stage=filters` all ship, verified against the running server. Nothing to do.
`HasRootOnlyPattern` uses `Any`, so a mixed array claims the root-only rewrite when
only one entry is root-only; that is left alone deliberately, because the advice it
gives is still the correct fix for that entry.

## `3e5f239b` — `pack_context.expand_related`

`seeds`, `hops` of one or two, `direction` taking the same enum
`related_files.direction` takes. `related_files` keeps its own purpose.

**Expansion only ever narrows, structurally rather than by a later check.** The
neighbourhood is computed over the dependency index built from the plan's own
included files, which is what the baseline, profile, exclusions, Git scope,
`tracked_only`, `paths`, the glob parameters and `max_file_bytes` already decided. A
file those filters kept out is not in the index, so no parameter value can reach it,
and an excluded file cannot bridge two hops — a test pins exactly that. Only
resolved edges travel; an ambiguous reference names a file the engine would not
commit to.

Two hops do not bound a neighbourhood, so the expansion stops at **400 files**
counting the seeds, takes each hop in ordinal path order so the admitted prefix is
deterministic, and names that constant in the response when it decided the answer.
A test drives 460 dependents and asserts the reported first-hop count and the limit
sentence.

Expansion picks the candidate set and does not order it, so it composes with the
ordering that exists: `rank` orders what expansion admitted, `focus` puts chosen
files first, and a `focus` seed expansion did not admit is a path outside the
selection returning the usual error naming the effective filters. Both halves are
tested.

**Deviations from the issue text, for your call.** Seeds are not hoisted to the
front of admission order — the composition with `rank` and `focus` is the ordering
mechanism, and reprojection returns canonical order. An out-of-selection seed
returns `DPX-MCP-PATH-NOT-FOUND` naming the effective filters rather than
`DPX-MCP-INVALID-ARGUMENTS`, matching every other path argument in the tool. CLI
parity (`export context` with expansion flags) is **not** in this pass; it needs
three frozen option tokens and help strings across twenty locales, and none of it is
reachable from the MCP acceptance. `Docs/CommandLine.md` is therefore untouched.

## `f4746609` and `2e93ebee` — #314

**The parser already knew the answer and threw it away.** A syntax capture carries
the declaration node's start and end; every declaration fact funnels through one
helper that passes path, start line and evidence text and drops the rest. The whole
engine change is to stop dropping it: the capture keeps the end line the parser had
already computed, the helper forwards it, and a source site gained one init-only
property to hold it. **Three files, seventeen added lines, four removed, no call
site changed, nothing removed from the engine.**

Naming is **on by default**, with no parameter. After the match lines, inside the
same untrusted block, the response lists `path:line: Name`, and one trusted line
reports coverage in counts — which distinguishes a hit that sits in no declaration
from a file that was never parsed. A declaration name is text this project wrote, so
it stays inside the untrusted block; a test asserts its position relative to that
block. Names come from an index over the files that actually produced hits: one
bounded parse per such file, never one per hit, never over the whole selection.

Naming **shares** the 16,000-character search cap rather than adding to it, and a
response the cap already cut carries none at all, so switching this on cannot push
any response past the size it already had — pinned by a test on a search wide enough
to be cut. The renderer that produces a match line was not modified, so the byte
offsets its own unit tests compute still hold, and the match and file counters and
the additional-matches contract are untouched.

`get_file.symbol` is the other half: a qualified name, or a simple name unique in
the file. Three cases refuse rather than guess — several matches, no match, and a
file no declarations were extracted from, which is how an unsupported language
answers. An ambiguous name reports **how many** and asks for the qualified form; it
does not list them, because the error text sits outside the untrusted block. A test
asserts no refusal carries a declaration name.

**Granularity, stated plainly.** The index's declarations for C# are types, not
members, so a hit inside a method is named with its enclosing type. Member
granularity lives in the language query files, which this branch does not touch —
that was the one permitted engine intervention, spent on the two numbers above.

## Connection payload

Measured on the built binary, `tools/list` `result` characters:

| Point | Default | Delegation | Delta |
|---|---:|---:|---:|
| base `61b5f004` | 40,566 | 44,484 | 3,918 |
| after `expand_related` | 41,453 | 45,371 | 3,918 |
| after `get_file.symbol` | 41,917 | 45,835 | 3,918 |

**No pinned constant moved.** The ceiling stays 43,500 with 1,583 characters of
headroom, the floor is untouched, the exact exclusions-parameter cost is still
3,918 (it is a difference between two servers that both publish the new inputs), and
the expected-tool list is unchanged. Server instructions stay at 1,044. The
`pack_context` description was compressed to hold its new sentence inside the
published bounds: 760 to 754 characters, 88 to 87 words.

## Trusted-region discipline

Three new trusted lines ship: `[Name search]`, `[Expanded]`, `[Symbols]`, plus two
new continuation constants. Every one carries only constants, codes and numbers. No
caller-supplied string and no project-derived string enters any of them — the search
pattern and the requested paths become booleans, expansion reports counts, and
declaration names are written inside the untrusted block with the match lines they
describe. None of the three is memoised: each states a fact about one call, and the
documentation lists them with the other per-call lines.

## Verification

`origin/v5.2` had not moved from `61b5f004` at push time, so there was nothing to
merge. Local runs were filtered, never full suites: 111 real-process tests, 283
integration tests, and the MCP and dependency unit suites all pass, with a clean
Release build at zero warnings. CI is the arbiter.
