### PR TITLE
feat(dependencies): report the content each index pass observed

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -10,7 +10,8 @@ public sealed record PreparedDependencySource(
 	string Source,
 	DependencyFileStatus PreparedStatus = DependencyFileStatus.Supported,
 	string? PreparedStatusReason = null,
-	bool CanCache = true);
+	bool CanCache = true,
+	DependencySourceObservation ContentObservation = default);
 
 public sealed class DependencyManifestContentIdentities
 {

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -90,13 +90,17 @@ public sealed class DependencyFactsEngine : IDisposable
 					snapshot.Files.Count,
 					0,
 					started.ElapsedMilliseconds,
-					true)
+					true),
+				// Nothing was prepared or read here, so the observations an earlier pass made are
+				// not repeated as if this pass had just made them.
+				ContentObservations = NoContentObservations
 			};
 		}
 		var configuration = await _configurationProvider
 			.ReadAsync(root, manifest, cancellationToken)
 			.ConfigureAwait(false);
 		var prepared = new PreparedDependencyIdentity[manifest.Length];
+		var observations = new DependencySourceObservation[manifest.Length];
 		var parsedBefore = _extractor.ParseCount;
 		var facts = new FileFacts[prepared.Length];
 		var cacheable = new bool[prepared.Length];
@@ -119,6 +123,7 @@ public sealed class DependencyFactsEngine : IDisposable
 					canonicalManifest[index].RelativePath,
 					source.ContentFingerprint,
 					source.LanguageId);
+				observations[index] = source.ContentObservation;
 				if (source.PreparedStatus != DependencyFileStatus.Supported)
 				{
 					var extracted = _extractor.Extract(source, _limits, token);
@@ -215,6 +220,11 @@ public sealed class DependencyFactsEngine : IDisposable
 			if (!resolutionCacheHit)
 				RegisterIndexCacheWeight(cacheKey, cachedIndex, EstimateResolvedIndexBytes(resolved));
 		}
