### PR TITLE
fix(git): read repository settings twice before believing they are unavailable

### DIFF
--- a/Docs/CI-Known-Failures.md
+++ b/Docs/CI-Known-Failures.md
@@ -157,6 +157,47 @@ Whoever takes it will want the test to observe what `ReloadProjectAsync` returns
 publication from a busy flag.
 
 
+## 5. Git settings reported unavailable after one failed read
+
+- **Cause**: #377 — a failed read of a repository's git configuration was cached and served for five
+  seconds without anything looking again, so a single miss took the repository out of reach for
+  every caller in that window.
+- **Run**: [34584479932](https://github.com/Avazbek22/DevProjex/actions/runs/34584479932), job `103215930387`
+- **Commit**: `acbfa6bb` on `v5.2`
+- **Job**: `CI (Windows / Terminal)` — `Failed: 1, Passed: 1705, Skipped: 201, Total: 1907`
+- **Test**: `DevProjex.Tests.Terminal.GitModeCommandContractTests.DesktopOpenReadinessAcceptsValidMomentaryScopeWithoutGitIgnore(mode: Changes)`
+  (`Tests/DevProjex.Tests.Terminal/GitModeCommandContractTests.cs:532`, assertion at `:551`)
+- **Message**:
+
+```
+Assert.DoesNotContain() Failure: Filter matched in collection
+Collection: [ContextDiagnostic { Code = DPX-GIT-STATE-UNAVAILABLE, Severity = Error,
+Message = Git path comparison settings could not be resolved., … }]
+```
+
+The same job skipped seven tests with `Git is required for this regression test.` between the xUnit
+clock readings `00:00:58` and `00:02:00`, and the failure above lands at `00:01:05`, inside that
+window. So `git` could not be launched on that runner for about a minute; the read failed, the
+failure was cached, and a caller met it.
+
+**Named in #377, not reproduced here.** The issue cites two tests —
+`DevProjex.Tests.Integration.McpServerIntegrationTests.RemoteProjectClonesSelectsBranchReusesPinnedCacheAndKeepsJailAndRedaction`
+(`Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs:2629`) and a Windows terminal test
+on a cached remote workspace, which matches
+`DevProjex.Tests.Terminal.TerminalWorkspaceContractTests.CachedRemoteWorkspaceHydratesShallowDiffWithoutChangingItsCheckout`
+(`Tests/DevProjex.Tests.Terminal/TerminalWorkspaceContractTests.cs:1487`). Both are recorded here
+with #377 as their cause, as the issue asks. Neither was found failing: all 60 runs of `.NET CI`
+from 2026-09-09 to 2026-09-11 were searched, covering every run of the day the issue describes, and
+in them the first is `Passed` where it appears and the second is `Passed` or `NotExecuted` — it is
+one of the seven skipped in the window above. The mechanism is confirmed by the code and by the run
+recorded here; the two specific occurrences are not in the logs that remain.
+
+**Fixed.** The read is attempted twice before an unreadable answer is believed, so a single miss
+costs one extra read rather than five seconds of unavailability, and a repository that genuinely
+cannot be read still backs off after the retry instead of being probed by every caller. These
+entries come out of this list once the change has run clean for a week.
+
+
 ## What now fails that did not
 
 `Scripts/ci/Test-ExecutedTests.ps1` runs after each test step and fails the job when a results

--- a/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
+++ b/Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs
@@ -89,6 +89,18 @@ public sealed class GitConfigPathComparisonSemanticsResolver
 		}
 
 		var resolved = _repositorySemanticsResolver(repositoryRoot, gitMetadataPath);
