### PR TITLE
fix(mcp): retain useful search evidence within bounds

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -603,6 +603,9 @@ jobs:
           dotnet build tools/RankingEval/RankingEval.csproj -c Release
           dotnet test tools/RankingEval/Tests/RankingEval.Tests.csproj -c Release --verbosity minimal --filter "FullyQualifiedName~EvaluationMetricsTests" --logger "trx;LogFileName=ranking-eval.trx" --results-directory "TestResults/ranking-eval"
 
+      - name: Test MCP usage recorder
+        run: node --test tools/McpUsageRecorder/tests/recorder.test.mjs
+
       - name: Confirm the ranking evaluator tests executed
         if: ${{ success() }}
         shell: pwsh

--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -54,7 +54,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 		var method = typeof(DevProjexMcpTools).GetMethod(
 			methodName,
 			BindingFlags.Instance | BindingFlags.Public) ??
-		             throw new MissingMethodException(typeof(DevProjexMcpTools).FullName, methodName);
+					 throw new MissingMethodException(typeof(DevProjexMcpTools).FullName, methodName);
 		var description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
 		var options = new McpServerToolCreateOptions
 		{

--- a/Apps/Mcp/DevProjexMcpToolCatalog.cs
+++ b/Apps/Mcp/DevProjexMcpToolCatalog.cs
@@ -398,7 +398,7 @@ internal sealed class DevProjexMcpToolCatalog : IReadOnlyList<McpServerTool>
 	    {{MaxFileBytesProperty}},
 	    "context_lines": { "description": "Lines before and after each match, 0..20, default 2; overlapping windows are merged. Accepts an integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 0, "maximum": 20 }, { "type": "string", "pattern": "^[0-9]+$" } ] },
 	    "ignore_case": { "description": "Case-insensitive matching; accepts a boolean or the string 'true' or 'false'.", "default": true, "oneOf": [ { "type": "boolean" }, { "type": "string", "enum": ["true", "false"] } ] },
-	    "max_results": { "description": "Maximum displayed matching lines, 1..200, default 50; all selected text is still scanned so additional matches are counted. Accepts an integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1, "maximum": 200 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] }
+	    "max_results": { "description": "Maximum displayed matching lines, 1..200, default 50; matching continues through the inspected source budget, and the complete or partial boundary distinguishes encountered, retained, and written counts. Accepts an integer or numeric string.", "oneOf": [ { "type": "integer", "minimum": 1, "maximum": 200 }, { "type": "string", "pattern": "^0*[1-9][0-9]*$" } ] }
 	  },
 	  "required": ["pattern"],
 	  "additionalProperties": false

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -843,7 +843,7 @@ internal sealed class DevProjexMcpTools(
 		});
 
 	[Description(
-		"Searches safe transformed project text with a timed .NET regex and retains useful bounded evidence. It matches file content, never paths; find names with get_tree include_patterns. Use it for symbols or phrases; use related_files instead for dependency links. Returns path-grouped number:text matches, number-text context, merged groups, and a complete|partial boundary with inspected/retained/written counts plus continuation; line numbers refer to returned text, and redaction replacements never match. Parameters: pattern; paths=literal files/directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further. Read several hits with one batched get_file requests call.")]
+		"Searches safe transformed project text with a timed .NET regex and retains useful bounded evidence. It matches file content, never paths; find names with get_tree include_patterns. Use it for symbols or phrases; use related_files instead for dependency links. Returns path-grouped number:text matches, number-text context, merged groups, and a complete|partial boundary with inspected/retained/written counts plus continuation; line numbers refer to returned text, and generated redaction replacements never match. Parameters: pattern; paths=literal files/directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further. Read several hits with one batched get_file requests call.")]
 	public Task<CallToolResult> SearchProject(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -944,7 +944,7 @@ internal sealed class DevProjexMcpTools(
 					if (scan.TotalMatches > 0)
 					{
 						matchingFiles++;
-						McpSearchExecutionHooks.AfterScan?.Invoke(file.Path);
+						McpSearchExecutionHooks.AfterScan?.Invoke(relative);
 						var annotatedFiles = candidates.SelectFilesForAnnotation(McpSearchSymbols.MaximumAnnotatedFiles);
 						foreach (var stale in navigationByFile.Keys.Where(path => !annotatedFiles.Contains(path)).ToArray())
 							navigationByFile.Remove(stale);

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -43,7 +43,7 @@ internal sealed class DevProjexMcpTools(
 	// Named because a caller that sees part of a result is entitled to know what decided which part.
 	// A constant: the order is a rule, not a property of this project's files.
 	private const string SearchOrderNotice =
-		"[Search order] hits inside a declaration first, then the rest; selection order breaks ties.";
+		"[Search order] bounded evidence priority; canonical path and line break ties.";
 	// Closes a run of named hits when the next one belongs to nothing. A constant, not a name.
 	private static readonly string OutsideDeclarationHeader = $"in (no declaration){Environment.NewLine}";
 	// Asking for a file by name is the one request the selection vocabulary answers in a form a
@@ -842,7 +842,7 @@ internal sealed class DevProjexMcpTools(
 		});
 
 	[Description(
-		"Searches safe transformed project text with a timed .NET regular expression. It matches file content, never paths; find files by name with get_tree include_patterns. Use it to locate symbols or phrases; use related_files instead for dependency links. Returns matches under each path as number:text, context number-text, -- between groups, exact match and file counts, and additional matches beyond max_results; line numbers refer to that text, and generated redaction replacements never match. Key parameters: pattern; paths narrows to literal files or directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further. Read several hits with one batched get_file requests call.")]
+		"Searches safe transformed project text with a timed .NET regular expression and keeps the strongest bounded evidence from inspected sources. It matches file content, never paths; find names with get_tree include_patterns. Use it for symbols or phrases; use related_files instead for dependency links. Returns path-grouped number:text matches, number-text context, merged groups, a complete|partial boundary with inspected/retained/written counts, and continuation guidance; line numbers refer to returned text, and redaction replacements never match. Key parameters: pattern; paths narrows to literal files or directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further. Read several hits with one batched get_file requests call.")]
 	public Task<CallToolResult> SearchProject(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>
@@ -887,6 +887,7 @@ internal sealed class DevProjexMcpTools(
 			var storeHitMatchBound = false;
 			var storeHitCharacterBound = false;
 			long inspectedBytes = 0;
+			var inspectedSourceCount = 0;
 			foreach (var path in plan.IncludedFiles)
 			{
 				if (plan.EffectiveFileSizes?.TryGetValue(path, out var fileBytes) != true ||
@@ -898,13 +899,15 @@ internal sealed class DevProjexMcpTools(
 				inspectedBytes += fileBytes;
 			}
 			var inspectionBudgetReached = inspectedFiles.Count < plan.IncludedFiles.Count;
-			var materialisedMatches = 0;
-			var groups = new List<McpSearchRenderedGroup>();
+			var candidates = new McpSearchCandidateCollector(
+				MaximumStoredSearchMatches,
+				MaximumStoredSearchCharacters);
 			var navigationByFile = new Dictionary<string, IReadOnlyList<NavigationDeclaration>>(StringComparer.Ordinal);
 			await using var searched = await Projects.ConsumeSearchTextAsync(
 				plan with { IncludedFiles = inspectedFiles },
 				(file, token) =>
 				{
+					inspectedSourceCount++;
 					// Matching runs to the stored bound rather than to what the response can show,
 					// because a match the response withholds is exactly the one the caller would
 					// otherwise ask a second search to find. Groups are rendered and set aside here
@@ -914,32 +917,39 @@ internal sealed class DevProjexMcpTools(
 						file.Content,
 						regex,
 						contextLines,
-						Math.Max(0, MaximumStoredSearchMatches - materialisedMatches),
+						MaximumStoredSearchMatches,
 						file.ReplacementRanges,
 						token);
 					totalMatches += scan.TotalMatches;
 					var found = scan.Matches.Sum(static group => group.MatchLineNumbers.Count);
-					materialisedMatches += found;
 					if (scan.TotalMatches > 0)
 						matchingFiles++;
-					if (found < scan.TotalMatches)
-						storeHitMatchBound = true;
+					McpSearchExecutionHooks.AfterScan?.Invoke(file.Path);
 
 					var relative = McpProjectService.ToRelative(plan.SourceRoot, file.Path);
-					if (found > 0 && navigationByFile.Count < McpSearchSymbols.MaximumAnnotatedFiles &&
-					    !navigationByFile.ContainsKey(relative))
+					if (found > 0)
 					{
-						navigationByFile[relative] = McpSearchSymbols.CaptureNavigation(
+						var navigation = McpSearchSymbols.CaptureNavigation(
 							Projects.DependencyFactsEngine,
 							relative,
 							file.Content,
 							token);
-					}
-					foreach (var match in scan.Matches)
-					{
-						var rendered = RenderGroupLines(relative, file.Content, match);
-						if (rendered.Count > 0)
-							groups.Add(new McpSearchRenderedGroup(relative, file.Path, match.MatchLineNumbers, rendered));
+						AddSearchCandidates(
+							candidates,
+							relative,
+							file.Path,
+							file.Content,
+							scan.Matches,
+							navigation,
+							regex,
+							contextLines,
+							explicitScope: HasItems(paths));
+
+						var annotatedFiles = candidates.SelectFilesForAnnotation(McpSearchSymbols.MaximumAnnotatedFiles);
+						foreach (var stale in navigationByFile.Keys.Where(path => !annotatedFiles.Contains(path)).ToArray())
+							navigationByFile.Remove(stale);
+						if (annotatedFiles.Contains(relative))
+							navigationByFile[relative] = navigation;
 					}
 
 					return ValueTask.CompletedTask;
@@ -950,14 +960,14 @@ internal sealed class DevProjexMcpTools(
 			// case where that choice exists is a slice: when max_results withholds, the response
 			// carries some of what was found and the rest is paged. A search that shows everything
 			// it found has nothing to choose between and is left exactly as it was.
-			var withholdsByCount = totalMatches > maximumResults;
-			var ordering = withholdsByCount && groups.Count > 0
-				? OrderDeclarationsFirst(
-						groups,
-						navigationByFile,
-						cancellationToken)
-				: null;
-			var ordered = ordering ?? groups;
+			var ordered = BuildOrderedSearchGroups(candidates.Snapshot());
+			storeHitMatchBound = candidates.MatchCapacityReached;
+			var retentionCharacterBoundReached = candidates.CharacterCapacityReached;
+			var retainedMatches = candidates.Count;
+			var retainedMatchingFiles = ordered
+				.Select(static group => group.RelativePath)
+				.Distinct(StringComparer.Ordinal)
+				.Count();
 
 			// Which groups are shown is decided one file at a time, so every matched file gets a
 			// hit before any file gets a second. A listing cut alphabetically never reached the file
@@ -1019,25 +1029,36 @@ internal sealed class DevProjexMcpTools(
 			{
 				if (!withheldByFile.ContainsKey(group.RelativePath))
 					continue;
-				if (withheld.Length >= MaximumStoredSearchCharacters)
+				var heading = !string.Equals(group.RelativePath, storedFile, StringComparison.Ordinal)
+					? EscapeSingleLine(group.RelativePath) + Environment.NewLine
+					: "--" + Environment.NewLine;
+				var firstEvidenceCharacters = group.Lines
+					.TakeWhile(static line => !line.IsMatch)
+					.Append(group.Lines.First(static line => line.IsMatch))
+					.Sum(static line => line.Text.Length + Environment.NewLine.Length);
+				if (withheld.Length + heading.Length + firstEvidenceCharacters > MaximumStoredSearchCharacters)
 				{
 					storeHitCharacterBound = true;
 					break;
 				}
 
-				if (!string.Equals(group.RelativePath, storedFile, StringComparison.Ordinal))
-				{
-					withheld.Append(EscapeSingleLine(group.RelativePath)).Append(Environment.NewLine);
-					storedFile = group.RelativePath;
-				}
-				else
-				{
-					withheld.Append("--").Append(Environment.NewLine);
-				}
+				withheld.Append(heading);
+				storedFile = group.RelativePath;
 
 				foreach (var line in group.Lines)
+				{
+					var lineCharacters = line.Text.Length + Environment.NewLine.Length;
+					if (withheld.Length + lineCharacters > MaximumStoredSearchCharacters)
+					{
+						storeHitCharacterBound = true;
+						break;
+					}
 					withheld.Append(line.Text).Append(Environment.NewLine);
-				withheldStored += group.MatchLines.Count;
+					if (line.IsMatch)
+						withheldStored++;
+				}
+				if (storeHitCharacterBound)
+					break;
 			}
 
 			// Resolved on every search that showed a hit, including one the cap cut: the selector
@@ -1058,20 +1079,41 @@ internal sealed class DevProjexMcpTools(
 					.ConfigureAwait(false);
 			AppendWithheldDistribution(output, withheldByFile);
 			var additionalMatchesNotice = totalMatches > shownMatches
-				? $"[{totalMatches - shownMatches} additional matches not shown; narrow the pattern or filters.]"
+				? $"[{totalMatches - shownMatches} additional observed matches not shown; narrow the pattern or filters.]"
 				: null;
 			// Sizing information is only worth its characters when the caller did not
 			// receive every match the pattern found. A group cut in its trailing context
 			// lines withheld no match and gets the cap notice alone.
 			var searchTotalsNotice = totalMatches > shownMatches
-				? $"[Search totals] matches={totalMatches.ToString(CultureInfo.InvariantCulture)} · " +
-				  $"files={matchingFiles.ToString(CultureInfo.InvariantCulture)}"
+				? $"[Search observed] matches={totalMatches.ToString(CultureInfo.InvariantCulture)} · " +
+				  $"matching-files={matchingFiles.ToString(CultureInfo.InvariantCulture)} within inspected sources"
 				: null;
 			// An empty search result must say whether nothing matched or nothing was searched;
 			// the count is trusted data, the file names never are.
-			var noMatches = totalMatches == 0 && plan.IncludedFiles.Count > 0
-				? $"[No matches] The pattern matched nothing in {plan.IncludedFiles.Count} selected file(s) ({McpEffectiveFilters.Describe(plan)})."
+			var noMatches = totalMatches == 0 && inspectedSourceCount > 0
+				? $"[No matches] The pattern matched nothing in {inspectedSourceCount} inspected selected file(s); " +
+				  $"the search boundary below states whether inspection was complete ({McpEffectiveFilters.Describe(plan)})."
 				: null;
+			var namedDeclarationFiles = namesRefused
+				? 0
+				: symbols.Names.Keys.Select(static key => key.RelativePath).Distinct(StringComparer.Ordinal).Count();
+			var requestResultLimitReached = shownMatches < retainedMatches && shownMatches >= maximumResults;
+			var annotationLimitReached = retainedMatchingFiles > McpSearchSymbols.MaximumAnnotatedFiles;
+			var boundary = new McpSearchBoundary(
+				plan.IncludedFiles.Count,
+				inspectedSourceCount,
+				totalMatches,
+				retainedMatches,
+				shownMatches,
+				namedDeclarationFiles,
+				inspectionBudgetReached,
+				storeHitMatchBound,
+				annotationLimitReached,
+				resultGroupTruncated,
+				requestResultLimitReached,
+				retentionCharacterBoundReached,
+				storeHitCharacterBound,
+				searched.UnscannableFiles.Count);
 			// A stored result whose id never reaches the caller is a file nobody can page and
 			// nobody will remove, so it is dropped unless this response carries its id out.
 			var retained = false;
@@ -1082,7 +1124,7 @@ internal sealed class DevProjexMcpTools(
 					FormatUnscannableNotice(searched.UnscannableFiles, UnscannableResultKind.Search),
 					McpTrustedDiagnosticFormatter.FormatWarnings(plan),
 					noMatches,
-					ordering is null ? null : SearchOrderNotice,
+					ordered.Count == 0 ? null : SearchOrderNotice,
 				declarationsListed ? ReadDeclarationsNotice : null,
 					FormatStoredSearchNotice(
 						storedSearch,
@@ -1094,9 +1136,7 @@ internal sealed class DevProjexMcpTools(
 					FormatNameSearchNotice(plan, paths, pattern, totalMatches),
 					additionalMatchesNotice,
 					searchTotalsNotice,
-					inspectionBudgetReached
-						? "[Search incomplete] The inspected-text byte budget was reached; additional selected files were not searched and match counts are partial."
-						: null,
+					FormatSearchBoundaryNotice(boundary, storedSearch is not null),
 					resultGroupTruncated ? SearchContentCapNotice : null,
 					SelectionNotices(
 						plan,
@@ -2583,6 +2623,172 @@ internal sealed class DevProjexMcpTools(
 		return lines;
 	}
 
+	internal static void AddSearchCandidates(
+		McpSearchCandidateCollector collector,
+		string relativePath,
+		string fullPath,
+		string content,
+		IReadOnlyList<McpSearchMatchContext> matches,
+		IReadOnlyList<NavigationDeclaration> declarations,
+		McpSearchRegex regex,
+		int contextLines,
+		bool explicitScope)
+	{
+		var repeatedLines = new Dictionary<string, int>(StringComparer.Ordinal);
+		var ownerOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+		var fileOccurrence = 0;
+		foreach (var match in matches)
+		{
+			foreach (var matchLine in match.MatchLineNumbers)
+			{
+				var line = match.Lines.First(item => item.LineNumber == matchLine);
+				var firstContextLine = Math.Max(1, matchLine - contextLines);
+				var lastContextLine = checked(matchLine + contextLines);
+				var candidateContext = new McpSearchMatchContext(
+					[matchLine],
+					match.Lines
+						.Where(item => item.LineNumber >= firstContextLine && item.LineNumber <= lastContextLine)
+						.ToArray(),
+					StartsNewGroup: false);
+				var rendered = RenderGroupLines(relativePath, content, candidateContext);
+				if (rendered.Count == 0)
+					continue;
+
+				var declaration = FindContainingDeclaration(declarations, matchLine);
+				var quality = declaration is null
+					? McpDeclarationMatchQuality.None
+					: regex.DeclarationMatchQuality(declaration.Name);
+				var owner = declaration?.Owner ?? declaration?.Name ?? relativePath;
+				var ownerOccurrence = ownerOccurrences.GetValueOrDefault(owner);
+				ownerOccurrences[owner] = ownerOccurrence + 1;
+				var sourceLineIdentity = ContentFingerprint
+					.Compute(content.AsSpan(line.Offset, line.Length))
+					.ToHexString();
+				var repeated = repeatedLines.GetValueOrDefault(sourceLineIdentity);
+				repeatedLines[sourceLineIdentity] = repeated + 1;
+				var hint = regex.HasDeclarationHint(content, line.Offset, line.Length);
+				var group = new McpSearchRenderedGroup(
+					relativePath,
+					fullPath,
+					[matchLine],
+					rendered);
+				var stableText = rendered.First(item => item.IsMatch).Text;
+				collector.Consider(new McpSearchCandidate(
+					group,
+					matchLine,
+					McpSearchCandidateCollector.Score(
+						explicitScope,
+						fileOccurrence++,
+						quality,
+						hint,
+						ownerOccurrence,
+						repeated),
+					stableText,
+					checked(rendered.Sum(static item => item.Text.Length + Environment.NewLine.Length) +
+					        relativePath.Length + Environment.NewLine.Length)));
+			}
+		}
+	}
+
+	private static NavigationDeclaration? FindContainingDeclaration(
+		IReadOnlyList<NavigationDeclaration> declarations,
+		int line)
+	{
+		NavigationDeclaration? best = null;
+		foreach (var declaration in declarations)
+		{
+			if (line < declaration.StartLine || line > declaration.EndLine)
+				continue;
+			if (best is null ||
+			    declaration.EndLine - declaration.StartLine < best.EndLine - best.StartLine ||
+			    declaration.EndLine - declaration.StartLine == best.EndLine - best.StartLine &&
+			    declaration.EndIndex - declaration.StartIndex < best.EndIndex - best.StartIndex)
+			{
+				best = declaration;
+			}
+		}
+		return best;
+	}
+
+	internal static IReadOnlyList<McpSearchRenderedGroup> BuildOrderedSearchGroups(
+		IReadOnlyList<McpSearchCandidate> candidates)
+	{
+		if (candidates.Count == 0)
+			return [];
+
+		var fileOrder = new List<string>();
+		var byFile = new Dictionary<string, List<McpSearchCandidate>>(StringComparer.Ordinal);
+		foreach (var candidate in candidates)
+		{
+			if (!byFile.TryGetValue(candidate.Group.RelativePath, out var fileCandidates))
+			{
+				fileCandidates = [];
+				byFile[candidate.Group.RelativePath] = fileCandidates;
+				fileOrder.Add(candidate.Group.RelativePath);
+			}
+			fileCandidates.Add(candidate);
+		}
+
+		var result = new List<McpSearchRenderedGroup>(candidates.Count);
+		foreach (var path in fileOrder)
+		{
+			var ordered = byFile[path].OrderBy(static item => item.MatchLine).ToArray();
+			var currentMatches = new List<int>();
+			var currentLines = new SortedDictionary<int, McpSearchGroupLine>();
+			foreach (var candidate in ordered)
+			{
+				var firstLine = candidate.Group.Lines[0].LineNumber;
+				var adjacent = currentLines.Count == 0 || firstLine <= currentLines.Keys.Last() + 1;
+				if (!adjacent)
+				{
+					result.Add(new McpSearchRenderedGroup(
+						path,
+						ordered[0].Group.FullPath,
+						currentMatches.ToArray(),
+						currentLines.Values.ToArray()));
+					currentMatches.Clear();
+					currentLines.Clear();
+				}
+
+				currentMatches.Add(candidate.MatchLine);
+				foreach (var line in candidate.Group.Lines)
+				{
+					if (currentLines.TryGetValue(line.LineNumber, out var existing))
+					{
+						var isMatch = existing.IsMatch || line.IsMatch;
+						currentLines[line.LineNumber] = existing with
+						{
+							IsMatch = isMatch,
+							Text = isMatch && !existing.IsMatch
+								? MarkRenderedLineAsMatch(existing)
+								: existing.Text
+						};
+					}
+					else
+						currentLines[line.LineNumber] = line;
+				}
+			}
+
+			if (currentLines.Count > 0)
+			{
+				result.Add(new McpSearchRenderedGroup(
+					path,
+					ordered[0].Group.FullPath,
+					currentMatches.ToArray(),
+					currentLines.Values.ToArray()));
+			}
+		}
+		return result;
+	}
+
+	private static string MarkRenderedLineAsMatch(McpSearchGroupLine line)
+	{
+		var marker = line.LineNumber.ToString(CultureInfo.InvariantCulture).Length;
+		return marker < line.Text.Length && line.Text[marker] == '-'
+			? string.Concat(line.Text.AsSpan(0, marker), ":", line.Text.AsSpan(marker + 1))
+			: line.Text;
+	}
+
 	/// <summary>
 	/// Writes one set-aside group into the response, heading it with its path when the file changes
 	/// and separating it from the previous group of the same file otherwise. Stops on the match that
@@ -2929,7 +3135,7 @@ internal sealed class DevProjexMcpTools(
 		var bound = hitMatchBound
 			? $"{MaximumStoredSearchMatches.ToString("N0", CultureInfo.InvariantCulture)}-match"
 			: $"{MaximumStoredSearchCharacters.ToString("N0", CultureInfo.InvariantCulture)}-character";
-		return $"{reported}, and stopped at the {bound} store limit, so it holds only the first of them.";
+		return $"{reported}, and stopped at the {bound} store limit, so it holds only the retained subset that fit.";
 	}
 
 	/// <summary>
@@ -3052,6 +3258,42 @@ internal sealed class DevProjexMcpTools(
 			  $"{MaximumSearchContentCharacters.ToString(CultureInfo.InvariantCulture)}-character " +
 			  "search cap, so none were written."
 			: $"{reported}.";
+	}
+
+	internal static string FormatSearchBoundaryNotice(McpSearchBoundary boundary, bool hasStoredContinuation)
+	{
+		var prefix = boundary.IsComplete ? "[Search boundary] complete" : "[Search boundary] partial";
+		var counts =
+			$"sources inspected={boundary.InspectedSources.ToString(CultureInfo.InvariantCulture)}/" +
+			$"{boundary.EligibleSources.ToString(CultureInfo.InvariantCulture)} · " +
+			$"matches retained={boundary.RetainedMatches.ToString(CultureInfo.InvariantCulture)}/" +
+			$"{boundary.EncounteredMatches.ToString(CultureInfo.InvariantCulture)} · " +
+			$"matches written={boundary.WrittenMatches.ToString(CultureInfo.InvariantCulture)} · " +
+			$"declaration files named={boundary.NamedDeclarationFiles.ToString(CultureInfo.InvariantCulture)}";
+		if (boundary.IsComplete)
+			return $"{prefix} · {counts}.";
+
+		var limits = new List<string>(7);
+		if (boundary.InspectionByteLimitReached)
+			limits.Add("inspection-bytes");
+		if (boundary.RetainedMatchLimitReached)
+			limits.Add("retained-matches");
+		if (boundary.AnnotationFileLimitReached)
+			limits.Add("annotation-files");
+		if (boundary.ResponseCharacterLimitReached)
+			limits.Add("response-characters");
+		if (boundary.RequestResultLimitReached)
+			limits.Add("max-results");
+		if (boundary.RetainedCharacterLimitReached)
+			limits.Add("retained-characters");
+		if (boundary.StoredCharacterLimitReached)
+			limits.Add("stored-characters");
+		if (boundary.UnscannableSources > 0)
+			limits.Add("unscannable-sources");
+		var continuation = hasStoredContinuation
+			? "continue with read_pack for retained matches; narrow pattern, paths, or include_patterns and rerun for omitted evidence"
+			: "narrow pattern, paths, or include_patterns and continue the search";
+		return $"{prefix} · {counts} · limits={string.Join(',', limits)}; {continuation}.";
 	}
 
 	/// <summary>

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -28,7 +28,8 @@ internal sealed class DevProjexMcpTools(
 	private const int MaximumSearchContentCharacters = 16_000;
 	// A search that withholds matches keeps the rest of what it already scanned, so the caller can
 	// page it instead of running the same scan again. These bound what one session will hold for
-	// that: matches beyond the first are counted but not kept, and the response says so.
+	// that: weaker matches are displaced as stronger evidence arrives, and the response says when
+	// either bound withheld observed matches.
 	private const int MaximumStoredSearchMatches = 5_000;
 	private const int MaximumStoredSearchCharacters = 2_000_000;
 	private const int MaximumWithheldFilesReported = 20;
@@ -197,9 +198,9 @@ internal sealed class DevProjexMcpTools(
 				MaximumTreeLines,
 				cancellationToken);
 			int? automaticDepth = depth is null &&
-			                     format is TreeTextFormat.Ascii or TreeTextFormat.Markdown &&
-			                     !depthFit.FullTreeFits &&
-			                     depthFit.DeepestCompleteDepth >= 1
+								 format is TreeTextFormat.Ascii or TreeTextFormat.Markdown &&
+								 !depthFit.FullTreeFits &&
+								 depthFit.DeepestCompleteDepth >= 1
 				? depthFit.DeepestCompleteDepth
 				: null;
 			var effectiveDepth = depth ?? automaticDepth;
@@ -461,7 +462,7 @@ internal sealed class DevProjexMcpTools(
 				};
 			}
 			if (prepared.CompressionSnapshot?.Availability is
-			    { IsUnavailable: true, PrimaryReason: { Length: > 0 } reason } availability)
+				{ IsUnavailable: true, PrimaryReason: { Length: > 0 } reason } availability)
 			{
 				envelope["compressionUnavailable"] = new
 				{
@@ -842,7 +843,7 @@ internal sealed class DevProjexMcpTools(
 		});
 
 	[Description(
-		"Searches safe transformed project text with a timed .NET regular expression and keeps the strongest bounded evidence from inspected sources. It matches file content, never paths; find names with get_tree include_patterns. Use it for symbols or phrases; use related_files instead for dependency links. Returns path-grouped number:text matches, number-text context, merged groups, a complete|partial boundary with inspected/retained/written counts, and continuation guidance; line numbers refer to returned text, and redaction replacements never match. Key parameters: pattern; paths narrows to literal files or directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further. Read several hits with one batched get_file requests call.")]
+		"Searches safe transformed project text with a timed .NET regex and retains useful bounded evidence. It matches file content, never paths; find names with get_tree include_patterns. Use it for symbols or phrases; use related_files instead for dependency links. Returns path-grouped number:text matches, number-text context, merged groups, and a complete|partial boundary with inspected/retained/written counts plus continuation; line numbers refer to returned text, and redaction replacements never match. Parameters: pattern; paths=literal files/directories; context_lines=0..20; ignore_case=true|false; max_results=1..200; git_scope=staged|changes|diff:<ref>..<ref>; patterns and max_file_bytes narrow further. Read several hits with one batched get_file requests call.")]
 	public Task<CallToolResult> SearchProject(
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken) =>
@@ -891,7 +892,7 @@ internal sealed class DevProjexMcpTools(
 			foreach (var path in plan.IncludedFiles)
 			{
 				if (plan.EffectiveFileSizes?.TryGetValue(path, out var fileBytes) != true ||
-				    fileBytes < 0 || fileBytes > MaximumSearchInspectedBytes - inspectedBytes)
+					fileBytes < 0 || fileBytes > MaximumSearchInspectedBytes - inspectedBytes)
 				{
 					break;
 				}
@@ -908,47 +909,46 @@ internal sealed class DevProjexMcpTools(
 				(file, token) =>
 				{
 					inspectedSourceCount++;
-					// Matching runs to the stored bound rather than to what the response can show,
-					// because a match the response withholds is exactly the one the caller would
-					// otherwise ask a second search to find. Groups are rendered and set aside here
-					// because this is the only point at which the file's text exists; which of them
-					// the response carries is decided once the whole result is known.
-					var scan = McpSearchTextScanner.Scan(
+					// Every match in the inspected source reaches the bounded collector while this is
+					// the only point at which the transformed text exists. Only compact rendered windows
+					// survive the callback, and stronger late evidence can displace an earlier window.
+					var relative = McpProjectService.ToRelative(plan.SourceRoot, file.Path);
+					IReadOnlyList<NavigationDeclaration>? navigation = null;
+					var priorityState = new McpSearchFilePriorityState();
+					var scan = McpSearchTextScanner.ScanEach(
 						file.Content,
 						regex,
 						contextLines,
-						MaximumStoredSearchMatches,
 						file.ReplacementRanges,
+						match =>
+						{
+							navigation ??= McpSearchSymbols.CaptureNavigation(
+								Projects.DependencyFactsEngine,
+								relative,
+								file.Content,
+								token);
+							AddSearchCandidates(
+								candidates,
+								relative,
+								file.Path,
+								file.Content,
+								[match],
+								navigation,
+								regex,
+								contextLines,
+								explicitScope: HasItems(paths),
+								priorityState);
+						},
 						token);
 					totalMatches += scan.TotalMatches;
-					var found = scan.Matches.Sum(static group => group.MatchLineNumbers.Count);
 					if (scan.TotalMatches > 0)
-						matchingFiles++;
-					McpSearchExecutionHooks.AfterScan?.Invoke(file.Path);
-
-					var relative = McpProjectService.ToRelative(plan.SourceRoot, file.Path);
-					if (found > 0)
 					{
-						var navigation = McpSearchSymbols.CaptureNavigation(
-							Projects.DependencyFactsEngine,
-							relative,
-							file.Content,
-							token);
-						AddSearchCandidates(
-							candidates,
-							relative,
-							file.Path,
-							file.Content,
-							scan.Matches,
-							navigation,
-							regex,
-							contextLines,
-							explicitScope: HasItems(paths));
-
+						matchingFiles++;
+						McpSearchExecutionHooks.AfterScan?.Invoke(file.Path);
 						var annotatedFiles = candidates.SelectFilesForAnnotation(McpSearchSymbols.MaximumAnnotatedFiles);
 						foreach (var stale in navigationByFile.Keys.Where(path => !annotatedFiles.Contains(path)).ToArray())
 							navigationByFile.Remove(stale);
-						if (annotatedFiles.Contains(relative))
+						if (navigation is not null && annotatedFiles.Contains(relative))
 							navigationByFile[relative] = navigation;
 					}
 
@@ -956,10 +956,8 @@ internal sealed class DevProjexMcpTools(
 				},
 				cancellationToken).ConfigureAwait(false);
 
-			// A declaration of the searched term is worth more than a mention of it, and the only
-			// case where that choice exists is a slice: when max_results withholds, the response
-			// carries some of what was found and the rest is paged. A search that shows everything
-			// it found has nothing to choose between and is left exactly as it was.
+			// Candidate priority is applied before response sizing, so the retained set and the
+			// displayed slice are both independent of directory traversal order.
 			var ordered = BuildOrderedSearchGroups(candidates.Snapshot());
 			storeHitMatchBound = candidates.MatchCapacityReached;
 			var retentionCharacterBoundReached = candidates.CharacterCapacityReached;
@@ -1388,7 +1386,7 @@ internal sealed class DevProjexMcpTools(
 				resolvedRequests.Add(new McpResolvedFileReadRequest(item, physicalPath));
 			}
 			catch (McpToolException exception) when (exception.Code is
-			       McpErrorCodes.PathNotFound or McpErrorCodes.RootViolation)
+				   McpErrorCodes.PathNotFound or McpErrorCodes.RootViolation)
 			{
 				resolvedRequests.Add(new McpResolvedFileReadRequest(item, PhysicalPath: null));
 			}
@@ -1413,7 +1411,7 @@ internal sealed class DevProjexMcpTools(
 		{
 			var resolved = resolvedRequests[index];
 			if (resolved.Request.Symbol is null || resolved.PhysicalPath is null ||
-			    !transformed.TryGetValue(resolved.PhysicalPath, out var file))
+				!transformed.TryGetValue(resolved.PhysicalPath, out var file))
 				continue;
 			var located = McpSearchSymbols.ResolveSymbol(
 				Projects.DependencyFactsEngine,
@@ -1492,7 +1490,7 @@ internal sealed class DevProjexMcpTools(
 			var headerLines = 4;
 			var availableLines = sectionBudgetLines - usedLines - (sections.Length == 0 ? 0 : 1) - headerLines;
 			var availableCharacters = sectionBudgetCharacters - sections.Length - separator.Length -
-			                          headerPrefix.Length - "Status: partial\nLines: 1-1 of 1\n".Length;
+									  headerPrefix.Length - "Status: partial\nLines: 1-1 of 1\n".Length;
 			if (availableLines <= 0 || availableCharacters <= 0)
 			{
 				foreach (var range in group.Ranges)
@@ -1552,7 +1550,7 @@ internal sealed class DevProjexMcpTools(
 		var counts = status.Values.GroupBy(static value => value, StringComparer.Ordinal)
 			.ToDictionary(static group => group.Key, static group => group.Count(), StringComparer.Ordinal);
 		var summary = $"[Batch read] ok={GetCount("ok")} · partial={GetCount("partial")} · " +
-		              $"not-returned={GetCount("not-returned")} · unavailable={GetCount("unavailable")}.";
+					  $"not-returned={GetCount("not-returned")} · unavailable={GetCount("unavailable")}.";
 		return new McpBatchFileReadResult(
 			body,
 			summary,
@@ -1582,7 +1580,7 @@ internal sealed class DevProjexMcpTools(
 			{
 				var matching = groups
 					.Where(group => SameRequestedFile(group, request) &&
-					                group.StartLine <= range.EndLine && range.StartLine <= group.EndLine)
+									group.StartLine <= range.EndLine && range.StartLine <= group.EndLine)
 					.ToArray();
 				if (matching.Length == 0)
 				{
@@ -1649,8 +1647,8 @@ internal sealed class DevProjexMcpTools(
 		if (page.IsTruncated)
 		{
 			return $"[Showing lines {page.StartLine}-{page.EndLine} of {page.TotalLines}; " +
-			       $"continue with start_line={page.NextLine ?? page.EndLine + 1}" +
-			       (page.NextColumn is > 1 ? $" start_column={page.NextColumn}" : string.Empty) + ".]";
+				   $"continue with start_line={page.NextLine ?? page.EndLine + 1}" +
+				   (page.NextColumn is > 1 ? $" start_column={page.NextColumn}" : string.Empty) + ".]";
 		}
 
 		return requestedEnd > page.TotalLines
@@ -1806,7 +1804,7 @@ internal sealed class DevProjexMcpTools(
 		foreach (var descriptor in ProjectPresentationCatalog.Exclusions)
 		{
 			if (string.Equals(descriptor.Token, token, StringComparison.OrdinalIgnoreCase) &&
-			    descriptor.Id is { } exclusion)
+				descriptor.Id is { } exclusion)
 			{
 				return exclusion;
 			}
@@ -2044,7 +2042,7 @@ internal sealed class DevProjexMcpTools(
 			return McpSpotlight.Wrap(content);
 
 		return McpSpotlight.Wrap(content) + "\n\n" +
-		       McpSpotlight.Wrap(formattedBudgetReport);
+			   McpSpotlight.Wrap(formattedBudgetReport);
 	}
 
 	private static string BuildStoredPackResponse(
@@ -2057,7 +2055,7 @@ internal sealed class DevProjexMcpTools(
 		string? planWarnings)
 	{
 		var header = $"Pack stored as '{pack.Id}' ({pack.Characters} characters, {pack.Lines} lines). " +
-		             "Call read_pack with this pack_id to read ranges, or search_project to locate source content.\n";
+					 "Call read_pack with this pack_id to read ranges, or search_project to locate source content.\n";
 		var treePreview = TakeCompleteScalarPrefix(tree, MaximumStoredTreePreviewCharacters);
 		var treePreviewWasTruncated = treeWasTruncated || treePreview.Length < tree.Length;
 		var budgetReport = formattedBudgetReport is null
@@ -2189,9 +2187,9 @@ internal sealed class DevProjexMcpTools(
 		var prefixLimit = maximumCharacters - marker.Length - 1;
 		var prefixLength = Math.Min(prefixLimit, content.Length);
 		if (prefixLength > 0 &&
-		    prefixLength < content.Length &&
-		    char.IsHighSurrogate(content[prefixLength - 1]) &&
-		    char.IsLowSurrogate(content[prefixLength]))
+			prefixLength < content.Length &&
+			char.IsHighSurrogate(content[prefixLength - 1]) &&
+			char.IsLowSurrogate(content[prefixLength]))
 		{
 			prefixLength--;
 		}
@@ -2206,9 +2204,9 @@ internal sealed class DevProjexMcpTools(
 	{
 		var length = Math.Min(content.Length, maximumCharacters);
 		if (length > 0 &&
-		    length < content.Length &&
-		    char.IsHighSurrogate(content[length - 1]) &&
-		    char.IsLowSurrogate(content[length]))
+			length < content.Length &&
+			char.IsHighSurrogate(content[length - 1]) &&
+			char.IsLowSurrogate(content[length]))
 		{
 			length--;
 		}
@@ -2251,8 +2249,8 @@ internal sealed class DevProjexMcpTools(
 			_ => throw new ArgumentOutOfRangeException(nameof(resultKind), resultKind, null)
 		};
 		return $"[Warning {McpErrorCodes.PayloadTruncated}] Mandatory redaction could not fully inspect {subject}. " +
-		       $"{consequence} Results are partial. Set max_file_bytes={SecretRedactionOutputPreparer.MaximumScannableFileBytes} " +
-		       "or lower, exclude oversized or unsupported files, and retry.";
+			   $"{consequence} Results are partial. Set max_file_bytes={SecretRedactionOutputPreparer.MaximumScannableFileBytes} " +
+			   "or lower, exclude oversized or unsupported files, and retry.";
 	}
 
 	private static string? FormatCompressionUnavailable(CodeCompressionSnapshot? snapshot)
@@ -2265,13 +2263,13 @@ internal sealed class DevProjexMcpTools(
 			.Distinct(StringComparer.Ordinal)
 			.Count();
 		return $"[Compression unavailable] failures={availability.Failures.Count.ToString(CultureInfo.InvariantCulture)} · " +
-		       $"languages={languages.ToString(CultureInfo.InvariantCulture)}";
+			   $"languages={languages.ToString(CultureInfo.InvariantCulture)}";
 	}
 
 	private static ProjectContextPlan WithoutWarningDiagnostics(ProjectContextPlan plan)
 	{
 		if (!plan.Diagnostics.Any(static diagnostic =>
-			    diagnostic.Severity == ContextDiagnosticSeverity.Warning))
+				diagnostic.Severity == ContextDiagnosticSeverity.Warning))
 			return plan;
 		return plan with
 		{
@@ -2420,10 +2418,10 @@ internal sealed class DevProjexMcpTools(
 			listed.Select(pattern => McpTextEscaping.EscapeSingleLine(Truncate(pattern))));
 		var remaining = mix.UnmatchedPatterns.Count - listed.Length;
 		return summary +
-		       $"\n[Detail] unmatched: {names}" +
-		       (remaining > 0
-			       ? $" and {remaining.ToString(CultureInfo.InvariantCulture)} more"
-			       : string.Empty);
+			   $"\n[Detail] unmatched: {names}" +
+			   (remaining > 0
+				   ? $" and {remaining.ToString(CultureInfo.InvariantCulture)} more"
+				   : string.Empty);
 	}
 
 	private static string Truncate(string pattern) =>
@@ -2473,7 +2471,7 @@ internal sealed class DevProjexMcpTools(
 		if (report.SkippedFileCount > 0)
 		{
 			output.Append(report.RankedSkippedFiles is { Count: > 0 } &&
-			              report.LargestSkippedFiles.Any(file => file.EstimatedTokens > report.MaximumEstimatedTokens)
+						  report.LargestSkippedFiles.Any(file => file.EstimatedTokens > report.MaximumEstimatedTokens)
 				? "Tip: increase max_tokens or lower detail for a file that is larger than the entire budget."
 				: "Tip: use detail=compact or detail=signatures, narrow the selection, or increase max_tokens.");
 		}
@@ -2494,12 +2492,12 @@ internal sealed class DevProjexMcpTools(
 		for (var attempt = 0; attempt < 8; attempt++)
 		{
 			var accounting = $"[Budget accounting] content ≈ {report.IncludedEstimatedTokens.ToString(CultureInfo.InvariantCulture)} of " +
-			                 $"{report.MaximumEstimatedTokens.ToString(CultureInfo.InvariantCulture)} tokens · budget report ≈ " +
-			                 $"{reportTokens.ToString(CultureInfo.InvariantCulture)}" +
-			                 (storedDocumentCharacters is { } storedCharacters
-				                 ? $" · stored document ≈ {CodeCompressionSnapshot.EstimateTokens(storedCharacters).ToString(CultureInfo.InvariantCulture)}"
-				                 : string.Empty) +
-			                 $" · reply ≈ {replyTokens.ToString(CultureInfo.InvariantCulture)}";
+							 $"{report.MaximumEstimatedTokens.ToString(CultureInfo.InvariantCulture)} tokens · budget report ≈ " +
+							 $"{reportTokens.ToString(CultureInfo.InvariantCulture)}" +
+							 (storedDocumentCharacters is { } storedCharacters
+								 ? $" · stored document ≈ {CodeCompressionSnapshot.EstimateTokens(storedCharacters).ToString(CultureInfo.InvariantCulture)}"
+								 : string.Empty) +
+							 $" · reply ≈ {replyTokens.ToString(CultureInfo.InvariantCulture)}";
 			result = AppendTrustedNotices(responseWithoutAccounting, accounting);
 			var next = CodeCompressionSnapshot.EstimateTokens(result.Length + additionalReplyCharacters);
 			if (next == replyTokens)
@@ -2519,10 +2517,10 @@ internal sealed class DevProjexMcpTools(
 			.Distinct(StringComparer.Ordinal)
 			.Count();
 		return $"[Dependency configuration] problems={diagnostics.Count.ToString(CultureInfo.InvariantCulture)} · " +
-		       $"missing={diagnostics.Count(static diagnostic => diagnostic.State == DependencyConfigurationState.Missing).ToString(CultureInfo.InvariantCulture)} · " +
-		       $"corrupt={diagnostics.Count(static diagnostic => diagnostic.State == DependencyConfigurationState.Corrupt).ToString(CultureInfo.InvariantCulture)} · " +
-		       $"unsupported-semantics={diagnostics.Count(static diagnostic => diagnostic.State == DependencyConfigurationState.UnsupportedSemantics).ToString(CultureInfo.InvariantCulture)} · " +
-		       $"affected-scopes={affectedScopes.ToString(CultureInfo.InvariantCulture)}";
+			   $"missing={diagnostics.Count(static diagnostic => diagnostic.State == DependencyConfigurationState.Missing).ToString(CultureInfo.InvariantCulture)} · " +
+			   $"corrupt={diagnostics.Count(static diagnostic => diagnostic.State == DependencyConfigurationState.Corrupt).ToString(CultureInfo.InvariantCulture)} · " +
+			   $"unsupported-semantics={diagnostics.Count(static diagnostic => diagnostic.State == DependencyConfigurationState.UnsupportedSemantics).ToString(CultureInfo.InvariantCulture)} · " +
+			   $"affected-scopes={affectedScopes.ToString(CultureInfo.InvariantCulture)}";
 	}
 
 	private static string? FormatDependencyConfigurationData(
@@ -2632,11 +2630,10 @@ internal sealed class DevProjexMcpTools(
 		IReadOnlyList<NavigationDeclaration> declarations,
 		McpSearchRegex regex,
 		int contextLines,
-		bool explicitScope)
+		bool explicitScope,
+		McpSearchFilePriorityState? priorityState = null)
 	{
-		var repeatedLines = new Dictionary<string, int>(StringComparer.Ordinal);
-		var ownerOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
-		var fileOccurrence = 0;
+		priorityState ??= new McpSearchFilePriorityState();
 		foreach (var match in matches)
 		{
 			foreach (var matchLine in match.MatchLineNumbers)
@@ -2659,13 +2656,11 @@ internal sealed class DevProjexMcpTools(
 					? McpDeclarationMatchQuality.None
 					: regex.DeclarationMatchQuality(declaration.Name);
 				var owner = declaration?.Owner ?? declaration?.Name ?? relativePath;
-				var ownerOccurrence = ownerOccurrences.GetValueOrDefault(owner);
-				ownerOccurrences[owner] = ownerOccurrence + 1;
+				var ownerOccurrence = priorityState.TakeOwnerOccurrence(owner);
 				var sourceLineIdentity = ContentFingerprint
 					.Compute(content.AsSpan(line.Offset, line.Length))
 					.ToHexString();
-				var repeated = repeatedLines.GetValueOrDefault(sourceLineIdentity);
-				repeatedLines[sourceLineIdentity] = repeated + 1;
+				var repeated = priorityState.TakeRepeatedLineOccurrence(sourceLineIdentity);
 				var hint = regex.HasDeclarationHint(content, line.Offset, line.Length);
 				var group = new McpSearchRenderedGroup(
 					relativePath,
@@ -2678,14 +2673,14 @@ internal sealed class DevProjexMcpTools(
 					matchLine,
 					McpSearchCandidateCollector.Score(
 						explicitScope,
-						fileOccurrence++,
+						priorityState.TakeFileOccurrence(),
 						quality,
 						hint,
 						ownerOccurrence,
 						repeated),
 					stableText,
 					checked(rendered.Sum(static item => item.Text.Length + Environment.NewLine.Length) +
-					        relativePath.Length + Environment.NewLine.Length)));
+							relativePath.Length + Environment.NewLine.Length)));
 			}
 		}
 	}
@@ -2700,9 +2695,9 @@ internal sealed class DevProjexMcpTools(
 			if (line < declaration.StartLine || line > declaration.EndLine)
 				continue;
 			if (best is null ||
-			    declaration.EndLine - declaration.StartLine < best.EndLine - best.StartLine ||
-			    declaration.EndLine - declaration.StartLine == best.EndLine - best.StartLine &&
-			    declaration.EndIndex - declaration.StartIndex < best.EndIndex - best.StartIndex)
+				declaration.EndLine - declaration.StartLine < best.EndLine - best.StartLine ||
+				declaration.EndLine - declaration.StartLine == best.EndLine - best.StartLine &&
+				declaration.EndIndex - declaration.StartIndex < best.EndIndex - best.StartIndex)
 			{
 				best = declaration;
 			}
@@ -2956,56 +2951,6 @@ internal sealed class DevProjexMcpTools(
 	}
 
 	/// <summary>
-	/// Puts the groups whose matches sit inside a declaration ahead of those whose do not, keeping
-	/// the order the selection produced within each. A generated report that declares nothing
-	/// therefore stops crowding out the declaration of the term that was searched for.
-	/// </summary>
-	/// <remarks>
-	/// The signal is the one the naming already computes, so this is a comparison rather than a
-	/// mechanism: no directory list, no ranking graph, no index a search does not already build.
-	/// Both sides keep their existing relative order, so the same query on the same tree always
-	/// produces the same answer.
-	/// </remarks>
-	private static IReadOnlyList<McpSearchRenderedGroup>? OrderDeclarationsFirst(
-		IReadOnlyList<McpSearchRenderedGroup> groups,
-		IReadOnlyDictionary<string, IReadOnlyList<NavigationDeclaration>> navigationByFile,
-		CancellationToken cancellationToken)
-	{
-		var hits = groups
-			.SelectMany(group => group.MatchLines.Select(line =>
-				new McpSearchHit(group.RelativePath, group.FullPath, line)))
-			.ToArray();
-		var declarations = McpSearchSymbols.Resolve(hits, navigationByFile, cancellationToken);
-		// A search that touched more files than the naming can reach knows nothing about the ones
-		// past that bound, and ordering on a signal it does not have would claim an order it did
-		// not apply. It keeps selection order instead, and says nothing.
-		if (declarations.Names.Count == 0 || declarations.FilesBeyondTheLimit > 0)
-			return null;
-
-		// Files, not groups: a file's groups must stay one block, in their own order, or the same
-		// path is written twice and its line numbers stop climbing.
-		var declaringFiles = new HashSet<string>(StringComparer.Ordinal);
-		foreach (var group in groups)
-		{
-			if (group.MatchLines.Any(line =>
-				    declarations.Names.ContainsKey(new McpSearchHitKey(group.RelativePath, line))))
-			{
-				declaringFiles.Add(group.RelativePath);
-			}
-		}
-
-		if (declaringFiles.Count == 0)
-			return null;
-
-		var declaring = new List<McpSearchRenderedGroup>(groups.Count);
-		var mentioning = new List<McpSearchRenderedGroup>(groups.Count);
-		foreach (var group in groups)
-			(declaringFiles.Contains(group.RelativePath) ? declaring : mentioning).Add(group);
-
-		return [.. declaring, .. mentioning];
-	}
-
-	/// <summary>
 	/// Keeps what the response could not carry, under an id the caller can page, so the matches
 	/// this scan already found are not scanned for a second time.
 	/// </summary>
@@ -3235,9 +3180,9 @@ internal sealed class DevProjexMcpTools(
 	private static string? FormatSymbolCoverageNotice(McpSearchSymbolResult symbols, bool namesRefused)
 	{
 		if (!namesRefused &&
-		    symbols.AnnotatedHits == 0 &&
-		    symbols.FilesWithoutDeclarations == 0 &&
-		    symbols.FilesBeyondTheLimit == 0)
+			symbols.AnnotatedHits == 0 &&
+			symbols.FilesWithoutDeclarations == 0 &&
+			symbols.FilesBeyondTheLimit == 0)
 		{
 			return null;
 		}
@@ -3499,7 +3444,7 @@ internal sealed class DevProjexMcpTools(
 				.Append(entry.Dependencies.ToString(CultureInfo.InvariantCulture))
 				.Append(" · commits ")
 				.Append(entry.Commits?.ToString(CultureInfo.InvariantCulture) ??
-				        $"unavailable: {entry.GitUnavailableReason}")
+						$"unavailable: {entry.GitUnavailableReason}")
 				.Append('/')
 				.Append(report.GitWindow.ToString(CultureInfo.InvariantCulture));
 			if (entry.Role == ImportanceFileRole.TestSource)
@@ -3699,7 +3644,7 @@ internal sealed class DevProjexMcpTools(
 			else
 			{
 				jsonDeltas[childDepth] += 1L + directoryCount + fileCount +
-				                          (directoryCount > 0 && fileCount > 0 ? 2 : 0);
+										  (directoryCount > 0 && fileCount > 0 ? 2 : 0);
 				xmlDeltas[childDepth] += 1L + directoryCount + fileCount;
 			}
 		}
@@ -3893,9 +3838,9 @@ internal sealed class DevProjexMcpTools(
 	{
 		var length = Math.Min(value.Length, maximumCharacters);
 		if (length > 0 &&
-		    length < value.Length &&
-		    char.IsHighSurrogate(value[length - 1]) &&
-		    char.IsLowSurrogate(value[length]))
+			length < value.Length &&
+			char.IsHighSurrogate(value[length - 1]) &&
+			char.IsLowSurrogate(value[length]))
 		{
 			length--;
 		}

--- a/Apps/Mcp/DevProjexMcpTools.cs
+++ b/Apps/Mcp/DevProjexMcpTools.cs
@@ -1068,6 +1068,7 @@ internal sealed class DevProjexMcpTools(
 			var namesRefused = !InsertDeclarationHeaders(output, renderedLines, symbols);
 			if (namesRefused)
 				symbols = symbols with { AnnotatedHits = 0 };
+			var responseCharacterLimitReached = resultGroupTruncated || namesRefused;
 			var declarationsListed = AppendDeclarationSelectors(output, symbols.Declarations);
 			// What the response could not carry is kept in the session, so the way forward is to
 			// page what this scan already found rather than to run the same scan again.
@@ -1107,7 +1108,7 @@ internal sealed class DevProjexMcpTools(
 				inspectionBudgetReached,
 				storeHitMatchBound,
 				annotationLimitReached,
-				resultGroupTruncated,
+				responseCharacterLimitReached,
 				requestResultLimitReached,
 				retentionCharacterBoundReached,
 				storeHitCharacterBound,

--- a/Apps/Mcp/McpSearchCandidateCollector.cs
+++ b/Apps/Mcp/McpSearchCandidateCollector.cs
@@ -88,8 +88,8 @@ internal sealed class McpSearchCandidateCollector(int capacity, int characterCap
 		};
 		var repetitionPenalty = Math.Min(MaximumRepetitionPenalty, repeatedContentOccurrence);
 		return (explicitScope ? ExplicitScopeWeight : 0) +
-		       fileDiversity + declaration + (declarationHint ? DeclarationHintWeight : 0) +
-		       ownerDiversity - repetitionPenalty;
+			   fileDiversity + declaration + (declarationHint ? DeclarationHintWeight : 0) +
+			   ownerDiversity - repetitionPenalty;
 	}
 
 	private sealed class McpSearchCandidateComparer : IComparer<McpSearchCandidate>
@@ -116,6 +116,33 @@ internal sealed class McpSearchCandidateCollector(int capacity, int characterCap
 				return line;
 			return StringComparer.Ordinal.Compare(left.StableText, right.StableText);
 		}
+	}
+}
+
+internal sealed class McpSearchFilePriorityState
+{
+	private const int MaximumTrackedIdentities = 5_000;
+	private readonly Dictionary<string, int> repeatedLines = new(StringComparer.Ordinal);
+	private readonly Dictionary<string, int> ownerOccurrences = new(StringComparer.Ordinal);
+	private int fileOccurrence;
+
+	public int TakeFileOccurrence() => fileOccurrence++;
+
+	public int TakeOwnerOccurrence(string owner) => TakeOccurrence(ownerOccurrences, owner);
+
+	public int TakeRepeatedLineOccurrence(string identity) => TakeOccurrence(repeatedLines, identity);
+
+	private static int TakeOccurrence(Dictionary<string, int> occurrences, string key)
+	{
+		if (occurrences.TryGetValue(key, out var occurrence))
+		{
+			occurrences[key] = occurrence + 1;
+			return occurrence;
+		}
+
+		if (occurrences.Count < MaximumTrackedIdentities)
+			occurrences[key] = 1;
+		return 0;
 	}
 }
 

--- a/Apps/Mcp/McpSearchCandidateCollector.cs
+++ b/Apps/Mcp/McpSearchCandidateCollector.cs
@@ -1,0 +1,161 @@
+namespace DevProjex.Mcp;
+
+/// <summary>
+/// Keeps the strongest bounded set of matches seen so far. Every comparison is derived from the
+/// candidate itself, so replacing a weak early match with a stronger late one is independent of
+/// directory traversal order.
+/// </summary>
+internal sealed class McpSearchCandidateCollector(int capacity, int characterCapacity)
+{
+	internal const int ExplicitScopeWeight = 1024;
+	internal const int FileDiversityWeight = 512;
+	internal const int FullyQualifiedDeclarationWeight = 160;
+	internal const int SimpleDeclarationWeight = 128;
+	internal const int DeclarationHintWeight = 64;
+	internal const int OwnerDiversityWeight = 32;
+	internal const int MaximumRepetitionPenalty = 31;
+
+	private readonly SortedSet<McpSearchCandidate> candidates = new(McpSearchCandidateComparer.Instance);
+	private int retainedCharacters;
+
+	public int Count => candidates.Count;
+	public int RetainedCharacters => retainedCharacters;
+	public bool MatchCapacityReached { get; private set; }
+	public bool CharacterCapacityReached { get; private set; }
+
+	public void Consider(McpSearchCandidate candidate)
+	{
+		ArgumentNullException.ThrowIfNull(candidate);
+		if (capacity <= 0)
+		{
+			MatchCapacityReached = true;
+			return;
+		}
+		if (candidate.StorageCharacters > characterCapacity)
+		{
+			CharacterCapacityReached = true;
+			return;
+		}
+		if (!candidates.Add(candidate))
+			return;
+		retainedCharacters += candidate.StorageCharacters;
+		while (candidates.Count > capacity || retainedCharacters > characterCapacity)
+		{
+			MatchCapacityReached |= candidates.Count > capacity;
+			CharacterCapacityReached |= retainedCharacters > characterCapacity;
+			var removed = candidates.Max!;
+			candidates.Remove(removed);
+			retainedCharacters -= removed.StorageCharacters;
+		}
+	}
+
+	public IReadOnlyList<McpSearchCandidate> Snapshot() => candidates.ToArray();
+
+	public IReadOnlySet<string> SelectFilesForAnnotation(int maximumFiles)
+	{
+		if (maximumFiles <= 0 || candidates.Count == 0)
+			return new HashSet<string>(StringComparer.Ordinal);
+
+		var selected = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var candidate in candidates)
+		{
+			if (!selected.Add(candidate.Group.RelativePath))
+				continue;
+			if (selected.Count == maximumFiles)
+				break;
+		}
+		return selected;
+	}
+
+	public static int Score(
+		bool explicitScope,
+		int fileOccurrence,
+		McpDeclarationMatchQuality declarationQuality,
+		bool declarationHint,
+		int ownerOccurrence,
+		int repeatedContentOccurrence)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(fileOccurrence);
+		ArgumentOutOfRangeException.ThrowIfNegative(ownerOccurrence);
+		ArgumentOutOfRangeException.ThrowIfNegative(repeatedContentOccurrence);
+		var fileDiversity = FileDiversityWeight / checked(fileOccurrence + 1);
+		var ownerDiversity = OwnerDiversityWeight / checked(ownerOccurrence + 1);
+		var declaration = declarationQuality switch
+		{
+			McpDeclarationMatchQuality.FullyQualified => FullyQualifiedDeclarationWeight,
+			McpDeclarationMatchQuality.SimpleName => SimpleDeclarationWeight,
+			_ => 0
+		};
+		var repetitionPenalty = Math.Min(MaximumRepetitionPenalty, repeatedContentOccurrence);
+		return (explicitScope ? ExplicitScopeWeight : 0) +
+		       fileDiversity + declaration + (declarationHint ? DeclarationHintWeight : 0) +
+		       ownerDiversity - repetitionPenalty;
+	}
+
+	private sealed class McpSearchCandidateComparer : IComparer<McpSearchCandidate>
+	{
+		public static readonly McpSearchCandidateComparer Instance = new();
+
+		public int Compare(McpSearchCandidate? left, McpSearchCandidate? right)
+		{
+			if (ReferenceEquals(left, right))
+				return 0;
+			if (left is null)
+				return 1;
+			if (right is null)
+				return -1;
+
+			var score = right.Score.CompareTo(left.Score);
+			if (score != 0)
+				return score;
+			var path = StringComparer.Ordinal.Compare(left.Group.RelativePath, right.Group.RelativePath);
+			if (path != 0)
+				return path;
+			var line = left.MatchLine.CompareTo(right.MatchLine);
+			if (line != 0)
+				return line;
+			return StringComparer.Ordinal.Compare(left.StableText, right.StableText);
+		}
+	}
+}
+
+internal enum McpDeclarationMatchQuality
+{
+	None,
+	SimpleName,
+	FullyQualified
+}
+
+internal sealed record McpSearchCandidate(
+	McpSearchRenderedGroup Group,
+	int MatchLine,
+	int Score,
+	string StableText,
+	int StorageCharacters);
+
+internal readonly record struct McpSearchBoundary(
+	int EligibleSources,
+	int InspectedSources,
+	int EncounteredMatches,
+	int RetainedMatches,
+	int WrittenMatches,
+	int NamedDeclarationFiles,
+	bool InspectionByteLimitReached,
+	bool RetainedMatchLimitReached,
+	bool AnnotationFileLimitReached,
+	bool ResponseCharacterLimitReached,
+	bool RequestResultLimitReached,
+	bool RetainedCharacterLimitReached,
+	bool StoredCharacterLimitReached,
+	int UnscannableSources)
+{
+	public bool IsComplete =>
+		!InspectionByteLimitReached &&
+		!RetainedMatchLimitReached &&
+		!AnnotationFileLimitReached &&
+		!ResponseCharacterLimitReached &&
+		!RequestResultLimitReached &&
+		!RetainedCharacterLimitReached &&
+		!StoredCharacterLimitReached &&
+		UnscannableSources == 0;
+}

--- a/Apps/Mcp/McpSearchExecutionHooks.cs
+++ b/Apps/Mcp/McpSearchExecutionHooks.cs
@@ -1,0 +1,12 @@
+namespace DevProjex.Mcp;
+
+internal static class McpSearchExecutionHooks
+{
+	private static Action<string>? afterScan;
+
+	internal static Action<string>? AfterScan
+	{
+		get => Volatile.Read(ref afterScan);
+		set => Volatile.Write(ref afterScan, value);
+	}
+}

--- a/Apps/Mcp/McpSearchRegex.cs
+++ b/Apps/Mcp/McpSearchRegex.cs
@@ -1,7 +1,13 @@
+using System.Buffers;
+
 namespace DevProjex.Mcp;
 
 internal sealed class McpSearchRegex
 {
+	private static readonly SearchValues<string> DeclarationKeywords = SearchValues.Create(
+		["class", "interface", "struct", "record", "enum", "delegate", "type", "trait", "def", "function", "func", "fn"],
+		StringComparison.Ordinal);
+	private static readonly SearchValues<char> DeclarationSeparators = SearchValues.Create(" \t({;:");
 	internal const int MaximumPatternLength = 4096;
 	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(2);
 	private readonly Regex _regex;
@@ -40,6 +46,56 @@ internal sealed class McpSearchRegex
 	{
 		ArgumentNullException.ThrowIfNull(input);
 		return IsMatch(input.AsSpan(start, length));
+	}
+
+	public McpDeclarationMatchQuality DeclarationMatchQuality(string declaredName)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(declaredName);
+		var separator = declaredName.AsSpan().LastIndexOfAny('.', '#', '/');
+		var simpleName = separator < 0 ? declaredName : declaredName[(separator + 1)..];
+		if (MatchesWhole(declaredName))
+			return McpDeclarationMatchQuality.FullyQualified;
+		return MatchesWhole(simpleName)
+			? McpDeclarationMatchQuality.SimpleName
+			: McpDeclarationMatchQuality.None;
+	}
+
+	public bool HasDeclarationHint(string input, int start, int length)
+	{
+		ArgumentNullException.ThrowIfNull(input);
+		try
+		{
+			foreach (var match in _regex.EnumerateMatches(input.AsSpan(start, length)))
+			{
+				var prefix = input.AsSpan(start, match.Index).TrimEnd();
+				var wordStart = prefix.LastIndexOfAny(DeclarationSeparators);
+				var word = prefix[(wordStart + 1)..];
+				if (DeclarationKeywords.Contains(word.ToString()))
+					return true;
+			}
+			return false;
+		}
+		catch (RegexMatchTimeoutException)
+		{
+			throw InvalidPatternTimeout();
+		}
+	}
+
+	private bool MatchesWhole(string input)
+	{
+		try
+		{
+			foreach (var match in _regex.EnumerateMatches(input))
+			{
+				if (match.Index == 0 && match.Length == input.Length)
+					return true;
+			}
+			return false;
+		}
+		catch (RegexMatchTimeoutException)
+		{
+			throw InvalidPatternTimeout();
+		}
 	}
 
 	public bool IsMatch(

--- a/Apps/Mcp/McpSearchTextScanner.cs
+++ b/Apps/Mcp/McpSearchTextScanner.cs
@@ -18,6 +18,10 @@ internal sealed record McpSearchTextScanResult(
 	IReadOnlyList<McpSearchMatchContext> Matches,
 	long ProtectedRangeComparisons);
 
+internal readonly record struct McpSearchStreamResult(
+	int TotalMatches,
+	long ProtectedRangeComparisons);
+
 internal readonly record struct McpSearchAppendResult(
 	int WrittenMatches,
 	bool Truncated);
@@ -40,20 +44,46 @@ internal static class McpSearchTextScanner
 		IReadOnlyList<TransformedTextRange> protectedRanges,
 		CancellationToken cancellationToken)
 	{
+		ArgumentOutOfRangeException.ThrowIfNegative(maximumStoredMatches);
+		var stored = new List<McpSearchMatchContext>(maximumStoredMatches);
+		var result = ScanEach(
+			content,
+			regex,
+			contextLines,
+			protectedRanges,
+			match =>
+			{
+				if (stored.Count < maximumStoredMatches)
+					stored.Add(match);
+			},
+			cancellationToken);
+		return new McpSearchTextScanResult(
+			result.TotalMatches,
+			MergeContexts(stored),
+			result.ProtectedRangeComparisons);
+	}
+
+	public static McpSearchStreamResult ScanEach(
+		string content,
+		McpSearchRegex regex,
+		int contextLines,
+		IReadOnlyList<TransformedTextRange> protectedRanges,
+		Action<McpSearchMatchContext> consume,
+		CancellationToken cancellationToken)
+	{
 		ArgumentNullException.ThrowIfNull(content);
 		ArgumentNullException.ThrowIfNull(regex);
 		ArgumentNullException.ThrowIfNull(protectedRanges);
+		ArgumentNullException.ThrowIfNull(consume);
 		ArgumentOutOfRangeException.ThrowIfNegative(contextLines);
-		ArgumentOutOfRangeException.ThrowIfNegative(maximumStoredMatches);
 		cancellationToken.ThrowIfCancellationRequested();
 		if (content.Length == 0)
-			return new McpSearchTextScanResult(0, [], 0);
+			return new McpSearchStreamResult(0, 0);
 
 		var previous = contextLines == 0
 			? null
 			: new Queue<McpTextLineRange>(contextLines);
-		var active = new List<PendingMatch>(Math.Min(contextLines + 1, maximumStoredMatches));
-		var stored = new List<PendingMatch>(maximumStoredMatches);
+		var active = new List<PendingMatch>(contextLines + 1);
 		var totalMatches = 0;
 		var protectedRangeIndex = 0;
 		long protectedRangeComparisons = 0;
@@ -66,30 +96,31 @@ internal static class McpSearchTextScanner
 				pending.Lines.Add(line);
 				pending.RemainingContextLines--;
 				if (pending.RemainingContextLines == 0)
+				{
 					active.RemoveAt(index);
+					consume(pending.ToContext());
+				}
 			}
 
 			if (regex.IsMatch(
-				    content,
-				    line.Offset,
-				    line.Length,
-				    protectedRanges,
-				    ref protectedRangeIndex,
-				    ref protectedRangeComparisons,
-				    cancellationToken))
+					content,
+					line.Offset,
+					line.Length,
+					protectedRanges,
+					ref protectedRangeIndex,
+					ref protectedRangeComparisons,
+					cancellationToken))
 			{
 				totalMatches++;
-				if (stored.Count < maximumStoredMatches)
-				{
-					var lines = previous is null
-						? new List<McpTextLineRange>(1)
-						: new List<McpTextLineRange>(previous);
-					lines.Add(line);
-					var pending = new PendingMatch(line.LineNumber, lines, contextLines);
-					stored.Add(pending);
-					if (contextLines > 0)
-						active.Add(pending);
-				}
+				var lines = previous is null
+					? new List<McpTextLineRange>(1)
+					: new List<McpTextLineRange>(previous);
+				lines.Add(line);
+				var pending = new PendingMatch(line.LineNumber, lines, contextLines);
+				if (contextLines > 0)
+					active.Add(pending);
+				else
+					consume(pending.ToContext());
 			}
 
 			if (previous is null)
@@ -114,14 +145,13 @@ internal static class McpSearchTextScanner
 			lineStart = index + 1;
 		}
 		ProcessLine(new McpTextLineRange(lineNumber, lineStart, content.Length - lineStart));
+		foreach (var pending in active)
+			consume(pending.ToContext());
 
-		return new McpSearchTextScanResult(
-			totalMatches,
-			MergeContexts(stored),
-			protectedRangeComparisons);
+		return new McpSearchStreamResult(totalMatches, protectedRangeComparisons);
 	}
 
-	private static IReadOnlyList<McpSearchMatchContext> MergeContexts(IReadOnlyList<PendingMatch> matches)
+	private static IReadOnlyList<McpSearchMatchContext> MergeContexts(IReadOnlyList<McpSearchMatchContext> matches)
 	{
 		if (matches.Count == 0)
 			return [];
@@ -160,5 +190,7 @@ internal static class McpSearchTextScanner
 		public int MatchLineNumber { get; } = matchLineNumber;
 		public List<McpTextLineRange> Lines { get; } = lines;
 		public int RemainingContextLines { get; set; } = remainingContextLines;
+
+		public McpSearchMatchContext ToContext() => new([MatchLineNumber], Lines.ToArray(), false);
 	}
 }

--- a/Docs/McpServer.md
+++ b/Docs/McpServer.md
@@ -320,7 +320,7 @@ description has to fit a budget rather than grow one silently.
 | `analyze` | `project?`, `branch?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `detail?`, `detail_by_pattern?`, `tracked_only?`, `git_scope?`, `top_files?`, `max_file_bytes?`, `max_tokens?`, `rank?`, `focus?` | File, character, and token metrics plus the requested largest files by tokens. `contentMetrics` separates measured transformed bodies from size-based estimates; `documentMetrics` models `pack_context` with `view=content`, `format=text`, relative file headings, and its Root line. Every ranked file carries `estimated`; an uninspected one also carries `uninspected: true`. The `topFiles` array has a 32,000-character aggregate budget; `topFilesTruncated` and `topFilesRemaining` make any omission explicit. With `max_tokens` the result also carries `admission`: which files that budget would admit, from the same greedy pass `pack_context` uses and without producing content. `rank` and `focus` order that admission and are invalid without `max_tokens`. |
 | `pack_context` | `project?`, `branch?`, `paths?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `detail?`, `detail_by_pattern?`, `tracked_only?`, `git_scope?`, `max_tokens?`, `rank?`, `focus?`, `max_file_bytes?`, `view?`, `format?` | Exact DevProjex context pipeline. `max_tokens` measures the safe transformed selection, applies the ordinary token admission order, and materializes only admitted content without changing the budget report. `rank: "importance"` opts into importance-aware admission and document order; `focus` seeds graph-hop order within it. `detail_by_pattern` overrides `detail` per file. Inline through 50,000 characters; otherwise returns a `pack_id` valid until this server process exits. After restart, call `pack_context` again. |
 | `read_pack` | `pack_id`, `start_line?`, `end_line?`, `start_column?` | Pages a stored result from `pack_context`, `search_project`, or `related_files`. Inclusive, 1-based line range; `start_column` continues within `start_line` using 1-based Unicode characters. At most 1,000 lines or 50,000 characters per call. An `end_line` after EOF is clamped and reported. Call the originating tool again after server restart or quota eviction. |
-| `search_project` | `project?`, `branch?`, `pattern`, `paths?`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `git_scope?`, `max_file_bytes?`, `context_lines?`, `ignore_case?`, `max_results?` | Matches over safe transformed text, grouped by file: the relative path stands on its own line, then each line of the group is written as `line:text` for a match and `line-text` for context. Line numbers refer to that returned text after replacements. `search_project` matches file content only and never matches paths; use `get_tree` with `include_patterns` to find files by name. The returned match text is capped at 16,000 characters. Overlapping or adjacent context windows are merged and distinct groups use `--`. Regex patterns are limited to 4,096 characters and a 2-second timeout; `max_results` cannot exceed 200, while all additional matches inside the inspected prefix are counted. A request inspects at most 64 MiB of selected source bytes and reports `[Search incomplete]` when later files were not searched. Actual text inserted by redaction never matches. Withheld files are counted in the partial-result warning. |
+| `search_project` | `project?`, `branch?`, `pattern`, `paths?`, `include_patterns?`, `exclude_patterns?`, `tracked_only?`, `git_scope?`, `max_file_bytes?`, `context_lines?`, `ignore_case?`, `max_results?` | Matches over safe transformed text, grouped by file: the relative path stands on its own line, then each line of the group is written as `line:text` for a match and `line-text` for context. Line numbers refer to that returned text after replacements. `search_project` matches file content only and never matches paths; use `get_tree` with `include_patterns` to find files by name. A bounded collector keeps stronger evidence from everything inspected instead of preserving arrival order. The returned match text is capped at 16,000 characters. Overlapping or adjacent context windows are merged and distinct groups use `--`. Regex patterns are limited to 4,096 characters and a 2-second timeout; `max_results` cannot exceed 200. The trusted `[Search boundary]` line distinguishes a complete result from every partial limit and reports inspected sources, encountered and retained matches, written matches, named declaration files, and continuation guidance. Actual text inserted by redaction never matches. |
 | `related_files` | `project?`, `branch?`, `path`, `direction?`, `include_patterns?`, `exclude_patterns?`, `profile?`, `tracked_only?`, `git_scope?`, `max_file_bytes?` | Statically evidenced dependencies and dependents for one seed or up to 16 seeds. `direction` is `dependencies`, `dependents`, or `both` (default). The trusted `[Resolution]` line counts resolved, ambiguous, unresolved, and external edges for the call. Coverage distinguishes recognized supported languages from unsupported files and reports configuration diagnostics. Results larger than 50,000 characters use `read_pack`. |
 | `get_file` | `project?`, `branch?`, `profile?`, either `path` with `start_line?`, `end_line?`, `start_column?`, `symbol?`, or `requests` | Redacted text from one effective file or a batch of up to eight file requests and sixteen ranges or named declarations. Every returned section starts with its path and returned line interval. Batch items contain `path` and exactly one of `ranges` or `symbol`; ranges are inclusive, each physical file is read and redacted once, overlaps merge, and every item reports `ok`, `partial`, `not-returned`, or `unavailable`. Both forms share the 1,000-line/50,000-character limit. Coordinates refer to returned text after replacements. A non-empty file that cannot pass the 16 MiB mandatory-redaction boundary is withheld; the single form returns `DPX-MCP-PAYLOAD-TRUNCATED` and never returns an empty success, while batch output reports the count-only unavailable status. `profile` applies the same effective selection and transformations as `analyze` and `pack_context`. Markdown-escaped names copied from default `get_tree` are accepted (`\_` and other ASCII punctuation); use `format: "text"` to copy unescaped names. |
 
@@ -598,7 +598,7 @@ filters]` line.
 
 Only the repetition of unchanged trusted lines changes. Lines that state a fact
 about one call — `[Remote] commit=`, `[Resolution]`, `[Facts coverage]`,
-`[Search scope]`, `[Budget accounting]`, `[Search totals]`, `[Name search]`,
+`[Search scope]`, `[Budget accounting]`, `[Search observed]`, `[Search boundary]`, `[Name search]`,
 search and tree truncation notices, and every `[Warning ...]` — are computed and sent for every
 call as before, and the untrusted-data wrapper around project text is never
 affected.
@@ -629,14 +629,25 @@ context lines could otherwise spend a large share of an agent's context in one
 unpredictable call. When the cap stops the output, the response adds the constant
 `[Search truncated] The returned text reached the 16000-character search cap. Narrow
 the pattern, add paths or include_patterns, or lower context_lines.` Whenever a call
-does not return every match it found — because `max_results`, the cap, or both
-withheld some — it also reports `[Search totals] matches=N · files=M`, the exact
-number of matches and the exact number of files containing at least one match inside
-the inspected selection. A group cut only in its trailing context lines withheld no
-match, so it receives the cap notice without the totals line. Both lines are trusted
-counts and constants; no path enters them. A call whose output was not cut and that
-returned every match it found keeps its previous response unchanged. The
-`[N additional matches not shown]` count keeps its existing meaning and precision.
+does not return every match it encountered, it also reports
+`[Search observed] matches=N · matching-files=M within inspected sources` and
+`[N additional observed matches not shown]`. These counts are exact for sources that were actually inspected,
+not a claim about an uninspected suffix. A group cut only in its trailing context
+lines withheld no match, so it receives the cap notice without an additional-match
+line. Trusted counts and constants remain outside the untrusted block; no path enters
+them.
+
+Every search ends with a trusted boundary line. A complete search says:
+
+```text
+[Search boundary] complete · sources inspected=X/Y · matches retained=R/T · matches written=W · declaration files named=N.
+```
+
+A partial search uses the same counters, names the exact bound or bounds that applied,
+and tells the caller to page a stored retained result when available or to narrow and
+rerun for omitted evidence. Consequently, a complete zero-match response is evidence
+that the whole effective selection was searched, while a partial zero-match response
+is only evidence about its inspected sources.
 
 Unavailable compression is reduced optimization, not unsafe output. The affected
 file remains complete, and `analyze`, `pack_context`, and `get_file` append
@@ -915,9 +926,10 @@ distinguishes a hit that sits in no declaration from a file that was never
 parsed, plus a `files-past-the-64-file naming limit=` term when a search touched
 more files than the naming bound allows.
 
-The names come from the dependency index built over the files that actually
-produced hits: one bounded parse per such file, never one per hit, and never over
-the whole selection. Granularity is whatever that index declares, which for C# is
+The names come from bounded navigation extraction over files that actually produced
+hits: one parse per matching file as it passes, never one per hit, and never over
+the whole selection. Only navigation for the best 64 candidate files remains resident,
+and that set can evict an earlier weaker file. Granularity is whatever the index declares, which for C# is
 the enclosing type rather than the enclosing member. Hit lines are lines of the
 transformed text the tool returns and the index parses the file on disk; redaction
 replaces a secret with a placeholder on the same line and adds no lines, so the
@@ -931,15 +943,16 @@ that are already present, so no header can be left as the last line of a respons
 with no hit under it. Placement is all or nothing: a header skipped for want of room
 would leave the hits beneath it reading as part of the declaration named above them,
 so when the headers do not fit, none are written and the coverage line reports that
-nothing was named, rather than going silent about naming it did compute. The match lines, the `--` group separators, the match and file
-counters, and the "N additional matches" contract are unchanged.
+nothing was named, rather than going silent about naming it did compute. The match
+lines, the `--` group separators, and all boundary counters describe the same finished
+render.
 
 ### A withheld search stays in the session
 
-A search that has to withhold matches keeps the rest of what it already found, so
-the way forward is to page that result rather than to run the same search again.
-Nothing changes for a search that returns everything it found: it stores nothing,
-says nothing new, and is byte-identical.
+A search that has to withhold retained matches keeps the rest of those matches, so
+the way forward is to page that result rather than to repeat the same scan. A search
+that returns every retained match stores nothing. Its boundary still says explicitly
+whether all eligible sources and all encountered matches were covered.
 
 When matches are withheld the response carries three things beyond what it carried
 before. Inside the untrusted block, after the matches, the distribution of what was
@@ -986,45 +999,40 @@ heading with nothing under it would report a search that found something and the
 show none of it. A trusted line that points at one of those lists is written only
 when the list was.
 
-### What a slice shows when matches are withheld
+### What a bounded result retains
 
-When `max_results` withholds, the response chooses which matches to carry rather than
-taking whatever the file order happened to reach first. Two rules decide it, and a
-constant names them:
+The search chooses which compact match records to retain while transformed files
+stream past. A stronger late record can evict a weaker early record; the server does
+not keep an unbounded list and sort it afterward. The constant naming this rule is:
 
 ```text
-[Search order] hits inside a declaration first, then the rest; selection order breaks ties.
+[Search order] bounded evidence priority; canonical path and line break ties.
 ```
 
-A hit that sits inside a declaration comes before one that does not, so a committed
-generated report stops crowding out the declaration of the term that was searched
-for. The signal is the one the naming already computes; there is no directory list,
-which this project does not keep on principle, and no ranking graph, which needs an
-index a search does not build. Files are ordered, not groups, so each file's matches
-stay one block with its line numbers climbing.
+Priority is the sum of soft signals: exact agreement between the pattern and an
+enclosing declaration name, an explicitly requested `paths` scope, breadth across
+files and declaration owners, and a bounded penalty for repeated line content.
+These weights are 160 for a qualified declaration, 128 for a simple declaration,
+64 for declaration syntax, 1,024 for explicit scope, 512 divided by the occurrence
+within one file, 32 divided by the occurrence within one owner, and at most 31 points
+of repetition penalty. No test, generated, snapshot, or unsupported-language category
+is excluded or categorically demoted. Project-wide importance ranking is not used.
+Equal priorities use canonical relative path and line number, both ordinal, so
+filesystem traversal order cannot decide the answer.
 
-Whichever bound cuts the listing, every matched file gets a hit before any file gets
-a second. An alphabetical cut that never reached the file a caller wanted was the
-largest single class of whole-file reads in the recorded sessions.
-
-Ordering rests on the naming, and the naming reaches a bounded number of files. A
-search that matched more files than it can name knows nothing about the ones past
-that bound, so it applies no order and announces none rather than claiming an order
-it did not apply. A search that showed everything it found has nothing to choose
-between: it keeps selection order, says nothing, and is byte-identical.
-
-Two bounds apply, and the response says when either decided the answer. Matching
-runs to 5,000 matches per search, and the stored text stops at 2,000,000 characters;
-beyond either, the id holds only the first of the withheld matches and the trusted
-line says so. A stored search result is subject to the same session quota and
+The collector retains at most 5,000 matches and 2,000,000 characters of bounded
+fragments. It never retains whole transformed files after their pipeline callback.
+Declaration extraction is attempted for matched files as they pass, while navigation
+data remains resident only for the same best 64 files selected by candidate priority.
+Thus a late useful file can displace an early repetitive file in both match storage
+and the declaration-naming budget. A stored search result is subject to the same session quota and
 least-recently-read eviction as any other stored result, and expiry or eviction of
 one is reported in search terms: it names the search result and tells the caller to
 call `search_project` again, not `pack_context`.
 
-The counting contract is untouched. The match and matching-file totals, the withheld
-count in `[N additional matches not shown]`, `[Search totals]` and the truncation
-notice all report exactly what they reported before, and `max_results` still bounds
-the matches a response displays.
+`max_results` still bounds the matches a response displays. Encountered, retained,
+written, and declaration-named counts are deliberately separate; none is presented
+as the count for the whole project unless the boundary says `complete`.
 
 ### The search result carries the selector
 

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.SearchEvidence.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.SearchEvidence.cs
@@ -209,10 +209,7 @@ public sealed partial class McpServerIntegrationTests
 		var changed = false;
 		McpSearchExecutionHooks.AfterScan = scannedPath =>
 		{
-			if (changed || !string.Equals(
-				Path.GetFullPath(scannedPath),
-				Path.GetFullPath(path),
-				OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+			if (changed || !string.Equals(scannedPath, "Mutable.txt", StringComparison.Ordinal))
 				return;
 			changed = true;
 			File.WriteAllText(path, "inserted\nalpha\nneedle new\nomega\n");

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.SearchEvidence.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.SearchEvidence.cs
@@ -156,7 +156,7 @@ public sealed partial class McpServerIntegrationTests
 		});
 
 		Assert.Contains("[Search boundary] complete · sources inspected=2/2 · matches retained=1/1 · " +
-		                "matches written=1 · declaration files named=0.", Text(result), StringComparison.Ordinal);
+						"matches written=1 · declaration files named=0.", Text(result), StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.SearchEvidence.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.SearchEvidence.cs
@@ -1,0 +1,261 @@
+using System.Text;
+using DevProjex.Mcp;
+
+namespace DevProjex.Tests.Integration;
+
+public sealed partial class McpServerIntegrationTests
+{
+	[Fact]
+	public async Task SearchKeepsAUsefulDeclarationAfterFiveThousandEarlyRepetitions()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "a-repetitions.txt"),
+			string.Concat(Enumerable.Repeat("Needle repeated mention\n", 5_000)));
+		Directory.CreateDirectory(Path.Combine(project, "zz"));
+		File.WriteAllText(
+			Path.Combine(project, "zz", "PublicApi.cs"),
+			"namespace Contracts;\npublic sealed class Needle { }\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "Needle",
+			["context_lines"] = 0,
+			["max_results"] = 1
+		});
+		var text = Text(result);
+
+		Assert.NotEqual(true, result.IsError);
+		Assert.Contains("zz/PublicApi.cs", text, StringComparison.Ordinal);
+		Assert.Contains("2:public sealed class Needle { }", text, StringComparison.Ordinal);
+		Assert.Contains("[Search boundary] partial", text, StringComparison.Ordinal);
+		Assert.Contains("matches retained=5000/5001", text, StringComparison.Ordinal);
+		Assert.Contains("limits=retained-matches,max-results", text, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SearchNamesADeclarationInTheLastOfManyMatchingFiles()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		for (var index = 0; index < 80; index++)
+			File.WriteAllText(Path.Combine(project, $"mention-{index:D2}.txt"), "PublicContract mention\n");
+		File.WriteAllText(
+			Path.Combine(project, "zz-PublicContract.cs"),
+			"public sealed class PublicContract { }\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "PublicContract",
+			["context_lines"] = 0,
+			["max_results"] = 1
+		});
+		var text = Text(result);
+
+		Assert.Contains("zz-PublicContract.cs", text, StringComparison.Ordinal);
+		Assert.Contains("1:public sealed class PublicContract { }", text, StringComparison.Ordinal);
+		Assert.Contains("in PublicContract", text, StringComparison.Ordinal);
+		Assert.Contains("declaration files named=1", text, StringComparison.Ordinal);
+		Assert.Contains("limits=annotation-files,max-results", text, StringComparison.Ordinal);
+	}
+
+	[Theory]
+	[InlineData("tests/PublicApiTests.cs")]
+	[InlineData("generated/PublicApi.snapshot")]
+	public async Task ExplicitlySelectedEvidenceIsNotDemotedByItsPath(string selectedPath)
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var fullPath = Path.Combine(project, selectedPath.Replace('/', Path.DirectorySeparatorChar));
+		Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+		File.WriteAllText(fullPath, "PublicApiCompatibility expected-signature\n");
+		File.WriteAllText(Path.Combine(project, "ordinary.txt"), "PublicApiCompatibility mention\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "PublicApiCompatibility",
+			["paths"] = new[] { selectedPath },
+			["context_lines"] = 0,
+			["max_results"] = 1
+		});
+
+		McpSearchOutputAssertions.ContainsMatch(
+			Text(result),
+			selectedPath,
+			1,
+			"PublicApiCompatibility expected-signature");
+	}
+
+	[Fact]
+	public async Task ApprovedSnapshotCanSupplyThePublicApiCompatibilityEvidence()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "a-repeated.txt"),
+			string.Concat(Enumerable.Repeat("PublicContract mention\n", 100)));
+		Directory.CreateDirectory(Path.Combine(project, "snapshots"));
+		File.WriteAllText(
+			Path.Combine(project, "snapshots", "PublicApi.approved.txt"),
+			"interface PublicContract { Execute(value: string): Result }\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "PublicContract",
+			["context_lines"] = 0,
+			["max_results"] = 1
+		});
+
+		McpSearchOutputAssertions.ContainsMatch(
+			Text(result),
+			"snapshots/PublicApi.approved.txt",
+			1,
+			"interface PublicContract { Execute(value: string): Result }");
+	}
+
+	[Fact]
+	public async Task UnsupportedLanguageMatchRemainsVisibleBesideSupportedDeclarations()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(Path.Combine(project, "contract.lua"), "PublicSurface = expected\n");
+		File.WriteAllText(Path.Combine(project, "Contract.cs"), "public sealed class PublicSurface { }\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "PublicSurface",
+			["context_lines"] = 0,
+			["max_results"] = 2
+		});
+		var text = Text(result);
+
+		McpSearchOutputAssertions.ContainsMatch(text, "contract.lua", 1, "PublicSurface = expected");
+		Assert.Contains("Contract.cs", text, StringComparison.Ordinal);
+		Assert.Contains("1:public sealed class PublicSurface { }", text, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SearchWithoutReachedLimitsDeclaresTheObservedSelectionComplete()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(Path.Combine(project, "one.txt"), "needle\n");
+		File.WriteAllText(Path.Combine(project, "two.txt"), "nothing\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "needle",
+			["context_lines"] = 0
+		});
+
+		Assert.Contains("[Search boundary] complete · sources inspected=2/2 · matches retained=1/1 · " +
+		                "matches written=1 · declaration files named=0.", Text(result), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SearchReportsTheAnnotationFileLimitSeparately()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		for (var index = 0; index < 65; index++)
+			File.WriteAllText(Path.Combine(project, $"file-{index:D2}.txt"), "needle\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "needle",
+			["context_lines"] = 0,
+			["max_results"] = 100
+		});
+
+		Assert.Contains("[Search boundary] partial", Text(result), StringComparison.Ordinal);
+		Assert.Contains("limits=annotation-files", Text(result), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SearchReportsTheResponseCharacterLimitSeparately()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(Path.Combine(project, "large.txt"), "needle " + new string('x', 20_000));
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "needle",
+			["context_lines"] = 0
+		});
+
+		Assert.Contains("[Search boundary] partial", Text(result), StringComparison.Ordinal);
+		Assert.Contains("limits=response-characters", Text(result), StringComparison.Ordinal);
+		Assert.Contains("narrow pattern, paths, or include_patterns", Text(result), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task SearchKeepsCoordinatesAndTextFromOneSnapshotWhenSourceChangesAfterScanning()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		var path = Path.Combine(project, "Mutable.txt");
+		File.WriteAllText(path, "alpha\nneedle old\nomega\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+		var changed = false;
+		McpSearchExecutionHooks.AfterScan = scannedPath =>
+		{
+			if (changed || !string.Equals(
+				Path.GetFullPath(scannedPath),
+				Path.GetFullPath(path),
+				OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+				return;
+			changed = true;
+			File.WriteAllText(path, "inserted\nalpha\nneedle new\nomega\n");
+		};
+		try
+		{
+			var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+			{
+				["pattern"] = "needle",
+				["context_lines"] = 0,
+				["ignore_case"] = false
+			});
+			var text = Text(result);
+
+			Assert.True(changed);
+			McpSearchOutputAssertions.ContainsMatch(text, "Mutable.txt", 2, "needle old");
+			Assert.DoesNotContain("needle new", text, StringComparison.Ordinal);
+		}
+		finally
+		{
+			McpSearchExecutionHooks.AfterScan = null;
+		}
+	}
+
+	[Fact]
+	public async Task ProtectedUnicodePrefixDoesNotShiftReturnedMatchOrBoundaryCounts()
+	{
+		using var workspace = new TemporaryDirectory();
+		var project = workspace.CreateDirectory("project");
+		File.WriteAllText(
+			Path.Combine(project, "Unicode.txt"),
+			$"πππ {Secret}\nλ needle evidence\n");
+		await using var server = await McpTestServer.StartAsync(project, workspace.Path);
+
+		var result = await server.CallAsync("search_project", new Dictionary<string, object?>
+		{
+			["pattern"] = "needle",
+			["context_lines"] = 0,
+			["ignore_case"] = false
+		});
+		var text = Text(result);
+
+		McpSearchOutputAssertions.ContainsMatch(text, "Unicode.txt", 2, "λ needle evidence");
+		Assert.Contains("sources inspected=1/1 · matches retained=1/1 · matches written=1", text, StringComparison.Ordinal);
+	}
+}

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -245,7 +245,9 @@ public sealed partial class McpServerIntegrationTests
 		var noMatches = Text(await server.CallAsync(
 			"search_project",
 			new Dictionary<string, object?> { ["pattern"] = "absent-marker" }));
-		Assert.Contains("[No matches] The pattern matched nothing in 1 selected file(s) (git: gitignore; exclusions: smart-ignore, empty-folders).", noMatches, StringComparison.Ordinal);
+		Assert.Contains("[No matches] The pattern matched nothing in 1 inspected selected file(s); " +
+		                "the search boundary below states whether inspection was complete " +
+		                "(git: gitignore; exclusions: smart-ignore, empty-folders).", noMatches, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Empty selection]", noMatches, StringComparison.Ordinal);
 
 		var matched = Text(await server.CallAsync(
@@ -3255,11 +3257,11 @@ public sealed partial class McpServerIntegrationTests
 
 		var text = Text(result);
 		Assert.True(text.Length <= 55_000, $"Search response was {text.Length} characters.");
-		Assert.Contains("\n[1 additional matches not shown", text.Replace("\r\n", "\n", StringComparison.Ordinal));
+		Assert.Contains("\n[1 additional observed matches not shown", text.Replace("\r\n", "\n", StringComparison.Ordinal));
 		Assert.Contains("narrow the pattern or filters", text, StringComparison.Ordinal);
 		AssertTrustedTrailerOutsideSpotlight(
 			result,
-			"[1 additional matches not shown; narrow the pattern or filters.]");
+			"[1 additional observed matches not shown; narrow the pattern or filters.]");
 	}
 
 	[Fact]
@@ -6629,9 +6631,8 @@ public sealed partial class McpServerIntegrationTests
 
 		Assert.NotEqual(true, result.IsError);
 		McpSearchOutputAssertions.DoesNotContainMatch(text, "Large4.txt", 1);
-		Assert.Contains("[Search incomplete] The inspected-text byte budget was reached; " +
-		                "additional selected files were not searched and match counts are partial.", text,
-			StringComparison.Ordinal);
+		Assert.Contains("[Search boundary] partial · sources inspected=4/5", text, StringComparison.Ordinal);
+		Assert.Contains("limits=inspection-bytes", text, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/McpServerIntegrationTests.cs
@@ -246,8 +246,10 @@ public sealed partial class McpServerIntegrationTests
 			"search_project",
 			new Dictionary<string, object?> { ["pattern"] = "absent-marker" }));
 		Assert.Contains("[No matches] The pattern matched nothing in 1 inspected selected file(s); " +
-		                "the search boundary below states whether inspection was complete " +
-		                "(git: gitignore; exclusions: smart-ignore, empty-folders).", noMatches, StringComparison.Ordinal);
+						"the search boundary below states whether inspection was complete " +
+						"(git: gitignore; exclusions: smart-ignore, empty-folders).", noMatches, StringComparison.Ordinal);
+		Assert.Contains("[Search boundary] complete · sources inspected=1/1 · matches retained=0/0 · " +
+						"matches written=0 · declaration files named=0.", noMatches, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Empty selection]", noMatches, StringComparison.Ordinal);
 
 		var matched = Text(await server.CallAsync(
@@ -297,11 +299,11 @@ public sealed partial class McpServerIntegrationTests
 		Assert.DoesNotContain("Notes.txt", braces, StringComparison.Ordinal);
 
 		foreach (var (pattern, reason) in new[]
-		         {
-			         ("!src/**", "negation ('!') is not supported"),
-			         ("[Ss]rc/**", "character classes ('[...]') are not supported"),
-			         ("**/*.{cs,md", "unbalanced '{'")
-		         })
+				 {
+					 ("!src/**", "negation ('!') is not supported"),
+					 ("[Ss]rc/**", "character classes ('[...]') are not supported"),
+					 ("**/*.{cs,md", "unbalanced '{'")
+				 })
 		{
 			var rejected = await server.CallAsync(
 				"get_tree",
@@ -1508,7 +1510,7 @@ public sealed partial class McpServerIntegrationTests
 			return false;
 		process.WaitForExit();
 		return process.ExitCode == 0 &&
-		       File.GetAttributes(path).HasFlag(FileAttributes.Hidden);
+			   File.GetAttributes(path).HasFlag(FileAttributes.Hidden);
 	}
 
 
@@ -4020,7 +4022,7 @@ public sealed partial class McpServerIntegrationTests
 				(notification, _) =>
 				{
 					if (notification.Params?.Deserialize<ProgressNotificationParams>() is { } value &&
-					    value.ProgressToken == progressToken)
+						value.ProgressToken == progressToken)
 						progress.Report(value.Progress);
 					return ValueTask.CompletedTask;
 				});
@@ -4037,7 +4039,7 @@ public sealed partial class McpServerIntegrationTests
 			var request = Assert.Single(
 				server.GetInputWireMessages(firstInputMessage),
 				static message => message.TryGetProperty("method", out var method) &&
-				                  method.GetString() == RequestMethods.ToolsCall);
+								  method.GetString() == RequestMethods.ToolsCall);
 			var requestToken = request.GetProperty("params")
 				.GetProperty("_meta")
 				.GetProperty("progressToken");
@@ -4052,7 +4054,7 @@ public sealed partial class McpServerIntegrationTests
 			var resultIndex = Array.FindIndex(
 				messages,
 				static message => message.TryGetProperty("result", out var wireResult) &&
-				                  wireResult.TryGetProperty("content", out _));
+								  wireResult.TryGetProperty("content", out _));
 			Assert.True(resultIndex >= 0, "The tool result was not recorded on the wire.");
 			Assert.All(progressMessages, item => Assert.True(item.Index < resultIndex));
 
@@ -4094,7 +4096,7 @@ public sealed partial class McpServerIntegrationTests
 			request = Assert.Single(
 				server.GetInputWireMessages(firstInputMessage),
 				static message => message.TryGetProperty("method", out var method) &&
-				                  method.GetString() == RequestMethods.ToolsCall);
+								  method.GetString() == RequestMethods.ToolsCall);
 			if (request.GetProperty("params").TryGetProperty("_meta", out var requestMeta))
 				Assert.False(requestMeta.TryGetProperty("progressToken", out _));
 			Assert.DoesNotContain(
@@ -6268,7 +6270,7 @@ public sealed partial class McpServerIntegrationTests
 			(notification, _) =>
 			{
 				if (notification.Params?.Deserialize<ProgressNotificationParams>() is { } value &&
-				    value.ProgressToken == token)
+					value.ProgressToken == token)
 					progress.Report(value.Progress);
 				return ValueTask.CompletedTask;
 			});
@@ -7249,7 +7251,7 @@ public sealed partial class McpServerIntegrationTests
 	private static int CountOccurrences(string value, string fragment)
 	{
 		var count = 0;
-		for (var offset = 0;;)
+		for (var offset = 0; ;)
 		{
 			var index = value.IndexOf(fragment, offset, StringComparison.Ordinal);
 			if (index < 0)
@@ -7606,9 +7608,9 @@ public sealed partial class McpServerIntegrationTests
 			RedirectStandardError = true
 		});
 		if (process is null ||
-		    !process.WaitForExit(TimeSpan.FromSeconds(5)) ||
-		    process.ExitCode != 0 ||
-		    !Directory.Exists(linkPath))
+			!process.WaitForExit(TimeSpan.FromSeconds(5)) ||
+			process.ExitCode != 0 ||
+			!Directory.Exists(linkPath))
 		{
 			try
 			{
@@ -7666,9 +7668,9 @@ public sealed partial class McpServerIntegrationTests
 				Assert.Skip("Windows per-directory case sensitivity is unavailable.");
 		}
 		catch (Exception exception) when (exception is
-			       InvalidOperationException or
-			       IOException or
-			       System.ComponentModel.Win32Exception)
+				   InvalidOperationException or
+				   IOException or
+				   System.ComponentModel.Win32Exception)
 		{
 			Assert.Skip($"Windows per-directory case sensitivity is unavailable: {exception.GetType().Name}.");
 		}
@@ -7687,8 +7689,8 @@ public sealed partial class McpServerIntegrationTests
 				ArgumentList = { "--version" }
 			});
 			return process is not null &&
-			       process.WaitForExit(TimeSpan.FromSeconds(5)) &&
-			       process.ExitCode == 0;
+				   process.WaitForExit(TimeSpan.FromSeconds(5)) &&
+				   process.ExitCode == 0;
 		}
 		catch (System.ComponentModel.Win32Exception)
 		{
@@ -7773,14 +7775,14 @@ public sealed partial class McpServerIntegrationTests
 		{
 			CloneCallCount++;
 			return inner?.CloneAsync(url, targetDirectory, progress, cancellationToken) ??
-			       Task.FromResult(new GitCloneResult(
-				       Success: false,
-				       LocalPath: targetDirectory,
-				       ProjectSourceType.GitClone,
-				       DefaultBranch: null,
-				       RepositoryName: null,
-				       RepositoryUrl: url,
-				       ErrorMessage: "simulated clone failure"));
+				   Task.FromResult(new GitCloneResult(
+					   Success: false,
+					   LocalPath: targetDirectory,
+					   ProjectSourceType.GitClone,
+					   DefaultBranch: null,
+					   RepositoryName: null,
+					   RepositoryUrl: url,
+					   ErrorMessage: "simulated clone failure"));
 		}
 
 		public Task<IReadOnlyList<GitBranch>> GetBranchesAsync(
@@ -7951,8 +7953,8 @@ public sealed partial class McpServerIntegrationTests
 			{
 				using var document = JsonDocument.Parse(messages[index].TrimEnd('\r'));
 				if (document.RootElement.TryGetProperty("result", out var result) &&
-				    result.ValueKind == JsonValueKind.Object &&
-				    result.TryGetProperty("content", out _))
+					result.ValueKind == JsonValueKind.Object &&
+					result.TryGetProperty("content", out _))
 				{
 					return result.Clone();
 				}

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -211,7 +211,8 @@ public sealed class DocumentationAndPackagingContractTests
 			"`search_project` matches file content only and never matches paths",
 			normalized,
 			StringComparison.Ordinal);
-		Assert.Contains("[Search totals] matches=N · files=M", server, StringComparison.Ordinal);
+		Assert.Contains("[Search observed] matches=N · matching-files=M within inspected sources", server, StringComparison.Ordinal);
+		Assert.Contains("[Search boundary] complete · sources inspected=X/Y · matches retained=R/T · matches written=W · declaration files named=N.", server, StringComparison.Ordinal);
 		Assert.Contains("[Search truncated]", server, StringComparison.Ordinal);
 		Assert.Contains("16,000 characters", normalized, StringComparison.Ordinal);
 		Assert.Contains("### Finding a file by name", server, StringComparison.Ordinal);
@@ -236,19 +237,19 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("### The search result carries the selector", server, StringComparison.Ordinal);
 		Assert.Contains("Declarations found (path, symbol, line):", server, StringComparison.Ordinal);
 		Assert.Contains("[Read declarations]", server, StringComparison.Ordinal);
-		Assert.Contains("**A cut listing keeps its breadth.**", server, StringComparison.Ordinal);
 		Assert.Contains(
-			"### What a slice shows when matches are withheld",
+			"### What a bounded result retains",
 			server,
 			StringComparison.Ordinal);
 		Assert.Contains(
-			"[Search order] hits inside a declaration first, then the rest; selection order breaks ties.",
+			"[Search order] bounded evidence priority; canonical path and line break ties.",
 			server,
 			StringComparison.Ordinal);
 		Assert.Contains(
-			"applies no order and announces none rather than claiming an order it did not apply",
+			"No test, generated, snapshot, or unsupported-language category is excluded or categorically demoted",
 			normalized,
 			StringComparison.Ordinal);
+		Assert.Contains("A stronger late record can evict a weaker early record", normalized, StringComparison.Ordinal);
 		Assert.Contains("### A withheld search stays in the session", server, StringComparison.Ordinal);
 		Assert.Contains("Withheld matches by file:", server, StringComparison.Ordinal);
 		Assert.Contains("Counts, not line numbers", normalized, StringComparison.Ordinal);

--- a/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
+++ b/Tests/DevProjex.Tests.Terminal/DocumentationAndPackagingContractTests.cs
@@ -755,11 +755,11 @@ public sealed class DocumentationAndPackagingContractTests
 
 		var corePathPatterns = new[] { "'Apps/Mcp/**'", "'Application/**'", "'Kernel/**'", "'Infrastructure/**'" };
 		foreach (var workflowName in new[]
-		         {
-			         "publish-packages.yml",
-			         "package-headless.yml",
-			         "publish-container.yml"
-		         })
+				 {
+					 "publish-packages.yml",
+					 "package-headless.yml",
+					 "publish-container.yml"
+				 })
 		{
 			var workflow = File.ReadAllText(Path.Combine(
 				rootPath,
@@ -840,11 +840,11 @@ public sealed class DocumentationAndPackagingContractTests
 		Assert.Contains("uses: ./.github/workflows/store-package-smoke.yml", releaseCandidate, StringComparison.Ordinal);
 		Assert.Contains("Release candidate report", releaseCandidate, StringComparison.Ordinal);
 		foreach (var gate in new[]
-		         {
-			         "'AppImage dry-run' = $env:APPIMAGE_RESULT",
-			         "'Grammar Delivery' = $env:GRAMMAR_RESULT",
-			         "'Store Package Smoke' = $env:STORE_RESULT"
-		         })
+				 {
+					 "'AppImage dry-run' = $env:APPIMAGE_RESULT",
+					 "'Grammar Delivery' = $env:GRAMMAR_RESULT",
+					 "'Store Package Smoke' = $env:STORE_RESULT"
+				 })
 		{
 			Assert.Contains(gate, releaseCandidate, StringComparison.Ordinal);
 		}
@@ -1061,7 +1061,7 @@ public sealed class DocumentationAndPackagingContractTests
 			RegexOptions.CultureInvariant);
 		Assert.True(readinessRow.Success, "Desktop Control Git-readiness state contract is missing.");
 		foreach (var descriptor in ProjectPresentationCatalog.GitFiltering.Where(static item =>
-			         DesktopOpenReadiness.RequiresGitReadiness(item.Id)))
+					 DesktopOpenReadiness.RequiresGitReadiness(item.Id)))
 		{
 			Assert.Contains($"`{descriptor.Token}`", readinessRow.Value, StringComparison.Ordinal);
 		}
@@ -1254,8 +1254,7 @@ public sealed class DocumentationAndPackagingContractTests
 			completionStepIndex + completionStepName.Length,
 			StringComparison.Ordinal);
 		var completionStep = workflow[
-			completionStepIndex..
-			(completionStepEndIndex >= 0 ? completionStepEndIndex : workflow.Length)];
+			completionStepIndex..(completionStepEndIndex >= 0 ? completionStepEndIndex : workflow.Length)];
 		Assert.Contains(
 			"artifacts/publish/${{ matrix.rid }}/${{ matrix.binary }}",
 			completionStep,
@@ -1565,7 +1564,7 @@ public sealed class DocumentationAndPackagingContractTests
 		};
 
 		foreach (var file in productRoots.SelectMany(path =>
-			         Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories)))
+					 Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories)))
 		{
 			var source = File.ReadAllText(file);
 			Assert.DoesNotContain(
@@ -1595,9 +1594,9 @@ public sealed class DocumentationAndPackagingContractTests
 		};
 
 		foreach (var sourcePath in Directory.EnumerateFiles(
-			         testsRoot,
-			         "*.cs",
-			         SearchOption.AllDirectories))
+					 testsRoot,
+					 "*.cs",
+					 SearchOption.AllDirectories))
 		{
 			var source = File.ReadAllText(sourcePath);
 			foreach (var obsoletePathPattern in obsoletePathPatterns)
@@ -1748,8 +1747,8 @@ public sealed class DocumentationAndPackagingContractTests
 		{
 			var line = lines[index].TrimEnd('\r');
 			if (line.Length > 0 &&
-			    !line.StartsWith("    ", StringComparison.Ordinal) &&
-			    !line.StartsWith("  #", StringComparison.Ordinal))
+				!line.StartsWith("    ", StringComparison.Ordinal) &&
+				!line.StartsWith("  #", StringComparison.Ordinal))
 			{
 				break;
 			}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.BatchReads.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.BatchReads.cs
@@ -214,9 +214,8 @@ public sealed partial class McpServerProcessTests
 			var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
 			Assert.NotEqual(true, result.IsError);
 			Assert.DoesNotContain("Large4.txt", text, StringComparison.Ordinal);
-			Assert.Contains("[Search incomplete] The inspected-text byte budget was reached; " +
-			                "additional selected files were not searched and match counts are partial.", text,
-				StringComparison.Ordinal);
+			Assert.Contains("[Search boundary] partial", text, StringComparison.Ordinal);
+			Assert.Contains("limits=inspection-bytes", text, StringComparison.Ordinal);
 		}
 		finally
 		{

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.BatchReads.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.BatchReads.cs
@@ -214,8 +214,10 @@ public sealed partial class McpServerProcessTests
 			var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
 			Assert.NotEqual(true, result.IsError);
 			Assert.DoesNotContain("Large4.txt", text, StringComparison.Ordinal);
+			Assert.Contains("[No matches] The pattern matched nothing in 4 inspected selected file(s)", text, StringComparison.Ordinal);
 			Assert.Contains("[Search boundary] partial", text, StringComparison.Ordinal);
 			Assert.Contains("limits=inspection-bytes", text, StringComparison.Ordinal);
+			Assert.Contains("continue the search", text, StringComparison.Ordinal);
 		}
 		finally
 		{

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchAccounting.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchAccounting.cs
@@ -150,7 +150,7 @@ public sealed partial class McpServerProcessTests
 			text,
 			@"^(?:\d+:needle-\d{3}-😀-a{290}|\d+:needle-\d{3}-b{296})$",
 			RegexOptions.Multiline).Count;
-		var additionalMatch = Regex.Match(text, @"\[(\d+) additional matches not shown;");
+		var additionalMatch = Regex.Match(text, @"\[(\d+) additional observed matches not shown;");
 
 		Assert.NotEqual(true, result.IsError);
 		Assert.InRange(shown, 1, 199);
@@ -217,7 +217,7 @@ public sealed partial class McpServerProcessTests
 		Assert.Contains("Narrow the pattern", wideText, StringComparison.Ordinal);
 		Assert.Contains("lower context_lines", wideText, StringComparison.Ordinal);
 		// 40 files carry 20 matching lines each, and the counters stay exact under the cap.
-		Assert.Contains("[Search totals] matches=800 · files=40", wideText, StringComparison.Ordinal);
+		Assert.Contains("[Search observed] matches=800 · matching-files=40 within inspected sources", wideText, StringComparison.Ordinal);
 		// Matches are grouped under their path, so a shown match is a numbered line; the paths
 		// are counted separately to prove every matching file still heads its own block.
 		var shown = Regex.Matches(wideText, @"^\d+:const needle", RegexOptions.Multiline).Count;
@@ -226,7 +226,7 @@ public sealed partial class McpServerProcessTests
 		var headings = Regex.Matches(wideText, @"^src/Module\d{2}\.ts$", RegexOptions.Multiline).Count;
 		Assert.InRange(headings, 1, 40);
 		Assert.Equal(shown, Regex.Matches(wideText, @"^\d+:", RegexOptions.Multiline).Count);
-		var additional = Regex.Match(wideText, @"\[(\d+) additional matches not shown;");
+		var additional = Regex.Match(wideText, @"\[(\d+) additional observed matches not shown;");
 		Assert.True(additional.Success, wideText);
 		Assert.Equal(800, shown + int.Parse(additional.Groups[1].Value));
 
@@ -235,7 +235,7 @@ public sealed partial class McpServerProcessTests
 		Assert.NotEqual(true, narrow.IsError);
 		Assert.Contains("src/Single.ts", narrowText, StringComparison.Ordinal);
 		Assert.Contains("1:const solitaryMarker = 1", narrowText, StringComparison.Ordinal);
-		Assert.DoesNotContain("[Search totals]", narrowText, StringComparison.Ordinal);
+		Assert.DoesNotContain("[Search observed]", narrowText, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Search truncated]", narrowText, StringComparison.Ordinal);
 		Assert.DoesNotContain("additional matches", narrowText, StringComparison.Ordinal);
 	}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchOrder.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchOrder.cs
@@ -88,7 +88,7 @@ public sealed partial class McpServerProcessTests
 		Assert.True(declaration >= 0 && report > declaration, complete);
 		Assert.Contains("[Search order] bounded evidence priority", complete, StringComparison.Ordinal);
 		Assert.Contains("[Search boundary] complete · sources inspected=4/4 · matches retained=5/5 · " +
-		                "matches written=5", complete, StringComparison.Ordinal);
+						"matches written=5", complete, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Search stored]", complete, StringComparison.Ordinal);
 		Assert.DoesNotContain("additional matches", complete, StringComparison.Ordinal);
 	}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchOrder.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.SearchOrder.cs
@@ -31,13 +31,13 @@ public sealed partial class McpServerProcessTests
 
 		// The order in force is named, in a constant that carries nothing from the project.
 		Assert.Contains(
-			"[Search order] hits inside a declaration first, then the rest; selection order breaks ties.",
+			"[Search order] bounded evidence priority; canonical path and line break ties.",
 			slice,
 			StringComparison.Ordinal);
 
 		// What was not shown is still counted and still reachable.
-		Assert.Contains("[Search totals] matches=5 · files=4", slice, StringComparison.Ordinal);
-		Assert.Contains("[3 additional matches not shown", slice, StringComparison.Ordinal);
+		Assert.Contains("[Search observed] matches=5 · matching-files=4 within inspected sources", slice, StringComparison.Ordinal);
+		Assert.Contains("[3 additional observed matches not shown", slice, StringComparison.Ordinal);
 		Assert.Contains("[Search stored] pack_id=", slice, StringComparison.Ordinal);
 	}
 
@@ -66,7 +66,7 @@ public sealed partial class McpServerProcessTests
 	}
 
 	[Fact]
-	public async Task RealProcessLeavesASearchThatShowedEverythingInSelectionOrder()
+	public async Task RealProcessUsesStableEvidenceOrderEvenWhenEveryMatchFits()
 	{
 		using var workspace = new TemporaryDirectory();
 		var project = await StartOrderProjectAsync(workspace);
@@ -81,12 +81,14 @@ public sealed partial class McpServerProcessTests
 				["context_lines"] = 0
 			})));
 
-		// Nothing was withheld, so there was no slice to choose: the generated report keeps its
-		// place at the front, exactly where selection order puts it, and no order is announced.
+		// Arrival order is not evidence: the same stable rule applies even when every match fits,
+		// otherwise raising max_results would silently put an early repeated report first again.
 		var declaration = complete.IndexOf("src/Core/LevelOverrideMap.cs", StringComparison.Ordinal);
 		var report = complete.IndexOf("results/report.md", StringComparison.Ordinal);
-		Assert.True(report >= 0 && declaration > report, complete);
-		Assert.DoesNotContain("[Search order]", complete, StringComparison.Ordinal);
+		Assert.True(declaration >= 0 && report > declaration, complete);
+		Assert.Contains("[Search order] bounded evidence priority", complete, StringComparison.Ordinal);
+		Assert.Contains("[Search boundary] complete · sources inspected=4/4 · matches retained=5/5 · " +
+		                "matches written=5", complete, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Search stored]", complete, StringComparison.Ordinal);
 		Assert.DoesNotContain("additional matches", complete, StringComparison.Ordinal);
 	}

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.StoredSearch.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.StoredSearch.cs
@@ -52,8 +52,8 @@ public sealed partial class McpServerProcessTests
 		// this file was shown, so nine of its ten are withheld.
 		Assert.Contains("9 src/File01.cs", searched, StringComparison.Ordinal);
 		Assert.Contains("10 src/File05.cs", searched, StringComparison.Ordinal);
-		Assert.Contains("[55 additional matches not shown", searched, StringComparison.Ordinal);
-		Assert.Contains("[Search totals] matches=60 · files=6", searched, StringComparison.Ordinal);
+		Assert.Contains("[55 additional observed matches not shown", searched, StringComparison.Ordinal);
+		Assert.Contains("[Search observed] matches=60 · matching-files=6 within inspected sources", searched, StringComparison.Ordinal);
 
 		var stored = Regex.Match(searched, @"\[Search stored\] pack_id=([0-9a-f]+) · matches=(\d+) · files=(\d+);");
 		Assert.True(stored.Success, searched);
@@ -115,7 +115,7 @@ public sealed partial class McpServerProcessTests
 		Assert.DoesNotContain("[Search stored]", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("Withheld matches by file:", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("additional matches", text, StringComparison.Ordinal);
-		Assert.DoesNotContain("[Search totals]", text, StringComparison.Ordinal);
+		Assert.DoesNotContain("[Search observed]", text, StringComparison.Ordinal);
 	}
 
 }

--- a/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.StoredSearch.cs
+++ b/Tests/DevProjex.Tests.Terminal/McpServerProcessTests.StoredSearch.cs
@@ -110,12 +110,13 @@ public sealed partial class McpServerProcessTests
 			"search_project",
 			new Dictionary<string, object?> { ["pattern"] = "=> 1", ["context_lines"] = 0 })));
 
-		// Nothing was withheld, so nothing is stored and nothing new is said.
+		// Nothing was withheld, so nothing is stored; the boundary still proves completeness.
 		Assert.Contains("src/App.cs\nin P.App.Run\n5:", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Search stored]", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("Withheld matches by file:", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("additional matches", text, StringComparison.Ordinal);
 		Assert.DoesNotContain("[Search observed]", text, StringComparison.Ordinal);
+		Assert.Contains("[Search boundary] complete", text, StringComparison.Ordinal);
 	}
 
 }

--- a/Tests/DevProjex.Tests.Unit/McpSearchCandidateCollectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpSearchCandidateCollectorTests.cs
@@ -1,4 +1,5 @@
 using DevProjex.Mcp;
+using DevProjex.Application.Dependencies;
 
 namespace DevProjex.Tests.Unit;
 
@@ -24,6 +25,43 @@ public sealed class McpSearchCandidateCollectorTests
 		Assert.Equal(5_000, retained.Count);
 		Assert.Contains(retained, item => item.Group.RelativePath == "src/PublicApi.cs");
 		Assert.Equal(4_999, retained.Count(item => item.Group.RelativePath == "generated/repetitions.txt"));
+		Assert.True(collector.MatchCapacityReached);
+	}
+
+	[Fact]
+	public void StreamingScanLetsALateDeclarationDisplaceAnEarlierMatchInTheSameFile()
+	{
+		var content = string.Concat(Enumerable.Repeat("Needle repeated mention\n", 5_000)) +
+					  "public sealed class Needle { }\n";
+		var regex = new McpSearchRegex("Needle", ignoreCase: false);
+		var collector = new McpSearchCandidateCollector(5_000, 2_000_000);
+		var state = new McpSearchFilePriorityState();
+		var declarations = new[]
+		{
+			new NavigationDeclaration("Needle", NavigationSymbolKind.Type, null, 5_001, 5_001, "fixture")
+		};
+
+		var scan = McpSearchTextScanner.ScanEach(
+			content,
+			regex,
+			0,
+			[],
+			match => DevProjexMcpTools.AddSearchCandidates(
+				collector,
+				"File.cs",
+				"File.cs",
+				content,
+				[match],
+				declarations,
+				regex,
+				0,
+				explicitScope: false,
+				state),
+			TestContext.Current.CancellationToken);
+
+		Assert.Equal(5_001, scan.TotalMatches);
+		Assert.Equal(5_000, collector.Count);
+		Assert.Contains(collector.Snapshot(), candidate => candidate.MatchLine == 5_001);
 		Assert.True(collector.MatchCapacityReached);
 	}
 
@@ -65,6 +103,29 @@ public sealed class McpSearchCandidateCollectorTests
 			false, 1, McpDeclarationMatchQuality.FullyQualified, true, 1, 0);
 
 		Assert.True(unsupportedFirst > supportedRepeated);
+	}
+
+	[Fact]
+	public void DeclarationPrecisionAddsSoftOrderedWeights()
+	{
+		var plain = McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.None, false, 0, 0);
+		var hint = McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.None, true, 0, 0);
+		var simple = McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.SimpleName, false, 0, 0);
+		var qualified = McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.FullyQualified, false, 0, 0);
+
+		Assert.True(plain < hint);
+		Assert.True(hint < simple);
+		Assert.True(simple < qualified);
+	}
+
+	[Fact]
+	public void RepetitionLowersButNeverEliminatesAMatch()
+	{
+		var first = McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.None, false, 0, 0);
+		var repeated = McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.None, false, 0, 10_000);
+
+		Assert.True(repeated < first);
+		Assert.True(repeated > 0);
 	}
 
 	[Fact]
@@ -140,7 +201,7 @@ public sealed class McpSearchCandidateCollectorTests
 		var notice = DevProjexMcpTools.FormatSearchBoundaryNotice(Boundary(), false);
 
 		Assert.Equal("[Search boundary] complete · sources inspected=10/10 · matches retained=3/3 · " +
-		             "matches written=3 · declaration files named=2.", notice);
+					 "matches written=3 · declaration files named=2.", notice);
 	}
 
 	[Theory]

--- a/Tests/DevProjex.Tests.Unit/McpSearchCandidateCollectorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/McpSearchCandidateCollectorTests.cs
@@ -1,0 +1,233 @@
+using DevProjex.Mcp;
+
+namespace DevProjex.Tests.Unit;
+
+public sealed class McpSearchCandidateCollectorTests
+{
+	[Fact]
+	public void UsefulLateMatchDisplacesOneOfFiveThousandEarlyRepetitions()
+	{
+		var collector = new McpSearchCandidateCollector(5_000, 2_000_000);
+		for (var line = 1; line <= 5_000; line++)
+		{
+			collector.Consider(Candidate(
+				"generated/repetitions.txt",
+				line,
+				McpSearchCandidateCollector.Score(false, line - 1, McpDeclarationMatchQuality.None, false, line - 1, line - 1)));
+		}
+		collector.Consider(Candidate(
+			"src/PublicApi.cs",
+			1,
+			McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.SimpleName, true, 0, 0)));
+
+		var retained = collector.Snapshot();
+		Assert.Equal(5_000, retained.Count);
+		Assert.Contains(retained, item => item.Group.RelativePath == "src/PublicApi.cs");
+		Assert.Equal(4_999, retained.Count(item => item.Group.RelativePath == "generated/repetitions.txt"));
+		Assert.True(collector.MatchCapacityReached);
+	}
+
+	[Fact]
+	public void PermutingCandidateArrivalProducesTheSameBoundedResult()
+	{
+		var source = Enumerable.Range(1, 40)
+			.Select(index => Candidate(
+				$"owner-{index % 5}/file-{index:D2}.txt",
+				index,
+				(index * 37) % 211))
+			.ToArray();
+		var forward = Collect(source, 11);
+		var reverse = Collect(source.Reverse(), 11);
+		var interleaved = Collect(source.Where((_, index) => index % 2 == 0)
+			.Concat(source.Where((_, index) => index % 2 != 0)), 11);
+
+		Assert.Equal(forward, reverse);
+		Assert.Equal(forward, interleaved);
+	}
+
+	[Fact]
+	public void ExplicitSnapshotCandidateKeepsPriorityWithoutAnOriginPenalty()
+	{
+		var explicitScore = McpSearchCandidateCollector.Score(
+			true, 0, McpDeclarationMatchQuality.None, false, 0, 0);
+		var ordinaryDeclarationScore = McpSearchCandidateCollector.Score(
+			false, 0, McpDeclarationMatchQuality.FullyQualified, true, 0, 0);
+
+		Assert.True(explicitScore > ordinaryDeclarationScore);
+	}
+
+	[Fact]
+	public void UnsupportedLanguageGetsAFirstMatchBeforeRepeatedSupportedMatches()
+	{
+		var unsupportedFirst = McpSearchCandidateCollector.Score(
+			false, 0, McpDeclarationMatchQuality.None, false, 0, 0);
+		var supportedRepeated = McpSearchCandidateCollector.Score(
+			false, 1, McpDeclarationMatchQuality.FullyQualified, true, 1, 0);
+
+		Assert.True(unsupportedFirst > supportedRepeated);
+	}
+
+	[Fact]
+	public void LateDeclarationCanEnterTheSixtyFourFileAnnotationSet()
+	{
+		var collector = new McpSearchCandidateCollector(5_000, 2_000_000);
+		for (var index = 0; index < 100; index++)
+		{
+			collector.Consider(Candidate(
+				$"generated/file-{index:D3}.txt",
+				1,
+				McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.None, false, 0, 0)));
+		}
+		collector.Consider(Candidate(
+			"zz/PublicContract.cs",
+			1,
+			McpSearchCandidateCollector.Score(false, 0, McpDeclarationMatchQuality.FullyQualified, true, 0, 0)));
+
+		var selected = collector.SelectFilesForAnnotation(64);
+		Assert.Equal(64, selected.Count);
+		Assert.Contains("zz/PublicContract.cs", selected);
+	}
+
+	[Fact]
+	public void RetainedFragmentsStayInsideTheCharacterBound()
+	{
+		var collector = new McpSearchCandidateCollector(10, 100);
+		collector.Consider(Candidate("a.txt", 1, 10, storageCharacters: 70));
+		collector.Consider(Candidate("b.txt", 1, 20, storageCharacters: 70));
+
+		Assert.Single(collector.Snapshot());
+		Assert.Equal(70, collector.RetainedCharacters);
+		Assert.True(collector.CharacterCapacityReached);
+		Assert.Equal("b.txt", collector.Snapshot()[0].Group.RelativePath);
+	}
+
+	[Fact]
+	public void SplittingMergedContextsKeepsEveryMatchingLineMarked()
+	{
+		var content = string.Join('\n', Enumerable.Range(1, 12)
+			.Select(line => line % 3 == 1 ? $"const needle{line} = 1" : $"const filler{line} = 1"));
+		var regex = new McpSearchRegex("needle", ignoreCase: false);
+		var scan = McpSearchTextScanner.Scan(content, regex, 3, 100, CancellationToken.None);
+		var collector = new McpSearchCandidateCollector(100, 100_000);
+
+		DevProjexMcpTools.AddSearchCandidates(
+			collector,
+			"src/File.ts",
+			"src/File.ts",
+			content,
+			scan.Matches,
+			[],
+			regex,
+			3,
+			explicitScope: false);
+		var groups = DevProjexMcpTools.BuildOrderedSearchGroups(collector.Snapshot());
+
+		Assert.Equal(4, collector.Count);
+		Assert.Equal([1, 4, 7, 10], groups.SelectMany(group => group.Lines)
+			.Where(line => line.IsMatch)
+			.Select(line => line.LineNumber)
+			.Distinct()
+			.Order()
+			.ToArray());
+		Assert.All(
+			groups.SelectMany(group => group.Lines).Where(line => line.IsMatch),
+			line => Assert.StartsWith($"{line.LineNumber}:", line.Text, StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void CompleteBoundaryStatesThatEveryEligibleSourceWasInspected()
+	{
+		var notice = DevProjexMcpTools.FormatSearchBoundaryNotice(Boundary(), false);
+
+		Assert.Equal("[Search boundary] complete · sources inspected=10/10 · matches retained=3/3 · " +
+		             "matches written=3 · declaration files named=2.", notice);
+	}
+
+	[Theory]
+	[InlineData("inspection-bytes", 0)]
+	[InlineData("retained-matches", 1)]
+	[InlineData("annotation-files", 2)]
+	[InlineData("response-characters", 3)]
+	public void PartialBoundaryNamesEachPublishedSearchLimit(string expected, int limit)
+	{
+		var flags = new bool[7];
+		flags[limit] = true;
+		var boundary = Boundary() with
+		{
+			InspectionByteLimitReached = flags[0],
+			RetainedMatchLimitReached = flags[1],
+			AnnotationFileLimitReached = flags[2],
+			ResponseCharacterLimitReached = flags[3]
+		};
+
+		var notice = DevProjexMcpTools.FormatSearchBoundaryNotice(boundary, true);
+
+		Assert.Contains("[Search boundary] partial", notice, StringComparison.Ordinal);
+		Assert.Contains($"limits={expected}", notice, StringComparison.Ordinal);
+		Assert.Contains("continue with read_pack", notice, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void BoundaryKeepsEncounteredRetainedAndWrittenCountsDistinct()
+	{
+		var boundary = Boundary() with
+		{
+			EncounteredMatches = 8_000,
+			RetainedMatches = 5_000,
+			WrittenMatches = 151,
+			RetainedMatchLimitReached = true,
+			ResponseCharacterLimitReached = true
+		};
+
+		var notice = DevProjexMcpTools.FormatSearchBoundaryNotice(boundary, false);
+
+		Assert.Contains("matches retained=5000/8000", notice, StringComparison.Ordinal);
+		Assert.Contains("matches written=151", notice, StringComparison.Ordinal);
+		Assert.Contains("continue the search", notice, StringComparison.Ordinal);
+	}
+
+	private static IReadOnlyList<string> Collect(IEnumerable<McpSearchCandidate> source, int capacity)
+	{
+		var collector = new McpSearchCandidateCollector(capacity, 2_000_000);
+		foreach (var candidate in source)
+			collector.Consider(candidate);
+		return collector.Snapshot()
+			.Select(item => $"{item.Group.RelativePath}:{item.MatchLine}:{item.Score}")
+			.ToArray();
+	}
+
+	private static McpSearchCandidate Candidate(
+		string path,
+		int line,
+		int score,
+		int storageCharacters = 20)
+	{
+		var text = $"{line}:needle";
+		return new McpSearchCandidate(
+			new McpSearchRenderedGroup(
+				path,
+				path,
+				[line],
+				[new McpSearchGroupLine(line, true, text)]),
+			line,
+			score,
+			text,
+			storageCharacters);
+	}
+
+	private static McpSearchBoundary Boundary() => new(
+		EligibleSources: 10,
+		InspectedSources: 10,
+		EncounteredMatches: 3,
+		RetainedMatches: 3,
+		WrittenMatches: 3,
+		NamedDeclarationFiles: 2,
+		InspectionByteLimitReached: false,
+		RetainedMatchLimitReached: false,
+		AnnotationFileLimitReached: false,
+		ResponseCharacterLimitReached: false,
+		RequestResultLimitReached: false,
+		RetainedCharacterLimitReached: false,
+		StoredCharacterLimitReached: false,
+		UnscannableSources: 0);
+}

--- a/tools/McpUsageRecorder/README.md
+++ b/tools/McpUsageRecorder/README.md
@@ -1,0 +1,45 @@
+# MCP usage recorder
+
+This tool converts a client-observed NDJSON capture into one session report without estimating
+model tokens from characters. It records MCP response bytes on the wire, decoded response size,
+the exact model-input size when the client exposes it, each API usage counter, model turns, tool
+calls, client and model identity, tool-loading mode, duration, and session outcome.
+
+Run it with one command:
+
+```text
+node tools/McpUsageRecorder/record.mjs --input capture.ndjson --output report.json --client-version 1.2.3 --model example-model --tool-loading-mode dynamic
+```
+
+Use `-` for stdin or stdout. Payload text is represented by byte counts and SHA-256 hashes; the
+report does not copy project or prompt text.
+
+## Capture events
+
+Each input line is one JSON object:
+
+- `session`: optional `clientVersion`, `model`, `toolLoadingMode`, and `startedAt`.
+- `mcp.response`: exactly one of `wireBase64` or `wireText`, optional `decodedText`, `requestId`,
+  `turnId`, and `success`.
+- `model.input`: `turnId` plus observable `text`, or `bytes` and optional `sha256` when the adapter
+  can observe only the encoded request.
+- `model.usage`: `turnId`, a `usage` object, optional `toolCallIds`, and `responseError`. Snake-case
+  API fields and camel-case recorder fields are accepted.
+- `tool.call`: stable `id`, `turnId`, optional `name`, and `success`.
+- `session.end`: `status` (`success`, `error`, or `aborted`), optional `endedAt` and `durationMs`.
+
+Usage is grouped by `turnId`. Multiple snapshots from streaming events or parallel tool calls use
+the maximum observed value of each counter for that turn, never their sum. Counters are summed only
+across distinct model turns. If the capture ends without `session.end`, the report marks it aborted
+and retains every observed usage counter and failed call.
+
+The four model counters remain separate: ordinary input, prompt-cache write, prompt-cache read, and
+output. `modelTurns` and `toolCalls` are also separate. A client adapter should emit `model.input`
+only at the final request boundary; if that boundary is not observable, omit the event rather than
+substituting MCP wire bytes.
+
+Run the parser tests with:
+
+```text
+node --test tools/McpUsageRecorder/tests/recorder.test.mjs
+```

--- a/tools/McpUsageRecorder/lib/recorder.mjs
+++ b/tools/McpUsageRecorder/lib/recorder.mjs
@@ -1,0 +1,295 @@
+import { createHash } from 'node:crypto';
+import { createInterface } from 'node:readline';
+
+const usageNames = Object.freeze({
+  inputTokens: ['inputTokens', 'input_tokens'],
+  cacheWriteTokens: [
+    'cacheWriteTokens',
+    'cache_write_input_tokens',
+    'cache_creation_input_tokens',
+  ],
+  cacheReadTokens: ['cacheReadTokens', 'cache_read_input_tokens'],
+  outputTokens: ['outputTokens', 'output_tokens'],
+});
+
+export async function recordCapture(readable, defaults = {}) {
+  const state = createState(defaults);
+  const lines = createInterface({ input: readable, crlfDelay: Infinity });
+  let lineNumber = 0;
+  for await (const line of lines) {
+    lineNumber++;
+    if (line.trim().length === 0)
+      continue;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`Invalid JSON on capture line ${lineNumber}: ${error.message}`);
+    }
+    applyEvent(state, event, lineNumber);
+  }
+  return finish(state);
+}
+
+export function recordEvents(events, defaults = {}) {
+  const state = createState(defaults);
+  events.forEach((event, index) => applyEvent(state, event, index + 1));
+  return finish(state);
+}
+
+function createState(defaults) {
+  return {
+    metadata: {
+      clientVersion: defaults.clientVersion ?? null,
+      model: defaults.model ?? null,
+      toolLoadingMode: defaults.toolLoadingMode ?? null,
+    },
+    startedAt: defaults.startedAt ?? null,
+    endedAt: null,
+    durationMs: defaults.durationMs ?? null,
+    status: null,
+    responses: [],
+    modelInputs: [],
+    turns: new Map(),
+    toolCalls: new Map(),
+    diagnostics: [],
+  };
+}
+
+function applyEvent(state, event, lineNumber) {
+  if (!event || typeof event !== 'object' || Array.isArray(event))
+    throw new Error(`Capture line ${lineNumber} must contain an object.`);
+  switch (event.type) {
+    case 'session':
+      state.metadata.clientVersion = scalar(event.clientVersion, state.metadata.clientVersion);
+      state.metadata.model = scalar(event.model, state.metadata.model);
+      state.metadata.toolLoadingMode = scalar(event.toolLoadingMode, state.metadata.toolLoadingMode);
+      state.startedAt = scalar(event.startedAt, state.startedAt);
+      break;
+    case 'mcp.response':
+      captureResponse(state, event, lineNumber);
+      break;
+    case 'model.input':
+      captureModelInput(state, event, lineNumber);
+      break;
+    case 'model.usage':
+      captureUsage(state, event, lineNumber);
+      break;
+    case 'tool.call':
+      captureToolCall(state, event, lineNumber);
+      break;
+    case 'session.end':
+      state.status = normalizeStatus(event.status);
+      state.endedAt = scalar(event.endedAt, state.endedAt);
+      state.durationMs = nonNegativeNumber(event.durationMs, 'durationMs', lineNumber, true) ?? state.durationMs;
+      break;
+    default:
+      throw new Error(`Unknown capture event type on line ${lineNumber}: ${String(event.type)}`);
+  }
+}
+
+function captureResponse(state, event, lineNumber) {
+  const wire = readWire(event, lineNumber);
+  const decoded = optionalText(event.decodedText, 'decodedText', lineNumber);
+  const response = {
+    requestId: scalar(event.requestId, null),
+    turnId: scalar(event.turnId, null),
+    success: event.success !== false,
+    wireBytes: wire.length,
+    wireSha256: digest(wire),
+    decodedObserved: decoded !== null,
+    decodedBytes: decoded === null ? null : Buffer.byteLength(decoded),
+    decodedCharacters: decoded?.length ?? null,
+    decodedSha256: decoded === null ? null : digest(Buffer.from(decoded)),
+  };
+  state.responses.push(response);
+}
+
+function captureModelInput(state, event, lineNumber) {
+  const turnId = requiredId(event.turnId, 'turnId', lineNumber);
+  const text = optionalText(event.text, 'text', lineNumber);
+  const byteCount = nonNegativeNumber(event.bytes, 'bytes', lineNumber, true);
+  if (text === null && byteCount === null)
+    throw new Error(`model.input on line ${lineNumber} requires text or bytes.`);
+  state.modelInputs.push({
+    turnId,
+    observed: event.observed !== false,
+    bytes: text === null ? byteCount : Buffer.byteLength(text),
+    characters: text?.length ?? null,
+    sha256: text === null ? scalar(event.sha256, null) : digest(Buffer.from(text)),
+  });
+}
+
+function captureUsage(state, event, lineNumber) {
+  const turnId = requiredId(event.turnId, 'turnId', lineNumber);
+  let turn = state.turns.get(turnId);
+  if (!turn) {
+    turn = {
+      turnId,
+      usage: emptyUsage(),
+      usageRecords: 0,
+      toolCallIds: new Set(),
+      responseError: false,
+    };
+    state.turns.set(turnId, turn);
+  }
+  turn.usageRecords++;
+  for (const [target, aliases] of Object.entries(usageNames)) {
+    const value = firstNumber(event.usage ?? event, aliases, lineNumber);
+    if (value !== null)
+      turn.usage[target] = Math.max(turn.usage[target], value);
+  }
+  if (Array.isArray(event.toolCallIds)) {
+    for (const id of event.toolCallIds)
+      turn.toolCallIds.add(requiredId(id, 'toolCallIds[]', lineNumber));
+  }
+  turn.responseError ||= event.responseError === true;
+}
+
+function captureToolCall(state, event, lineNumber) {
+  const id = requiredId(event.id, 'id', lineNumber);
+  const turnId = requiredId(event.turnId, 'turnId', lineNumber);
+  const existing = state.toolCalls.get(id);
+  if (existing && existing.turnId !== turnId)
+    throw new Error(`tool.call '${id}' is associated with multiple turns.`);
+  state.toolCalls.set(id, {
+    id,
+    turnId,
+    name: scalar(event.name, existing?.name ?? null),
+    success: event.success !== false,
+  });
+  let turn = state.turns.get(turnId);
+  if (!turn) {
+    turn = {
+      turnId,
+      usage: emptyUsage(),
+      usageRecords: 0,
+      toolCallIds: new Set(),
+      responseError: false,
+    };
+    state.turns.set(turnId, turn);
+  }
+  turn.toolCallIds.add(id);
+}
+
+function finish(state) {
+  const turns = [...state.turns.values()].map(turn => ({
+    turnId: turn.turnId,
+    usage: turn.usage,
+    usageRecords: turn.usageRecords,
+    toolCalls: turn.toolCallIds.size,
+    responseError: turn.responseError,
+  }));
+  const usage = turns.reduce((sum, turn) => addUsage(sum, turn.usage), emptyUsage());
+  const decodedObserved = state.responses.filter(response => response.decodedObserved).length;
+  const inputObserved = state.modelInputs.filter(input => input.observed).length;
+  const status = state.status ?? 'aborted';
+  return {
+    schemaVersion: 1,
+    session: {
+      ...state.metadata,
+      startedAt: state.startedAt,
+      endedAt: state.endedAt,
+      durationMs: state.durationMs,
+      status,
+      successful: status === 'success',
+    },
+    totals: {
+      wireResponseBytes: sum(state.responses, 'wireBytes'),
+      decodedResponseBytes: sumNullable(state.responses, 'decodedBytes'),
+      decodedResponsesObserved: decodedObserved,
+      decodedResponsesUnobserved: state.responses.length - decodedObserved,
+      modelInputBytes: sumNullable(state.modelInputs.filter(input => input.observed), 'bytes'),
+      modelInputsObserved: inputObserved,
+      modelInputsUnobserved: state.modelInputs.length - inputObserved,
+      modelTurns: turns.length,
+      toolCalls: state.toolCalls.size,
+      failedToolCalls: [...state.toolCalls.values()].filter(call => !call.success).length,
+      failedMcpResponses: state.responses.filter(response => !response.success).length,
+      usage,
+    },
+    turns,
+    responses: state.responses,
+    modelInputs: state.modelInputs,
+    toolCalls: [...state.toolCalls.values()],
+    diagnostics: state.diagnostics,
+  };
+}
+
+function readWire(event, lineNumber) {
+  const hasBase64 = event.wireBase64 !== undefined;
+  const hasText = event.wireText !== undefined;
+  if (hasBase64 === hasText)
+    throw new Error(`mcp.response on line ${lineNumber} requires exactly one of wireBase64 or wireText.`);
+  if (hasBase64) {
+    if (typeof event.wireBase64 !== 'string')
+      throw new Error(`wireBase64 on line ${lineNumber} must be a string.`);
+    return Buffer.from(event.wireBase64, 'base64');
+  }
+  if (typeof event.wireText !== 'string')
+    throw new Error(`wireText on line ${lineNumber} must be a string.`);
+  return Buffer.from(event.wireText);
+}
+
+function firstNumber(source, names, lineNumber) {
+  for (const name of names) {
+    if (source[name] !== undefined)
+      return nonNegativeNumber(source[name], name, lineNumber, false);
+  }
+  return null;
+}
+
+function emptyUsage() {
+  return { inputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 0, outputTokens: 0 };
+}
+
+function addUsage(left, right) {
+  for (const name of Object.keys(left))
+    left[name] += right[name];
+  return left;
+}
+
+function sum(values, property) {
+  return values.reduce((total, value) => total + value[property], 0);
+}
+
+function sumNullable(values, property) {
+  const observed = values.map(value => value[property]).filter(value => value !== null);
+  return observed.length === 0 ? null : observed.reduce((total, value) => total + value, 0);
+}
+
+function digest(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function optionalText(value, name, lineNumber) {
+  if (value === undefined || value === null)
+    return null;
+  if (typeof value !== 'string')
+    throw new Error(`${name} on line ${lineNumber} must be a string.`);
+  return value;
+}
+
+function requiredId(value, name, lineNumber) {
+  if (typeof value !== 'string' || value.length === 0)
+    throw new Error(`${name} on line ${lineNumber} must be a non-empty string.`);
+  return value;
+}
+
+function nonNegativeNumber(value, name, lineNumber, nullable) {
+  if (nullable && (value === undefined || value === null))
+    return null;
+  if (!Number.isSafeInteger(value) || value < 0)
+    throw new Error(`${name} on line ${lineNumber} must be a non-negative safe integer.`);
+  return value;
+}
+
+function scalar(value, fallback) {
+  return value === undefined || value === null ? fallback : value;
+}
+
+function normalizeStatus(value) {
+  if (value === 'success' || value === 'error' || value === 'aborted')
+    return value;
+  throw new Error(`session.end status must be success, error, or aborted.`);
+}

--- a/tools/McpUsageRecorder/record.mjs
+++ b/tools/McpUsageRecorder/record.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { recordCapture } from './lib/recorder.mjs';
+
+const options = parseArguments(process.argv.slice(2));
+const input = options.input === '-'
+  ? process.stdin
+  : createReadStream(resolve(options.input), { encoding: 'utf8' });
+const report = await recordCapture(input, {
+  clientVersion: options.clientVersion,
+  model: options.model,
+  toolLoadingMode: options.toolLoadingMode,
+});
+const json = JSON.stringify(report, null, 2) + '\n';
+if (options.output === '-') {
+  process.stdout.write(json);
+} else {
+  const outputPath = resolve(options.output);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await new Promise((resolveWrite, rejectWrite) => {
+    const output = createWriteStream(outputPath, { encoding: 'utf8' });
+    output.on('error', rejectWrite);
+    output.on('finish', resolveWrite);
+    output.end(json);
+  });
+}
+
+function parseArguments(args) {
+  const options = { input: '-', output: '-' };
+  for (let index = 0; index < args.length; index++) {
+    const name = args[index];
+    if (name === '--help') {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (!['--input', '--output', '--client-version', '--model', '--tool-loading-mode'].includes(name))
+      fail(`Unknown option: ${name}`);
+    const value = args[++index];
+    if (!value)
+      fail(`Missing value for ${name}.`);
+    const property = name.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    options[property] = value;
+  }
+  return options;
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n${usage()}`);
+  process.exit(2);
+}
+
+function usage() {
+  return 'Usage: node tools/McpUsageRecorder/record.mjs --input capture.ndjson --output report.json ' +
+    '[--client-version VERSION] [--model MODEL] [--tool-loading-mode MODE]\n';
+}

--- a/tools/McpUsageRecorder/tests/recorder.test.mjs
+++ b/tools/McpUsageRecorder/tests/recorder.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { recordEvents } from '../lib/recorder.mjs';
+
+test('parallel tool calls share one model turn and one usage snapshot', () => {
+  const report = recordEvents([
+    { type: 'session', clientVersion: '1.0', model: 'model-a', toolLoadingMode: 'dynamic' },
+    { type: 'model.usage', turnId: 'turn-1', usage: {
+      input_tokens: 100,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 30,
+      output_tokens: 5,
+    }, toolCallIds: ['call-a', 'call-b'] },
+    { type: 'tool.call', id: 'call-a', turnId: 'turn-1', name: 'search_project' },
+    { type: 'tool.call', id: 'call-b', turnId: 'turn-1', name: 'get_file' },
+    { type: 'model.usage', turnId: 'turn-1', usage: {
+      input_tokens: 100,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 30,
+      output_tokens: 5,
+    } },
+    { type: 'session.end', status: 'success', durationMs: 250 },
+  ]);
+
+  assert.equal(report.totals.modelTurns, 1);
+  assert.equal(report.totals.toolCalls, 2);
+  assert.deepEqual(report.totals.usage, {
+    inputTokens: 100,
+    cacheWriteTokens: 20,
+    cacheReadTokens: 30,
+    outputTokens: 5,
+  });
+  assert.equal(report.turns[0].usageRecords, 2);
+});
+
+test('aborted capture retains usage and failed work', () => {
+  const report = recordEvents([
+    { type: 'model.usage', turnId: 'turn-1', usage: { input_tokens: 40, output_tokens: 2 } },
+    { type: 'tool.call', id: 'call-a', turnId: 'turn-1', name: 'search_project', success: false },
+    { type: 'mcp.response', turnId: 'turn-1', requestId: 'call-a', wireText: '{"error":true}', success: false },
+  ]);
+
+  assert.equal(report.session.status, 'aborted');
+  assert.equal(report.session.successful, false);
+  assert.equal(report.totals.usage.inputTokens, 40);
+  assert.equal(report.totals.failedToolCalls, 1);
+  assert.equal(report.totals.failedMcpResponses, 1);
+});
+
+test('model turn without tool calls remains a turn', () => {
+  const report = recordEvents([
+    { type: 'model.input', turnId: 'turn-1', text: 'plain request' },
+    { type: 'model.usage', turnId: 'turn-1', usage: { input_tokens: 3, output_tokens: 7 } },
+    { type: 'session.end', status: 'success' },
+  ]);
+
+  assert.equal(report.totals.modelTurns, 1);
+  assert.equal(report.totals.toolCalls, 0);
+  assert.equal(report.totals.modelInputBytes, Buffer.byteLength('plain request'));
+});
+
+test('error response records wire and decoded boundaries independently', () => {
+  const wire = Buffer.from([0, 1, 2, 255]);
+  const decoded = 'DPX-MCP-ERROR';
+  const report = recordEvents([
+    {
+      type: 'mcp.response',
+      requestId: 'request-1',
+      wireBase64: wire.toString('base64'),
+      decodedText: decoded,
+      success: false,
+    },
+    { type: 'session.end', status: 'error', durationMs: 12 },
+  ]);
+
+  assert.equal(report.totals.wireResponseBytes, 4);
+  assert.equal(report.totals.decodedResponseBytes, Buffer.byteLength(decoded));
+  assert.equal(report.totals.failedMcpResponses, 1);
+  assert.equal(report.session.status, 'error');
+});
+
+test('streaming usage fields merge within a turn and sum across turns', () => {
+  const report = recordEvents([
+    { type: 'model.usage', turnId: 'turn-1', usage: { input_tokens: 10, cache_read_input_tokens: 5 } },
+    { type: 'model.usage', turnId: 'turn-1', usage: { output_tokens: 9 } },
+    { type: 'model.usage', turnId: 'turn-2', usage: { input_tokens: 3, output_tokens: 2 } },
+    { type: 'session.end', status: 'success' },
+  ]);
+
+  assert.deepEqual(report.totals.usage, {
+    inputTokens: 13,
+    cacheWriteTokens: 0,
+    cacheReadTokens: 5,
+    outputTokens: 11,
+  });
+  assert.equal(report.totals.modelTurns, 2);
+});


### PR DESCRIPTION
## Summary\n\n- add a one-command NDJSON recorder that separates MCP wire bytes, decoded text, observable model input, model turns, tool calls, and per-turn usage fields\n- replace arrival-ordered search retention with a bounded deterministic best-candidate collector\n- distribute declaration naming over retained evidence instead of the first matching files\n- report complete and partial search boundaries with inspected, encountered, retained, written, and named-file counts\n- document continuation behavior and the unchanged safety limits\n\n## Validation\n\n- targeted unit, integration, and real-process MCP search tests\n- recorder stream parser tests\n- TerminalHost Release build with zero warnings\n- CI on the final commit