+		var contentObservations = new Dictionary<string, DependencySourceObservation>(
+			manifest.Length,
+			PathComparer);
+		for (var index = 0; index < manifest.Length; index++)
+			contentObservations[manifest[index]] = observations[index];
 		var coverage = BuildCoverage(resolved.Files, configuration.ConfigurationDiagnostics);
 		var result = new DependencyIndexSnapshot(
 			root,
@@ -233,7 +243,8 @@ public sealed class DependencyFactsEngine : IDisposable
 				started.ElapsedMilliseconds,
 				resolutionCacheHit))
 		{
-			FileByPath = resolved.FileByPath
+			FileByPath = resolved.FileByPath,
+			ContentObservations = contentObservations
 		};
 		var finalStamps = TryCaptureFileStamps(manifest);
 		if (canCacheIndex && initialStamps is not null && finalStamps is not null && initialStamps.SequenceEqual(finalStamps) &&
@@ -825,6 +836,9 @@ public sealed class DependencyFactsEngine : IDisposable
 	private static StringComparer PathComparer => OperatingSystem.IsWindows()
 		? StringComparer.OrdinalIgnoreCase
 		: StringComparer.Ordinal;
+
+	private static readonly IReadOnlyDictionary<string, DependencySourceObservation> NoContentObservations =
+		new Dictionary<string, DependencySourceObservation>(PathComparer);
 
 	public void Dispose()
 	{

--- a/Application/Dependencies/DependencyFactsModels.cs
+++ b/Application/Dependencies/DependencyFactsModels.cs
@@ -181,6 +181,34 @@ public sealed record DependencyIndexMetrics(
 	long ElapsedMilliseconds,
 	bool ResolutionCacheHit);
 
+/// <summary>
+/// How much an indexing pass learned about one file's bytes while it built the snapshot.
+/// </summary>
+public enum DependencySourceObservationKind
+{
+	/// <summary>The pass did not observe the file's content.</summary>
+	None,
+
+	/// <summary>The pass read the file's bytes and reported their digest.</summary>
+	Read,
+
+	/// <summary>
+	/// A preparation cached from an earlier pass was reused, so nothing was read this time.
+	/// </summary>
+	ReusedPreparation
+}
+
+/// <summary>
+/// What an indexing pass observed of one file's content. <see cref="ContentDigest"/> is the
+/// uppercase hexadecimal SHA-256 of the raw bytes the extractor read, and is present only for
+/// <see cref="DependencySourceObservationKind.Read"/>. A caller that hashed the same file
+/// before indexing can compare the two digests to learn whether it was rewritten in between;
+/// where there is no digest there was no second observation to compare against.
+/// </summary>
+public readonly record struct DependencySourceObservation(
+	DependencySourceObservationKind Kind,
+	string? ContentDigest = null);
+
 public sealed record DependencyIndexSnapshot(
 	string SourceRoot,
 	string ManifestGeneration,
@@ -195,6 +223,13 @@ public sealed record DependencyIndexSnapshot(
 {
 	public IReadOnlyDictionary<string, FileFacts> FileByPath { get; init; } =
 		new Dictionary<string, FileFacts>(StringComparer.Ordinal);
+
+	/// <summary>
+	/// What this pass observed of each manifest file's content, keyed by absolute path. A
+	/// snapshot served whole from the cache observed nothing and reports nothing.
+	/// </summary>
+	public IReadOnlyDictionary<string, DependencySourceObservation> ContentObservations { get; init; } =
+		new Dictionary<string, DependencySourceObservation>(StringComparer.Ordinal);
 }
 
 public sealed record RelatedFile(

--- a/Application/Ranking/ImportanceRankingModels.cs
+++ b/Application/Ranking/ImportanceRankingModels.cs
@@ -114,6 +114,15 @@ public sealed record ImportanceRankingReport(
 	internal IReadOnlyDictionary<string, RankingSourceVersion> SourceVersions { get; init; } =
 		new Dictionary<string, RankingSourceVersion>(StringComparer.Ordinal);
 
+	/// <summary>
+	/// Whether indexing read each selected file again after <see cref="SourceVersions"/> was
+	/// captured, keyed by absolute path. A file reported as read was observed twice and the two
+	/// observations agreed; a file reported as reused or absent from this map was observed once,
+	/// and only a later currency check can speak for it.
+	/// </summary>
+	internal IReadOnlyDictionary<string, DependencySourceObservation> SourceObservations { get; init; } =
+		new Dictionary<string, DependencySourceObservation>(StringComparer.Ordinal);
+
 	internal DependencyIndexMetrics? DependencyMetrics { get; init; }
 }
 

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -229,6 +229,7 @@ public sealed class ImportanceRankingService(
 			HasMissingSignals = hasMissingSignals,
 			MissingSignalPolicy = MissingSignalPolicy,
 			SourceVersions = sourceVersions,
+			SourceObservations = dependency.ContentObservations,
 			DependencyMetrics = dependency.Metrics
 		};
 		return focus is null
@@ -257,10 +258,10 @@ public sealed class ImportanceRankingService(
 	{
 		for (var attempt = 0; attempt < 2; attempt++)
 		{
-			var before = await CaptureVersionsAsync(candidatePaths, cancellationToken)
+			var versions = await CaptureVersionsAsync(candidatePaths, cancellationToken)
 				.ConfigureAwait(false);
 			var contentIdentities = new DependencyManifestContentIdentities(
-				before.ToDictionary(
+				versions.ToDictionary(
 					static pair => pair.Key,
 					static pair => pair.Value.ContentHash ?? string.Empty,
 					PathComparer.Default));
@@ -272,13 +273,36 @@ public sealed class ImportanceRankingService(
 					cancellationToken,
 					contentIdentities)
 				.ConfigureAwait(false);
-			var after = await CaptureVersionsAsync(candidatePaths, cancellationToken)
-				.ConfigureAwait(false);
-			if (VersionsEqual(before, after))
-				return (snapshot, after);
+			if (!ContentChangedDuringIndexing(versions, snapshot.ContentObservations))
+				return (snapshot, versions);
 		}
 
 		throw new IOException("Selected source files changed while dependency facts were being indexed.");
+	}
+
+	/// <summary>
+	/// Indexing reads every file it prepares, and the snapshot reports the digest of the bytes
+	/// it read. That digest and the one captured above are two observations of the same file at
+	/// two moments, so comparing them detects a rewrite that happened in between, including one
+	/// that leaves length and write time untouched. Files the pass did not read carry no digest
+	/// and are not compared: there is no second observation to compare them against, and the
+	/// report says so for each of them.
+	/// </summary>
+	private static bool ContentChangedDuringIndexing(
+		IReadOnlyDictionary<string, RankingSourceVersion> versions,
+		IReadOnlyDictionary<string, DependencySourceObservation> observations)
+	{
+		foreach (var (path, version) in versions)
+		{
+			if (version.ContentHash is not { } captured ||
+			    !observations.TryGetValue(path, out var observation) ||
+			    observation.ContentDigest is not { } observed)
+				continue;
+			if (!string.Equals(captured, observed, StringComparison.Ordinal))
+				return true;
+		}
+
+		return false;
 	}
 
 	private static async Task<IReadOnlyDictionary<string, RankingSourceVersion>> CaptureVersionsAsync(
@@ -296,11 +320,6 @@ public sealed class ImportanceRankingService(
 		return versions;
 	}
 
-	private static bool VersionsEqual(
-		IReadOnlyDictionary<string, RankingSourceVersion> left,
-		IReadOnlyDictionary<string, RankingSourceVersion> right) =>
-		left.Count == right.Count && left.All(pair =>
-			right.TryGetValue(pair.Key, out var version) && version == pair.Value);
 
 	internal static IReadOnlyDictionary<string, double?> RankNormalize(
 		IReadOnlyDictionary<string, double?> values,

--- a/Application/Ranking/ImportanceRankingService.cs
+++ b/Application/Ranking/ImportanceRankingService.cs
@@ -295,8 +295,8 @@ public sealed class ImportanceRankingService(
 		foreach (var (path, version) in versions)
 		{
 			if (version.ContentHash is not { } captured ||
-			    !observations.TryGetValue(path, out var observation) ||
-			    observation.ContentDigest is not { } observed)
+				!observations.TryGetValue(path, out var observation) ||
+				observation.ContentDigest is not { } observed)
 				continue;
 			if (!string.Equals(captured, observed, StringComparison.Ordinal))
 				return true;

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -316,10 +316,18 @@ length, modification-time, and creation-time compromise. A same-length replaceme
 are deliberately restored can therefore remain cached for those two related-file surfaces until the
 entry is evicted or its metadata changes.
 
-The content identity passed to the extractor is an observed cache label; the extractor does not hash
-the bytes again while reading. An adversarial `hash A -> read B -> restore A -> hash A` sequence between
-the two observations is therefore not detected. This is a known coherence limitation, not evidence
-that the intermediate bytes belonged to identity A.
+The content identity passed to the extractor is an opaque cache label, but the extractor no longer
+relies on it to describe what it read. While it decodes a file it digests the raw bytes in the same
+pass, and the index snapshot reports that digest per file. Importance ranking hashes each source once
+before indexing and compares its own hash with the reported digest, so a `hash A -> replace with B ->
+restore A's metadata` sequence between the two observations is detected even though length, write time
+and creation time never changed.
+
+That comparison covers every file the pass actually read. Where the pass answered from a retained
+prepared source or a retained manifest snapshot it read nothing, and the snapshot reports reuse instead
+of a digest rather than repeating an earlier observation as a fresh one. Those files carry one
+observation, and the currency check performed when their content is read for output remains their
+second.
 
 Changing one source reparses that source. Changing resolver configuration invalidates resolution but
 reuses file facts, so no source parse is required. Before every result is exposed, it is gated against

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -150,6 +150,14 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				RemovePreparedSource(key, entry);
 				throw;
 			}
+			// Only a call that performed the read may claim to have observed the file. A reused
+			// preparation is reported as reuse, so a caller can tell an observation apart from an
+			// echo of the identity it supplied itself.
+			var observation = !ownsEntry
+				? new DependencySourceObservation(DependencySourceObservationKind.ReusedPreparation)
+				: content.ObservedContentDigest is { } observedDigest
+					? new DependencySourceObservation(DependencySourceObservationKind.Read, observedDigest)
+					: default;
 			return new PreparedDependencySource(
 				fullPath,
 				relative,
@@ -160,7 +168,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				content.Source,
 				content.Status,
 				content.StatusReason,
-				content.CanCache);
+				content.CanCache,
+				observation);
 		}
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Security.SecurityException)
 		{
@@ -251,7 +260,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				read.Source,
 				read.Status,
 				read.StatusReason,
-				read.CanCache);
+				read.CanCache,
+				read.ObservedContentDigest);
 		}
 		await using var snapshot = await _contentAnalyzer
 			.OpenCompleteSnapshotAsync(fullPath, cancellationToken)
@@ -1021,6 +1031,10 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				var lastWrite = File.GetLastWriteTimeUtc(stream.SafeFileHandle).Ticks;
 				var byteBufferSize = checked((int)Math.Clamp(length, 1, BufferSize));
 				byteBuffer = ArrayPool<byte>.Shared.Rent(byteBufferSize);
+				// Digest the bytes in the pass that decodes them, so a caller that hashed the same
+				// file earlier can compare without opening it again. It covers the whole stream,
+				// preamble included, and is only reported when the stream was read to its end.
+				using var observed = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 				Decoder? decoder = null;
 				StringBuilder? source = null;
 				while (true)
@@ -1032,6 +1046,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 					if (bytesRead == 0)
 						break;
 					bytesReadTotal += bytesRead;
+					observed.AppendData(byteBuffer.AsSpan(0, bytesRead));
 					var input = byteBuffer.AsSpan(0, bytesRead);
 					if (decoder is null)
 					{
@@ -1099,13 +1114,15 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 						MetadataFingerprint("binary", length, lastWrite),
 						string.Empty,
 						DependencyFileStatus.ExtractionFailed,
-						"source is binary");
+						"source is binary",
+						ObservedContentDigest: Convert.ToHexString(observed.GetCurrentHash()));
 				}
 				return new BoundedDependencySourceRead(
 					ContentFingerprint.Compute(content.AsSpan()).ToHexString().ToLowerInvariant(),
 					content,
 					DependencyFileStatus.Supported,
-					null);
+					null,
+					ObservedContentDigest: Convert.ToHexString(observed.GetCurrentHash()));
 			}
 			catch (DecoderFallbackException)
 			{
@@ -1178,7 +1195,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		string Source,
 		DependencyFileStatus Status,
 		string? StatusReason,
-		bool CanCache = true);
+		bool CanCache = true,
+		string? ObservedContentDigest = null);
 
 	internal readonly record struct DependencyExtractionWorkState(
 		long RawCapturesVisited,
@@ -1207,7 +1225,8 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		string Source,
 		DependencyFileStatus Status = DependencyFileStatus.Supported,
 		string? StatusReason = null,
-		bool CanCache = true);
+		bool CanCache = true,
+		string? ObservedContentDigest = null);
 
 	private sealed record LanguageDefinition(
 		string Library,

--- a/Tests/DevProjex.Tests.Terminal/ExportContextDocumentContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/ExportContextDocumentContractTests.cs
@@ -566,9 +566,11 @@ public sealed class ExportContextDocumentContractTests
 		Assert.Equal(0, diagnostics.PreparedFilesMaterialized);
 		Assert.Equal(0, diagnostics.PreparedWriteBytes);
 		Assert.Equal(0, diagnostics.DocumentWriteBytes);
-		Assert.Equal(6, diagnostics.SourceVersionHashPasses);
+		// One pass captures the selection for ranking and one verifies it at write time. The
+		// observation that used to cost a third pass now comes from the bytes indexing read.
+		Assert.Equal(4, diagnostics.SourceVersionHashPasses);
 		Assert.Equal(
-			3 * (new FileInfo(firstPath).Length + new FileInfo(secondPath).Length),
+			2 * (new FileInfo(firstPath).Length + new FileInfo(secondPath).Length),
 			diagnostics.SourceVersionHashBytes);
 	}
 