+		if (!resolved.IsAuthoritative)
+		{
+			// A failure to read is cached, and while it is cached every caller of this repository is
+			// told the settings are unavailable without anything looking again. That is the right
+			// trade for a repository that genuinely cannot be read, and the wrong one for a single
+			// miss: a clone that has just finished writing its metadata loses every call made in the
+			// next few seconds. So the read is attempted once more before the answer is believed. A
+			// repository that is genuinely unreadable costs one extra read and then backs off as
+			// before; a momentary miss costs nothing beyond that read.
+			resolved = _repositorySemanticsResolver(repositoryRoot, gitMetadataPath);
+		}
+
 		lock (_cacheSync)
 		{
 			if (cacheGeneration != _cacheGeneration ||

--- a/Tests/DevProjex.Tests.Unit/GitConfigPathComparisonSemanticsResolverTests.cs
+++ b/Tests/DevProjex.Tests.Unit/GitConfigPathComparisonSemanticsResolverTests.cs
@@ -4,6 +4,15 @@ namespace DevProjex.Tests.Unit;
 
 public sealed class GitConfigPathComparisonSemanticsResolverTests
 {
+	/// <summary>
+	/// A repository whose settings cannot be read backs off rather than being probed on every
+	/// call, and is read again once the back-off has passed.
+	/// </summary>
+	/// <remarks>
+	/// The read is attempted twice before an unreadable answer is believed, so the counts here
+	/// are in pairs. That is the point of the pair: a single miss is not what puts a repository
+	/// out of reach.
+	/// </remarks>
 	[Fact]
 	public void Resolve_RetriesUnavailableRepositorySemanticsAfterBackoff()
 	{
@@ -13,7 +22,7 @@ public sealed class GitConfigPathComparisonSemanticsResolverTests
 		var now = new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc);
 		var resolutionCount = 0;
 		var resolver = new GitConfigPathComparisonSemanticsResolver(
-			(_, _) => ++resolutionCount == 1
+			(_, _) => ++resolutionCount <= 2
 				? new GitPathComparisonSemantics(
 					IgnoreCase: true,
 					NormalizeUnicode: true,
@@ -35,7 +44,106 @@ public sealed class GitConfigPathComparisonSemanticsResolverTests
 		Assert.True(recovered.IsAuthoritative);
 		Assert.False(recovered.IgnoreCase);
 		Assert.Equal(recovered, cached);
+		// Two reads to disbelieve the first miss, one to recover after the back-off. The call
+		// between them and the call after recovery are served from the cache and read nothing.
+		Assert.Equal(3, resolutionCount);
+	}
+
+	/// <summary>
+	/// One miss does not put a repository out of reach: the next call sees the settings.
+	/// </summary>
+	[Fact]
+	public void Resolve_DoesNotBelieveASingleFailedRead()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		var now = new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc);
+		var resolutionCount = 0;
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) => ++resolutionCount == 1
+				? new GitPathComparisonSemantics(
+					IgnoreCase: true,
+					NormalizeUnicode: true,
+					IsAuthoritative: false)
+				: new GitPathComparisonSemantics(
+					IgnoreCase: false,
+					NormalizeUnicode: false),
+			() => now,
+			TimeSpan.FromMinutes(1));
+
+		var first = resolver.Resolve(repositoryRoot);
+		var second = resolver.Resolve(repositoryRoot);
+
+		// The miss is not returned to anyone and never reaches the cache, so the settings the
+		// second read found are what both calls see.
+		Assert.True(first.IsAuthoritative);
+		Assert.False(first.IgnoreCase);
+		Assert.Equal(first, second);
 		Assert.Equal(2, resolutionCount);
+	}
+
+	/// <summary>
+	/// A repository that fails every read is read twice and then left alone until the back-off
+	/// passes, rather than being probed by every caller.
+	/// </summary>
+	[Fact]
+	public void Resolve_StopsReadingARepositoryThatAlwaysFails()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		var now = new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc);
+		var resolutionCount = 0;
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) =>
+			{
+				resolutionCount++;
+				return new GitPathComparisonSemantics(
+					IgnoreCase: true,
+					NormalizeUnicode: true,
+					IsAuthoritative: false);
+			},
+			() => now,
+			TimeSpan.FromMinutes(1));
+
+		var first = resolver.Resolve(repositoryRoot);
+		var readsAfterFirstCall = resolutionCount;
+		for (var call = 0; call < 8; call++)
+			_ = resolver.Resolve(repositoryRoot);
+
+		Assert.False(first.IsAuthoritative);
+		// The retry is one extra read, not a read for every caller: eight further calls inside
+		// the back-off read nothing at all.
+		Assert.Equal(2, readsAfterFirstCall);
+		Assert.Equal(2, resolutionCount);
+	}
+
+	/// <summary>
+	/// The counts the cases above rest on are counts of something. A repository that is read
+	/// successfully is read once, so a resolver that had stopped reading at all would fail here
+	/// rather than quietly satisfy every assertion that a count is small.
+	/// </summary>
+	[Fact]
+	public void Resolve_ReadsOnceWhenTheFirstReadSucceeds()
+	{
+		using var workspace = new TemporaryDirectory();
+		var repositoryRoot = workspace.CreateFolder("repository");
+		workspace.CreateFolder("repository/.git");
+		var resolutionCount = 0;
+		var resolver = new GitConfigPathComparisonSemanticsResolver(
+			(_, _) =>
+			{
+				resolutionCount++;
+				return new GitPathComparisonSemantics(IgnoreCase: false, NormalizeUnicode: false);
+			},
+			static () => new DateTime(2026, 8, 20, 1, 0, 0, DateTimeKind.Utc),
+			TimeSpan.FromMinutes(1));
+
+		var resolved = resolver.Resolve(repositoryRoot);
+
+		Assert.True(resolved.IsAuthoritative);
+		Assert.Equal(1, resolutionCount);
 	}
 
 	[Fact]


