### PR TITLE
feat(dependencies): resolve Go names inside their package directory

### DIFF
--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -2141,6 +2141,8 @@ public sealed class DependencyFactsEngine : IDisposable
 				else if (!requiresQualifiedLookup)
 					candidates = SelectVisibleCSharpCandidates(source, reference, candidates);
 			}
+			else if (source.LanguageId == LanguageId.Go)
+				candidates = SelectSamePackageGoCandidates(source, candidates);
 			if (candidates.Length == 0 && attributeName is not null)
 			{
 				candidates = attributeName.Contains('.')
@@ -2491,6 +2493,27 @@ public sealed class DependencyFactsEngine : IDisposable
 				: 0;
 		}
 
+		/// <summary>
+		/// A Go package is a directory, so a name is visible to a file only when it is declared in
+		/// the same directory. Without this the one Go scope spans the whole root and a name
+		/// declared in two packages would read as ambiguous.
+		/// </summary>
+		private static DeclarationFact[] SelectSamePackageGoCandidates(
+			FileFacts source,
+			DeclarationFact[] candidates)
+		{
+			var package = GoPackageDirectory(source.Path);
+			return candidates
+				.Where(candidate => candidate.DeclarationSites.Any(site =>
+					string.Equals(GoPackageDirectory(site.File), package, StringComparison.Ordinal)))
+				.ToArray();
+		}
+
+		private static string GoPackageDirectory(string portablePath)
+		{
+			var separator = portablePath.LastIndexOf('/');
+			return separator < 0 ? string.Empty : portablePath[..separator];
+		}
 		private static string SimpleName(string qualified)
 		{
 			var value = qualified[(Math.Max(qualified.LastIndexOf('.'), qualified.LastIndexOf('#')) + 1)..];

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -7,6 +7,7 @@ public enum LanguageId
 	JavaScript,
 	Tsx,
 	Python,
+	Go,
 	Unsupported
 }
 

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -167,6 +167,20 @@ an absent control file, so its later appearance invalidates a cached dependency 
 existing base is outside the effective manifest, the manifest-snapshot shortcut is bypassed; this
 keeps later edits observable without widening the selected dependency manifest.
 
+Go has one narrow capability: a package is a directory, so a name declared at the top level of
+one file is visible to its siblings without an import, and that is the relationship the adapter
+makes resolvable. Top-level `func`, method and `type` declarations are importable names within
+their directory, and a type reference resolves to the file in the same directory that declares
+it. A name declared in two directories stays two declarations, so a reference never reaches
+across packages; it resolves to the one in its own directory or to nothing.
+
+Everything else in Go is outside this capability and produces no edge rather than a guessed one.
+Import paths are not resolved: `go.mod` is not read, a module path is not mapped to a directory,
+and vendor directories, build tags, import aliases, dot imports and `internal` visibility are not
+interpreted. Package-level `const` and `var` declarations are not yet importable names, and a
+named type is recorded as one declaration without distinguishing struct, interface and alias.
+Go needs no configuration file, so a Go file has no owning-configuration failure mode.
+
 Configuration reads have four explicit outcomes: valid, missing, corrupt, and unsupported semantics.
 A malformed JSON document, a `null` or non-object `compilerOptions`, or an unsupported value shape is
 never replaced by an implicit default. References whose resolution depends on that control file remain
@@ -219,7 +233,7 @@ produces `External`.
 
 ## Extraction, limits, and diagnostics
 
-C#, TypeScript/TSX/JavaScript, and Python adapters use shipped Tree-sitter grammars and embedded
+C#, TypeScript/TSX/JavaScript, Python, and Go adapters use shipped Tree-sitter grammars and embedded
 `declarations.scm` and `references.scm` query data. Each supported source file is parsed once per
 content fingerprint; its syntax tree is disposed immediately and only compact facts remain. Files
 without an adapter are counted as unsupported instead of disappearing. Read, grammar, and query

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -179,7 +179,18 @@ Import paths are not resolved: `go.mod` is not read, a module path is not mapped
 and vendor directories, build tags, import aliases, dot imports and `internal` visibility are not
 interpreted. Package-level `const` and `var` declarations are not yet importable names, and a
 named type is recorded as one declaration without distinguishing struct, interface and alias.
