### PR TITLE
chore(ci): check a skipped job against the change rather than against the plan

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,6 +51,7 @@ jobs:
       run_terminal_command: ${{ steps.plan.outputs.run_terminal_command }}
       run_ignore_scanner: ${{ steps.plan.outputs.run_ignore_scanner }}
       run_documentation: ${{ steps.plan.outputs.run_documentation }}
+      changed_paths: ${{ steps.plan.outputs.changed_paths }}
 
     steps:
       - uses: actions/checkout@v7
@@ -69,6 +70,10 @@ jobs:
       - name: Validate the indentation gate
         shell: pwsh
         run: ./Scripts/ci/Test-IndentationContract.ps1
+
+      - name: Validate the CI gate
+        shell: pwsh
+        run: ./Scripts/ci/Test-CiGateContract.ps1
 
       - name: Select CI plan
         id: plan
@@ -621,6 +626,11 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
+          fetch-depth: 0
+
       - name: Verify selected jobs
         shell: pwsh
         env:
@@ -650,3 +660,70 @@ jobs:
             $details = $failed.ForEach({ "$($_.Key)=$($_.Value)" }) -join ', '
             throw "Selected CI jobs failed: $details"
           }
+
+      - name: Verify that skipped jobs could not have been affected
+        if: ${{ always() && inputs.force_full != true }}
+        shell: pwsh
+        env:
+          PREPARE_RESULT: ${{ needs.prepare-matrix.result }}
+          TEST_RESULT: ${{ needs.test-suite.result }}
+          TERMINAL_COMMAND_RESULT: ${{ needs.terminal-command-cross-platform.result }}
+          IGNORE_SCANNER_RESULT: ${{ needs.ignore-scanner-cross-platform.result }}
+          DOCUMENTATION_RESULT: ${{ needs.documentation-contracts.result }}
+          PLANNER_PATHS: ${{ needs.prepare-matrix.outputs.changed_paths }}
+          PLANNER_HAS_TESTS: ${{ needs.prepare-matrix.outputs.has_test_matrix }}
+          PLANNER_TERMINAL_COMMAND: ${{ needs.prepare-matrix.outputs.run_terminal_command }}
+          PLANNER_IGNORE_SCANNER: ${{ needs.prepare-matrix.outputs.run_ignore_scanner }}
+          PLANNER_DOCUMENTATION: ${{ needs.prepare-matrix.outputs.run_documentation }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          # A plan the gate has not checked is a plan the gate is trusting. The changed paths are
+          # worked out here, from the commits, rather than taken from the job that made the plan.
+          if ($env:PREPARE_RESULT -ne 'success') {
+            Write-Host 'No plan was produced, so there is no skip to vouch for.'
+            exit 0
+          }
+
+          $results = @{
+            tests = $env:TEST_RESULT
+            terminalCommand = $env:TERMINAL_COMMAND_RESULT
+            ignoreScanner = $env:IGNORE_SCANNER_RESULT
+            documentation = $env:DOCUMENTATION_RESULT
+          }
+          $planned = @{
+            tests = $env:PLANNER_HAS_TESTS
+            terminalCommand = $env:PLANNER_TERMINAL_COMMAND
+            ignoreScanner = $env:PLANNER_IGNORE_SCANNER
+            documentation = $env:PLANNER_DOCUMENTATION
+          }
+          $skipped = @($results.GetEnumerator() | Where-Object { $_.Value -eq 'skipped' } |
+            ForEach-Object { $_.Key })
+          if ($skipped.Count -eq 0) {
+            Write-Host 'No job was skipped.'
+            exit 0
+          }
+
+          $willRun = @($planned.GetEnumerator() | Where-Object { $_.Value -eq 'true' } |
+            ForEach-Object { $_.Key })
+          $head = git rev-parse HEAD
+          $base = if ([string]::IsNullOrWhiteSpace($env:BASE_SHA) -or $env:BASE_SHA -match '^0+$') {
+            ''
+          } else {
+            $env:BASE_SHA
+          }
+          if ([string]::IsNullOrWhiteSpace($base)) {
+            Write-Host 'There is no base to compare against, so the change cannot be established here.'
+            exit 0
+          }
+
+          $changed = @(git -c core.quotepath=false diff --name-only "$base...$head" --)
+          if ($LASTEXITCODE -ne 0) {
+            throw "The changed paths could not be worked out from $base...$head, so the skips cannot be checked."
+          }
+
+          ./Scripts/ci/Test-CiGateSkip.ps1 `
+            -ChangedPath $changed `
+            -PlannerChangedPathJson $env:PLANNER_PATHS `
+            -SkippedJob $skipped `
+            -PlannerWillRunJob $willRun
+

--- a/Scripts/ci/CiChangePlanner.psm1
+++ b/Scripts/ci/CiChangePlanner.psm1
@@ -266,10 +266,10 @@ function New-CiTestMatrix {
 	param([Parameter(Mandatory)][System.Collections.IDictionary] $Plan)
 
 	$suites = @(
-		@{ Name = 'Unit'; Id = 'unit'; Project = 'Tests/DevProjex.Tests.Unit/DevProjex.Tests.Unit.csproj'; Trx = 'unit.trx'; Filter = '' },
-		@{ Name = 'Integration'; Id = 'integration'; Project = 'Tests/DevProjex.Tests.Integration/DevProjex.Tests.Integration.csproj'; Trx = 'integration.trx'; Filter = '--filter Category!=TerminalCommand' },
-		@{ Name = 'Terminal'; Id = 'terminal'; Project = 'Tests/DevProjex.Tests.Terminal/DevProjex.Tests.Terminal.csproj'; Trx = 'terminal.trx'; Filter = '' },
-		@{ Name = 'UI'; Id = 'ui'; Project = 'Tests/DevProjex.Tests.UI/DevProjex.Tests.UI.csproj'; Trx = 'ui.trx'; Filter = '' }
+		@{ Name = 'Unit'; Id = 'unit'; Project = 'Tests/DevProjex.Tests.Unit/DevProjex.Tests.Unit.csproj'; Trx = 'unit.trx' },
+		@{ Name = 'Integration'; Id = 'integration'; Project = 'Tests/DevProjex.Tests.Integration/DevProjex.Tests.Integration.csproj'; Trx = 'integration.trx' },
+		@{ Name = 'Terminal'; Id = 'terminal'; Project = 'Tests/DevProjex.Tests.Terminal/DevProjex.Tests.Terminal.csproj'; Trx = 'terminal.trx' },
+		@{ Name = 'UI'; Id = 'ui'; Project = 'Tests/DevProjex.Tests.UI/DevProjex.Tests.UI.csproj'; Trx = 'ui.trx' }
 	)
 	$operatingSystems = @(
 		@{ Name = 'Windows'; Runner = 'windows-latest'; Id = 'windows' },
@@ -292,7 +292,6 @@ function New-CiTestMatrix {
 				suite_id = $suite.Id
 				project_path = $suite.Project
 				trx_name = $suite.Trx
-				test_filter_args = $suite.Filter
 			})
 		}
 	}