@@ -729,7 +731,7 @@ public sealed class ExportContextDocumentContractTests
 	}
 
 	[Fact]
-	public async Task RankedSourceBackedExportHashesEachSourceThreeTimes()
+	public async Task RankedSourceBackedExportHashesEachSourceTwice()
 	{
 		using var workspace = new TemporaryDirectory();
 		var firstPath = workspace.WriteFile("A.cs", "public sealed class A { }\n");
@@ -747,9 +749,11 @@ public sealed class ExportContextDocumentContractTests
 				rank: true));
 		var diagnostics = measurement.Capture();
 
-		Assert.Equal(6, diagnostics.SourceVersionHashPasses);
+		// One pass captures the selection for ranking and one verifies it at write time. The
+		// observation that used to cost a third pass now comes from the bytes indexing read.
+		Assert.Equal(4, diagnostics.SourceVersionHashPasses);
 		Assert.Equal(
-			3 * (new FileInfo(firstPath).Length + new FileInfo(secondPath).Length),
+			2 * (new FileInfo(firstPath).Length + new FileInfo(secondPath).Length),
 			diagnostics.SourceVersionHashBytes);
 	}
 

--- a/Tests/DevProjex.Tests.Unit/ImportanceRankingManifestIdentityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ImportanceRankingManifestIdentityTests.cs
@@ -1,4 +1,5 @@
 using DevProjex.Application.Dependencies;
