### PR TITLE
test(mcp): wait for the terminal progress notification instead of assuming it

### DIFF
--- a/Docs/CI-Known-Failures.md
+++ b/Docs/CI-Known-Failures.md
@@ -66,8 +66,12 @@ all mid-scan values. When almost nothing has been dispatched yet, the count asse
 There is no poll and no wait: `[Fact(Timeout = 120_000)]` bounds the whole test, not the arrival of
 a notification. The test carries no `Category` trait, so no CI filter excludes it.
 
-**Not fixed here.** This list is a record; changing the test is a separate change. Whoever takes it
-will want the test to wait for the terminal notification rather than assume it has arrived.
+**Fixed under #382, pending a clean week.** The loss was measured to the side of the boundary it
+happens on: the server writes the terminal notification before the result of the call, so a value
+missing on the client was already on the wire and was lost on delivery. The test now waits for the
+terminal notification instead of assuming the return of the call means it has arrived, and the
+write order is pinned separately against the recorded transport. This entry closes once that has
+run clean for a week; until then the occurrences above stand as the record.
 
 ## 2. The runner enumerating zero tests
 

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.BatchReads.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.BatchReads.cs
@@ -95,6 +95,17 @@ public sealed partial class McpServerProcessTests
 		process.Dispose();
 	}
 
+	/// <summary>
+	/// A large manifest reports progress while it is walked, and the walk ends at 100.
+	/// </summary>
+	/// <remarks>
+	/// The terminal notification is waited for rather than assumed. The server writes it before
+	/// the result — <see cref="AssertFinalProgressPrecedesResult"/> pins that on the recorded stream —
+	/// but it is delivered on its own path, and the return of the call says nothing about whether
+	/// that delivery has happened yet. Reading the collected values at the moment the call returns
+	/// asked the wrong question, and answered it differently depending on how loaded the machine
+	/// was: the last value, or all of them, could still be in flight.
+	/// </remarks>
 	[Fact(Timeout = 120_000)]
 	public async Task RealProcessThrottlesDependencyProgressForTenThousandFiles()
 	{
@@ -113,6 +124,9 @@ public sealed partial class McpServerProcessTests
 				TestContext.Current.CancellationToken);
 
 			Assert.NotEqual(true, result.IsError);
+			await progress
+				.WaitForAsync(static value => value.Progress >= 100f, TestContext.Current.CancellationToken)
+				.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 			Assert.InRange(progress.Values.Count, 2, 20);
 			Assert.Equal(5f, progress.Values[0].Progress);
 			Assert.Equal(100f, progress.Values[^1].Progress);
@@ -123,7 +137,60 @@ public sealed partial class McpServerProcessTests
 			await client.DisposeAsync();
 		}
 		await CompletePublishedMcpAsync(process, errorTask, output);
+		AssertFinalProgressPrecedesResult(output.GetRecordedText());
 	}