--- a/Scripts/ci/Select-CiPlan.ps1
+++ b/Scripts/ci/Select-CiPlan.ps1
@@ -187,6 +187,13 @@ if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
 	Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $markdownSummary -Encoding utf8 -NoNewline
 }
 
+# The change the plan was decided from, sorted and de-duplicated so the gate can compare it as a
+# set against the change it works out for itself.
+$recordedChangedPaths = @($ChangedPath |
+	Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+	ForEach-Object { $_.Trim() } |
+	Sort-Object -Unique)
+
 $output = [ordered]@{
 	test_matrix = $plan.TestMatrix | ConvertTo-Json -Compress -Depth 5
 	has_test_matrix = $plan.HasTestMatrix.ToString().ToLowerInvariant()
@@ -198,6 +205,13 @@ $output = [ordered]@{
 	full = $plan.Full.ToString().ToLowerInvariant()
 	previous_gate_verified = $previousGateVerified.ToString().ToLowerInvariant()
 	summary = $safeSummary
+	# What the plan was decided from, so the gate can check the decision against the change
+	# rather than take the plan's word for it. Sorted and de-duplicated so the two sides can be
+	# compared as sets without either having to sort first.
+	# Passed as a typed array argument rather than piped: an empty pipeline reaches ConvertTo-Json
+	# as no input at all and yields an empty string, where the gate has to tell "no paths" from
+	# "nothing was recorded".
+	changed_paths = (ConvertTo-Json -Compress -InputObject ([string[]] $recordedChangedPaths))
 }
 
 if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {

--- a/Scripts/ci/Test-CiGateContract.ps1
+++ b/Scripts/ci/Test-CiGateContract.ps1
@@ -1,0 +1,168 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+	Checks that the gate accepts a skip only when the change could not have affected what was
+	skipped, and that the planner and the gate still agree about what "could not have affected"
+	means.
+
+.DESCRIPTION
+	Two things are checked here, and the second is the one that rots quietly.
+
+	The gate's own rules, driven with synthetic path lists: a documentation-only change keeps its
+	fast path, a change that touches tested code fails rather than passing on skipped suites, a plan
+	made from a different set of paths fails with both lists, and a job skipped while the plan
+	expected it to run fails without any of that being consulted.
+
+	And the agreement between the two sides. The gate keeps its own, shorter list of paths that
+	could not have affected a suite, precisely so that it does not take the planner's word. Kept
+	apart by hand, the two would drift: someone widens the planner, suites start being skipped for
+	the new paths, and the gate — which has not heard of them — would fail every such change. So
+	every path the planner treats as skippable is run past the gate here, and the pair has to agree.
+#>
+[CmdletBinding()]
+param(
+	[string] $GatePath = (Join-Path $PSScriptRoot 'Test-CiGateSkip.ps1'),
+	[string] $PlannerModulePath = (Join-Path $PSScriptRoot 'CiChangePlanner.psm1')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$failures = [Collections.Generic.List[string]]::new()
+
+function Test-Case {
+	param(
+		[string] $Name,
+		[string[]] $ChangedPath,
+		[string[]] $PlannerPath,
+		[string[]] $SkippedJob,
+		[string[]] $PlannerWillRunJob = @(),
+		[switch] $ShouldPass,
+		[string] $ExpectMessage
+	)
+
+	$json = if ($null -eq $PlannerPath) { '[]' } else { $PlannerPath | ConvertTo-Json -Compress -AsArray }
+	$accepted = $true
+	$message = ''
+	try {
+		& $GatePath `
+			-ChangedPath $ChangedPath `
+			-PlannerChangedPathJson $json `
+			-SkippedJob $SkippedJob `
+			-PlannerWillRunJob $PlannerWillRunJob | Out-Null
+	}
+	catch {
+		$accepted = $false
+		$message = $_.Exception.Message
+	}
+
+	if ($ShouldPass -and -not $accepted) {
+		$failures.Add("$Name should have been accepted but was rejected: $message")
+		return
+	}
+	if (-not $ShouldPass -and $accepted) {
+		$failures.Add("$Name should have been rejected but was accepted.")
+		return
+	}
+	if ($ExpectMessage -and -not $accepted -and $message -notmatch [regex]::Escape($ExpectMessage)) {
+		$failures.Add("$Name was rejected for the wrong reason; expected '$ExpectMessage', got: $message")
+	}
+}
+
+# --- a change that could not have affected what was skipped -----------------------------------
+Test-Case -Name 'documentation only keeps its fast path' `
+	-ChangedPath @('Docs/McpServer.md', 'README.md') `
+	-PlannerPath @('Docs/McpServer.md', 'README.md') `
+	-SkippedJob @('tests', 'terminalCommand') -ShouldPass
+
+Test-Case -Name 'repository metadata only keeps its fast path' `
+	-ChangedPath @('AGENTS.md', '.gitignore', 'notes.txt') `
+	-PlannerPath @('AGENTS.md', '.gitignore', 'notes.txt') `
+	-SkippedJob @('tests') -ShouldPass
+
+Test-Case -Name 'nothing skipped needs no justification' `
+	-ChangedPath @('Apps/Mcp/McpProjectService.cs') `
+	-PlannerPath @('Apps/Mcp/McpProjectService.cs') `
+	-SkippedJob @() -ShouldPass
+
+# --- a change that could ------------------------------------------------------------------------
+Test-Case -Name 'tested code skipped as if it were metadata' `
+	-ChangedPath @('AGENTS.md', 'Application/Services/GitScopeFilter.cs') `
+	-PlannerPath @('AGENTS.md', 'Application/Services/GitScopeFilter.cs') `
+	-SkippedJob @('tests') `
+	-ExpectMessage 'Application/Services/GitScopeFilter.cs'
+
+Test-Case -Name 'a test project skipped as if it were metadata' `
+	-ChangedPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-SkippedJob @('tests') `
+	-ExpectMessage 'could have'
+
+# --- the plan does not match the change ---------------------------------------------------------
+Test-Case -Name 'the plan saw a path that did not change' `
+	-ChangedPath @('Docs/McpServer.md') `
+	-PlannerPath @('Docs/McpServer.md', 'Docs/Security.md') `
+	-SkippedJob @('tests') `
+	-ExpectMessage 'seen by the plan, and not changed'
+
+Test-Case -Name 'the plan did not see a path that changed' `
+	-ChangedPath @('Docs/McpServer.md', 'Kernel/Models/ProjectRelativeGlob.cs') `
+	-PlannerPath @('Docs/McpServer.md') `
+	-SkippedJob @('tests') `
+	-ExpectMessage 'changed, and not seen by the plan'
+
+Test-Case -Name 'the plan recorded nothing at all' `
+	-ChangedPath @('Docs/McpServer.md') `
+	-PlannerPath @() `
+	-SkippedJob @('tests') `
+	-ExpectMessage 'changed, and not seen by the plan'
+
+# --- skipped for a reason the plan never gave ----------------------------------------------------
+Test-Case -Name 'a job the plan expected to run was skipped' `
+	-ChangedPath @('Docs/McpServer.md') `
+	-PlannerPath @('Docs/McpServer.md') `
+	-SkippedJob @('documentation') `
+	-PlannerWillRunJob @('documentation') `
+	-ExpectMessage 'the plan said they would run'
+
+# --- the two sides still agree about what is skippable -------------------------------------------
+Import-Module $PlannerModulePath -Force
+$skippableByPlanner = @(
+	'README.md', 'Docs/McpServer.md', 'Docs/Media/readme-demo/frame.gif', 'Packaging/Notes.md',
+	'.idea/workspace.xml', '.run/Configuration.xml', '.github/ISSUE_TEMPLATE/bug.md',
+	'.github/PULL_REQUEST_TEMPLATE.md', '.github/FUNDING.yml', '.gitattributes', '.gitignore',
+	'LICENSE', 'AGENTS.md', 'AboutProject.md', 'CODE_OF_CONDUCT.md', 'CONTRIBUTING.md',
+	'SECURITY.md', 'SUPPORT.md', 'TRADEMARKS.md', 'Setup-AI-Agents.ps1', 'SetupAI.txt', 'notes.txt')
+
+foreach ($path in $skippableByPlanner) {
+	$plan = Get-CiChangePlan -ChangedPath @($path)
+	if ($plan.HasTestMatrix) {
+		# The planner runs suites for it, so the gate is never asked to vouch for it.
+		continue
+	}
+
+	$accepted = $true
+	try {
+		& $GatePath -ChangedPath @($path) -PlannerChangedPathJson (@($path) | ConvertTo-Json -Compress -AsArray) `
+			-SkippedJob @('tests') -PlannerWillRunJob @() | Out-Null
+	}
+	catch {
+		$accepted = $false
+	}
+
+	if (-not $accepted) {
+		$failures.Add(
+			"the planner skips the test suites for '$path' but the gate will not vouch for it, " +
+			"so every change touching that path would fail the gate")
+	}
+}
+
+if ($failures.Count -gt 0) {
+	Write-Host 'The CI gate no longer behaves as its own documentation says:'
+	foreach ($failure in $failures) {
+		Write-Host "  $failure"
+	}
+	throw "Test-CiGateSkip.ps1 failed $($failures.Count) of its own contract cases."
+}
+
+Write-Host 'CI gate skip contract cases passed.'

--- a/Scripts/ci/Test-CiGateSkip.ps1
+++ b/Scripts/ci/Test-CiGateSkip.ps1
@@ -1,0 +1,139 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+	Fails the gate when a job was skipped for a reason the gate cannot vouch for.
+
+.DESCRIPTION
+	A skipped job counts as a pass, which is right only when something has checked that the change
+	could not have affected it. That check used to be the change planner's word: it classified the
+	changed paths, whole suites were skipped on the strength of that classification, and the gate
+	accepted the result without ever seeing the change.
+
+	So this asks two questions the planner cannot answer about itself.
+
+	Did the planner see the change that was actually made? The paths it decided from are compared
+	against the paths the gate works out for itself from the same commits. Any difference fails,
+	with both lists in the message, because a plan made from a different change is not a plan for
+	this one.
+
+	Is every changed path one that could not have affected a skipped job? That is answered here,
+	from a list kept deliberately shorter than the planner's. Only documentation and repository
+	metadata qualify. Anything this does not recognise fails the gate, so the two lists drifting
+	apart shows up as a red gate rather than as a suite quietly not running — and
+	`Test-CiGateContract.ps1` fails if the planner ever calls something skippable that this does
+	not.
+
+	A job skipped while the planner expected it to run is not the planner's doing at all, and fails
+	without any of the above being consulted.
+#>
+[CmdletBinding()]
+param(
+	# The paths the gate worked out for itself, from the same commits the planner used.
+	[Parameter(Mandatory)]
+	[AllowEmptyCollection()]
+	[string[]] $ChangedPath,
+
+	# The paths the planner recorded having decided from, as the JSON array it wrote.
+	[Parameter(Mandatory)]
+	[AllowEmptyString()]
+	[string] $PlannerChangedPathJson,
+
+	# Jobs whose result was 'skipped'.
+	[Parameter(Mandatory)]
+	[AllowEmptyCollection()]
+	[string[]] $SkippedJob,
+
+	# Jobs the planner's own outputs said would run.
+	[Parameter(Mandatory)]
+	[AllowEmptyCollection()]
+	[string[]] $PlannerWillRunJob
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-PathSet {
+	param([AllowEmptyCollection()][string[]] $Path)
+
+	return @($Path |
+		Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+		ForEach-Object { $_.Trim() } |
+		Sort-Object -Unique)
+}
+
+function Test-SkippablePath {
+	param([string] $Path)
+
+	# Documentation.
+	if ($Path -eq 'README.md') { return $true }
+	if ($Path.StartsWith('Docs/', [StringComparison]::OrdinalIgnoreCase)) { return $true }
+	if ($Path.StartsWith('Packaging/', [StringComparison]::OrdinalIgnoreCase) -and
+		$Path.EndsWith('.md', [StringComparison]::OrdinalIgnoreCase)) {
+		return $true
+	}
+
+	# Repository metadata.
+	foreach ($prefix in @('.idea/', '.run/', '.github/ISSUE_TEMPLATE/')) {
+		if ($Path.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+	}
+	$metadataFiles = @(
+		'.github/PULL_REQUEST_TEMPLATE.md', '.github/FUNDING.yml', '.gitattributes', '.gitignore',
+		'LICENSE', 'AGENTS.md', 'AboutProject.md', 'CODE_OF_CONDUCT.md', 'CONTRIBUTING.md',
+		'SECURITY.md', 'SUPPORT.md', 'TRADEMARKS.md', 'Setup-AI-Agents.ps1', 'SetupAI.txt')
+	if ($metadataFiles -contains $Path) { return $true }
+	if (-not $Path.Contains('/') -and $Path.EndsWith('.txt', [StringComparison]::OrdinalIgnoreCase)) {
+		return $true
+	}
+
+	return $false
+}
+
+# Wrapped at the call: a function returning one item returns it as a scalar, and asking a
+# scalar for Count is an error under strict mode.
+$skipped = @(ConvertTo-PathSet -Path $SkippedJob)
+if ($skipped.Count -eq 0) {
+	Write-Host 'No job was skipped; nothing to vouch for.'
+	exit 0
+}
+
+# A job the planner expected to run, and which did not, was not skipped by the plan. Whatever
+# stopped it is outside what this can vouch for.
+$unplanned = @($skipped | Where-Object { $PlannerWillRunJob -contains $_ })
+if ($unplanned.Count -gt 0) {
+	throw "These jobs were skipped although the plan said they would run, so the plan does not " +
+	      "account for it: $($unplanned -join ', ')."
+}
+
+$actual = @(ConvertTo-PathSet -Path $ChangedPath)
+$recorded = @()
+if (-not [string]::IsNullOrWhiteSpace($PlannerChangedPathJson)) {
+	try {
+		$recorded = @(ConvertTo-PathSet -Path @($PlannerChangedPathJson | ConvertFrom-Json))
+	}
+	catch {
+		throw "The plan recorded no readable list of the paths it decided from, so its decision " +
+		      "cannot be checked against the change: $($_.Exception.Message)"
+	}
+}
+
+$missing = @($actual | Where-Object { $recorded -notcontains $_ })
+$extra = @($recorded | Where-Object { $actual -notcontains $_ })
+if ($missing.Count -gt 0 -or $extra.Count -gt 0) {
+	throw "The plan was decided from a different change than the one being gated, so its skips " +
+	      "cannot be trusted." + [Environment]::NewLine +
+	      "  changed, and not seen by the plan: $(if ($missing.Count) { $missing -join ', ' } else { '(none)' })" +
+	      [Environment]::NewLine +
+	      "  seen by the plan, and not changed: $(if ($extra.Count) { $extra -join ', ' } else { '(none)' })" +
+	      [Environment]::NewLine +
+	      "  gate saw $($actual.Count) path(s); the plan recorded $($recorded.Count)."
+}
+
+$unvouched = @($actual | Where-Object { -not (Test-SkippablePath -Path $_) })
+if ($unvouched.Count -gt 0) {
+	throw "These jobs were skipped: $($skipped -join ', '). That is only acceptable when the " +
+	      "change could not have affected them, and these paths could have:" +
+	      [Environment]::NewLine + "  $($unvouched -join [Environment]::NewLine + '  ')"
+}
+
+Write-Host ("Skipped " + ($skipped -join ', ') +
+	"; all $($actual.Count) changed path(s) are documentation or repository metadata.")


### PR DESCRIPTION
Closes #379.

The gate counted a skipped job as a pass, and which suites run is decided by classifying the changed
paths. A change the planner misread could therefore go green having executed almost nothing.

## Why the gate could not have noticed

Three things had to be true at once, and all three were:

- the reasons for a skip existed only as **prose**, `'; '`-joined and truncated at 16 KB, in the
  `summary` output;
- `summary` is not among the five outputs `prepare-matrix` re-exports, so no downstream job could
  read it even as prose;
- the list of paths the plan was decided from was **never written down at all** — it lived in a
  local variable and was discarded.

And `ci-gate` did not check the repository out, so it had nothing of its own to compare against. It
accepted `skipped` because it had no means to do anything else.

## What the gate does now

It checks the repository out and asks two questions the plan cannot answer about itself.

**Did the plan see the change that was actually made?** The planner now records the paths it decided
from, as a sorted JSON array, and `prepare-matrix` re-exports it. The gate works the same list out
from the same commits and compares them as sets. Any difference fails, with both lists in the
message.

**Could the change have affected what was skipped?** Answered from a list in the gate that is
deliberately **shorter** than the planner's — only documentation and repository metadata qualify.
Anything the gate does not recognise fails. The asymmetry is the point: if the two lists drift, the
result is a red gate, not a suite quietly not running.

A job skipped while the plan expected it to run is not the plan's doing, and fails without either
question being reached. `FORCE_FULL` is untouched — the new step does not run there, because that
run already refuses a skip outright.

## Keeping the two lists from drifting

The obvious failure of "the gate keeps its own list" is that someone widens the planner, suites
start being skipped for paths the gate has never heard of, and every such change fails. So
`Test-CiGateContract.ps1` runs **every path the planner treats as skippable** past the gate and
requires the pair to agree. Widening one without the other fails the contract rather than CI.

## Checked

Ten synthetic cases, plus the agreement sweep:

| case | result |
|---|---|
| documentation only, suites skipped | passes |
| repository metadata only, suites skipped | passes |
| nothing skipped | passes, nothing to vouch for |
| tested code skipped as if it were metadata | fails, naming the path |
| a test project skipped as if it were metadata | fails |
| the plan saw a path that did not change | fails, both lists |
| the plan did not see a path that changed | fails, both lists |
| the plan recorded nothing | fails |
| a job the plan expected to run was skipped | fails, without consulting paths |
| every path the planner calls skippable | the gate vouches for each |

End to end, planner into gate, run locally:

```
planner recorded ["AGENTS.md","Docs/McpServer.md"], suites will run: false
  -> Skipped tests; all 2 changed path(s) are documentation or repository metadata.

planner recorded ["AGENTS.md"], gate also sees Application/Services/GitScopeFilter.cs
  -> The plan was decided from a different change than the one being gated,
     so its skips cannot be trusted.
```

All four CI self-tests pass — planner, gate, executed-tests, indentation — and `actionlint` accepts
the workflow.

## `test_filter_args`

Removed. It was written into every matrix row and read by nothing, and it had already drifted from
the filter the workflow actually passes: the planner recorded `--filter Category!=TerminalCommand`
while `dotnet.yml` computes `(Category!=TerminalCommand)&(Category!=LocalPerformance)&(Category!=Performance)`
inline. A field that is written, never read, and wrong is the worst of the three states, because a
reader assumes it is honoured. The `Filter` column it came from is gone with it, and
`Test-CiChangePlanner.ps1` still passes.