+using DevProjex.Application.Diagnostics;
 using DevProjex.Application.Ranking;
 using DevProjex.Infrastructure.Dependencies;
 
@@ -69,6 +70,215 @@ public sealed class ImportanceRankingManifestIdentityTests
 		Assert.True(warm.DependencyMetrics.ResolutionCacheHit);
 	}
 
+	[Fact]
+	public async Task RankingReadsEachSelectedFileOnce()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var source = workspace.CreateFile("project/Use.cs", "public class Use { Target Value; }");
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+		using var measurement = ContentPipelineDiagnostics.BeginMeasurement();
+
+		var report = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+		var diagnostics = measurement.Capture();
+
+		// One pass over each candidate. The second observation of a file is the digest of the
+		// bytes indexing decoded, so it costs no further read.
+		Assert.Equal(3, diagnostics.SourceVersionHashPasses);
+		Assert.Equal(
+			new FileInfo(project).Length + new FileInfo(target).Length + new FileInfo(source).Length,
+			diagnostics.SourceVersionHashBytes);
+		Assert.Equal(
+			DependencySourceObservationKind.Read,
+			report.SourceObservations[Path.GetFullPath(source)].Kind);
+	}
+
+	[Fact]
+	public async Task ContentRewrittenUnderAnUnchangedStampBeforeEveryReadIsRejected()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var source = workspace.CreateFile("project/Use.cs", Revision(0));
+		var rewriter = new SameStampRewritingOpener(source, int.MaxValue);
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(rewriter.Open),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+
+		var failure = await Assert.ThrowsAsync<IOException>(async () => await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken));
+
+		// Length, write time and creation time are unchanged across every rewrite, so only a
+		// comparison of content against content can see them.
+		rewriter.SkipUnlessStampPreserved();
+		Assert.Equal(
+			"Selected source files changed while dependency facts were being indexed.",
+			failure.Message);
+	}
+
+	[Fact]
+	public async Task ContentRewrittenUnderAnUnchangedStampBeforeTheFirstReadIsRetried()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var source = workspace.CreateFile("project/Use.cs", Revision(0));
+		var rewriter = new SameStampRewritingOpener(source, 1);
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(rewriter.Open),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+
+		var report = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+
+		rewriter.SkipUnlessStampPreserved();
+		Assert.Equal(1, rewriter.Applied);
+		var key = Path.GetFullPath(source);
+		var observation = report.SourceObservations[key];
+		Assert.Equal(DependencySourceObservationKind.Read, observation.Kind);
+		Assert.Equal(report.SourceVersions[key].ContentHash, observation.ContentDigest);
+		Assert.Equal(Revision(1), await File.ReadAllTextAsync(source, TestContext.Current.CancellationToken));
+	}
+
+	[Fact]
+	public async Task AnUnreadableSelectedFileLeavesAnUnchangedSelectionRankable()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var locked = workspace.CreateFile("project/Locked.cs", "public class Locked { Target Value; }");
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+		using var exclusive = new FileStream(locked, FileMode.Open, FileAccess.Read, FileShare.None);
+
+		var report = await ranking.RankAsync(
+			root,
+			[project, target, locked],
+			TestContext.Current.CancellationToken);
+
+		// Neither side could look at the bytes, so there is nothing to disagree about and the
+		// selection ranks as it did before.
+		var key = Path.GetFullPath(locked);
+		Assert.Equal(3, report.Entries.Count);
+		Assert.Null(report.SourceVersions[key].ContentHash);
+		Assert.Equal(DependencySourceObservationKind.None, report.SourceObservations[key].Kind);
+	}
+
+	[Fact]
+	public async Task ASameStampRewriteBetweenRankingsReplacesThePreparedEntryAndIsReadAgain()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var source = workspace.CreateFile("project/Use.cs", Revision(0));
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+
+		var first = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+		ReplaceWithSameFileStampOrSkip(source, Revision(1));
+		var second = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+
+		// The cache key still matches the file stamp, but the supplied identity no longer matches
+		// the entry, so the entry goes and the file is read again instead of answered from it.
+		var key = Path.GetFullPath(source);
+		Assert.NotEqual(first.SourceVersions[key].ContentHash, second.SourceVersions[key].ContentHash);
+		Assert.Equal(DependencySourceObservationKind.Read, second.SourceObservations[key].Kind);
+		Assert.Equal(second.SourceVersions[key].ContentHash, second.SourceObservations[key].ContentDigest);
+	}
+
+	[Fact]
+	public async Task AnUnchangedSecondRankingReportsNoSecondObservation()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var source = workspace.CreateFile("project/Use.cs", "public class Use { Target Value; }");
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+
+		var cold = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+		var warm = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+
+		// A repeated ranking of an unchanged selection reads nothing, so it has no second
+		// observation to offer and does not pretend otherwise. Only a later currency check, which
+		// does read, can speak for these files.
+		Assert.Equal(
+			DependencySourceObservationKind.Read,
+			cold.SourceObservations[Path.GetFullPath(source)].Kind);
+		Assert.DoesNotContain(
+			warm.SourceObservations.Values,
+			static observation => observation.Kind == DependencySourceObservationKind.Read);
+	}
+
+	[Fact]
+	public async Task APreparationReusedForAWiderSelectionIsReportedAsReuse()
+	{
+		using var workspace = new TemporaryDirectory();
+		var root = workspace.CreateFolder("project");
+		var project = workspace.CreateFile("project/Fixture.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+		var target = workspace.CreateFile("project/Target.cs", "public class Target { }");
+		var source = workspace.CreateFile("project/Use.cs", "public class Use { Target Value; }");
+		var added = workspace.CreateFile("project/Added.cs", "public class Added { Target Value; }");
+		using var engine = new DependencyFactsEngine(
+			new TreeSitterDependencyFactExtractor(),
+			new FileDependencyConfigurationProvider());
+		var ranking = new ImportanceRankingService(engine, new UnavailableHistoryReader());
+
+		_ = await ranking.RankAsync(
+			root,
+			[project, target, source],
+			TestContext.Current.CancellationToken);
+		var wider = await ranking.RankAsync(
+			root,
+			[project, target, source, added],
+			TestContext.Current.CancellationToken);
+
+		// The file whose preparation was reused carries no digest: what the cache holds came from
+		// an earlier read, and repeating it here would be an echo, not an observation.
+		var reused = wider.SourceObservations[Path.GetFullPath(source)];
+		Assert.Equal(DependencySourceObservationKind.ReusedPreparation, reused.Kind);
+		Assert.Null(reused.ContentDigest);
+		Assert.Equal(
+			DependencySourceObservationKind.Read,
+			wider.SourceObservations[Path.GetFullPath(added)].Kind);
+	}
 	private static Task<ImportanceRankingReport> RankAsync(
 		ImportanceRankingService ranking,
 		string root,
@@ -114,6 +324,72 @@ public sealed class ImportanceRankingManifestIdentityTests
 		}
 	}
 
