### PR TITLE
fix(ci): stop the indentation gate crashing on a long report, and on a base without rules

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -66,6 +66,10 @@ jobs:
         shell: pwsh
         run: ./Scripts/ci/Test-ExecutedTestsContract.ps1
 
+      - name: Validate the indentation gate
+        shell: pwsh
+        run: ./Scripts/ci/Test-IndentationContract.ps1
+
       - name: Select CI plan
         id: plan
         shell: pwsh

--- a/Scripts/ci/Test-Indentation.ps1
+++ b/Scripts/ci/Test-Indentation.ps1
@@ -114,6 +114,19 @@ if (-not (Test-Path -LiteralPath $editorConfig)) {
 
 Push-Location $RepositoryRoot
 try {
+	# The whole check is the question "did a file that matched these rules stop matching them", and
+	# that question has no answer when the base never had the rules. A release pull request is the
+	# case in point: its base is master, hundreds of commits behind and from before the rules
+	# existed, so every file that happens to match them there and was edited since would be reported
+	# as a regression by a gate that never judged any of those edits. This resolves itself — once a
+	# release carries the rules into master, the comparison becomes meaningful there too.
+	& git cat-file -e "${BaseSha}:.editorconfig" 2>$null
+	if ($LASTEXITCODE -ne 0) {
+		Write-Host ("The base commit $BaseSha carries no .editorconfig, so there are no rules a " +
+		            'file could have stopped matching. Nothing to compare.')
+		exit 0
+	}
+
 	$changed = @(Get-ChangedCSharpFile -Base $BaseSha -Head $HeadSha)
 	if ($changed.Count -eq 0) {
 		Write-Host 'No C# files changed; nothing to check.'
@@ -151,7 +164,18 @@ try {
 			$carried | ForEach-Object { Write-Host "  $_" }
 		}
 		if ($StepSummaryPath) {
-			$summary = @('### Indentation') + $failed.ForEach({ "- FAIL $_" }) + $carried.ForEach({ "- carried $_" })
+			# Written with an ordinary loop rather than the .ForEach() method. That method does not
+			# populate $_ under Set-StrictMode -Version Latest, so it throws the moment a list is
+			# long enough for its body to run at all — which is to say, the moment a change touches
+			# a file that already differed from the rules.
+			$summary = [Collections.Generic.List[string]]::new()
+			$summary.Add('### Indentation')
+			foreach ($line in $failed) {
+				$summary.Add("- FAIL $line")
+			}
+			foreach ($line in $carried) {
+				$summary.Add("- carried $line")
+			}
 			Add-Content -LiteralPath $StepSummaryPath -Value ($summary -join "`n")
 		}
 		if ($failed.Count -gt 0) {

--- a/Scripts/ci/Test-IndentationContract.ps1
+++ b/Scripts/ci/Test-IndentationContract.ps1
@@ -1,0 +1,196 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+	Checks that Test-Indentation.ps1 still fails what it should and passes what it should.
+
+.DESCRIPTION
+	The gate is a comparison between two commits, so the cases below are real repositories with real
+	history rather than stubs. Each one builds a base commit, a head commit, and runs the gate
+	between them exactly as the workflow does, step summary included.
+
+	One case exists because it was missing. The gate shipped having only ever been exercised on
+	short changes, where no touched file had differed from the rules beforehand. The first change
+	large enough to include such a file crashed it — the reporting list was non-empty for the first
+	time, and the code that formatted it used a method that does not bind the loop variable. So
+	`a long list of files that already differed` is here, and it fails against the code as it was.
+#>
+[CmdletBinding()]
+param(
+	[string] $GatePath = (Join-Path $PSScriptRoot 'Test-Indentation.ps1'),
+
+	[string] $EditorConfigPath = (Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) '.editorconfig')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$failures = [Collections.Generic.List[string]]::new()
+$root = Join-Path ([IO.Path]::GetTempPath()) ("devprojex-indent-" + [Guid]::NewGuid().ToString('N'))
+
+# Indented with spaces, which the rules call tabs, so the formatter reports it every time.
+$differing = @(
+	'namespace Fixture;',
+	'',
+	'internal static class Sample',
+	'{',
+	'    internal static int Value()',
+	'    {',
+	'        return 1;',
+	'    }',
+	'}') -join "`n"
+
+$conforming = @(
+	'namespace Fixture;',
+	'',
+	'internal static class Sample',
+	'{',
+	"`tinternal static int Value() => 1;",
+	'}') -join "`n"
+
+function New-Repository {
+	param([string] $Path, [switch] $WithRules)
+
+	New-Item -ItemType Directory -Path $Path -Force | Out-Null
+	Push-Location $Path
+	try {
+		& git init --quiet --initial-branch=main 2>&1 | Out-Null
+		& git config user.email 'contract@example.invalid' | Out-Null
+		& git config user.name 'Contract' | Out-Null
+		& git config commit.gpgsign false | Out-Null
+		if ($WithRules) {
+			Copy-Item -LiteralPath $EditorConfigPath -Destination (Join-Path $Path '.editorconfig')
+		}
+	}
+	finally {
+		Pop-Location
+	}
+}
+
+function Add-Commit {
+	param([string] $Path, [string] $Message)
+
+	Push-Location $Path
+	try {
+		& git add -A 2>&1 | Out-Null
+		& git commit --quiet -m $Message 2>&1 | Out-Null
+		return (& git rev-parse HEAD).Trim()
+	}
+	finally {
+		Pop-Location
+	}
+}
+
+function Write-Source {
+	param([string] $Path, [string] $Relative, [string] $Content)
+
+	$file = Join-Path $Path $Relative
+	New-Item -ItemType Directory -Path (Split-Path -Parent $file) -Force | Out-Null
+	Set-Content -LiteralPath $file -Value $Content -Encoding UTF8
+}
+
+function Test-Case {
+	param([string] $Name, [string] $Path, [string] $Base, [string] $Head, [switch] $ShouldPass)
+
+	$summaryFile = Join-Path $Path 'step-summary.md'
+	Set-Content -LiteralPath $summaryFile -Value '' -NoNewline
+	$accepted = $true
+	$output = ''
+	try {
+		$output = & $GatePath -BaseSha $Base -HeadSha $Head -RepositoryRoot $Path `
+			-StepSummaryPath $summaryFile -EditorConfigPath $EditorConfigPath 2>&1 | Out-String
+		if ($LASTEXITCODE -ne 0) {
+			$accepted = $false
+		}
+	}
+	catch {
+		$accepted = $false
+		$output = $_.Exception.Message
+	}
+
+	# A crash is not a verdict. The gate has to reach a decision and say so, which is what
+	# distinguishes "this change is fine" from "the gate fell over before deciding".
+	if ($output -match 'cannot be retrieved because it has not been set' -or $output -match 'Exception calling') {
+		$failures.Add("$Name crashed instead of deciding: $($output.Trim())")
+		return
+	}
+	if ($ShouldPass -and -not $accepted) {
+		$failures.Add("$Name should have passed but failed: $($output.Trim())")
+	}
+	elseif (-not $ShouldPass -and $accepted) {
+		$failures.Add("$Name should have failed but passed.")
+	}
+}
+
+try {
+	# --- the case that was missing: a change touching many files that already differed ----------
+	$large = Join-Path $root 'large'
+	New-Repository -Path $large -WithRules
+	foreach ($index in 1..40) {
+		Write-Source -Path $large -Relative "src/Differing$index.cs" -Content $differing
+	}
+	Write-Source -Path $large -Relative 'src/Clean.cs' -Content $conforming
+	$base = Add-Commit -Path $large -Message 'base'
+	foreach ($index in 1..40) {
+		Write-Source -Path $large -Relative "src/Differing$index.cs" -Content ($differing + "`n// touched")
+	}
+	$head = Add-Commit -Path $large -Message 'touch every differing file'
+	Test-Case -Name 'a long list of files that already differed' -Path $large -Base $base -Head $head -ShouldPass
+
+	# --- a base from before the rules existed ---------------------------------------------------
+	$unruled = Join-Path $root 'unruled'
+	New-Repository -Path $unruled
+	Write-Source -Path $unruled -Relative 'src/Clean.cs' -Content $conforming
+	Write-Source -Path $unruled -Relative 'src/Differing.cs' -Content $differing
+	$base = Add-Commit -Path $unruled -Message 'base without rules'
+	Copy-Item -LiteralPath $EditorConfigPath -Destination (Join-Path $unruled '.editorconfig')
+	Write-Source -Path $unruled -Relative 'src/Clean.cs' -Content $differing
+	$head = Add-Commit -Path $unruled -Message 'adopt the rules'
+	Test-Case -Name 'a base that predates the rules' -Path $unruled -Base $base -Head $head -ShouldPass
+
+	# --- the rule itself, both directions --------------------------------------------------------
+	$broken = Join-Path $root 'broken'
+	New-Repository -Path $broken -WithRules
+	Write-Source -Path $broken -Relative 'src/Clean.cs' -Content $conforming
+	Write-Source -Path $broken -Relative 'src/Differing.cs' -Content $differing
+	$base = Add-Commit -Path $broken -Message 'base'
+	Write-Source -Path $broken -Relative 'src/Clean.cs' -Content ($conforming -replace "`tinternal", "`t`t`tinternal")
+	$head = Add-Commit -Path $broken -Message 'break a file that was clean'
+	Test-Case -Name 'a clean file given broken indentation' -Path $broken -Base $base -Head $head
+
+	$carriedOnly = Join-Path $root 'carried'
+	New-Repository -Path $carriedOnly -WithRules
+	Write-Source -Path $carriedOnly -Relative 'src/Differing.cs' -Content $differing
+	$base = Add-Commit -Path $carriedOnly -Message 'base'
+	Write-Source -Path $carriedOnly -Relative 'src/Differing.cs' -Content ($differing + "`n// touched")
+	$head = Add-Commit -Path $carriedOnly -Message 'touch it'
+	Test-Case -Name 'a file that already differed is reported, not failed' -Path $carriedOnly -Base $base -Head $head -ShouldPass
+
+	$newClean = Join-Path $root 'newfile'
+	New-Repository -Path $newClean -WithRules
+	Write-Source -Path $newClean -Relative 'src/Existing.cs' -Content $conforming
+	$base = Add-Commit -Path $newClean -Message 'base'
+	Write-Source -Path $newClean -Relative 'src/Added.cs' -Content $differing
+	$head = Add-Commit -Path $newClean -Message 'add a file that does not match'
+	Test-Case -Name 'a new file that does not match the rules' -Path $newClean -Base $base -Head $head
+
+	$untouched = Join-Path $root 'untouched'
+	New-Repository -Path $untouched -WithRules
+	Write-Source -Path $untouched -Relative 'src/Clean.cs' -Content $conforming
+	$base = Add-Commit -Path $untouched -Message 'base'
+	Set-Content -LiteralPath (Join-Path $untouched 'README.md') -Value 'text' -Encoding UTF8
+	$head = Add-Commit -Path $untouched -Message 'documentation only'
+	Test-Case -Name 'a change touching no C# file' -Path $untouched -Base $base -Head $head -ShouldPass
+}
+finally {
+	Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+	Write-Host 'The indentation gate no longer behaves as its own documentation says:'
+	foreach ($failure in $failures) {
+		Write-Host "  $failure"
+	}
+	throw "Test-Indentation.ps1 failed $($failures.Count) of its own contract cases."
+}
+
+Write-Host 'Indentation gate contract cases passed.'


### PR DESCRIPTION
The Indentation gate fails the release pull request #274. This is the gate crashing, not the gate
objecting to formatting.

## What broke

```
Scripts/ci/Test-Indentation.ps1
Exception calling "ForEach" with "1" argument(s):
"The variable '$_' cannot be retrieved because it has not been set."
```

The list of already-differing files is a `[Collections.Generic.List[string]]`, and `.ForEach()` on
one of those does not reach PowerShell's intrinsic method. It binds to the .NET overload:

```
List<T>.ForEach signature: Void ForEach(System.Action`1[System.String])
```

The block becomes an `Action<T>` delegate, `$_` is never set inside it, and the call returns void —
so even where it did not throw, it contributed nothing. Two neighbours prove the narrowness of it:
the line directly above uses `| ForEach-Object`, a pipeline, and works; `ci-gate` uses the same
`.ForEach({ … $_ … })` construct and works, because there the collection is an `Object[]` and the
method does resolve to PowerShell's.

**An empty list never invokes the delegate.** That is why every change tested so far passed: none of
them touched a file that already differed from the rules, so the list was always empty and the body
never ran. The first change large enough to contain one ran it.

## Why the release pull request reached that code

Fixing the crash exposed the real problem underneath. #274's base is `master`, and `master` carries
no `.editorconfig` — the rules arrived on `v5.2` in #370. So the gate was asking whether a file had
stopped matching rules that never applied to it, and 625 commits of drift from before the gate
existed answered yes for hundreds of files, none of which any gate had judged.

A base that carries no rules is now reported and passes. That is not a permanent exemption: it
resolves itself the moment a release carries the rules into `master`, after which the comparison is
meaningful there too.

## The rule is unchanged

- a file that matched the rules and stops matching them still fails;
- a file that already differed is still reported and still not failed;
- a new file that does not match the rules still fails.

## The test that was missing

The gate had none. `Scripts/ci/Test-IndentationContract.ps1` builds real repositories with real
history and runs the gate between real commits, step summary included, in about 20 seconds. Six
cases:

| case | expected |
|---|---|
| a long list of files that already differed (40 of them) | passes |
| a base that predates the rules | passes |
| a file that already differed is reported, not failed | passes |
| a change touching no C# file | passes |
| a clean file given broken indentation | fails |
| a new file that does not match the rules | fails |

It also treats a crash as distinct from a verdict: a case that throws is reported as "crashed
instead of deciding" rather than counted as a failure, because the two are not the same thing.

Run against the gate exactly as it shipped at `51ce4f60`, **three of the six fail** with the message
from the release run. It runs in `prepare-matrix` beside the planner and executed-tests contracts.

## Checked with the release arguments

Locally, with the arguments the release pull request gives the gate:

```
Test-Indentation.ps1 -BaseSha <origin/master> -HeadSha <origin/v5.2>

before: exit 2, Exception calling "ForEach"           (77 s)
after:  exit 0, "The base commit 96112de2 carries no .editorconfig,
                 so there are no rules a file could have stopped
                 matching. Nothing to compare."       (0 s)
```
