### PR TITLE
fix(cli): decide what a project argument is before opening it

### DIFF
--- a/Apps/Terminal/Execution/TerminalProjectSourceResolver.cs
+++ b/Apps/Terminal/Execution/TerminalProjectSourceResolver.cs
@@ -1,4 +1,5 @@
 using DevProjex.Infrastructure.Git;
+using DevProjex.Mcp;
 using DevProjex.Terminal.CommandLine;
 using DevProjex.Terminal.Rendering;
 
@@ -122,8 +123,17 @@ internal sealed class TerminalProjectSourceResolver(
 			return false;
 		if (source.Contains("://", StringComparison.Ordinal))
 			return true;
-		if (Directory.Exists(source))
-			return false;
+		// The probe below exists to tell an existing directory from an scp-style remote, and it is
+		// the wrong question to ask of a path that names a host: opening one is what makes the
+		// operating system contact that host, and here that would happen before anything has
+		// decided what the string is. Such a form is settled from its spelling instead, by the same
+		// classifier the server-side resolver uses, so there is one place that decides this.
+		if (!McpRemoteProviderPath.ReachesRemoteProvider(source))
+		{
+			McpProjectPathProbe.Record();
+			if (Directory.Exists(source))
+				return false;
+		}
 		var colon = source.IndexOf(':');
 		return colon > 0 &&
 		       (source[..colon].Contains('@') || source[..colon].Contains('.'));

--- a/Tests/DevProjex.Tests.Terminal/TerminalSourceClassificationTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/TerminalSourceClassificationTests.cs
@@ -1,0 +1,110 @@
+using DevProjex.Mcp;
+using DevProjex.Terminal.Execution;
+
+namespace DevProjex.Tests.Terminal;
+
+/// <summary>
+/// The command line decides what a project argument is before opening it, so that naming a host
+/// cannot make the classification itself contact that host.
+/// </summary>
+/// <remarks>
+/// The proof is the same one the server-side resolver carries: every place that hands a path to the
+/// operating system reports itself through <see cref="McpProjectPathProbe"/>, and these cases count
+/// those reports rather than inferring anything from a result. No host is named that could answer —
+/// <c>.invalid</c> is reserved by RFC 2606 — and nothing waits.
+/// </remarks>
+public sealed class TerminalSourceClassificationTests
+{
+	[Theory]
+	[InlineData(@"\\host.invalid\share\repository")]
+	[InlineData("//host.invalid/share/repository")]
+	[InlineData(@"\\?\UNC\host.invalid\share")]
+	[InlineData(@"\??\UNC\host.invalid\share")]
+	[InlineData(@"\\.\pipe\..\UNC\host.invalid\share")]
+	[InlineData("/net/host.invalid/share")]
+	public async Task APathThatNamesAHostIsClassifiedWithoutOpeningIt(string source)
+	{
+		using var data = new TemporaryDirectory();
+		var resolver = CreateResolver(data);
+
+		using var probes = McpProjectPathProbe.Count();
+		await using var resolved = await resolver.ResolveAsync(
+			source,
+			branch: null,
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(0, probes.Value);
+		// Settled as a local path, exactly as it was before: the probe only ever told an existing
+		// directory from an scp-style remote, and for these forms it never changed the answer.
+		Assert.False(resolved.IsRepositoryUrl);
+		Assert.Equal(source, resolved.ProjectPath);
+	}
+
+	/// <summary>
+	/// An ordinary path is still opened to classify it. Without this the cases above would be
+	/// satisfied by a resolver that had stopped probing altogether, which would prove nothing.
+	/// </summary>
+	[Fact]
+	public async Task AnOrdinaryPathIsStillProbed()
+	{
+		using var data = new TemporaryDirectory();
+		var resolver = CreateResolver(data);
+
+		using var probes = McpProjectPathProbe.Count();
+		await using var resolved = await resolver.ResolveAsync(
+			Path.Combine(data.Path, "project"),
+			branch: null,
+			TestContext.Current.CancellationToken);
+
+		Assert.True(probes.Value > 0, "Classifying an ordinary path no longer opens it, so the cases that assert nothing was opened prove nothing.");
+		Assert.False(resolved.IsRepositoryUrl);
+	}
+
+	/// <summary>
+	/// A url is settled by its scheme before anything is opened, as it always was.
+	/// </summary>
+	[Fact]
+	public async Task AUrlIsClassifiedBeforeAnythingIsOpened()
+	{
+		using var data = new TemporaryDirectory();
+		var resolver = CreateResolver(data);
+
+		using var probes = McpProjectPathProbe.Count();
+		var failure = await Assert.ThrowsAsync<TerminalProjectSourceException>(() =>
+			resolver.ResolveAsync(
+				"http://host.invalid/team/repository.git",
+				branch: null,
+				TestContext.Current.CancellationToken));
+
+		// Recognised as a url and refused for its transport, which happens before any clone and
+		// without the classifier opening anything.
+		Assert.Equal(0, probes.Value);
+		Assert.Equal("DPX-CLI-GIT-URL-INVALID", failure.Code);
+	}
+
+	/// <summary>
+	/// An scp-style source keeps being read as a repository rather than as a path.
+	/// </summary>
+	[Fact]
+	public async Task AnScpStyleSourceIsStillARepository()
+	{
+		using var data = new TemporaryDirectory();
+		var resolver = CreateResolver(data);
+
+		var failure = await Assert.ThrowsAsync<TerminalProjectSourceException>(() =>
+			resolver.ResolveAsync(
+				"git@host.invalid:team/repository.git",
+				branch: "not a branch",
+				TestContext.Current.CancellationToken));
+
+		// The branch is rejected, which is only reached once the source has been accepted as a
+		// supported repository url.
+		Assert.Equal("DPX-CLI-GIT-BRANCH-INVALID", failure.Code);
+	}
+
+	private static TerminalProjectSourceResolver CreateResolver(TemporaryDirectory data) =>
+		new(
+			new TerminalServiceFactory(() => data.Path).Create(AppLanguage.En),
+			new TestTerminalEnvironment(),
+			new TerminalOutputOptions());
+}


### PR DESCRIPTION
Closes #378.

`Apps/Terminal/Execution/TerminalProjectSourceResolver.cs` asked the filesystem about a source
string in order to classify it, before anything had decided what the string was. On Windows that
question, asked of a path that names a host, is what makes the operating system contact that host,
with the account the process runs under. The server side stopped doing this in #369; this was the
last resolver still on the old shape.

The string here comes from local `argv` and there is no remote-permission concept on the command
line, so this is not the exposure #358 was. It is the same defect, and leaving it meant two
behaviours for one concept.

## The change

The probe is kept, because it answers a real question — it tells an existing directory from an
scp-style remote. It is simply not asked of a form that names a host, which is settled from its
spelling:

```csharp
if (!McpRemoteProviderPath.ReachesRemoteProvider(source))
{
    McpProjectPathProbe.Record();
    if (Directory.Exists(source))
        return false;
}
```

**One classifier, not two copies.** `Apps/Terminal` already had a project reference to `Apps/Mcp`,
and `Apps/Mcp` already declared `InternalsVisibleTo` for `DevProjex.Terminal`, so the existing
classifier is used directly — **no file under `Apps/Mcp` is modified by this change**. The probe
counter is the same one, so both resolvers report to a single place.

## Behaviour is unchanged

A form that names a host was already classified as a local path: it carries no colon, so it fell
through to the same answer the probe would have produced. What changes is that reaching that answer
no longer costs an outbound connection. Ordinary paths are still probed, urls are still settled by
their scheme, and scp-style sources are still read as repositories.

## How it is shown

Counted probes, as in #369, not an error code — no host that could answer, and nothing that waits:

| case | probes |
|---|---|
| six forms that name a host, including `\??\UNC\…` and a `\\.\pipe\..\UNC\…` traversal | 0, and each resolves as a local path |
| an ordinary path | more than 0 |
| a url | 0, refused for its transport before any clone |
| an scp-style source with a bad branch | reaches the branch check, so it is still a repository |

The ordinary-path case is the positive control. The others assert that a count is zero, and a
resolver that had stopped probing would satisfy every one of them.

| mutation | result |
|---|---|
| restore the old order, probing before classification | 6 of 9 fail |
| remove the probe entirely | the positive control fails |

## Note on a local test failure, and why it is not from this change

`TerminalTreeMousePtyTests.MouseTogglesSelectionAcrossTheWholeRowAndDoubleClickExpandsFolders` fails
on this machine, three runs out of three. It also fails on a clean checkout of `a2200b33` with none
of this applied, verified in a separate working tree, and CI does not run it at all —
`DEVPROJEX_SKIP_TUI_PTY_TESTS: 1` is set at workflow level. It is a local environment failure in the
terminal interface, a subsystem this change does not touch.