+
+	/// <summary>
+	/// The terminal progress notification is written before the result of the call it belongs to,
+	/// so a caller that treats the result as the end of the call cannot be handed a truncated
+	/// sequence by anything the server did.
+	/// </summary>
+	/// <remarks>
+	/// Read from the recorded bytes rather than from what arrived, because the two are different
+	/// claims: this one is about the order things were written in, and it is the half that a test
+	/// waiting for delivery would otherwise stop checking.
+	/// </remarks>
+	private static void AssertFinalProgressPrecedesResult(string recordedTransport)
+	{
+		var finalProgress = -1;
+		var callResult = -1;
+		var position = 0;
+		foreach (var line in recordedTransport.Split('\n'))
+		{
+			position++;
+			if (line.Contains("notifications/progress", StringComparison.Ordinal))
+			{
+				var reported = Regex.Match(line, @"""progress""\s*:\s*([0-9.]+)");
+				if (reported.Success &&
+					float.TryParse(
+						reported.Groups[1].Value,
+						System.Globalization.CultureInfo.InvariantCulture,
+						out var value) &&
+					value >= 100f)
+				{
+					finalProgress = position;
+				}
+			}
+			else if (line.Contains("\"result\"", StringComparison.Ordinal))
+			{
+				callResult = position;
+			}
+		}
+
+		Assert.True(finalProgress > 0, "The server never wrote a terminal progress notification.");
+		Assert.True(callResult > 0, "The server never wrote a result for the call.");
+		Assert.True(
+			finalProgress < callResult,
+			$"The result was written at line {callResult}, ahead of the terminal progress " +
+			$"notification at line {finalProgress}, so a caller that stops at the result cannot " +
+			"see the whole sequence.");
+	}
+
+	/// <summary>
+	/// The same check, reachable from the cases that drive it with a written-out sequence.
+	/// </summary>
+	internal static void AssertFinalProgressPrecedesResultForContract(string recordedTransport) =>
+		AssertFinalProgressPrecedesResult(recordedTransport);
 
 	[Fact(Timeout = 120_000)]
 	public async Task RealProcessReportsWhenSearchStopsAtTheInspectedByteBudget()

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs
@@ -1156,16 +1156,58 @@ public sealed partial class McpServerProcessTests
 
 		public void Report(T value)
 		{
+			TaskCompletionSource? satisfied = null;
 			lock (_sync)
+			{
 				_values.Add(value);
+				if (_awaited is not null && _awaited(value))
+				{
+					satisfied = _awaitedSignal;
+					_awaited = null;
+					_awaitedSignal = null;
+				}
+			}
+
 			_reported.TrySetResult();
+			satisfied?.TrySetResult();
 		}
 
 		private readonly TaskCompletionSource _reported = new(
 			TaskCreationOptions.RunContinuationsAsynchronously);
+		private Func<T, bool>? _awaited;
+		private TaskCompletionSource? _awaitedSignal;
 
 		public Task WaitForValueAsync(CancellationToken cancellationToken) =>
 			_reported.Task.WaitAsync(cancellationToken);
+
+		/// <summary>
+		/// Waits until a reported value satisfies <paramref name="predicate"/>, counting values that
+		/// have already arrived.
+		/// </summary>
+		/// <remarks>
+		/// A notification is delivered on its own path and its arrival is not tied to the return of
+		/// the call it belongs to. Reading the collected values the moment a call returns therefore
+		/// asks whether delivery has happened yet, which is a different question from whether it
+		/// will.
+		/// </remarks>
+		public Task WaitForAsync(Func<T, bool> predicate, CancellationToken cancellationToken)
+		{
+			TaskCompletionSource signal;
+			lock (_sync)
+			{
+				foreach (var value in _values)
+				{
+					if (predicate(value))
+						return Task.CompletedTask;
+				}
+
+				signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+				_awaited = predicate;
+				_awaitedSignal = signal;
+			}
+
+			return signal.Task.WaitAsync(cancellationToken);
+		}
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Terminal/ProgressOrderingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ProgressOrderingContractTests.cs
@@ -1,0 +1,64 @@
+namespace DevProjex.Tests.Terminal;
+
+/// <summary>
+/// The ordering check that the large-manifest progress test relies on, driven directly.
+/// </summary>
+/// <remarks>
+/// That test waits for the terminal notification before reading what arrived, which is what stops
+/// it failing on delivery. Waiting, on its own, would also pass a server that wrote the result
+/// first — the notification would simply turn up later. So the order the server wrote in is checked
+/// separately, and these cases are what show that check can tell the two apart. Without them it
+/// could quietly stop distinguishing anything and every run would still be green.
+/// </remarks>
+public sealed class ProgressOrderingContractTests
+{
+	private const string TerminalProgress =
+		"""{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"throttle","progress":100,"total":100}}""";
+
+	private const string EarlierProgress =
+		"""{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"throttle","progress":5,"total":100}}""";
+
+	private const string CallResult =
+		"""{"jsonrpc":"2.0","id":2,"result":{"content":[],"isError":false}}""";
+
+	private const string InitializeResult =
+		"""{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}""";
+
+	[Fact]
+	public void TheRecordedOrderIsAcceptedWhenProgressPrecedesTheResult() =>
+		McpServerProcessTests.AssertFinalProgressPrecedesResultForContract(
+			string.Join('\n', InitializeResult, EarlierProgress, TerminalProgress, CallResult));
+
+	[Fact]
+	public void AResultWrittenAheadOfTheTerminalProgressIsRejected()
+	{
+		var reordered = string.Join('\n', InitializeResult, EarlierProgress, CallResult, TerminalProgress);
+
+		var failure = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() =>
+			McpServerProcessTests.AssertFinalProgressPrecedesResultForContract(reordered));
+
+		Assert.Contains("ahead of the terminal progress", failure.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ASequenceWithoutATerminalProgressIsRejected()
+	{
+		var truncated = string.Join('\n', InitializeResult, EarlierProgress, CallResult);
+
+		var failure = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() =>
+			McpServerProcessTests.AssertFinalProgressPrecedesResultForContract(truncated));
+
+		Assert.Contains("never wrote a terminal progress notification", failure.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ASequenceWithoutAResultIsRejected()
+	{
+		var unfinished = string.Join('\n', EarlierProgress, TerminalProgress);
+
+		var failure = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() =>
+			McpServerProcessTests.AssertFinalProgressPrecedesResultForContract(unfinished));
+
+		Assert.Contains("never wrote a result", failure.Message, StringComparison.Ordinal);
+	}
+}


### PR DESCRIPTION
Closes #382.

## Which side lost the value, and how that was established

Measured before anything was changed, by recording the bytes the server wrote and the values the
client delivered in the same run:

```
WIRE ORDER (what the server wrote):  result | progress 5 | progress 10.0065 | progress 100 | result
CLIENT AT RESULT:                    5, 10.0065, 100
CLIENT AFTER EOF:                    5, 10.0065, 100
```

The first `result` is the reply to `initialize`; the last is the result of the tool call.

**The loss is on the client side of the boundary, not the server's.** The server writes `progress
100` *before* the result of the call, so a value the client is missing while it holds the result was
already on the wire ahead of that result. It can only have been dropped on delivery. That reading is
deterministic — it looks at the order the bytes were written in, so it does not need the race to
reproduce, and locally it does not.

A second confirmation from the same run: **`10.0065` is the intermediate notification of a healthy
run.** It is the value the failures report as the last one, which is the same fact seen from the
other end — the last of three was dropped. The other symptom, `Actual: 0`, is all three dropped.

This also settles where the fix belongs: the write order is already correct, so there is nothing to
order on the server, and `Apps/Mcp` is untouched by this change.

## What changed

The test waits for the terminal notification instead of reading the collected values the moment the
call returns. `InlineProgress` gains a wait that counts values already delivered, so there is no
window between checking and waiting.

The assertion that the final value is 100 is unchanged. What changed is that it is reached once
delivery has happened, rather than whenever it happens to have happened.

## Why waiting alone is not enough

A test that only waits would also accept a server that wrote the result first — the notification
would simply turn up later. So the write order is pinned separately, against the recorded transport:
the terminal notification must appear before the result of the call.

`ProgressOrderingContractTests` drives that check directly, which is what shows it can tell the two
apart:

| case | expected |
|---|---|
| terminal notification written before the result | accepted |
| result written ahead of the terminal notification | rejected, naming both positions |
| no terminal notification at all | rejected |
| no result at all | rejected |

Without those the check could quietly stop distinguishing anything and every run would still be
green.

## Not in scope

The retry policy is untouched — this is not a change about reruns. No notice, parameter or document
of the public surface changes. The known-failures entry records the measurement and **stays open**
until the test has run clean for a week, as the issue asks.

## Checked

`RealProcessThrottlesDependencyProgressForTenThousandFiles` passes in 10 s, the four ordering cases
pass, and the documentation contract tests pass.