+	private static string Revision(int index) =>
+		string.Create(CultureInfo.InvariantCulture, $"public class Use {{ Target Value; }} /*{index:D4}*/");
+
+	/// <summary>
+	/// Rewrites one file with fresh content of the same length and restores its stamps, in the
+	/// moment between a caller hashing the file and the extractor opening it.
+	/// </summary>
+	private sealed class SameStampRewritingOpener(string target, int rewrites)
+	{
+		private string? _stampFailure;
+
+		public int Applied { get; private set; }
+
+		public FileStream Open(string path, int bufferSize, FileShare fileShare, bool asynchronous)
+		{
+			if (Applied < rewrites &&
+			    PathComparer.Default.Equals(Path.GetFullPath(path), Path.GetFullPath(target)))
+				Rewrite();
+			return new FileStream(
+				path,
+				new FileStreamOptions
+				{
+					Mode = FileMode.Open,
+					Access = FileAccess.Read,
+					Share = fileShare,
+					BufferSize = Math.Max(bufferSize, 1),
+					Options = asynchronous ? FileOptions.Asynchronous : FileOptions.None
+				});
+		}
+
+		public void SkipUnlessStampPreserved()
+		{
+			if (_stampFailure is not null)
+				Assert.Skip(_stampFailure);
+		}
+
+		private void Rewrite()
+		{
+			var before = new FileInfo(target);
+			var length = before.Length;
+			var lastWrite = before.LastWriteTimeUtc;
+			var creation = before.CreationTimeUtc;
+			Applied++;
+			try
+			{
+				File.WriteAllText(target, Revision(Applied), new UTF8Encoding(false));
+				File.SetLastWriteTimeUtc(target, lastWrite);
+				File.SetCreationTimeUtc(target, creation);
+			}
+			catch (Exception exception) when (
+				exception is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+			{
+				_stampFailure ??= $"The file system cannot restore write timestamps: {exception.Message}";
+				return;
+			}
+
+			var after = new FileInfo(target);
+			if (after.Length != length || after.LastWriteTimeUtc != lastWrite || after.CreationTimeUtc != creation)
+			{
+				_stampFailure ??=
+					$"The file system did not preserve the complete file stamp: " +
+					$"length {length}/{after.Length}, mtime {lastWrite:o}/{after.LastWriteTimeUtc:o}, " +
+					$"creation {creation:o}/{after.CreationTimeUtc:o}.";
+			}
+		}
+	}
 	private sealed class UnavailableHistoryReader : IProjectGitHistoryReader
 	{
 		public Task<ProjectGitHistorySnapshot> ReadAsync(

--- a/Tests/DevProjex.Tests.Unit/ImportanceRankingManifestIdentityTests.cs
+++ b/Tests/DevProjex.Tests.Unit/ImportanceRankingManifestIdentityTests.cs
@@ -340,7 +340,7 @@ public sealed class ImportanceRankingManifestIdentityTests
 		public FileStream Open(string path, int bufferSize, FileShare fileShare, bool asynchronous)
 		{
 			if (Applied < rewrites &&
-			    PathComparer.Default.Equals(Path.GetFullPath(path), Path.GetFullPath(target)))
+				PathComparer.Default.Equals(Path.GetFullPath(path), Path.GetFullPath(target)))
 				Rewrite();
 			return new FileStream(
 				path,


### PR DESCRIPTION
Closes #374.

## What changes

The extractor already reads every supported file in full in order to decode it. It now digests the
raw bytes in that same pass, and the index snapshot carries the digest per file.

Importance ranking used to hash the whole selection twice around indexing — once to supply the cache
identity, once afterwards to notice a file rewritten in between. It now hashes once and compares its
hash against the snapshot digest. That is still a comparison of content against content, so a
replacement that restores length, write time and creation time is still detected; it is not a
metadata check.

A pass that answers from a retained preparation or a retained manifest snapshot reads nothing, so it
has no digest to report. The snapshot reports reuse instead of repeating an earlier observation as a
fresh one, and the ranking report carries that per file. Those files are left uncompared rather than
compared against an echo of the identity the caller supplied itself, and the currency check performed
when their content is read for output remains their second observation.

## Measurement rule — recorded before the first measurement

- Three corpora: `devprojex` (2299 candidate files), `repomix` (951), `flask` (212), at the commits
  pinned in `tools/RankingEval/registry.json`.
- `measure-one --mode cold --order importance-v1`, five samples per corpus, median reported.
- Base and candidate measured on the same machine, in the same session, alternating nothing: base
  first, then candidate, both built `Release` from the same worktree.
- Base is `f698c5a6`, the commit this branch starts from.
- Tolerance: a corpus regresses if its candidate median exceeds its base median by more than 10%.
  Any regression beyond that is a rollback, not a note.
- The warm cold-start gate is not used here. Warm ranking reuses the cached index and never reaches
  extraction, so it cannot observe this change; the cold path is the one that reads.

## Evaluation

Frozen run on both commits, same registry, same workspace, same corpora.

| | base `f698c5a6` | candidate `7ff30d4d` |
|---|---|---|
| criterion | PASS | PASS |
| eligible cells | 15 | 15 |
| overall recallNew delta | 0.3667 | 0.3667 |
| cells compared | 270 | 270 |
| cells differing | — | 0 |

All 270 cells (3 corpora x 5 tasks x 3 budgets x 6 orders) are identical.

## Read count

`ContentPipelineDiagnostics.SourceVersionHashPasses`, two sources, one ranked source-backed export:

| | passes | bytes |
|---|---|---|
| before | 6 | 3 x (len A + len B) |
| after | 4 | 2 x (len A + len B) |

Pinned by `RankedSourceBackedExportHashesEachSourceTwice` and
`RankedCompressedDryRunUsesMeasuredBudgetWithoutMaterializingOrSerializing`. A bare `RankAsync` over
three candidates now reports three passes, one per file, pinned by `RankingReadsEachSelectedFileOnce`.

## Tests

- `RankingReadsEachSelectedFileOnce` — one pass per candidate, and the file is still reported as read.
- `ContentRewrittenUnderAnUnchangedStampBeforeEveryReadIsRejected` — content replaced between the hash
  and every open, with length, write time and creation time restored each time; both attempts see it
  and the call fails. Skips if the file system will not restore the stamp.
- `ContentRewrittenUnderAnUnchangedStampBeforeTheFirstReadIsRetried` — the same replacement once; the
  second attempt succeeds and the report's digest matches its captured hash.
- `AnUnreadableSelectedFileLeavesAnUnchangedSelectionRankable` — a file held open exclusively ranks
  without failing the selection; neither side observed it and nothing is compared.
- `ASameStampRewriteBetweenRankingsReplacesThePreparedEntryAndIsReadAgain` — the cache key still
  matches the stamp but the supplied identity does not, so the entry is dropped and the file is read
  again.
- `AnUnchangedSecondRankingReportsNoSecondObservation` — a repeated ranking of an unchanged selection
  reads nothing and says so rather than reporting a read.
- `APreparationReusedForAWiderSelectionIsReportedAsReuse` — a reused preparation carries no digest and
  is reported as reuse.

## Not covered

- A file above the character parse limit, a file that fails to decode, and an unsupported language are
  never read to the end, so they carry no digest and are never compared. They keep exactly the
  coverage they had before this change, which is none.
- Files whose preparation or whose whole snapshot is reused are not compared during ranking. This is
  the conditional part of the guarantee; the ranking report states it per file rather than leaving it
  implicit.

## Timings

`measure-one --mode cold --order importance-v1`, five samples, medians in milliseconds. Base
`f698c5a6` measured first, candidate `7ff30d4d` second, same machine and session.

| corpus | base samples | base median | candidate samples | candidate median | delta |
|---|---|---|---|---|---|
| devprojex (2299) | 2819, 2782, 2879, 2910, 2800 | 2818.8 | 2449, 2360, 2522, 2551, 2695 | 2522.3 | -10.5% |
| repomix (951) | 770, 757, 741, 802, 771 | 769.9 | 595, 592, 611, 612, 616 | 611.0 | -20.6% |
| flask (212) | 471, 462, 469, 477, 472 | 470.5 | 415, 427, 456, 428, 468 | 428.2 | -9.0% |

Every corpus is faster; nothing approaches the 10% regression threshold in the other direction.