### PR DESCRIPTION
Closes #377.

A failed read of a repository's git configuration was cached and served back for five seconds with
nothing looking again, so one miss took the repository out of reach for every caller in that window.

## The defect

`Infrastructure/Git/GitConfigPathComparisonSemanticsResolver.cs:101-103` stores the result
unconditionally, authoritative or not:

```csharp
_repositoryCache[repositoryRoot] = new RepositorySemanticsCacheEntry(resolved, _utcNowProvider());
```

and `:71-72` serves a non-authoritative entry for the whole retry delay without re-probing. Nothing
distinguishes a first miss from a repeated one, so the cost of one unlucky read is five seconds of
`DPX-GIT-STATE-UNAVAILABLE` for every caller of that root.

## The change

The read is attempted once more before an unreadable answer is believed. A repository that
genuinely cannot be read costs one extra read and then backs off exactly as before — it is still
not probed by every caller. A momentary miss costs that one read and nothing else.

Nothing else moves: no notice, no parameter, no document of the public surface. The retry delay,
the cache limit, the eviction, the sequence guard and `Invalidate` are untouched.

## How it is shown

The cases drive an injected reader and count its calls, so they need no sleep and no real
repository:

| case | reads | outcome |
|---|---|---|
| one miss, then a good read | 2 | authoritative, the miss is never returned or cached |
| every read fails | 2, then 0 for eight further calls | unavailable, back-off holds |
| the first read succeeds | 1 | authoritative, no extra read |
| fails, then recovers after the back-off | 2 + 1 | the existing back-off case |

The third is there because the others assert that a count is small, and a resolver that had stopped
reading would satisfy all of them. It asserts a count that must not shrink.

With the retry removed, **three of the seven cases fail**.

## One existing case changed, and why

`Resolve_RetriesUnavailableRepositorySemanticsAfterBackoff` asserted two reads. Its subject is
unchanged — a repository that fails is left alone and read again once the back-off has passed — but
a single read is no longer what puts it in that state, so the injected reader now fails twice and
the case asserts three reads rather than two. The assertion was adapted to a deliberate change of
behaviour, not relaxed to make anything pass; the case still fails without the fix.

## The log entry, and where it differs from the issue

The mechanism is confirmed by the code and by a real run:
[34584479932](https://github.com/Avazbek22/DevProjex/actions/runs/34584479932), `CI (Windows /
Terminal)` on `v5.2` at `acbfa6bb`, where
`GitModeCommandContractTests.DesktopOpenReadinessAcceptsValidMomentaryScopeWithoutGitIgnore` met
`DPX-GIT-STATE-UNAVAILABLE`. That job also skipped seven tests with `Git is required for this
regression test.` between clock `00:00:58` and `00:02:00`, and the failure lands at `00:01:05` —
inside a window where git could not be launched at all.

The two tests the issue names are recorded with #377 as their cause, as asked, and recorded as **not
reproduced**: all sixty runs of `.NET CI` from 2026-09-09 to 2026-09-11 were searched, covering
every run of the day the issue describes. In them the first passes where it appears and the second
passes or is skipped — it is one of the seven skipped in that window. The entry says so rather than
restating the issue as if it were measured.

One correction to the issue's mechanism section: it cites `:348-351` as a source of the
non-authoritative answer. Those catches walk to the parent directory and, failing that, route to the
*authoritative* filesystem fallback. The sources are the process catch at `:262-270`, the timeout
and output-limit returns at `:239-257`, the parse rejections at `:172-206`, and a false from
`GitLocalConfigSemanticsReader.TryRead`.