-Go needs no configuration file, so a Go file has no owning-configuration failure mode.
+Go needs no configuration file, so a Go file has no owning-configuration failure mode. A
+predeclared type such as `string` or `error` names no file and produces no reference, a
+declaration's own name is not a reference to itself, and a qualified reference such as
+`alpha.Shared` names another package and is dropped rather than matched against a same-named
+type in the referring directory.
+
+One consequence is worth stating because it is not visible in the edges. A Go file now counts as
+`Supported`, and extracted-facts coverage is supported files over candidates, so a selection
+containing Go reports higher coverage and gives the graph signal more weight in importance
+ranking than it did while Go was unsupported. That is the intended effect of adding an adapter,
+but Go's graph is package-local by construction, so its coverage is not comparable with the
+cross-file graphs the other four languages build.
 
 Configuration reads have four explicit outcomes: valid, missing, corrupt, and unsupported semantics.
 A malformed JSON document, a `null` or non-object `compilerOptions`, or an unsupported value shape is

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -806,6 +806,58 @@ internal sealed partial class TypeScriptDependencyLanguageAdapter : DependencyLa
 	[GeneratedRegex(@"\bnew\s+(?<type>[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)", RegexOptions.CultureInvariant)] private static partial Regex NewTypeRegex();
 }
 
+/// <summary>
+/// Go facts for one narrow capability: the package-level declarations a file contributes and
+/// the type names it mentions. A Go package is a directory, so a name declared in a sibling
+/// file needs no import; that is the relationship this adapter makes visible. Import paths are
+/// not resolved, and package-level constants and variables are not importable names yet.
+/// </summary>
+internal sealed class GoDependencyLanguageAdapter : DependencyLanguageAdapter
+{
+	public override FileFacts Extract(DependencyExtractionContext context, DependencyFactsLimits limits)
+	{
+		ArgumentNullException.ThrowIfNull(context);
+		ArgumentNullException.ThrowIfNull(limits);
+		// The package directory qualifies the name so that the same identifier declared in two
+		// packages stays two declarations instead of merging into one symbol with two sites.
+		var package = PackageDirectory(context.RelativePath);
+		var declarations = context.Declarations
+			.Where(static capture => !string.IsNullOrEmpty(capture.CapturedName))
+			.Select(capture => new DeclarationFact(
+				new SymbolIdentity(
+					context.ScopeId,
+					context.LanguageId,
+					capture.Name == "declaration.function" ? SymbolKind.Function : SymbolKind.Class,
+					package.Length == 0 ? capture.CapturedName! : $"{package}#{capture.CapturedName}",
+					0),
+				[Site(context, capture)]))
+			.ToArray();
+		var references = Distinct(context.References
+			.Where(static capture => capture.Name == "reference.type")
+			.Select(capture => new ReferenceFact(
+				EvidenceLayer.TypeReference,
+				capture.Text,
+				0,
+				capture.NodeType,
+				Site(context, capture))));
+		if (declarations.Length + references.Count > limits.MaximumFactsPerFile)
+			return Failed(context);
+		return Complete(context, declarations, [], references);
+	}
+
+	/// <summary>The directory that is the Go package, from an already portable relative path.</summary>
+	private static string PackageDirectory(string relativePath)
+	{
+		var separator = relativePath.LastIndexOf('/');
+		return separator < 0 ? string.Empty : relativePath[..separator];
+	}
+
+	private static FileFacts Failed(DependencyExtractionContext context) => new(
+		context.RelativePath, context.ScopeId, context.LanguageId, context.ContentFingerprint, context.Source.Length,
+		DependencyFileStatus.ExtractionFailed, "fact limit exceeded", context.HasSyntaxErrors, context.ErrorNodeKinds,
+		[], [], [], [], new Dictionary<string, string>(), [], new Dictionary<string, string>(), []);
+}
+
 internal sealed partial class PythonDependencyLanguageAdapter : DependencyLanguageAdapter
 {
 	public override FileFacts Extract(DependencyExtractionContext context, DependencyFactsLimits limits)

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -832,8 +832,24 @@ internal sealed class GoDependencyLanguageAdapter : DependencyLanguageAdapter
 					0),
 				[Site(context, capture)]))
 			.ToArray();
