### PR TITLE
fix(ci): keep a rebased pull request from failing its plan

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -673,6 +673,8 @@ jobs:
           DOCUMENTATION_RESULT: ${{ needs.documentation-contracts.result }}
           PLANNER_PATHS: ${{ needs.prepare-matrix.outputs.changed_paths }}
           PLANNER_SUITES: ${{ needs.prepare-matrix.outputs.planned_suites }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
           PLANNER_HAS_TESTS: ${{ needs.prepare-matrix.outputs.has_test_matrix }}
           PLANNER_TERMINAL_COMMAND: ${{ needs.prepare-matrix.outputs.run_terminal_command }}
           PLANNER_IGNORE_SCANNER: ${{ needs.prepare-matrix.outputs.run_ignore_scanner }}
@@ -726,10 +728,35 @@ jobs:
           $plannedSuites = @($env:PLANNER_SUITES -split ',' |
             Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
+          # The plan is also allowed to have been decided from the delta of the push that
+          # triggered this run, which is what the incremental tier does. It is worked out here
+          # too, so that the plan is checked against a change rather than believed about one.
+          # A rebase leaves the event naming a commit that is on no ref, so the commits are
+          # looked for before a range is built from them.
+          $pushed = @()
+          $pushedAvailable = $false
+          $sha = '^[0-9a-fA-F]{40}$'
+          if ($env:EVENT_BEFORE -match $sha -and $env:EVENT_BEFORE -notmatch '^0{40}$' -and
+              $env:EVENT_AFTER -match $sha) {
+            git cat-file -e "$($env:EVENT_BEFORE)^{commit}" 2>$null
+            $beforeExists = $LASTEXITCODE -eq 0
+            git cat-file -e "$($env:EVENT_AFTER)^{commit}" 2>$null
+            $afterExists = $LASTEXITCODE -eq 0
+            if ($beforeExists -and $afterExists) {
+              $pushed = @(git -c core.quotepath=false diff --name-only "$($env:EVENT_BEFORE)..$($env:EVENT_AFTER)" --)
+              $pushedAvailable = $LASTEXITCODE -eq 0
+            }
+          }
+          # Looking for a commit that is not there is an answer, not a failure, and the step is
+          # ended by whatever the last native command leaves behind.
+          $global:LASTEXITCODE = 0
+
           ./Scripts/ci/Test-CiGateSkip.ps1 `
             -ChangedPath $changed `
             -PlannerChangedPathJson $env:PLANNER_PATHS `
             -SkippedJob $skipped `
             -PlannerWillRunJob $willRun `
-            -PlannerWillRunSuite $plannedSuites
+            -PlannerWillRunSuite $plannedSuites `
+            -PushedChangedPath $pushed `
+            -PushedChangeAvailable:$pushedAvailable
 

--- a/Scripts/ci/CiChangePlanner.psm1
+++ b/Scripts/ci/CiChangePlanner.psm1
@@ -343,11 +343,33 @@ function Get-CiChangePlan {
 	}
 }
 
+# Whether a commit is in the checkout at all. A force-push leaves the event's `before` on no ref,
+# and fetch-depth 0 fetches refs, so the commit it names is simply absent. Asked before a range is
+# built from it, rather than found out by letting git fail on the range.
+function Test-CommitReachable {
+	param([Parameter(Mandatory)][AllowEmptyString()][string] $Sha)
+
+	if ($Sha -notmatch '^[0-9a-fA-F]{40}$' -or $Sha -match '^0{40}$') {
+		return $false
+	}
+
+	& git cat-file -e "$Sha^{commit}" 2>$null | Out-Null
+	$reachable = $LASTEXITCODE -eq 0
+	# A missing commit is an answer here, not a failure. The pwsh step wrapper ends the step with
+	# whatever the last native command left in $LASTEXITCODE, so this cannot be left set.
+	$global:LASTEXITCODE = 0
+	return $reachable
+}
+
 function Get-CiEventComparison {
 	[CmdletBinding()]
 	param(
 		[Parameter(Mandatory)][string] $EventName,
-		[Parameter(Mandatory)][psobject] $Event
+		[Parameter(Mandatory)][psobject] $Event,
+
+		# How a commit is looked for. Replaced in the contract tests, which work with commits that
+		# exist in no repository.
+		[scriptblock] $CommitReachable = { param([string] $Sha) Test-CommitReachable -Sha $Sha }
 	)
 
 	$validSha = '^[0-9a-fA-F]{40}$'
@@ -360,18 +382,25 @@ function Get-CiEventComparison {
 		return [pscustomobject]@{ Full = $true; BaseSha = ''; HeadSha = ''; MergeBase = $false }
 	}
 
-	# A synchronize event compares only the newly pushed delta. The previous HEAD already has CI evidence.
+	# A synchronize event compares only the newly pushed delta. The previous HEAD already has CI
+	# evidence -- but only while it still exists. A rebase or an amended push replaces it, and the
+	# event still names it, so the delta falls back to the same merge-base comparison an opened
+	# event uses. The previous gate is not consulted on that path, for the same reason it is not
+	# consulted for opened: the comparison already covers the pull request whole.
 	if ($EventName -eq 'pull_request' -and
 		$action -eq 'synchronize' -and
 		$eventBefore -match $validSha -and
-		$eventAfter -match $validSha) {
+		$eventAfter -match $validSha -and
+		(& $CommitReachable $eventBefore) -and
+		(& $CommitReachable $eventAfter)) {
 		return [pscustomobject]@{ Full = $false; BaseSha = $eventBefore; HeadSha = $eventAfter; MergeBase = $false }
 	}
 
 	if ($EventName -eq 'pull_request' -and $null -ne $pullRequest) {
 		$baseSha = [string]$pullRequest.base.sha
 		$headSha = [string]$pullRequest.head.sha
-		if ($baseSha -match $validSha -and $headSha -match $validSha) {
+		if ($baseSha -match $validSha -and $headSha -match $validSha -and
+			(& $CommitReachable $baseSha) -and (& $CommitReachable $headSha)) {
 			return [pscustomobject]@{ Full = $false; BaseSha = $baseSha; HeadSha = $headSha; MergeBase = $true }
 		}
 	}
@@ -379,7 +408,9 @@ function Get-CiEventComparison {
 	if ($EventName -eq 'push' -and
 		$eventBefore -match $validSha -and
 		$eventBefore -notmatch '^0{40}$' -and
-		$eventAfter -match $validSha) {
+		$eventAfter -match $validSha -and
+		(& $CommitReachable $eventBefore) -and
+		(& $CommitReachable $eventAfter)) {
 		return [pscustomobject]@{ Full = $false; BaseSha = $eventBefore; HeadSha = $eventAfter; MergeBase = $false }
 	}
 

--- a/Scripts/ci/Select-CiPlan.ps1
+++ b/Scripts/ci/Select-CiPlan.ps1
@@ -163,6 +163,12 @@ if (-not $Full -and -not [string]::IsNullOrWhiteSpace($effectiveBaseSha)) {
 		$Full = $true
 		$ChangedPath = @()
 	}
+
+	# The safe full plan is only safe if the step that built it succeeds. GitHub's pwsh shell ends
+	# a step with whatever the last native command left in $LASTEXITCODE, so git's code has to be
+	# cleared here: handling the failure and then failing the step anyway means the fallback never
+	# runs, and every job waiting on the plan goes down with it.
+	$global:LASTEXITCODE = 0
 }
 
 $plan = if ($Full) {

--- a/Scripts/ci/Test-CiChangePlanner.ps1
+++ b/Scripts/ci/Test-CiChangePlanner.ps1
@@ -170,7 +170,13 @@ if (-not $fullPlan.Documentation) {
 
 $beforeSha = '1111111111111111111111111111111111111111'
 $afterSha = '2222222222222222222222222222222222222222'
-$syncComparison = Get-CiEventComparison -EventName pull_request -Event ([pscustomobject]@{
+$baseSha = '3333333333333333333333333333333333333333'
+# None of these commits exist in any checkout, so what the comparison would find is said here
+# instead of looked up.
+$everythingExists = { param([string] $Sha) $true }
+$beforeIsGone = { param([string] $Sha) $Sha -ne $beforeSha }
+$nothingExists = { param([string] $Sha) $false }
+$syncComparison = Get-CiEventComparison -EventName pull_request -CommitReachable $everythingExists -Event ([pscustomobject]@{
 	action = 'synchronize'
 	before = $beforeSha
 	after = $afterSha
@@ -179,7 +185,7 @@ if ($syncComparison.Full -or $syncComparison.MergeBase -or $syncComparison.BaseS
 	throw '[PR synchronize] Expected an incremental previous-HEAD to new-HEAD comparison.'
 }
 
-$openedComparison = Get-CiEventComparison -EventName pull_request -Event ([pscustomobject]@{
+$openedComparison = Get-CiEventComparison -EventName pull_request -CommitReachable $everythingExists -Event ([pscustomobject]@{
 	action = 'opened'
 	pull_request = [pscustomobject]@{
 		base = [pscustomobject]@{ sha = $beforeSha }
@@ -190,12 +196,108 @@ if ($openedComparison.Full -or -not $openedComparison.MergeBase) {
 	throw '[PR opened] Expected a complete merge-base comparison.'
 }
 
-$newBranchComparison = Get-CiEventComparison -EventName push -Event ([pscustomobject]@{
+$newBranchComparison = Get-CiEventComparison -EventName push -CommitReachable $everythingExists -Event ([pscustomobject]@{
 	before = '0000000000000000000000000000000000000000'
 	after = $afterSha
 })
 if (-not $newBranchComparison.Full) {
 	throw '[New branch push] Expected safe full validation when no previous commit exists.'
+}
+
+# A rebase or an amended push leaves the event naming a commit that is on no ref. The delta
+# cannot be built from it, and the pull request still has a base to compare against.
+$forcePushComparison = Get-CiEventComparison -EventName pull_request -CommitReachable $beforeIsGone -Event ([pscustomobject]@{
+	action = 'synchronize'
+	before = $beforeSha
+	after = $afterSha
+	pull_request = [pscustomobject]@{
+		base = [pscustomobject]@{ sha = $baseSha }
+		head = [pscustomobject]@{ sha = $afterSha }
+	}
+})
+if ($forcePushComparison.Full) {
+	throw '[PR synchronize after a force-push] Expected the merge-base comparison, not the full plan.'
+}
+if (-not $forcePushComparison.MergeBase -or
+	$forcePushComparison.BaseSha -ne $baseSha -or
+	$forcePushComparison.HeadSha -ne $afterSha) {
+	throw '[PR synchronize after a force-push] Expected a base-to-head merge-base comparison.'
+}
+
+# With no pull request on the event there is nothing left to compare against.
+$forcePushWithoutPullRequest = Get-CiEventComparison -EventName pull_request -CommitReachable $beforeIsGone -Event ([pscustomobject]@{
+	action = 'synchronize'
+	before = $beforeSha
+	after = $afterSha
+})
+if (-not $forcePushWithoutPullRequest.Full) {
+	throw '[PR synchronize after a force-push] Expected the full plan when no base remains.'
+}
+
+# The same commit can be missing on an opened event, and on a branch push, where no merge base
+# is on offer at all.
+$openedWithoutBase = Get-CiEventComparison -EventName pull_request -CommitReachable $nothingExists -Event ([pscustomobject]@{
+	action = 'opened'
+	pull_request = [pscustomobject]@{
+		base = [pscustomobject]@{ sha = $baseSha }
+		head = [pscustomobject]@{ sha = $afterSha }
+	}
+})
+if (-not $openedWithoutBase.Full) {
+	throw '[PR opened with a missing base] Expected safe full validation.'
+}
+
+$forcePushToBranch = Get-CiEventComparison -EventName push -CommitReachable $beforeIsGone -Event ([pscustomobject]@{
+	before = $beforeSha
+	after = $afterSha
+})
+if (-not $forcePushToBranch.Full) {
+	throw '[Branch force-push] Expected safe full validation when the previous commit is gone.'
+}
+
+# A plan that was built has to end its step successfully, whichever plan it is. GitHub's pwsh shell
+# ends a step with whatever the last native command left in $LASTEXITCODE, so git failing on an
+# unbuildable range used to fail the step that had already fallen back to the full plan -- and every
+# job waiting on that plan with it. The step is composed here the way the runner composes one, with
+# the same prologue, epilogue and invocation.
+$planScriptPath = Join-Path $PSScriptRoot 'Select-CiPlan.ps1'
+$stepIdentifier = [Guid]::NewGuid().ToString('N')
+$stepOutputPath = Join-Path ([IO.Path]::GetTempPath()) "devprojex-ci-step-$stepIdentifier.txt"
+$stepScriptPath = Join-Path ([IO.Path]::GetTempPath()) "devprojex-ci-step-$stepIdentifier.ps1"
+$unreachableSha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+try {
+	Set-Content -LiteralPath $stepScriptPath -Encoding utf8 -Value @(
+		'$ErrorActionPreference = ''stop''',
+		"& '$planScriptPath' -BaseSha '$unreachableSha' -HeadSha '$unreachableSha' -GitHubOutputPath '$stepOutputPath'",
+		'if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) { exit $LASTEXITCODE }')
+
+	$shellCommand = Get-Command pwsh -ErrorAction SilentlyContinue
+	$shellPath = if ($shellCommand) {
+		$shellCommand.Source
+	}
+	else {
+		[Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+	}
+
+	& $shellPath -NoProfile -Command ". '$stepScriptPath'" *> $null
+	$stepExitCode = $LASTEXITCODE
+	# Cleared for the same reason the plan clears it: this file is a CI step too.
+	$global:LASTEXITCODE = 0
+
+	if ($stepExitCode -ne 0) {
+		throw "[Unbuildable range] The step ended with exit code $stepExitCode although it produced a plan."
+	}
+
+	$stepOutput = @(Get-Content -LiteralPath $stepOutputPath)
+	if ($stepOutput -notcontains 'full=true') {
+		throw '[Unbuildable range] Expected the safe full plan in the step outputs.'
+	}
+	if ($stepOutput -notcontains 'has_test_matrix=true') {
+		throw '[Unbuildable range] Expected the safe full plan to carry a test matrix.'
+	}
+}
+finally {
+	Remove-Item -LiteralPath $stepScriptPath, $stepOutputPath -Force -ErrorAction SilentlyContinue
 }
 
 $metadataPlan = Get-CiChangePlan -ChangedPath 'release-note.txt'

--- a/Scripts/ci/Test-CiGateContract.ps1
+++ b/Scripts/ci/Test-CiGateContract.ps1
@@ -55,7 +55,9 @@ function Invoke-Gate {
 		[string] $PlannerChangedPathJson,
 		[AllowEmptyCollection()][string[]] $SkippedJob,
 		[AllowEmptyCollection()][string[]] $PlannerWillRunJob,
-		[AllowEmptyCollection()][string[]] $PlannerWillRunSuite
+		[AllowEmptyCollection()][string[]] $PlannerWillRunSuite,
+		[AllowEmptyCollection()][string[]] $PushedChangedPath = @(),
+		[switch] $PushedChangeAvailable
 	)
 
 	$printed = [Collections.Generic.List[string]]::new()
@@ -70,7 +72,9 @@ function Invoke-Gate {
 			-PlannerChangedPathJson $PlannerChangedPathJson `
 			-SkippedJob $SkippedJob `
 			-PlannerWillRunJob $PlannerWillRunJob `
-			-PlannerWillRunSuite $PlannerWillRunSuite 6>&1 |
+			-PlannerWillRunSuite $PlannerWillRunSuite `
+			-PushedChangedPath $PushedChangedPath `
+			-PushedChangeAvailable:$PushedChangeAvailable 6>&1 |
 			ForEach-Object { $printed.Add([string] $_) }
 	}
 	catch {
@@ -93,6 +97,8 @@ function Test-Case {
 		[string[]] $SkippedJob,
 		[string[]] $PlannerWillRunJob = @(),
 		[string[]] $PlannerWillRunSuite = @(),
+		[string[]] $PushedChangedPath = @(),
+		[switch] $PushedChangeAvailable,
 		[switch] $ShouldPass,
 		[string] $ExpectMessage,
 		[string[]] $ExpectPrintedPath = @()
@@ -103,7 +109,9 @@ function Test-Case {
 		-PlannerChangedPathJson (ConvertTo-PlannerJson -Path $PlannerPath) `
 		-SkippedJob $SkippedJob `
 		-PlannerWillRunJob $PlannerWillRunJob `
-		-PlannerWillRunSuite $PlannerWillRunSuite
+		-PlannerWillRunSuite $PlannerWillRunSuite `
+		-PushedChangedPath $PushedChangedPath `
+		-PushedChangeAvailable:$PushedChangeAvailable
 
 	if ($ShouldPass -and -not $result.Accepted) {
 		$failures.Add("$Name should have been accepted but was rejected: $($result.Message)")
@@ -211,6 +219,48 @@ Test-Case -Name 'a job the gate cannot place is never vouched for' `
 	-PlannerPath @('Docs/McpServer.md') `
 	-SkippedJob @('releaseValidation') `
 	-ExpectMessage 'not ones this knows how to place'
+
+# --- a plan decided from the push rather than from the pull request ------------------------------
+# An incremental plan is decided from the delta of the push that triggered it, once the commit it
+# follows has a green gate of its own. The gate sees the pull request whole, so without knowing
+# about that delta it would call every incremental plan a plan for a different change.
+Test-Case -Name 'a plan decided from the push is a plan for a change this event describes' `
+	-ChangedPath @('Docs/McpServer.md', 'Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PushedChangedPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') -PushedChangeAvailable `
+	-SkippedJob @('ignoreScanner', 'documentation') `
+	-PlannerWillRunJob @('tests', 'terminalCommand') `
+	-PlannerWillRunSuite @('Unit') -ShouldPass
+
+# And the skips are then judged against that delta, not against the pull request.
+Test-Case -Name 'the push delta is what the skips are judged against' `
+	-ChangedPath @('Docs/McpServer.md', 'Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs') `
+	-PlannerPath @('Docs/McpServer.md') `
+	-PushedChangedPath @('Docs/McpServer.md') -PushedChangeAvailable `
+	-SkippedJob @('tests', 'terminalCommand', 'ignoreScanner') `
+	-PlannerWillRunJob @('documentation') -ShouldPass
+
+Test-Case -Name 'a job the push delta does reach stays refused' `
+	-ChangedPath @('Docs/McpServer.md', 'Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs') `
+	-PushedChangedPath @('Tests/DevProjex.Tests.Integration/IgnoreContractTests.cs') -PushedChangeAvailable `
+	-SkippedJob @('terminalCommand') `
+	-PlannerWillRunJob @('tests') `
+	-PlannerWillRunSuite @('Integration') `
+	-ExpectMessage 'terminalCommand'
+
+Test-Case -Name 'a delta the event never described is refused' `
+	-ChangedPath @('Docs/McpServer.md', 'Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PushedChangedPath @('Docs/McpServer.md') -PushedChangeAvailable `
+	-SkippedJob @('ignoreScanner') `
+	-ExpectMessage 'a change this event does not describe'
+
+Test-Case -Name 'a push delta is not on offer when the event names none' `
+	-ChangedPath @('Docs/McpServer.md', 'Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-PlannerPath @('Tests/DevProjex.Tests.Unit/McpInfrastructureTests.cs') `
+	-SkippedJob @('ignoreScanner') `
+	-ExpectMessage 'a change this event does not describe'
 
 # --- the plan does not match the change ---------------------------------------------------------
 Test-Case -Name 'the plan saw a path that did not change' `

--- a/Scripts/ci/Test-CiGateSkip.ps1
+++ b/Scripts/ci/Test-CiGateSkip.ps1
@@ -52,6 +52,17 @@ param(
 	[AllowEmptyCollection()]
 	[string[]] $PlannerWillRunJob,
 
+	# The delta of the push that triggered the run, when the event names a previous commit and that
+	# commit is still in the checkout. A plan is allowed to be decided from it instead of from the
+	# pull request whole -- that is what the incremental tier does, once the previous commit has a
+	# green gate of its own -- so the change the plan recorded has to match one of the two, and the
+	# one it matches is the change the skips are then judged against.
+	[AllowEmptyCollection()]
+	[string[]] $PushedChangedPath = @(),
+
+	# Whether there is such a delta at all, which an empty list of paths cannot say by itself.
+	[switch] $PushedChangeAvailable,
+
 	# Test suites the plan put in the matrix. Three of the jobs below run tests that a suite also
 	# runs, so which suites ran decides whether skipping those jobs leaves anything uncovered.
 	[AllowEmptyCollection()]
@@ -222,17 +233,41 @@ if (-not [string]::IsNullOrWhiteSpace($PlannerChangedPathJson)) {
 	}
 }
 
-$missing = @($actual | Where-Object { $recorded -notcontains $_ })
-$extra = @($recorded | Where-Object { $actual -notcontains $_ })
-if ($missing.Count -gt 0 -or $extra.Count -gt 0) {
-	throw "The plan was decided from a different change than the one being gated, so its skips " +
-	      "cannot be trusted." + [Environment]::NewLine +
+$candidates = [Collections.Generic.List[object]]::new()
+$candidates.Add([pscustomobject]@{ Name = 'the pull request'; Path = $actual })
+if ($PushedChangeAvailable) {
+	$candidates.Add([pscustomobject]@{
+		Name = 'the push that triggered this run'
+		Path = @(ConvertTo-TrimmedSet -Value $PushedChangedPath)
+	})
+}
+
+$matched = $null
+foreach ($candidate in $candidates) {
+	$candidateMissing = @($candidate.Path | Where-Object { $recorded -notcontains $_ })
+	$candidateExtra = @($recorded | Where-Object { $candidate.Path -notcontains $_ })
+	if ($candidateMissing.Count -eq 0 -and $candidateExtra.Count -eq 0) {
+		$matched = $candidate
+		break
+	}
+}
+
+if ($null -eq $matched) {
+	$missing = @($actual | Where-Object { $recorded -notcontains $_ })
+	$extra = @($recorded | Where-Object { $actual -notcontains $_ })
+	throw "The plan was decided from a change this event does not describe, so its skips cannot " +
+	      "be trusted. Against the pull request:" + [Environment]::NewLine +
 	      "  changed, and not seen by the plan: $(if ($missing.Count) { $missing -join ', ' } else { '(none)' })" +
 	      [Environment]::NewLine +
 	      "  seen by the plan, and not changed: $(if ($extra.Count) { $extra -join ', ' } else { '(none)' })" +
 	      [Environment]::NewLine +
-	      "  gate saw $($actual.Count) path(s); the plan recorded $($recorded.Count)."
+	      "  gate saw $($actual.Count) path(s) in the pull request" +
+	      $(if ($PushedChangeAvailable) { " and $($candidates[1].Path.Count) in the push" } else { '' }) +
+	      "; the plan recorded $($recorded.Count)."
 }
+
+# The skips are judged against the change the plan was actually decided from.
+$actual = $matched.Path
 
 $plannedSuites = @(ConvertTo-TrimmedSet -Value $PlannerWillRunSuite)
 $unknownJobs = @($skipped | Where-Object { $allJobs -notcontains $_ })
@@ -264,6 +299,6 @@ if ($unjustified.Count -gt 0) {
 }
 
 Write-Host ("Skipped " + ($skipped -join ', ') +
-	"; none of the $($actual.Count) changed path(s) reach them" +
+	"; none of the $($actual.Count) path(s) changed by $($matched.Name) reach them" +
 	$(if ($plannedSuites.Count) { " beyond the suites that ran ($($plannedSuites -join ', '))" } else { '' }) +
 	'.')


### PR DESCRIPTION
A force-push to a pull request branch reds the whole run. `Plan CI` and `Plan Release Validation`
both fail inside a minute, and a rerun cannot help: the event payload is the same one.

```
fatal: Invalid revision range d18db8de..3b4e5e14
WARNING: Unable to calculate changed paths for '...'; using the safe full plan.
##[error]Process completed with exit code 1.
```

Two separate faults produce that one line.

## Why the step failed after the failure was handled

The planner handles git's failure — it warns, sets the full plan and writes it. Reproduced locally
against the real script, the plan is produced in full: twelve outputs, `full=true`,
`has_test_matrix=true`. The step still ends non-zero.

GitHub's `pwsh` shell wraps a run block with `$ErrorActionPreference = 'stop'` and
`if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) { exit $LASTEXITCODE }`. `Select-CiPlan.ps1`
ends without an explicit `exit`, so git's `128` was still in `$LASTEXITCODE` when the wrapper read
it, and `pwsh -Command ". 'file'"` surfaces any non-zero exit from a dot-sourced script as `1`.

Measured, not assumed:

| shape | step exit |
|---|---|
| the run block without that epilogue | 0 |
| the run block with it, `$LASTEXITCODE` left at git's 128 | **1** |
| the same, with the code cleared once read | 0 |

`Test-Indentation.ps1` was checked for the same leak and does not have it: its early return is an
explicit `exit 0`, and an explicit exit resets `$LASTEXITCODE` for the caller. That was measured
too.

So the code git leaves behind is cleared once it has been read. A plan that was built ends its step
successfully, whichever plan it is.

## Why the range was unbuildable

A force-push leaves the event naming a `before` that is on no ref. A checkout fetches refs, so the
commit is absent, and the incremental range `before..after` cannot be diffed.

A missing `before` is not a reason to validate everything — the pull request still has a base. The
synchronize path now takes the incremental range only when both of its ends are in the checkout,
and otherwise falls through to the same `base...head` merge-base comparison an `opened` event uses.
The previous gate is not consulted there, for the reason it is not consulted for `opened`: the
comparison already covers the pull request whole.

The merge-base and branch-push paths ask the same question before building their ranges, so neither
can fail on a commit that is gone. With no base left to compare against, the full plan stands.

Reachability is asked with `git cat-file -e <sha>^{commit}` before a range is built, rather than
found out by letting git fail on one.

## The gate side

`CI Gate` does not build `before..after` — it builds `pull_request.base.sha...HEAD`, so a missing
`before` cannot reach it. But that difference is itself a defect, and this is where it shows:

The gate works the change out for itself and refuses a plan recorded from a different one. It only
ever worked out one change, the pull request whole, while an **incremental** plan is decided from
the delta of the push. Those are the same set only on a pull request whose first push is also its
last. The first incremental plan to reach a gate with anything skipped would have been called a
plan for a different change. Nothing has hit it yet only because every gate run so far reports `No
job was skipped`.

The event describes two changes a plan may have been decided from, so the gate now works out both
and requires the recorded one to match either. Whichever it matches is the change the skips are
judged against, which is what the incremental tier means by narrowing. The delta is offered only
when the event names a previous commit and that commit is in the checkout — so a rebase leaves one
candidate, the same one the plan falls back to, and the two agree by construction.

## Tests

In `Test-CiChangePlanner.ps1`:

- synchronize whose `before` is gone → the merge-base comparison, base to head
- the same with no pull request left to fall back to → the full plan
- `opened` whose base is gone → the full plan
- a branch force-push → the full plan
- the step exit code, by composing a step the way the runner composes one — same prologue, epilogue
  and invocation — pointing it at an unbuildable range and requiring exit 0 with the full plan in
  the outputs

In `Test-CiGateContract.ps1`:

- a plan decided from the push is a plan for a change the event describes
- the skips are judged against that delta, not against the pull request
- a job the delta does reach stays refused
- a recorded change that is neither → refused
- a delta claimed when the event named none → refused

Both sides have a positive control. Removing the reachability check fails the force-push case by
name; putting the leaked exit code back fails the step case with exit code 1; the gate cases each
fail if the second candidate is accepted blindly.

## Checked

The four `Scripts/ci` contracts pass. End to end against the real scripts, a synchronize whose
`before` is gone now exits 0 and produces a plan from the merge-base comparison, with
`previous_gate_verified=false` as that path intends.

No trigger or tier policy is touched. `Test-Indentation.ps1` is unchanged.
