### PR TITLE
chore(ci): decide a skipped job against the change, per job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,6 +52,7 @@ jobs:
       run_ignore_scanner: ${{ steps.plan.outputs.run_ignore_scanner }}
       run_documentation: ${{ steps.plan.outputs.run_documentation }}
       changed_paths: ${{ steps.plan.outputs.changed_paths }}
+      planned_suites: ${{ steps.plan.outputs.planned_suites }}
 
     steps:
       - uses: actions/checkout@v7
@@ -671,6 +672,7 @@ jobs:
           IGNORE_SCANNER_RESULT: ${{ needs.ignore-scanner-cross-platform.result }}
           DOCUMENTATION_RESULT: ${{ needs.documentation-contracts.result }}
           PLANNER_PATHS: ${{ needs.prepare-matrix.outputs.changed_paths }}
+          PLANNER_SUITES: ${{ needs.prepare-matrix.outputs.planned_suites }}
           PLANNER_HAS_TESTS: ${{ needs.prepare-matrix.outputs.has_test_matrix }}
           PLANNER_TERMINAL_COMMAND: ${{ needs.prepare-matrix.outputs.run_terminal_command }}
           PLANNER_IGNORE_SCANNER: ${{ needs.prepare-matrix.outputs.run_ignore_scanner }}
@@ -721,9 +723,13 @@ jobs:
             throw "The changed paths could not be worked out from $base...$head, so the skips cannot be checked."
           }
 