+		// A declaration's own name is a type identifier too, and so is every predeclared type, so
+		// neither becomes a reference. A type identifier inside a qualified type names another
+		// package, which is outside this capability, so it is dropped rather than matched against a
+		// same-named local declaration.
+		var declaredAt = context.Declarations
+			.Where(static capture => capture.CapturedNameStartIndex >= 0)
+			.Select(static capture => capture.CapturedNameStartIndex)
+			.ToHashSet();
+		var qualified = context.References
+			.Where(static capture => capture.Name == "context.qualified_type")
+			.Select(static capture => (capture.StartIndex, capture.EndIndex))
+			.ToArray();
 		var references = Distinct(context.References
-			.Where(static capture => capture.Name == "reference.type")
+			.Where(capture => capture.Name == "reference.type" &&
+				!declaredAt.Contains(capture.StartIndex) &&
+				!PredeclaredTypes.Contains(capture.Text) &&
+				!qualified.Any(span =>
+					capture.StartIndex >= span.StartIndex && capture.EndIndex <= span.EndIndex))
 			.Select(capture => new ReferenceFact(
 				EvidenceLayer.TypeReference,
 				capture.Text,
@@ -844,6 +860,14 @@ internal sealed class GoDependencyLanguageAdapter : DependencyLanguageAdapter
 			return Failed(context);
 		return Complete(context, declarations, [], references);
 	}
+
+	/// <summary>Go predeclared type names, which name no file in the manifest.</summary>
+	private static readonly HashSet<string> PredeclaredTypes = new(StringComparer.Ordinal)
+	{
+		"any", "bool", "byte", "comparable", "complex64", "complex128", "error", "float32",
+		"float64", "int", "int8", "int16", "int32", "int64", "rune", "string", "uint", "uint8",
+		"uint16", "uint32", "uint64", "uintptr"
+	};
 
 	/// <summary>The directory that is the Go package, from an already portable relative path.</summary>
 	private static string PackageDirectory(string relativePath)

--- a/Infrastructure/Dependencies/Languages/go/declarations.scm
+++ b/Infrastructure/Dependencies/Languages/go/declarations.scm
@@ -1,0 +1,3 @@
+(source_file (function_declaration) @declaration.function)
+(source_file (method_declaration) @declaration.function)
+(source_file (type_declaration (type_spec) @declaration.type))

--- a/Infrastructure/Dependencies/Languages/go/references.scm
+++ b/Infrastructure/Dependencies/Languages/go/references.scm
@@ -1,1 +1,2 @@
 (type_identifier) @reference.type
+(qualified_type) @context.qualified_type

--- a/Infrastructure/Dependencies/Languages/go/references.scm
+++ b/Infrastructure/Dependencies/Languages/go/references.scm
@@ -1,0 +1,1 @@
+(type_identifier) @reference.type

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -896,6 +896,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		".tsx" or ".jsx" => LanguageId.Tsx,
 		".js" or ".mjs" or ".cjs" => LanguageId.JavaScript,
 		".py" or ".pyi" => LanguageId.Python,
+		".go" => LanguageId.Go,
 		_ => LanguageId.Unsupported
 	};
 
@@ -1221,7 +1222,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				[LanguageId.TypeScript] = new("tree-sitter-typescript", "tree_sitter_typescript", "typescript", new TypeScriptDependencyLanguageAdapter()),
 				[LanguageId.Tsx] = new("tree-sitter-tsx", "tree_sitter_tsx", "typescript", new TypeScriptDependencyLanguageAdapter()),
 				[LanguageId.JavaScript] = new("tree-sitter-javascript", "tree_sitter_javascript", "javascript", new TypeScriptDependencyLanguageAdapter()),
-				[LanguageId.Python] = new("tree-sitter-python", "tree_sitter_python", "python", new PythonDependencyLanguageAdapter())
+				[LanguageId.Python] = new("tree-sitter-python", "tree_sitter_python", "python", new PythonDependencyLanguageAdapter()),
+				[LanguageId.Go] = new("tree-sitter-go", "tree_sitter_go", "go", new GoDependencyLanguageAdapter())
 			};
 	}
 

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -1064,6 +1064,82 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task GoFacts_ResolveNamesDeclaredInTheSamePackageDirectory()
+	{
+		using var fixture = new TemporaryDirectory();
+		var model = fixture.CreateFile("store/model.go", """
+			package store
+
+			type Record struct {
+				Name string
+			}
+			""");
+		var service = fixture.CreateFile("store/service.go", """
+			package store
+
+			func Load() Record {
+				return Record{}
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[model, service],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// A Go package is a directory, so a sibling file needs no import to use the name.
+		Assert.Contains(result.Edges, edge => edge.Source == "store/service.go" &&
+			edge.Reference == "Record" && edge.Status == ResolutionStatus.Resolved &&
+			edge.Target == "store/model.go");
+		Assert.All(
+			result.Files,
+			file => Assert.Equal(DependencyFileStatus.Supported, file.Status));
+	}
+
+	[Fact]
+	public async Task GoFacts_DoNotReachAcrossPackagesOrResolveImportPaths()
+	{
+		using var fixture = new TemporaryDirectory();
+		var first = fixture.CreateFile("alpha/kind.go", """
+			package alpha
+
+			type Shared struct {
+			}
+			""");
+		var second = fixture.CreateFile("beta/kind.go", """
+			package beta
+
+			type Shared struct {
+			}
+			""");
+		var consumer = fixture.CreateFile("beta/use.go", """
+			package beta
+
+			import "example.com/module/alpha"
+
+			func Use() Shared {
+				return Shared{}
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[first, second, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// The same name exists in two packages; only the one in this directory is a candidate.
+		Assert.Contains(result.Edges, edge => edge.Source == "beta/use.go" &&
+			edge.Reference == "Shared" && edge.Status == ResolutionStatus.Resolved &&
+			edge.Target == "beta/kind.go");
+		Assert.DoesNotContain(result.Edges, edge => edge.Source == "beta/use.go" &&
+			edge.Target == "alpha/kind.go");
+		// Import paths are outside this capability and produce no edge at all.
+		Assert.DoesNotContain(result.Edges, edge => edge.Source == "beta/use.go" &&
+			edge.Reference.Contains("example.com", StringComparison.Ordinal));
+	}
+	[Fact]
 	public async Task PythonFacts_ResolveRelativeImportsAndClassifyKnownStdlibOnly()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -1140,6 +1140,51 @@ public sealed class DependencyFactsEngineIntegrationTests
 			edge.Reference.Contains("example.com", StringComparison.Ordinal));
 	}
 	[Fact]
+	public async Task GoFacts_IgnorePredeclaredTypesDeclarationNamesAndOtherPackages()
+	{
+		using var fixture = new TemporaryDirectory();
+		var alpha = fixture.CreateFile("alpha/kind.go", """
+			package alpha
+
+			type Shared struct {
+			}
+			""");
+		var beta = fixture.CreateFile("beta/kind.go", """
+			package beta
+
+			type Shared struct {
+				Name string
+				Count int
+			}
+			""");
+		var consumer = fixture.CreateFile("beta/use.go", """
+			package beta
+
+			import "example.com/module/alpha"
+
+			func Borrow() alpha.Shared {
+				return alpha.Shared{}
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var result = await engine.IndexAsync(
+			fixture.Path,
+			[alpha, beta, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		// A declaration's own name is not a reference to itself.
+		Assert.DoesNotContain(result.Edges, edge => edge.Source == "beta/kind.go" &&
+			edge.Target == "beta/kind.go");
+		// Predeclared types name no file and produce no edge.
+		Assert.DoesNotContain(result.Edges, edge =>
+			edge.Reference == "string" || edge.Reference == "int");
+		// A qualified reference names another package, which is outside this capability, so it is
+		// not matched against the same-named type in this directory.
+		Assert.DoesNotContain(result.Edges, edge => edge.Source == "beta/use.go" &&
+			edge.Reference == "Shared");
+	}
+	[Fact]
 	public async Task PythonFacts_ResolveRelativeImportsAndClassifyKnownStdlibOnly()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Terminal/DependencyFactsDocumentationContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DependencyFactsDocumentationContractTests.cs
@@ -18,6 +18,11 @@ public sealed class DependencyFactsDocumentationContractTests
 		Assert.Contains("Merely failing to find a name in the manifest never", dependencies, StringComparison.Ordinal);
 		Assert.Contains("2 Mi characters", dependencies, StringComparison.Ordinal);
 		Assert.Contains(
+			"Go has one narrow capability: a package is a directory",
+			dependencies,
+			StringComparison.Ordinal);
+		Assert.Contains("Import paths are not resolved", dependencies, StringComparison.Ordinal);
+		Assert.Contains(
 			"Without an owning `tsconfig.json` or `jsconfig.json`, one narrow capability applies",
 			dependencies,
 			StringComparison.Ordinal);


### PR DESCRIPTION
Part of #340, item 3: the first new language adapter.

## The capability

A Go package is a directory. A top-level `func`, method or `type` declared in one file is visible to
its siblings with no import, and that relationship is what this adapter makes resolvable: a type
reference resolves to the file in the same directory that declares it.

The package directory qualifies every declared name, so the same identifier declared in two
directories stays two declarations. A reference is then narrowed to candidates declared in the
referring file's own directory, which is what makes it impossible for a reference to reach across
packages rather than merely unlikely.

## What is outside it, and produces no edge at all

Stated in `Docs/Dependencies.md` rather than left to be discovered:

- import paths are not resolved, `go.mod` is not read, and vendor directories, build tags, import
  aliases, dot imports and `internal` visibility are not interpreted;
- package-level `const` and `var` are not importable names yet;
- a named type is one declaration, without distinguishing struct, interface and alias;
- a predeclared type such as `string` or `error` names no file and produces no reference;
- a declaration's own name is not a reference to itself;
- a qualified reference such as `alpha.Shared` names another package and is dropped rather than
  matched against a same-named type in the referring directory.

Go needs no configuration file, so no fallback scope is registered for it; that absence is what lets
same-directory resolution proceed at all, and registering one would make every Go reference
unresolved with a missing-configuration reason.

## One consequence worth declaring

A Go file now counts as `Supported`, and extracted-facts coverage is supported files over
candidates, so a selection containing Go reports higher coverage and gives the graph signal more
weight in importance ranking than while Go was unsupported. That is what adding an adapter does, but
Go's graph is package-local by construction, so its coverage is not comparable with the cross-file
graphs the other four languages build. `Docs/Dependencies.md` says so.

## Frozen ranking evaluation

Base run on `51ce4f60`, candidate run on this branch, compared cell by cell: **regressions 0,
improvements 0, every cell identical**; `eligible=15`, `delta=0.3667`, `candidateFiles`
`{devprojex: 2299, repomix: 951, flask: 212}` on both sides, criterion passes on both.

No cell moves because no registered corpus contains Go, so the evaluation is insensitive to this
adapter by construction. The behavioural proof is in the integration tests.

## Validation

- three integration tests over the real extractor: same-package resolution, two packages declaring
  the same name where only the local one is a candidate, and the three cases that must produce no
  edge;
- 227 dependency and ranking integration tests, 48 terminal dependency, related-files and
  documentation tests, 55 dependency and ranking unit tests;
- the indentation gate run locally against `origin/v5.2`: no file lost its formatting.