+          $plannedSuites = @($env:PLANNER_SUITES -split ',' |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
           ./Scripts/ci/Test-CiGateSkip.ps1 `
             -ChangedPath $changed `
             -PlannerChangedPathJson $env:PLANNER_PATHS `
             -SkippedJob $skipped `
-            -PlannerWillRunJob $willRun
+            -PlannerWillRunJob $willRun `
+            -PlannerWillRunSuite $plannedSuites
 

--- a/Scripts/ci/CiChangePlanner.psm1
+++ b/Scripts/ci/CiChangePlanner.psm1
@@ -166,7 +166,9 @@ function Add-PathToCiPlan {
 	}
 
 	if (Test-PathStartsWith $normalized 'Tests/DevProjex.Tests.Unit/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Unit') -Reason "Unit tests: $normalized"
+		# The terminal command matrix builds and runs this same assembly under its own filter, so a
+		# change to any file in the project can break that job while leaving the Unit suite green.
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'TerminalCommand') -Reason "Unit tests: $normalized"
 		return
 	}
 
@@ -197,18 +199,21 @@ function Add-PathToCiPlan {
 	}
 
 	if ((Test-PathStartsWith $normalized 'Tests/DevProjex.Tests.Terminal.ProgressHost/') -or
-		(Test-PathStartsWith $normalized 'Tests/Shared/TerminalProgress/')) {
-		Enable-CiTargets -Plan $Plan -Targets @('Terminal') -Reason "Terminal test infrastructure: $normalized"
+		(Test-PathStartsWith $normalized 'Tests/Shared/TerminalProgress/') -or
+		(Test-PathStartsWith $normalized 'Tests/Shared/TerminalHost/')) {
+		# The Unit tests reference the progress host as well, and both shared folders are
+		# compiled into it, so a change here can break the Unit suite and not only the Terminal one.
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Terminal') -Reason "Terminal test infrastructure: $normalized"
 		return
 	}
 
 	if (Test-PathStartsWith $normalized 'Tests/Shared/ProjectLoadWorkflow/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'UI') -Reason "Shared project-load tests: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'UI', 'TerminalCommand') -Reason "Shared project-load tests: $normalized"
 		return
 	}
 
 	if (Test-PathStartsWith $normalized 'Tests/Shared/StoreListing/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration') -Reason "Shared Store-listing tests: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'TerminalCommand') -Reason "Shared Store-listing tests: $normalized"
 		return
 	}
 
@@ -218,12 +223,12 @@ function Add-PathToCiPlan {
 	}
 
 	if (Test-PathStartsWith $normalized 'Apps/Avalonia/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'UI', 'Release', 'Store') -Reason "Desktop production surface: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'Terminal', 'UI', 'TerminalCommand', 'Release', 'Store') -Reason "Desktop production surface: $normalized"
 		return
 	}
 
 	if (Test-PathStartsWith $normalized 'Apps/Terminal/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Integration', 'Terminal', 'TerminalCommand', 'Release', 'Store') -Reason "Terminal production surface: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'Terminal', 'TerminalCommand', 'Release', 'Store') -Reason "Terminal production surface: $normalized"
 		return
 	}
 
@@ -233,7 +238,7 @@ function Add-PathToCiPlan {
 		# read it: embedded-resource loading (Unit), per-language coverage (Integration)
 		# and the documentation contracts (Terminal, Documentation). Non-text files in the
 		# same directory stay on the shared production layer plan below.
-		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'Terminal', 'Documentation') -Reason "Help content: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'Terminal', 'TerminalCommand', 'Documentation') -Reason "Help content: $normalized"
 		return
 	}
 
@@ -249,12 +254,12 @@ function Add-PathToCiPlan {
 	}
 
 	if (Test-PathStartsWith $normalized 'Packaging/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'Release', 'Store') -Reason "Packaging contract: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'TerminalCommand', 'Documentation', 'Release', 'Store') -Reason "Packaging contract: $normalized"
 		return
 	}
 
 	if (Test-PathStartsWith $normalized 'Scripts/') {
-		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'Release', 'Store') -Reason "Build/release tooling: $normalized"
+		Enable-CiTargets -Plan $Plan -Targets @('Unit', 'Integration', 'TerminalCommand', 'Release', 'Store') -Reason "Build/release tooling: $normalized"
 		return
 	}
 

--- a/Scripts/ci/Select-CiPlan.ps1
+++ b/Scripts/ci/Select-CiPlan.ps1
@@ -194,6 +194,11 @@ $recordedChangedPaths = @($ChangedPath |
 	ForEach-Object { $_.Trim() } |
 	Sort-Object -Unique)
 
+# The suites the matrix will run. Three of the gated jobs run tests a suite also runs, so the
+# gate needs to know which suites ran before it can say whether skipping those jobs left
+# anything uncovered.
+$plannedSuites = @('Unit', 'Integration', 'Terminal', 'UI' | Where-Object { $plan.$_ })
+
 $output = [ordered]@{
 	test_matrix = $plan.TestMatrix | ConvertTo-Json -Compress -Depth 5
 	has_test_matrix = $plan.HasTestMatrix.ToString().ToLowerInvariant()
@@ -204,6 +209,7 @@ $output = [ordered]@{
 	run_store = $plan.Store.ToString().ToLowerInvariant()
 	full = $plan.Full.ToString().ToLowerInvariant()
 	previous_gate_verified = $previousGateVerified.ToString().ToLowerInvariant()
+	planned_suites = ($plannedSuites -join ',')
 	summary = $safeSummary
 	# What the plan was decided from, so the gate can check the decision against the change
 	# rather than take the plan's word for it. Sorted and de-duplicated so the two sides can be

--- a/Scripts/ci/Test-CiChangePlanner.ps1
+++ b/Scripts/ci/Test-CiChangePlanner.ps1
@@ -58,32 +58,32 @@ Assert-Plan -Name 'Root text note only' -Path 'release-note.txt' `
 	-Disabled ($allHeavyTargets + 'Documentation')
 
 Assert-Plan -Name 'Embedded help text runs only content-coupled suites' -Path 'Assets/HelpContent/help.de.txt' `
-	-Enabled @('Unit', 'Integration', 'Terminal', 'Documentation') `
-	-Disabled @('UI', 'TerminalCommand', 'IgnoreScanner', 'Release', 'Store', 'Full')
+	-Enabled @('Unit', 'Integration', 'Terminal', 'TerminalCommand', 'Documentation') `
+	-Disabled @('UI', 'IgnoreScanner', 'Release', 'Store', 'Full')
 
 Assert-Plan -Name 'Nested help text stays content-coupled' -Path 'Assets/HelpContent/en/overview.txt' `
-	-Enabled @('Unit', 'Integration', 'Terminal', 'Documentation') `
-	-Disabled @('UI', 'TerminalCommand', 'IgnoreScanner', 'Release', 'Store', 'Full')
+	-Enabled @('Unit', 'Integration', 'Terminal', 'TerminalCommand', 'Documentation') `
+	-Disabled @('UI', 'IgnoreScanner', 'Release', 'Store', 'Full')
 
 Assert-Plan -Name 'Non-text file under help content fails safe to production' -Path 'Assets/HelpContent/generate-help.ps1' `
 	-Enabled @('Unit', 'Integration', 'Terminal', 'UI', 'TerminalCommand', 'Release', 'Store') `
 	-Disabled @('Full')
 
 Assert-Plan -Name 'Desktop production change' -Path 'Apps/Avalonia/Views/MainWindow.axaml' `
-	-Enabled @('Unit', 'Integration', 'UI', 'Release', 'Store') `
-	-Disabled @('Terminal', 'TerminalCommand', 'IgnoreScanner', 'Full')
+	-Enabled @('Unit', 'Integration', 'Terminal', 'UI', 'TerminalCommand', 'Release', 'Store') `
+	-Disabled @('IgnoreScanner', 'Full')
 
 Assert-Plan -Name 'Terminal production change' -Path 'Apps/Terminal/Tui/TerminalWorkspace.cs' `
-	-Enabled @('Integration', 'Terminal', 'TerminalCommand', 'Release', 'Store') `
-	-Disabled @('Unit', 'UI', 'IgnoreScanner', 'Full')
+	-Enabled @('Unit', 'Integration', 'Terminal', 'TerminalCommand', 'Release', 'Store') `
+	-Disabled @('UI', 'IgnoreScanner', 'Full')
 
 Assert-Plan -Name 'Ignore production change' -Path 'Application/Services/IgnoreRulesService.cs' `
 	-Enabled @('Unit', 'Integration', 'Terminal', 'UI', 'TerminalCommand', 'IgnoreScanner', 'Release', 'Store') `
 	-Disabled @('Full')
 
-Assert-Plan -Name 'Unit test only' -Path 'Tests/DevProjex.Tests.Unit/FooTests.cs' `
-	-Enabled Unit `
-	-Disabled @('Integration', 'Terminal', 'UI', 'TerminalCommand', 'IgnoreScanner', 'Documentation', 'Release', 'Store', 'Full')
+Assert-Plan -Name 'Unit test carries the matrix that builds its project' -Path 'Tests/DevProjex.Tests.Unit/FooTests.cs' `
+	-Enabled @('Unit', 'TerminalCommand') `
+	-Disabled @('Integration', 'Terminal', 'UI', 'IgnoreScanner', 'Documentation', 'Release', 'Store', 'Full')
 
 Assert-Plan -Name 'Integration test covers excluded terminal category' -Path 'Tests/DevProjex.Tests.Integration/FooTests.cs' `
 	-Enabled @('Integration', 'TerminalCommand') `
@@ -92,6 +92,36 @@ Assert-Plan -Name 'Integration test covers excluded terminal category' -Path 'Te
 Assert-Plan -Name 'Ignore integration test' -Path 'Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs' `
 	-Enabled @('Integration', 'TerminalCommand', 'IgnoreScanner') `
 	-Disabled @('Unit', 'Terminal', 'UI', 'Documentation', 'Release', 'Store', 'Full')
+
+Assert-Plan -Name 'Terminal test infrastructure reaches the unit tests too' `
+	-Path 'Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs' `
+	-Enabled @('Unit', 'Terminal') `
+	-Disabled @('Integration', 'UI', 'TerminalCommand', 'IgnoreScanner', 'Documentation', 'Release', 'Store', 'Full')
+
+foreach ($sharedTerminalPath in @('Tests/Shared/TerminalProgress/Expectations.cs', 'Tests/Shared/TerminalHost/Harness.cs')) {
+	Assert-Plan -Name "Shared terminal test source: $sharedTerminalPath" -Path $sharedTerminalPath `
+		-Enabled @('Unit', 'Terminal') `
+		-Disabled @('Integration', 'UI', 'TerminalCommand', 'IgnoreScanner', 'Documentation', 'Release', 'Store', 'Full')
+}
+
+Assert-Plan -Name 'Shared project-load source carries the excluded terminal category' `
+	-Path 'Tests/Shared/ProjectLoadWorkflow/Steps.cs' `
+	-Enabled @('Unit', 'Integration', 'UI', 'TerminalCommand') `
+	-Disabled @('Terminal', 'IgnoreScanner', 'Documentation', 'Release', 'Store', 'Full')
+
+Assert-Plan -Name 'Shared Store-listing source carries the excluded terminal category' `
+	-Path 'Tests/Shared/StoreListing/Facts.cs' `
+	-Enabled @('Unit', 'Integration', 'TerminalCommand') `
+	-Disabled @('Terminal', 'UI', 'IgnoreScanner', 'Documentation', 'Release', 'Store', 'Full')
+
+Assert-Plan -Name 'Packaging files are read by the documentation contracts' `
+	-Path 'Packaging/Windows/StoreListing/listingData.csv' `
+	-Enabled @('Unit', 'Integration', 'TerminalCommand', 'Documentation', 'Release', 'Store') `
+	-Disabled @('Terminal', 'UI', 'IgnoreScanner', 'Full')
+
+Assert-Plan -Name 'Release tooling is linked into the integration tests' -Path 'Scripts/Build-Release.ps1' `
+	-Enabled @('Unit', 'Integration', 'TerminalCommand', 'Release', 'Store') `
+	-Disabled @('Terminal', 'UI', 'IgnoreScanner', 'Documentation', 'Full')
 
 Assert-Plan -Name 'Windows path normalization' -Path 'Tests\DevProjex.Tests.UI\MainWindowTests.cs' `
 	-Enabled UI `

--- a/Scripts/ci/Test-CiGateContract.ps1
+++ b/Scripts/ci/Test-CiGateContract.ps1
@@ -2,22 +2,31 @@
 <#
 .SYNOPSIS
 	Checks that the gate accepts a skip only when the change could not have affected what was
-	skipped, and that the planner and the gate still agree about what "could not have affected"
-	means.
+	skipped, and that the planner and the gate still agree, job by job, about what "could not have
+	affected" means.
 
 .DESCRIPTION
-	Two things are checked here, and the second is the one that rots quietly.
+	Three things are checked here, and the last is the one that rots quietly.
 
 	The gate's own rules, driven with synthetic path lists: a documentation-only change keeps its
 	fast path, a change that touches tested code fails rather than passing on skipped suites, a plan
 	made from a different set of paths fails with both lists, and a job skipped while the plan
 	expected it to run fails without any of that being consulted.
 
-	And the agreement between the two sides. The gate keeps its own, shorter list of paths that
-	could not have affected a suite, precisely so that it does not take the planner's word. Kept
-	apart by hand, the two would drift: someone widens the planner, suites start being skipped for
-	the new paths, and the gate — which has not heard of them — would fail every such change. So
-	every path the planner treats as skippable is run past the gate here, and the pair has to agree.
+	That the gate still tells the jobs apart. A gate that answered "unreachable" to everything would
+	pass every case below that expects a pass, so each job also gets a case where the change does
+	reach it and the gate has to refuse — including one that checks the reaching paths are printed,
+	because that list is the whole content of the failure.
+
+	And the agreement between the two sides, per job. The gate works out for itself which jobs a
+	path can reach, precisely so that it does not take the planner's word for it. Kept apart by
+	hand, the two would drift: someone narrows the planner, a job starts being skipped for paths
+	that reach it, and the gate — which has not heard of the narrowing — either fails every such
+	change or waves it through. A plan is rarely skipped whole; far more often it is narrowed to one
+	suite, which is exactly the case a "was it skipped entirely" check cannot see. So a file from
+	every test project, and from every other kind of path the planner classifies, is put to both
+	sides, and for every job the planner skips the gate has to agree that the change cannot reach
+	it.
 #>
 [CmdletBinding()]
 param(
@@ -29,6 +38,52 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $failures = [Collections.Generic.List[string]]::new()
+$gatedJobs = @('tests', 'terminalCommand', 'ignoreScanner', 'documentation')
+$suiteNames = @('Unit', 'Integration', 'Terminal', 'UI')
+
+function ConvertTo-PlannerJson {
+	param([AllowEmptyCollection()][string[]] $Path)
+
+	# Passed as a typed array rather than piped, the way the planner writes it: an empty pipeline
+	# reaches ConvertTo-Json as no input at all and comes back as an empty string.
+	return (ConvertTo-Json -Compress -InputObject ([string[]] @($Path)))
+}
+
+function Invoke-Gate {
+	param(
+		[AllowEmptyCollection()][string[]] $ChangedPath,
+		[string] $PlannerChangedPathJson,
+		[AllowEmptyCollection()][string[]] $SkippedJob,
+		[AllowEmptyCollection()][string[]] $PlannerWillRunJob,
+		[AllowEmptyCollection()][string[]] $PlannerWillRunSuite
+	)
+
+	$printed = [Collections.Generic.List[string]]::new()
+	$accepted = $true
+	$message = ''
+	try {
+		# The printed lines are collected through the pipeline rather than read off the thrown
+		# message: the gate prints each reaching path as it finds it, and that is the part of the
+		# failure that has to survive being surfaced in full.
+		& $GatePath `
+			-ChangedPath $ChangedPath `
+			-PlannerChangedPathJson $PlannerChangedPathJson `
+			-SkippedJob $SkippedJob `
+			-PlannerWillRunJob $PlannerWillRunJob `
+			-PlannerWillRunSuite $PlannerWillRunSuite 6>&1 |
+			ForEach-Object { $printed.Add([string] $_) }
+	}
+	catch {
+		$accepted = $false
+		$message = $_.Exception.Message
+	}
+
+	return [pscustomobject]@{
+		Accepted = $accepted
+		Message = $message
+		Printed = $printed.ToArray()
+	}
+}
 
 function Test-Case {
 	param(
@@ -37,35 +92,39 @@ function Test-Case {
 		[string[]] $PlannerPath,
 		[string[]] $SkippedJob,
 		[string[]] $PlannerWillRunJob = @(),
+		[string[]] $PlannerWillRunSuite = @(),
 		[switch] $ShouldPass,
-		[string] $ExpectMessage
+		[string] $ExpectMessage,
+		[string[]] $ExpectPrintedPath = @()
 	)
 
-	$json = if ($null -eq $PlannerPath) { '[]' } else { $PlannerPath | ConvertTo-Json -Compress -AsArray }
-	$accepted = $true
-	$message = ''
-	try {
-		& $GatePath `
-			-ChangedPath $ChangedPath `
-			-PlannerChangedPathJson $json `
-			-SkippedJob $SkippedJob `
-			-PlannerWillRunJob $PlannerWillRunJob | Out-Null
-	}
-	catch {
-		$accepted = $false
-		$message = $_.Exception.Message
-	}
+	$result = Invoke-Gate `
+		-ChangedPath $ChangedPath `
+		-PlannerChangedPathJson (ConvertTo-PlannerJson -Path $PlannerPath) `
+		-SkippedJob $SkippedJob `
+		-PlannerWillRunJob $PlannerWillRunJob `
+		-PlannerWillRunSuite $PlannerWillRunSuite
 
-	if ($ShouldPass -and -not $accepted) {
-		$failures.Add("$Name should have been accepted but was rejected: $message")
+	if ($ShouldPass -and -not $result.Accepted) {
+		$failures.Add("$Name should have been accepted but was rejected: $($result.Message)")
 		return
 	}
-	if (-not $ShouldPass -and $accepted) {
+	if (-not $ShouldPass -and $result.Accepted) {
 		$failures.Add("$Name should have been rejected but was accepted.")
 		return
 	}
-	if ($ExpectMessage -and -not $accepted -and $message -notmatch [regex]::Escape($ExpectMessage)) {
-		$failures.Add("$Name was rejected for the wrong reason; expected '$ExpectMessage', got: $message")
+	if ($ExpectMessage -and -not $result.Accepted -and
+		$result.Message -notmatch [regex]::Escape($ExpectMessage)) {
+		$failures.Add("$Name was rejected for the wrong reason; expected '$ExpectMessage', got: $($result.Message)")
+	}
+
+	foreach ($expected in $ExpectPrintedPath) {
+		$printedLine = @($result.Printed | Where-Object { $_.Trim() -eq $expected })
+		if ($printedLine.Count -eq 0) {
+			$failures.Add(
+				"$Name did not name '$expected' among the paths it printed, so the reason for the " +
+				"failure is not in the log: $($result.Printed -join ' | ')")
+		}
 	}
 }
 
@@ -85,18 +144,73 @@ Test-Case -Name 'nothing skipped needs no justification' `
 	-PlannerPath @('Apps/Mcp/McpProjectService.cs') `
 	-SkippedJob @() -ShouldPass
 
+# The change this gate was first asked about: a file in one test project narrows the plan to that
+# project's suite, and the three jobs that build the other projects are skipped for a reason the
+# gate can state on its own.
+Test-Case -Name 'a narrowed plan keeps the jobs it cannot reach skipped' `
+	-ChangedPath @('Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs') `
+	-SkippedJob @('terminalCommand', 'ignoreScanner', 'documentation') `
+	-PlannerWillRunJob @('tests') `
+	-PlannerWillRunSuite @('Terminal') -ShouldPass
+
 # --- a change that could ------------------------------------------------------------------------
 Test-Case -Name 'tested code skipped as if it were metadata' `
 	-ChangedPath @('AGENTS.md', 'Application/Services/GitScopeFilter.cs') `
 	-PlannerPath @('AGENTS.md', 'Application/Services/GitScopeFilter.cs') `
 	-SkippedJob @('tests') `
-	-ExpectMessage 'Application/Services/GitScopeFilter.cs'
+	-ExpectMessage 'the change reaches them: tests' `
+	-ExpectPrintedPath @('Application/Services/GitScopeFilter.cs')
 
 Test-Case -Name 'a test project skipped as if it were metadata' `
 	-ChangedPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
 	-PlannerPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
 	-SkippedJob @('tests') `
-	-ExpectMessage 'could have'
+	-ExpectMessage 'the change reaches them'
+
+# --- each job separately, so "unreachable" cannot become the answer to everything ---------------
+# The integration suite excludes Category=TerminalCommand, so the terminal command matrix is the
+# only place those tests run and no suite can stand in for it.
+Test-Case -Name 'the terminal command matrix skipped for an integration test change' `
+	-ChangedPath @('Tests/DevProjex.Tests.Integration/StoreListingParityTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Integration/StoreListingParityTests.cs') `
+	-SkippedJob @('terminalCommand') `
+	-PlannerWillRunJob @('tests') `
+	-PlannerWillRunSuite @('Integration') `
+	-ExpectMessage 'terminalCommand' `
+	-ExpectPrintedPath @('Tests/DevProjex.Tests.Integration/StoreListingParityTests.cs')
+
+# The unit suite runs that category itself, so the unit half of the same job is covered only while
+# the unit suite is in the matrix.
+Test-Case -Name 'the terminal command matrix skipped while the unit suite is not running' `
+	-ChangedPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-SkippedJob @('terminalCommand') `
+	-PlannerWillRunJob @() `
+	-PlannerWillRunSuite @() `
+	-ExpectMessage 'terminalCommand'
+
+Test-Case -Name 'the ignore/scanner matrix skipped while the integration suite is not running' `
+	-ChangedPath @('Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs') `
+	-SkippedJob @('ignoreScanner') `
+	-PlannerWillRunJob @() `
+	-PlannerWillRunSuite @() `
+	-ExpectMessage 'ignoreScanner'
+
+Test-Case -Name 'the documentation contracts skipped while the terminal suite is not running' `
+	-ChangedPath @('Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs') `
+	-SkippedJob @('documentation') `
+	-PlannerWillRunJob @() `
+	-PlannerWillRunSuite @() `
+	-ExpectMessage 'documentation'
+
+Test-Case -Name 'a job the gate cannot place is never vouched for' `
+	-ChangedPath @('Docs/McpServer.md') `
+	-PlannerPath @('Docs/McpServer.md') `
+	-SkippedJob @('releaseValidation') `
+	-ExpectMessage 'not ones this knows how to place'
 
 # --- the plan does not match the change ---------------------------------------------------------
 Test-Case -Name 'the plan saw a path that did not change' `
@@ -125,37 +239,86 @@ Test-Case -Name 'a job the plan expected to run was skipped' `
 	-PlannerWillRunJob @('documentation') `
 	-ExpectMessage 'the plan said they would run'
 
-# --- the two sides still agree about what is skippable -------------------------------------------
+# --- the two sides still agree, job by job -------------------------------------------------------
 Import-Module $PlannerModulePath -Force
-$skippableByPlanner = @(
-	'README.md', 'Docs/McpServer.md', 'Docs/Media/readme-demo/frame.gif', 'Packaging/Notes.md',
-	'.idea/workspace.xml', '.run/Configuration.xml', '.github/ISSUE_TEMPLATE/bug.md',
-	'.github/PULL_REQUEST_TEMPLATE.md', '.github/FUNDING.yml', '.gitattributes', '.gitignore',
-	'LICENSE', 'AGENTS.md', 'AboutProject.md', 'CODE_OF_CONDUCT.md', 'CONTRIBUTING.md',
-	'SECURITY.md', 'SUPPORT.md', 'TRADEMARKS.md', 'Setup-AI-Agents.ps1', 'SetupAI.txt', 'notes.txt')
 
-foreach ($path in $skippableByPlanner) {
-	$plan = Get-CiChangePlan -ChangedPath @($path)
-	if ($plan.HasTestMatrix) {
-		# The planner runs suites for it, so the gate is never asked to vouch for it.
-		continue
-	}
+function Test-PerJobAgreement {
+	param(
+		[Parameter(Mandatory)][string] $Kind,
+		[Parameter(Mandatory)][string[]] $Path
+	)
 
-	$accepted = $true
-	try {
-		& $GatePath -ChangedPath @($path) -PlannerChangedPathJson (@($path) | ConvertTo-Json -Compress -AsArray) `
-			-SkippedJob @('tests') -PlannerWillRunJob @() | Out-Null
-	}
-	catch {
-		$accepted = $false
-	}
+	foreach ($path in $Path) {
+		$plan = Get-CiChangePlan -ChangedPath @($path)
+		$runs = [ordered] @{
+			tests = [bool] $plan.HasTestMatrix
+			terminalCommand = [bool] $plan.TerminalCommand
+			ignoreScanner = [bool] $plan.IgnoreScanner
+			documentation = [bool] $plan.Documentation
+		}
+		$willRun = @($runs.GetEnumerator() | Where-Object { $_.Value } | ForEach-Object { $_.Key })
+		$suites = @($suiteNames | Where-Object { $plan.$_ })
+		$json = ConvertTo-PlannerJson -Path @($path)
 
-	if (-not $accepted) {
-		$failures.Add(
-			"the planner skips the test suites for '$path' but the gate will not vouch for it, " +
-			"so every change touching that path would fail the gate")
+		foreach ($job in $gatedJobs) {
+			if ($runs[$job]) {
+				# The planner runs it, so the gate is never asked to vouch for it.
+				continue
+			}
+
+			$result = Invoke-Gate `
+				-ChangedPath @($path) `
+				-PlannerChangedPathJson $json `
+				-SkippedJob @($job) `
+				-PlannerWillRunJob $willRun `
+				-PlannerWillRunSuite $suites
+			if (-not $result.Accepted) {
+				$failures.Add(
+					"$Kind '$path': the planner skips '$job' while the gate says the change reaches " +
+					"it. Either the planner has to run that job for this path, or the gate's " +
+					"reachability has to learn why it cannot be reached.")
+			}
+		}
 	}
 }
+
+# One file from every test project, and from every shared folder compiled into one, because a
+# change to any of them narrows the plan rather than emptying it.
+Test-PerJobAgreement -Kind 'test project' -Path @(
+	'Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs',
+	'Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs',
+	'Tests/DevProjex.Tests.Integration/StoreListingParityTests.cs',
+	'Tests/DevProjex.Tests.Terminal/McpServerProcessTests.cs',
+	'Tests/DevProjex.Tests.Terminal/PublishedSingleFileExtractionProcessTests.cs',
+	'Tests/DevProjex.Tests.UI/ProjectTreeViewTests.cs',
+	'Tests/DevProjex.Tests.Terminal.ProgressHost/Program.cs',
+	'Tests/Shared/TerminalProgress/ProgressExpectations.cs',
+	'Tests/Shared/TerminalHost/TerminalHostHarness.cs',
+	'Tests/Shared/ProjectLoadWorkflow/ProjectLoadSteps.cs',
+	'Tests/Shared/StoreListing/StoreListingFacts.cs',
+	'Tests/Fixtures/DependencyFacts/Sample.json')
+
+# And one of every other kind the planner classifies, since the same drift reaches them all.
+Test-PerJobAgreement -Kind 'path' -Path @(
+	'Kernel/Models/ProjectRelativeGlob.cs',
+	'Application/Services/GitScopeFilter.cs',
+	'Infrastructure/Scanning/FileSystemScanner.cs',
+	'Assets/HelpContent/help.en.txt',
+	'Assets/Icons/app.ico',
+	'Apps/Mcp/McpProjectService.cs',
+	'Apps/Avalonia/Views/MainWindow.axaml.cs',
+	'Apps/Terminal/Commands/ScanCommand.cs',
+	'Apps/TerminalHost/Program.cs',
+	'Packaging/Windows/StoreListing/listingData.csv',
+	'Packaging/Notes.md',
+	'Scripts/Build-Release.ps1',
+	'Scripts/ReleasePayloadInspection.cs',
+	'Docs/McpServer.md',
+	'README.md',
+	'.github/assets/banner.svg',
+	'AGENTS.md',
+	'tools/RankingEval/Program.cs',
+	'DevProjex.sln')
 
 if ($failures.Count -gt 0) {
 	Write-Host 'The CI gate no longer behaves as its own documentation says:'

--- a/Scripts/ci/Test-CiGateSkip.ps1
+++ b/Scripts/ci/Test-CiGateSkip.ps1
@@ -9,22 +9,26 @@
 	changed paths, whole suites were skipped on the strength of that classification, and the gate
 	accepted the result without ever seeing the change.
 
-	So this asks two questions the planner cannot answer about itself.
+	So this asks three questions the planner cannot answer about itself.
 
 	Did the planner see the change that was actually made? The paths it decided from are compared
 	against the paths the gate works out for itself from the same commits. Any difference fails,
 	with both lists in the message, because a plan made from a different change is not a plan for
 	this one.
 
-	Is every changed path one that could not have affected a skipped job? That is answered here,
-	from a list kept deliberately shorter than the planner's. Only documentation and repository
-	metadata qualify. Anything this does not recognise fails the gate, so the two lists drifting
-	apart shows up as a red gate rather than as a suite quietly not running — and
-	`Test-CiGateContract.ps1` fails if the planner ever calls something skippable that this does
-	not.
+	Was a job skipped although the plan expected it to run? That is not the planner's doing at all,
+	and fails before anything else is consulted.
 
-	A job skipped while the planner expected it to run is not the planner's doing at all, and fails
-	without any of the above being consulted.
+	And could the change have reached each skipped job? That is answered per job, from the gate's
+	own reading of what the workflow builds and runs rather than from the planner's opinion of the
+	same paths. A change can legitimately narrow the plan without emptying it — a file in one test
+	project runs that project's suite and nothing else — so asking it of the change as a whole,
+	rather than of every job separately, cannot tell a narrowed plan from a wrong one.
+
+	The two readings are kept apart on purpose, and `Test-CiGateContract.ps1` drives a file from
+	every test project past both of them and fails if they disagree about any single job. So the
+	pair drifting apart shows up there, rather than as a suite quietly not running or as a gate
+	that fails every change.
 #>
 [CmdletBinding()]
 param(
@@ -46,33 +50,70 @@ param(
 	# Jobs the planner's own outputs said would run.
 	[Parameter(Mandatory)]
 	[AllowEmptyCollection()]
-	[string[]] $PlannerWillRunJob
+	[string[]] $PlannerWillRunJob,
+
+	# Test suites the plan put in the matrix. Three of the jobs below run tests that a suite also
+	# runs, so which suites ran decides whether skipping those jobs leaves anything uncovered.
+	[AllowEmptyCollection()]
+	[string[]] $PlannerWillRunSuite = @()
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function ConvertTo-PathSet {
-	param([AllowEmptyCollection()][string[]] $Path)
-
-	return @($Path |
-		Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-		ForEach-Object { $_.Trim() } |
-		Sort-Object -Unique)
+# Which test project a path is built into, or read by, taken from the build graph rather than from
+# the plan. The .csproj files say which project compiles a folder and which projects reference each
+# other, and a job that builds a project is broken by any file in that project, not only by the
+# files its own filter selects. A `Tests/Shared` folder is compiled into several projects by
+# <Compile Include>, and a referenced project is built along with the project referencing it, so
+# each is listed under every project it ends up inside.
+#
+# Anything absent from this table is treated as reaching all four, so a path nobody has classified
+# fails a skip rather than passing one.
+$testProjectsByPrefix = [ordered] @{
+	'Tests/DevProjex.Tests.Unit/' = @('Unit')
+	'Tests/DevProjex.Tests.Integration/' = @('Integration')
+	'Tests/DevProjex.Tests.Terminal.ProgressHost/' = @('Unit', 'Terminal')
+	'Tests/DevProjex.Tests.Terminal/' = @('Terminal')
+	'Tests/DevProjex.Tests.UI/' = @('UI')
+	'Tests/Shared/TerminalProgress/' = @('Unit', 'Terminal')
+	'Tests/Shared/TerminalHost/' = @('Unit', 'Terminal')
+	'Tests/Shared/ProjectLoadWorkflow/' = @('Unit', 'Integration', 'UI')
+	'Tests/Shared/StoreListing/' = @('Unit', 'Integration')
+	# Production projects nothing else reaches. Apps/TerminalHost is referenced only by the Terminal
+	# test project; Apps/Terminal is reached by the Unit tests through their progress host as well.
+	'Apps/TerminalHost/' = @('Terminal')
+	'Apps/Terminal/' = @('Unit', 'Integration', 'Terminal')
+	# Not compiled anywhere. Packaging files are read by the Store listing tests and by the
+	# documentation and packaging contracts; Scripts/ReleasePayloadInspection.cs is linked into the
+	# integration tests.
+	'Packaging/' = @('Unit', 'Integration', 'Terminal')
+	'Scripts/' = @('Integration')
 }
 
-function Test-SkippablePath {
+$allJobs = @('tests', 'terminalCommand', 'ignoreScanner', 'documentation')
+$allTestProjects = @('Unit', 'Integration', 'Terminal', 'UI')
+
+function Test-DocumentPath {
 	param([string] $Path)
 
-	# Documentation.
-	if ($Path -eq 'README.md') { return $true }
+	if ($Path.Equals('README.md', [StringComparison]::OrdinalIgnoreCase)) { return $true }
 	if ($Path.StartsWith('Docs/', [StringComparison]::OrdinalIgnoreCase)) { return $true }
 	if ($Path.StartsWith('Packaging/', [StringComparison]::OrdinalIgnoreCase) -and
 		$Path.EndsWith('.md', [StringComparison]::OrdinalIgnoreCase)) {
 		return $true
 	}
+	if ($Path.StartsWith('.github/assets/', [StringComparison]::OrdinalIgnoreCase) -and
+		[IO.Path]::GetExtension($Path) -in @('.svg', '.png', '.jpg', '.jpeg', '.gif', '.webp')) {
+		return $true
+	}
 
-	# Repository metadata.
+	return $false
+}
+
+function Test-MetadataPath {
+	param([string] $Path)
+
 	foreach ($prefix in @('.idea/', '.run/', '.github/ISSUE_TEMPLATE/')) {
 		if ($Path.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) { return $true }
 	}
@@ -81,16 +122,81 @@ function Test-SkippablePath {
 		'LICENSE', 'AGENTS.md', 'AboutProject.md', 'CODE_OF_CONDUCT.md', 'CONTRIBUTING.md',
 		'SECURITY.md', 'SUPPORT.md', 'TRADEMARKS.md', 'Setup-AI-Agents.ps1', 'SetupAI.txt')
 	if ($metadataFiles -contains $Path) { return $true }
-	if (-not $Path.Contains('/') -and $Path.EndsWith('.txt', [StringComparison]::OrdinalIgnoreCase)) {
-		return $true
+
+	return (-not $Path.Contains('/')) -and $Path.EndsWith('.txt', [StringComparison]::OrdinalIgnoreCase)
+}
+
+<#
+.SYNOPSIS
+	The jobs a change to one path could make fail, given which suites the plan put in the matrix.
+
+.DESCRIPTION
+	What each job builds and runs, and what already covers it:
+
+	tests            the suite matrix. Every selected test project, on all three operating systems,
+	                 filtered only against the performance categories. Nothing else covers it.
+
+	terminalCommand  builds the Unit and Integration test projects and runs Category=TerminalCommand
+	                 in both. The Unit suite runs that category too, so the Unit half is covered
+	                 whenever the Unit suite runs. The Integration suite excludes the category, so
+	                 the Integration half is covered by nothing and this job is the only place those
+	                 tests run at all.
+
+	ignoreScanner    builds the Integration test project and runs the ignore and scanner names in it
+	                 on the same three operating systems the Integration suite uses, excluding
+	                 nothing that suite includes. Whenever the Integration suite runs, this job adds
+	                 no coverage.
+
+	documentation    builds the Terminal test project and runs two contract classes from it. The
+	                 Terminal suite runs the whole project, so whenever it runs, this job adds no
+	                 coverage. When it does not, these contracts are the only thing reading the
+	                 documents and packaging files.
+#>
+function Get-ReachableJob {
+	param(
+		[Parameter(Mandatory)][string] $Path,
+		[Parameter(Mandatory)][AllowEmptyCollection()][string[]] $PlannedSuite
+	)
+
+	if (Test-MetadataPath -Path $Path) { return @() }
+	if (Test-DocumentPath -Path $Path) { return @('documentation') }
+
+	$projects = $allTestProjects
+	foreach ($prefix in $testProjectsByPrefix.Keys) {
+		if ($Path.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+			$projects = @($testProjectsByPrefix[$prefix])
+			break
+		}
 	}
 
-	return $false
+	$jobs = [Collections.Generic.List[string]]::new()
+	$jobs.Add('tests')
+	if (($projects -contains 'Integration') -or
+		(($projects -contains 'Unit') -and ($PlannedSuite -notcontains 'Unit'))) {
+		$jobs.Add('terminalCommand')
+	}
+	if (($projects -contains 'Integration') -and ($PlannedSuite -notcontains 'Integration')) {
+		$jobs.Add('ignoreScanner')
+	}
+	if (($projects -contains 'Terminal') -and ($PlannedSuite -notcontains 'Terminal')) {
+		$jobs.Add('documentation')
+	}
+
+	return @($jobs)
+}
+
+function ConvertTo-TrimmedSet {
+	param([AllowEmptyCollection()][string[]] $Value)
+
+	return @($Value |
+		Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+		ForEach-Object { $_.Trim() } |
+		Sort-Object -Unique)
 }
 
 # Wrapped at the call: a function returning one item returns it as a scalar, and asking a
 # scalar for Count is an error under strict mode.
-$skipped = @(ConvertTo-PathSet -Path $SkippedJob)
+$skipped = @(ConvertTo-TrimmedSet -Value $SkippedJob)
 if ($skipped.Count -eq 0) {
 	Write-Host 'No job was skipped; nothing to vouch for.'
 	exit 0
@@ -104,11 +210,11 @@ if ($unplanned.Count -gt 0) {
 	      "account for it: $($unplanned -join ', ')."
 }
 
-$actual = @(ConvertTo-PathSet -Path $ChangedPath)
+$actual = @(ConvertTo-TrimmedSet -Value $ChangedPath)
 $recorded = @()
 if (-not [string]::IsNullOrWhiteSpace($PlannerChangedPathJson)) {
 	try {
-		$recorded = @(ConvertTo-PathSet -Path @($PlannerChangedPathJson | ConvertFrom-Json))
+		$recorded = @(ConvertTo-TrimmedSet -Value @($PlannerChangedPathJson | ConvertFrom-Json))
 	}
 	catch {
 		throw "The plan recorded no readable list of the paths it decided from, so its decision " +
@@ -128,12 +234,36 @@ if ($missing.Count -gt 0 -or $extra.Count -gt 0) {
 	      "  gate saw $($actual.Count) path(s); the plan recorded $($recorded.Count)."
 }
 
-$unvouched = @($actual | Where-Object { -not (Test-SkippablePath -Path $_) })
-if ($unvouched.Count -gt 0) {
-	throw "These jobs were skipped: $($skipped -join ', '). That is only acceptable when the " +
-	      "change could not have affected them, and these paths could have:" +
-	      [Environment]::NewLine + "  $($unvouched -join [Environment]::NewLine + '  ')"
+$plannedSuites = @(ConvertTo-TrimmedSet -Value $PlannerWillRunSuite)
+$unknownJobs = @($skipped | Where-Object { $allJobs -notcontains $_ })
+if ($unknownJobs.Count -gt 0) {
+	throw "These skipped jobs are not ones this knows how to place against a change, so it cannot " +
+	      "say whether skipping them was safe: $($unknownJobs -join ', ')."
+}
+
+$unjustified = [Collections.Generic.List[string]]::new()
+foreach ($job in $skipped) {
+	$reachedBy = @($actual | Where-Object { (Get-ReachableJob -Path $_ -PlannedSuite $plannedSuites) -contains $job })
+	if ($reachedBy.Count -eq 0) {
+		continue
+	}
+
+	$unjustified.Add($job)
+	# Written out here rather than gathered into the thrown message. The list of paths is what the
+	# message is for, and it is the long thrown message that gets cut off part-way through a path
+	# where the failure is surfaced.
+	Write-Host "$job was skipped, and the change reaches it through:"
+	foreach ($path in $reachedBy) {
+		Write-Host "  $path"
+	}
+}
+
+if ($unjustified.Count -gt 0) {
+	throw "These jobs were skipped although the change reaches them: $($unjustified -join ', '). " +
+	      "The paths that reach each one are listed above."
 }
 
 Write-Host ("Skipped " + ($skipped -join ', ') +
-	"; all $($actual.Count) changed path(s) are documentation or repository metadata.")
+	"; none of the $($actual.Count) changed path(s) reach them" +
+	$(if ($plannedSuites.Count) { " beyond the suites that ran ($($plannedSuites -join ', '))" } else { '' }) +
+	'.')


### PR DESCRIPTION
The skip gate added in #385 fails the first pull request that narrows a plan, and would have failed
nearly every one after it. It asked a single question of the whole change — is every changed path
one that could not have affected anything skipped — against a list holding only documentation and
repository metadata. But a plan is rarely skipped whole; far more often it narrows. A file in
`Tests/DevProjex.Tests.Terminal` runs that project's suite and nothing else, and a question asked of
the change as a whole cannot tell that apart from a plan that is simply wrong.

## What each job actually builds

Read off the workflow rather than off the plan:

| job | builds | runs | already covered by |
|---|---|---|---|
| `tests` | the selected test projects | everything but the performance categories, on three operating systems | nothing |
| `terminalCommand` | `Tests.Unit`, `Tests.Integration` | `Category=TerminalCommand` in both | the unit suite runs that category itself; the integration suite **excludes** it |
| `ignoreScanner` | `Tests.Integration` | the ignore and scanner names | the integration suite, on the same three operating systems, excluding none of them |
| `documentation` | `Tests.Terminal` | two contract classes | the terminal suite, which runs the project whole |

Two things follow. The terminal command matrix is the only place the integration `TerminalCommand`
tests run at all, so any plan that runs the integration suite has to carry it. And `ignoreScanner`
and `documentation` add nothing while the suite that contains them is in the matrix, so the gate
needs to know which suites the plan selected before it can call skipping them safe.

## The gate

`Get-ReachableJob` answers, for one path, which jobs a change to it could make fail, from the build
graph — which project compiles a folder, which projects reference each other — and from the table
above. Anything it does not recognise reaches all four, so an unclassified path fails a skip rather
than passing one. `Select-CiPlan.ps1` now also reports the suites it put in the matrix, and the gate
takes them.

The paths that reach a skipped job are printed as they are found, not gathered into the thrown
message. The thrown message is the one that gets cut off part-way through a path where the failure
is surfaced, and the list is the whole content of the failure.

## The planner

Every place the two sides disagreed, in the direction the build graph dictates:

| path | was missing |
|---|---|
| `Tests/DevProjex.Tests.Unit/**` | `TerminalCommand` — the matrix builds this project |
| `Tests/DevProjex.Tests.Terminal.ProgressHost/**`, `Tests/Shared/TerminalProgress/**`, `Tests/Shared/TerminalHost/**` | `Unit` — the unit tests reference the progress host |
| `Tests/Shared/ProjectLoadWorkflow/**`, `Tests/Shared/StoreListing/**` | `TerminalCommand` — compiled into the integration tests |
| `Apps/Avalonia/**` | `Terminal`, `TerminalCommand` — the terminal tests reference it |
| `Apps/Terminal/**` | `Unit` — reached through the progress host |
| `Assets/HelpContent/*.txt` | `TerminalCommand` |
| `Packaging/**` | `TerminalCommand`, `Documentation` — read by the packaging contracts |
| `Scripts/**` | `TerminalCommand` — `ReleasePayloadInspection.cs` is linked into the integration tests |

`Tests/DevProjex.Tests.Terminal/**` needed nothing: the terminal command matrix does not build that
project, and neither does the ignore/scanner matrix. It reaches `documentation`, which the terminal
suite covers.

## The contract

`Test-CiGateContract.ps1` now puts a file from every test project, every shared test folder and
every other kind of path the planner classifies to both sides, and fails on any single job where
they disagree. Partial narrowing was the case the old sweep could not see: it only drove paths the
planner skips entirely.

Both sides have a positive control. Reverting one planner target fails the contract on exactly that
path and names the job; a gate that answers "unreachable" to everything fails six cases.

## Checked

Three shapes driven end to end, plan then gate, as the workflow drives them:

```
Tests/DevProjex.Tests.Terminal/*.cs  suites=[Terminal]  skipped=[terminalCommand,ignoreScanner,documentation]  -> accepted
Kernel/Models/ProjectRelativeGlob.cs suites=[Unit,Integration,Terminal,UI] skipped=[ignoreScanner,documentation] -> accepted
Docs/McpServer.md                    suites=[]          skipped=[tests,terminalCommand,ignoreScanner]           -> accepted
```

The second is the ordinary production change the merged gate would also have failed.

`Test-CiChangePlanner.ps1`, `Test-CiGateContract.ps1`, `Test-ExecutedTestsContract.ps1` and
`Test-IndentationContract.ps1` all pass.
