### PR TITLE
fix(dependencies): improve live language evidence

### DIFF
--- a/Application/Dependencies/DependencyFactsContracts.cs
+++ b/Application/Dependencies/DependencyFactsContracts.cs
@@ -69,6 +69,7 @@ public sealed record DependencyScopeDescriptor(
 	public bool HasTypeScriptCustomConditions { get; init; }
 	public bool DisableTransitiveProjectReferences { get; init; }
 	public IReadOnlySet<string> RubyExternalPackages { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+	public IReadOnlyList<string> RustTargetRoots { get; init; } = [];
 }
 
 public sealed record PackageMapDescriptor(

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -2436,7 +2436,12 @@ public sealed class DependencyFactsEngine : IDisposable
 				if (!requiresQualifiedLookup)
 					candidates = SelectVisibleJavaCandidates(source, reference, candidates);
 				if (source.LanguageId == LanguageId.Kotlin)
+				{
 					candidates = FilterKotlinSourceSetCandidates(source, candidates);
+					if (reference.SyntaxKind == "identifier")
+						candidates = candidates.Where(static candidate =>
+							candidate.Identity.SymbolKind == SymbolKind.Module).ToArray();
+				}
 			}
 			else if (source.LanguageId == LanguageId.Rust && !requiresQualifiedLookup)
 				candidates = SelectVisibleRustCandidates(source, reference, candidates);

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1383,7 +1383,7 @@ public sealed class DependencyFactsEngine : IDisposable
 					"wildcard import is resolution context, not a dependency target", []);
 			if (import.IsCrateQualified)
 			{
-				var localDeclarations = LookupQualifiedInScope(source, import.Specifier, 0);
+				var localDeclarations = LookupRustCrateQualifiedInScope(source, import.Specifier);
 				var localFiles = localDeclarations.SelectMany(static declaration => declaration.DeclarationSites)
 					.Select(static site => site.File)
 					.Distinct(StringComparer.Ordinal)
@@ -1423,6 +1423,23 @@ public sealed class DependencyFactsEngine : IDisposable
 				1 => Edge(source, import, ResolutionStatus.Resolved, files[0], "one imported declaration", files),
 				_ => Edge(source, import, ResolutionStatus.Ambiguous, null, "multiple imported declarations", files)
 			};
+		}
+
+		private DeclarationFact[] LookupRustCrateQualifiedInScope(FileFacts source, string name)
+		{
+			var exact = LookupQualifiedInScope(source, name, 0);
+			if (exact.Length > 0)
+				return exact;
+
+			var normalized = QualifiedLookupName(name);
+			var suffix = "::" + normalized;
+			return _declarations.Where(declaration =>
+				declaration.Identity.ScopeId == source.ScopeId &&
+				declaration.Identity.LanguageId == LanguageId.Rust &&
+				declaration.Identity.GenericArity == 0 &&
+				QualifiedLookupName(declaration.Identity.QualifiedName)
+					.EndsWith(suffix, StringComparison.Ordinal) &&
+				IsVisible(source, declaration)).ToArray();
 		}
 
 		private static bool IsConventionalRustTargetRoot(DependencyScopeDescriptor? scope, string sourcePath)

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1351,14 +1351,16 @@ public sealed class DependencyFactsEngine : IDisposable
 
 		private DependencyEdge ResolveRustImport(FileFacts source, ImportFact import)
 		{
-			if (FindScope(source.ScopeId) is { } scope && ConfigurationFailure(scope) is { } configurationFailure)
+			var scope = FindScope(source.ScopeId);
+			if (scope is not null && ConfigurationFailure(scope) is { } configurationFailure)
 				return Edge(source, import, ResolutionStatus.Unresolved, null, configurationFailure, []);
 			if (import.ImportedName == "$module")
 			{
 				var sourcePath = Path.Combine(_root, source.Path);
 				var sourceDirectory = Path.GetDirectoryName(sourcePath)!;
 				var sourceStem = Path.GetFileNameWithoutExtension(sourcePath);
-				var directory = sourceStem is "lib" or "main" or "mod"
+				var directory = sourceStem is "lib" or "main" or "mod" ||
+				                IsConventionalRustTargetRoot(scope, sourcePath)
 					? sourceDirectory
 					: Path.Combine(sourceDirectory, sourceStem);
 				if (!string.IsNullOrEmpty(import.ContainingDeclaration))
@@ -1421,6 +1423,16 @@ public sealed class DependencyFactsEngine : IDisposable
 				1 => Edge(source, import, ResolutionStatus.Resolved, files[0], "one imported declaration", files),
 				_ => Edge(source, import, ResolutionStatus.Ambiguous, null, "multiple imported declarations", files)
 			};
+		}
+
+		private static bool IsConventionalRustTargetRoot(DependencyScopeDescriptor? scope, string sourcePath)
+		{
+			if (scope is null)
+				return false;
+			var relative = Path.GetRelativePath(scope.Root, sourcePath).Replace('\\', '/');
+			var separator = relative.IndexOf('/');
+			return separator > 0 && relative.IndexOf('/', separator + 1) < 0 &&
+			       relative[..separator] is "tests" or "examples" or "benches";
 		}
 
 		private DependencyEdge ResolveRubyImport(FileFacts source, ImportFact import)

--- a/Application/Dependencies/DependencyFactsEngine.cs
+++ b/Application/Dependencies/DependencyFactsEngine.cs
@@ -1433,13 +1433,32 @@ public sealed class DependencyFactsEngine : IDisposable
 
 			var normalized = QualifiedLookupName(name);
 			var suffix = "::" + normalized;
+			var scope = FindScope(source.ScopeId);
+			var sourceTarget = FindUniqueRustTarget(scope, source.Path);
+			if (sourceTarget is null)
+				return [];
 			return _declarations.Where(declaration =>
 				declaration.Identity.ScopeId == source.ScopeId &&
 				declaration.Identity.LanguageId == LanguageId.Rust &&
 				declaration.Identity.GenericArity == 0 &&
 				QualifiedLookupName(declaration.Identity.QualifiedName)
 					.EndsWith(suffix, StringComparison.Ordinal) &&
+				declaration.DeclarationSites.All(site =>
+					PathComparer.Equals(FindUniqueRustTarget(scope, site.File), sourceTarget)) &&
 				IsVisible(source, declaration)).ToArray();
+		}
+
+		private string? FindUniqueRustTarget(DependencyScopeDescriptor? scope, string relativePath)
+		{
+			if (scope is null || scope.RustTargetRoots.Count == 0)
+				return null;
+			var fullPath = Path.GetFullPath(Path.Combine(_root, relativePath));
+			var matches = scope.RustTargetRoots
+				.Where(target => PathComparer.Equals(target, fullPath) ||
+					IsWithin(Path.GetDirectoryName(target)!, fullPath))
+				.Take(2)
+				.ToArray();
+			return matches.Length == 1 ? matches[0] : null;
 		}
 
 		private static bool IsConventionalRustTargetRoot(DependencyScopeDescriptor? scope, string sourcePath)
@@ -1448,7 +1467,8 @@ public sealed class DependencyFactsEngine : IDisposable
 				return false;
 			var relative = Path.GetRelativePath(scope.Root, sourcePath).Replace('\\', '/');
 			var separator = relative.IndexOf('/');
-			return separator > 0 && relative.IndexOf('/', separator + 1) < 0 &&
+			return scope.RustTargetRoots.Any(target => PathComparer.Equals(target, sourcePath)) ||
+			       separator > 0 && relative.IndexOf('/', separator + 1) < 0 &&
 			       relative[..separator] is "tests" or "examples" or "benches";
 		}
 

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -221,6 +221,8 @@ to type references. Conventional multiplatform source-set paths constrain declar
 declarations are visible to platform source sets, while JVM sources exclude non-JVM, native, JS, and
 Wasm declaration sites. Class, function, and nested-class parameters shadow same-name declarations
 only inside their lexical owner; qualified names and types used by bounds remain ordinary references.
+Generic type references retain their declared arity while their type arguments are resolved or kept
+local independently, so `TypedOptions<T>` can resolve `TypedOptions` without turning `T` into a project edge.
 Capitalized receivers in qualified calls are type-reference evidence when no parameter or property
 with that name is declared in the file. This covers object and companion-style calls while keeping a
 same-named value as a local expression instead of inventing a type edge.

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -172,7 +172,9 @@ declared package and complete nesting chain. Exact imports resolve only to match
 the allowed manifest; static imports walk back to the nearest declaring type. Same-package types and
 types admitted by an exact or wildcard import are visible to type references. Two visible declarations
 remain ambiguous, and a name elsewhere in the repository is never selected merely because it is the
-only match. Class, method, constructor, and nested-type parameters shadow declarations only inside
+only match. Capitalized receivers of method and field access provide type-reference evidence, while
+lexically visible value declarations with the same name suppress that evidence. Class, method,
+constructor, and nested-type parameters shadow declarations only inside
 their lexical owner; qualified names and types used by bounds remain ordinary references. Bounded
 `pom.xml`, `build.gradle`, and `build.gradle.kts` files divide a repository into
 source scopes. Package-qualified declarations inside a source scope remain resolvable when Maven
@@ -273,7 +275,8 @@ error publishes neither recovered declarations nor recovered edges.
 PHP source files contribute classes, interfaces, traits, enums, and top-level functions under their
 declared namespace. Simple namespace `use` statements and aliases resolve only to matching declarations
 in the allowed manifest; inheritance, implemented interfaces, property types, parameters, return
-types, and unqualified static access inside the current namespace supply type-reference evidence.
+types, unqualified static access inside the current namespace, and fully qualified static access
+supply type-reference evidence.
 Bounded `composer.json` files provide package names, repository
 package dependencies, and literal PSR-4 mappings as data. Composer plugins, generated autoload files,
 installed vendor packages, grouped imports, and runtime class aliases are not executed or guessed and

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -236,7 +236,7 @@ name fall back to the nearest supported owner. A syntax tree containing an error
 recovered declarations nor recovered edges. Related-file coverage lists the bounded set of paths for
 which extraction failed, in addition to the aggregate count, so callers can inspect the omitted files.
 
-Ruby source files contribute classes and modules under their complete lexical owner chain. Literal
+Ruby source files (`.rb`, `.rake`, `.gemspec`, and Rack `.ru` entry files) contribute classes and modules under their complete lexical owner chain. Literal
 `require_relative` resolves only the corresponding `.rb` file beside the source, while literal
 `require` probes the repository root, its `lib` directory, and `lib` directories of repository gems
 made visible by a literal `path:` entry in `Gemfile`. Gem specifications are read as bounded data for

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -198,8 +198,10 @@ stem directory of an ordinary source file, and under every enclosing inline modu
 `#[path]` overrides stay unresolved because arbitrary module paths are not modeled. Private, `pub`, and
 restricted-visibility `use` trees, aliases, `crate`, `self`, and bounded `super` prefixes are expanded
 without executing code; `crate::`
-is resolved exclusively inside the nearest owning Cargo package, while exact
-items resolve only to matching declarations in the allowed manifest, while glob imports provide
+is resolved exclusively inside the nearest owning Cargo package. When a Cargo target uses a
+nonstandard source path, a crate-qualified item may match a unique declaration by its complete
+module suffix inside that package; equal suffixes remain ambiguous. Exact items otherwise resolve
+only to matching declarations in the allowed manifest, while glob imports provide
 visibility context without inventing a module edge. A bounded `Cargo.toml` supplies the crate name
 and literal local `path` dependencies, including dev and build dependencies. Referenced repository
 crates are visible transitively, but an unqualified declaration in the source file's own module and

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -193,7 +193,8 @@ edges.
 Rust source files contribute modules, structs, enums, unions, traits, type aliases, and free
 functions under the module path implied by their repository path and inline `mod` nesting. A
 literal `mod name;` resolves from the declaring module directory: beside a crate root or `mod.rs`,
-under the stem directory of an ordinary source file, and under every enclosing inline module.
+beside a conventional top-level Cargo integration-test, example, or benchmark target, under the
+stem directory of an ordinary source file, and under every enclosing inline module.
 `#[path]` overrides stay unresolved because arbitrary module paths are not modeled. Private, `pub`, and
 restricted-visibility `use` trees, aliases, `crate`, `self`, and bounded `super` prefixes are expanded
 without executing code; `crate::`

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -229,9 +229,10 @@ Wasm declaration sites. Class, function, and nested-class parameters shadow same
 only inside their lexical owner; qualified names and types used by bounds remain ordinary references.
 Generic type references retain their declared arity while their type arguments are resolved or kept
 local independently, so `TypedOptions<T>` can resolve `TypedOptions` without turning `T` into a project edge.
-Capitalized receivers in qualified calls are type-reference evidence when no parameter or property
-with that name is declared in the file. This covers object and companion-style calls while keeping a
-same-named value as a local expression instead of inventing a type edge.
+Capitalized receivers in qualified calls are type-reference evidence for a declared object when no
+parameter or property with that name is declared in the file. Class companion dispatch remains
+unresolved rather than inferred, and a same-named value remains a local expression instead of
+creating a type edge.
 Bounded `pom.xml`, `build.gradle`,
 and `build.gradle.kts` files define source scopes using the same literal repository-only Maven and
 Gradle project relationships described for Java. External artifacts, generated sources, compiler

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -202,7 +202,8 @@ restricted-visibility `use` trees, aliases, `crate`, `self`, and bounded `super`
 without executing code; `crate::`
 is resolved exclusively inside the nearest owning Cargo package. When a Cargo target uses a
 nonstandard source path, a crate-qualified item may match a unique declaration by its complete
-module suffix inside that package; equal suffixes remain ambiguous. Exact items otherwise resolve
+module suffix inside that explicit target; target boundaries and equal suffixes remain unresolved.
+Exact items otherwise resolve
 only to matching declarations in the allowed manifest, while glob imports provide
 visibility context without inventing a module edge. A bounded `Cargo.toml` supplies the crate name
 and literal local `path` dependencies, including dev and build dependencies. Referenced repository

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -363,6 +363,13 @@ TypeScript signatures, Go interface methods, and Java, Kotlin, Ruby, and PHP mem
 Python lambdas, Go function literals, unnamed Kotlin lambdas, Ruby metaprogramming, and anonymous PHP functions fall back to the nearest supported named owner rather than
 claiming a false member.
 
+C and C++ dependency facts remain unsupported. Their source grammars parse ordinary declarations,
+but project-defined prefix macros can change declaration syntax before the compiler sees it. Minimal
+valid inputs such as `UNITTEST void parse(void);` and `FMT_BEGIN_EXPORT class parsed_type {};` produce
+error nodes before preprocessing; the resulting tree can misclassify the macro as a type. DevProjex
+does not execute a project preprocessor or recover links from that ambiguous tree, because doing so
+could invent dependencies. C and C++ compression remains independent of dependency extraction.
+
 Each supported source file is parsed once per content fingerprint. Both fact and navigation queries
 run against that same live tree before it is disposed; only compact facts remain. Files
 without an adapter are counted as unsupported instead of disappearing. Read, grammar, and query

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -221,6 +221,9 @@ to type references. Conventional multiplatform source-set paths constrain declar
 declarations are visible to platform source sets, while JVM sources exclude non-JVM, native, JS, and
 Wasm declaration sites. Class, function, and nested-class parameters shadow same-name declarations
 only inside their lexical owner; qualified names and types used by bounds remain ordinary references.
+Capitalized receivers in qualified calls are type-reference evidence when no parameter or property
+with that name is declared in the file. This covers object and companion-style calls while keeping a
+same-named value as a local expression instead of inventing a type edge.
 Bounded `pom.xml`, `build.gradle`,
 and `build.gradle.kts` files define source scopes using the same literal repository-only Maven and
 Gradle project relationships described for Java. External artifacts, generated sources, compiler

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -252,9 +252,13 @@ owned class or module does not define the referenced entity inside the project. 
 `require` with no repository target provides the same evidence for its matching constant root. Ruby code in Gemfiles
 or gemspecs is never executed. Installed gems without a literal declaration, generated
 load paths, interpolated require strings, autoload hooks, and runtime constant mutation are not
-inferred and remain unresolved. Because Ruby containers can be reopened, a class or module identity
-declared in more than one repository file remains unresolved rather than creating a dependency on
-every file that reopens it. References to a uniquely declared nested entity still resolve normally.
+inferred and remain unresolved. Literal gem names supplied to `Gem::Specification.new` or assigned
+to that block's receiver identify repository gem scopes. Literal `add_dependency` and
+`add_runtime_dependency` calls expose a uniquely matching repository gem to that scope; assignments
+to unrelated receivers are not package-name evidence. Because Ruby containers can be reopened, a
+class or module identity declared in more than one repository file remains unresolved rather than
+creating a dependency on every file that reopens it. References to a uniquely declared nested entity
+still resolve normally.
 
 Ruby navigation includes nested modules and classes, ordinary methods, singleton methods, instance
 variable assignments, and lambdas bound by assignment. Names use `::` for nesting, `#` for ordinary

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -1099,17 +1099,17 @@ internal sealed partial class KotlinDependencyLanguageAdapter : DependencyLangua
 					 scope.StartIndex <= capture.StartIndex && scope.EndIndex >= capture.EndIndex)) &&
 				!importRanges.Any(range => capture.StartIndex >= range.StartIndex && capture.EndIndex <= range.EndIndex))
 			.SelectMany(capture => TypeNameRegex().Matches(capture.Text)
-				.Select(static match => match.Value)
-				.Where(static name => !PrimitiveTypes.Contains(name))
-				.Select(name =>
+				.Select(static match => (Name: match.Value, match.Index))
+				.Where(static item => !PrimitiveTypes.Contains(item.Name))
+				.Select(item =>
 				{
 					var owners = declarationCaptures
 						.Where(owner => owner.Name != "declaration.function" && Contains(owner, capture))
 						.OrderBy(static owner => owner.StartIndex).Select(static owner => owner.CapturedName!).ToArray();
 					return new ReferenceFact(
 						EvidenceLayer.TypeReference,
-						name,
-						0,
+						item.Name,
+						GenericArityAt(capture.Text, item.Index + item.Name.Length),
 						capture.NodeType,
 						Site(context, capture))
 					{

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -961,11 +961,19 @@ internal sealed class JavaDependencyLanguageAdapter : DependencyLanguageAdapter
 			.Where(static capture => capture.Name == "import.java")
 			.Select(static capture => (capture.StartIndex, capture.EndIndex))
 			.ToArray();
+		var valueScopes = context.References
+			.Where(static capture => capture.Name == "context.value_name" &&
+				!string.IsNullOrWhiteSpace(capture.CapturedName))
+			.ToArray();
 		var referenceCaptures = context.References
-			.Where(static capture => capture.Name == "reference.type")
+			.Where(static capture => capture.Name is "reference.type" or "reference.expression_receiver")
 			.ToArray();
 		var references = Distinct(referenceCaptures
 			.Where(capture =>
+				(capture.Name != "reference.expression_receiver" ||
+				 IsJavaTypeReceiver(capture.Text) &&
+				 !valueScopes.Any(scope => scope.CapturedName == capture.Text &&
+					 scope.StartIndex <= capture.StartIndex && scope.EndIndex >= capture.EndIndex)) &&
 				!declarationNames.Contains(capture.StartIndex) &&
 				!typeParameterNames.Contains(capture.StartIndex) &&
 				!PrimitiveTypes.Contains(capture.Text) &&
@@ -1014,6 +1022,13 @@ internal sealed class JavaDependencyLanguageAdapter : DependencyLanguageAdapter
 		{
 			TypeParameterScopes = typeParameterScopes
 		};
+	}
+
+	private static bool IsJavaTypeReceiver(string value)
+	{
+		var separator = value.LastIndexOf('.');
+		var name = separator < 0 ? value : value[(separator + 1)..];
+		return name.Length > 0 && char.IsUpper(name[0]);
 	}
 
 	private static FileFacts Failed(DependencyExtractionContext context, string reason) => new(

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -1086,9 +1086,17 @@ internal sealed partial class KotlinDependencyLanguageAdapter : DependencyLangua
 			.Where(static capture => capture.Name == "context.type_parameter" && capture.CapturedNameStartIndex >= 0)
 			.Select(static capture => capture.CapturedNameStartIndex)
 			.ToHashSet();
+		var valueScopes = context.References
+			.Where(static capture => capture.Name == "context.value_name" &&
+				!string.IsNullOrWhiteSpace(capture.CapturedName))
+			.ToArray();
 		var references = Distinct(context.References
-			.Where(capture => capture.Name == "reference.type" &&
+			.Where(capture => capture.Name is "reference.type" or "reference.expression_receiver" &&
 				!typeParameterNames.Contains(capture.StartIndex) &&
+				(capture.Name != "reference.expression_receiver" ||
+				 capture.Text.Length > 0 && char.IsUpper(capture.Text[0]) &&
+				 !valueScopes.Any(scope => scope.CapturedName == capture.Text &&
+					 scope.StartIndex <= capture.StartIndex && scope.EndIndex >= capture.EndIndex)) &&
 				!importRanges.Any(range => capture.StartIndex >= range.StartIndex && capture.EndIndex <= range.EndIndex))
 			.SelectMany(capture => TypeNameRegex().Matches(capture.Text)
 				.Select(static match => match.Value)

--- a/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
+++ b/Infrastructure/Dependencies/DependencyLanguageAdapters.cs
@@ -972,8 +972,7 @@ internal sealed class JavaDependencyLanguageAdapter : DependencyLanguageAdapter
 			.Where(capture =>
 				(capture.Name != "reference.expression_receiver" ||
 				 IsJavaTypeReceiver(capture.Text) &&
-				 !valueScopes.Any(scope => scope.CapturedName == capture.Text &&
-					 scope.StartIndex <= capture.StartIndex && scope.EndIndex >= capture.EndIndex)) &&
+				 !valueScopes.Any(scope => IsJavaReceiverShadowed(capture, scope))) &&
 				!declarationNames.Contains(capture.StartIndex) &&
 				!typeParameterNames.Contains(capture.StartIndex) &&
 				!PrimitiveTypes.Contains(capture.Text) &&
@@ -1029,6 +1028,17 @@ internal sealed class JavaDependencyLanguageAdapter : DependencyLanguageAdapter
 		var separator = value.LastIndexOf('.');
 		var name = separator < 0 ? value : value[(separator + 1)..];
 		return name.Length > 0 && char.IsUpper(name[0]);
+	}
+
+	private static bool IsJavaReceiverShadowed(
+		DependencySyntaxCapture receiver,
+		DependencySyntaxCapture value)
+	{
+		if (value.StartIndex > receiver.StartIndex || value.EndIndex < receiver.EndIndex)
+			return false;
+		var separator = receiver.Text.IndexOf('.');
+		var root = separator < 0 ? receiver.Text : receiver.Text[..separator];
+		return string.Equals(value.CapturedName, root, StringComparison.Ordinal);
 	}
 
 	private static FileFacts Failed(DependencyExtractionContext context, string reason) => new(

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -483,7 +483,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				true)
 			{
 				ConfigurationState = project.State,
-				ConfigurationDiagnostic = project.Reason
+				ConfigurationDiagnostic = project.Reason,
+				RustTargetRoots = project.Configuration.TargetPaths
 			});
 		}
 
@@ -1355,6 +1356,18 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			    package.TryGetValue("name", out var nameValue) && nameValue is string name)
 				packageName = name.Replace('-', '_');
 			var directories = new HashSet<string>(PathComparer);
+			var targetPaths = new HashSet<string>(PathComparer);
+			if (TryGetTable(model, "lib", out var library) &&
+			    library.TryGetValue("path", out var libraryPathValue) && libraryPathValue is string libraryPath)
+				AddRustTargetPath(path, libraryPath, targetPaths);
+			foreach (var targetSection in new[] { "bin", "test", "bench", "example" })
+			{
+				if (!model.TryGetValue(targetSection, out var targetsValue) || targetsValue is not TomlTableArray targets)
+					continue;
+				foreach (var target in targets)
+					if (target.TryGetValue("path", out var targetPathValue) && targetPathValue is string targetPath)
+						AddRustTargetPath(path, targetPath, targetPaths);
+			}
 			foreach (var section in new[] { "dependencies", "dev-dependencies", "build-dependencies" })
 			{
 				if (!TryGetTable(model, section, out var dependencies)) continue;
@@ -1371,7 +1384,10 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				}
 			}
 			return ConfigurationParseResult<RustProjectConfiguration>.Valid(
-				new RustProjectConfiguration(packageName, directories.Order(StringComparer.Ordinal).ToArray()));
+				new RustProjectConfiguration(
+					packageName,
+					directories.Order(StringComparer.Ordinal).ToArray(),
+					targetPaths.Order(StringComparer.Ordinal).ToArray()));
 		}
 		catch (Exception exception) when (exception is InvalidDataException or TomlException or InvalidOperationException)
 		{
@@ -1424,6 +1440,17 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			directories.Order(StringComparer.Ordinal).ToArray(),
 			externalPackages,
 			localPackages);
+	}
+
+	private static void AddRustTargetPath(string manifestPath, string relativePath, ISet<string> targetPaths)
+	{
+		if (Path.IsPathFullyQualified(relativePath))
+			throw new InvalidDataException("Cargo target path must be relative.");
+		var root = Path.GetDirectoryName(manifestPath)!;
+		var target = Path.GetFullPath(Path.Combine(root, relativePath));
+		if (!IsWithin(root, target))
+			throw new InvalidDataException("Cargo target path must stay inside the package.");
+		targetPaths.Add(target);
 	}
 
 	private static string? ReadRubyPackageName(string content)
@@ -1608,9 +1635,12 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 	{
 		public static JavaProjectConfiguration Empty { get; } = new(string.Empty, []);
 	}
-	private sealed record RustProjectConfiguration(string? PackageName, IReadOnlyList<string> ProjectDirectories)
+	private sealed record RustProjectConfiguration(
+		string? PackageName,
+		IReadOnlyList<string> ProjectDirectories,
+		IReadOnlyList<string> TargetPaths)
 	{
-		public static RustProjectConfiguration Empty { get; } = new(null, []);
+		public static RustProjectConfiguration Empty { get; } = new(null, [], []);
 	}
 	private sealed record RubyProjectConfiguration(
 		string? PackageName,

--- a/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
+++ b/Infrastructure/Dependencies/FileDependencyConfigurationProvider.cs
@@ -525,10 +525,18 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		}
 		var rubyScopeByDirectory = rubyProjects.ToDictionary(
 			static project => Path.GetFullPath(project.Directory), static project => project.ScopeId, PathComparer);
+		var rubyScopeByPackage = rubyProjects
+			.Where(static project => project.PackageName is not null)
+			.GroupBy(static project => project.PackageName!, StringComparer.OrdinalIgnoreCase)
+			.Where(static group => group.Count() == 1)
+			.ToDictionary(static group => group.Key, static group => group.Single().ScopeId,
+				StringComparer.OrdinalIgnoreCase);
 		foreach (var project in rubyProjects)
 		{
 			var references = project.ProjectDirectories.Where(rubyScopeByDirectory.ContainsKey)
 				.Select(directory => rubyScopeByDirectory[directory])
+				.Concat(project.ExternalPackages.Where(rubyScopeByPackage.ContainsKey)
+					.Select(package => rubyScopeByPackage[package]))
 				.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
 			scopes.Add(new DependencyScopeDescriptor(
 				project.ScopeId, project.Directory, LanguageId.Ruby, references, null, false,
@@ -538,6 +546,8 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 				ConfigurationState = project.State,
 				ConfigurationDiagnostic = project.Reason,
 				RubyExternalPackages = project.ExternalPackages
+					.Where(package => !rubyScopeByPackage.ContainsKey(package))
+					.ToHashSet(StringComparer.OrdinalIgnoreCase)
 			});
 		}
 
@@ -1380,10 +1390,7 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 		var localPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		if (path.EndsWith(".gemspec", StringComparison.OrdinalIgnoreCase))
 		{
-			var name = Regex.Match(content,
-				"""\b(?:name|spec\.name)\s*=\s*['\"](?<name>[^'\"]+)['\"]""",
-				RegexOptions.CultureInvariant);
-			if (name.Success) packageName = name.Groups["name"].Value;
+			packageName = ReadRubyPackageName(content);
 			foreach (Match dependency in Regex.Matches(content,
 				"""\b(?:add_dependency|add_runtime_dependency)\s*\(?\s*['\"](?<name>[^'\"]+)['\"]""",
 				RegexOptions.CultureInvariant))
@@ -1417,6 +1424,27 @@ public sealed class FileDependencyConfigurationProvider : IDependencyConfigurati
 			directories.Order(StringComparer.Ordinal).ToArray(),
 			externalPackages,
 			localPackages);
+	}
+
+	private static string? ReadRubyPackageName(string content)
+	{
+		var constructorName = Regex.Match(content,
+			"""\bGem::Specification\.new\s*(?:\(\s*)?['\"](?<name>[^'\"]+)['\"]""",
+			RegexOptions.CultureInvariant);
+		if (constructorName.Success)
+			return constructorName.Groups["name"].Value;
+
+		var specificationBlock = Regex.Match(content,
+			"""\bGem::Specification\.new\b[^\r\n]*(?:do\s*|\{\s*)\|(?<receiver>[a-z_]\w*)\|""",
+			RegexOptions.CultureInvariant);
+		if (!specificationBlock.Success)
+			return null;
+
+		var receiver = Regex.Escape(specificationBlock.Groups["receiver"].Value);
+		var assignment = Regex.Match(content,
+			$"""\b{receiver}\.name\s*=\s*['\"](?<name>[^'\"]+)['\"]""",
+			RegexOptions.CultureInvariant);
+		return assignment.Success ? assignment.Groups["name"].Value : null;
 	}
 
 	private static ConfigurationParseResult<ComposerProjectConfiguration> ParseComposerProject(string content)

--- a/Infrastructure/Dependencies/Languages/java/references.scm
+++ b/Infrastructure/Dependencies/Languages/java/references.scm
@@ -3,3 +3,25 @@
 (type_identifier) @reference.type
 (scoped_type_identifier) @reference.type
 (type_parameter) @context.type_parameter
+
+(method_invocation
+  object: [
+    (identifier)
+    (field_access)
+  ] @reference.expression_receiver)
+
+(field_access
+  object: (identifier) @reference.expression_receiver)
+
+(variable_declarator
+  name: (identifier) @context.value_name)
+
+(formal_parameter
+  name: (identifier) @context.value_name)
+
+(spread_parameter
+  (variable_declarator
+    name: (identifier) @context.value_name))
+
+(catch_formal_parameter
+  name: (identifier) @context.value_name)

--- a/Infrastructure/Dependencies/Languages/kotlin/references.scm
+++ b/Infrastructure/Dependencies/Languages/kotlin/references.scm
@@ -1,4 +1,10 @@
 (import) @import.kotlin
 
 (user_type) @reference.type
+(navigation_expression
+  (identifier) @reference.expression_receiver
+  .
+  (identifier))
+(variable_declaration (identifier) @context.value_name)
+(parameter (identifier) @context.value_name)
 (type_parameter) @context.type_parameter

--- a/Infrastructure/Dependencies/Languages/php/references.scm
+++ b/Infrastructure/Dependencies/Languages/php/references.scm
@@ -2,5 +2,9 @@
 (named_type) @reference.type
 (scoped_call_expression
   scope: (name) @reference.type)
+(scoped_call_expression
+  scope: (qualified_name) @reference.type)
 (class_constant_access_expression
   (name) @reference.type)
+(class_constant_access_expression
+  (qualified_name) @reference.type)

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -1402,7 +1402,7 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 		".java" => LanguageId.Java,
 		".rs" => LanguageId.Rust,
 		".kt" or ".kts" => LanguageId.Kotlin,
-		".rb" or ".rake" or ".gemspec" => LanguageId.Ruby,
+		".rb" or ".rake" or ".gemspec" or ".ru" => LanguageId.Ruby,
 		".php" or ".phtml" => LanguageId.Php,
 		_ => LanguageId.Unsupported
 	};

--- a/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
+++ b/Infrastructure/Dependencies/TreeSitterDependencyFactExtractor.cs
@@ -895,6 +895,28 @@ public sealed class TreeSitterDependencyFactExtractor : IDependencyFactExtractor
 				CapturedNameStartIndex: checked((int)(parameterNameNode?.StartIndex ?? node.StartIndex)),
 				Evidence: OneLineEvidence(name));
 		}
+		if (captureName == "context.value_name")
+		{
+			var name = materialization.Read(node);
+			var scope = node.Parent;
+			while (scope?.Parent is not null && scope.Type is not (
+			       "block" or "lambda_literal" or "function_declaration" or
+			       "class_body" or "source_file"))
+				scope = scope.Parent;
+			return new DependencySyntaxCapture(
+				captureName,
+				node.Type,
+				name,
+				checked((int)node.StartPosition.Row + 1),
+				checked((int)(scope?.StartIndex ?? node.StartIndex)),
+				checked((int)(scope?.EndIndex ?? node.EndIndex)),
+				name,
+				0,
+				false,
+				false,
+				CapturedNameStartIndex: checked((int)node.StartIndex),
+				Evidence: name);
+		}
 		string? moduleCallName = null;
 		if (captureName == "import.call" &&
 		    !TryReadSupportedModuleCall(node, materialization, out moduleCallName))

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -746,6 +746,31 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task RustIntegrationTestRootsResolveSiblingModules()
+	{
+		using var fixture = new TemporaryDirectory();
+		var manifest = fixture.CreateFile("Cargo.toml", "[package]\nname = \"matcher\"\nversion = \"1.0.0\"\n");
+		var root = fixture.CreateFile("tests/tests.rs", "mod util; mod test_matcher;\n");
+		var util = fixture.CreateFile("tests/util.rs", "pub fn setup() {}\n");
+		var matcher = fixture.CreateFile("tests/test_matcher.rs", "pub fn runs() {}\n");
+		var nested = fixture.CreateFile("src/tests.rs", "mod hidden;\n");
+		var nestedChild = fixture.CreateFile("src/tests/hidden.rs", "pub struct Hidden;\n");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[manifest, root, util, matcher, nested, nestedChild],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(index.Edges, static edge => edge.Source == "tests/tests.rs" &&
+			edge.Target == "tests/util.rs" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(index.Edges, static edge => edge.Source == "tests/tests.rs" &&
+			edge.Target == "tests/test_matcher.rs" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(index.Edges, static edge => edge.Source == "src/tests.rs" &&
+			edge.Target == "src/tests/hidden.rs" && edge.Status == ResolutionStatus.Resolved);
+	}
+
+	[Fact]
 	public async Task RustModuleDeclarationsFollowTheOwningModuleDirectory()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -48,7 +48,7 @@ public sealed class DependencyFactsEngineIntegrationTests
 		var middleware = fixture.CreateFile("src/Middleware.php", "<?php namespace GuzzleHttp; final class Middleware { public const NAME = 'value'; }");
 		var handler = fixture.CreateFile(
 			"src/HandlerStack.php",
-			"<?php namespace GuzzleHttp; final class HandlerStack { public function resolve() { Utils::choose(); return Middleware::NAME; } }");
+			"<?php namespace GuzzleHttp; final class HandlerStack { public function resolve() { Utils::choose(); \\GuzzleHttp\\Utils::choose(); return Middleware::NAME; } }");
 		using var engine = CreateEngine();
 
 		var index = await engine.IndexAsync(
@@ -58,6 +58,8 @@ public sealed class DependencyFactsEngineIntegrationTests
 
 		Assert.Contains(index.Edges, static edge => edge.Source == "src/HandlerStack.php" &&
 			edge.Reference == "Utils" && edge.Target == "src/Utils.php" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(index.Edges, static edge => edge.Source == "src/HandlerStack.php" &&
+			edge.Reference == "GuzzleHttp\\Utils" && edge.Target == "src/Utils.php" && edge.Status == ResolutionStatus.Resolved);
 		Assert.Contains(index.Edges, static edge => edge.Source == "src/HandlerStack.php" &&
 			edge.Reference == "Middleware" && edge.Target == "src/Middleware.php" && edge.Status == ResolutionStatus.Resolved);
 	}
@@ -969,6 +971,42 @@ public sealed class DependencyFactsEngineIntegrationTests
 			declaration.Name == "sample.Consumer.read" && declaration.Kind == NavigationSymbolKind.Method);
 		Assert.DoesNotContain(index.Declarations, static declaration =>
 			declaration.Identity.QualifiedName.EndsWith(".read", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task JavaTypeReceiversResolveWithoutTreatingValuesAsTypes()
+	{
+		using var fixture = new TemporaryDirectory();
+		var helper = fixture.CreateFile("src/sample/Helper.java", "package sample; public final class Helper { public static void run() {} }");
+		var consumer = fixture.CreateFile("src/sample/Consumer.java", """
+			package sample;
+			public class Consumer {
+			    void call() {
+			        Helper.run();
+			        sample.Helper.run();
+			    }
+			}
+			""");
+		var shadow = fixture.CreateFile("src/sample/Shadow.java", """
+			package sample;
+			public class Shadow {
+			    void call(Service Helper) {
+			        Helper.run();
+			    }
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[helper, consumer, shadow],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edges = index.Edges.Where(static edge => edge.Source == "src/sample/Consumer.java" &&
+			edge.Target == "src/sample/Helper.java" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Equal(["Helper", "sample.Helper"], edges.Select(static edge => edge.Reference).Order().ToArray());
+		Assert.DoesNotContain(index.Edges, static edge => edge.Source == "src/sample/Shadow.java" &&
+			edge.Target == "src/sample/Helper.java");
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -814,25 +814,38 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
-	public async Task RustCrateQualifiedSuffixesRemainUnresolvedWhenTargetsAreNotUnique()
+	public async Task RustCrateQualifiedSuffixesDoNotCrossExplicitTargets()
 	{
 		using var fixture = new TemporaryDirectory();
-		var manifest = fixture.CreateFile("Cargo.toml", "[package]\nname = \"command\"\nversion = \"1.0.0\"\n");
-		var source = fixture.CreateFile("crates/core/flags/mod.rs", "pub(crate) use crate::flags::doc::help::generate;\n");
-		var first = fixture.CreateFile("crates/core/flags/doc/help.rs", "pub fn generate() {}\n");
-		var second = fixture.CreateFile("alternate/flags/doc/help.rs", "pub fn generate() {}\n");
+		var manifest = fixture.CreateFile("Cargo.toml", """
+			[package]
+			name = "command"
+			version = "1.0.0"
+
+			[[bin]]
+			name = "first"
+			path = "first/main.rs"
+
+			[[bin]]
+			name = "second"
+			path = "second/main.rs"
+			""");
+		var firstRoot = fixture.CreateFile("first/main.rs", "mod facade;\n");
+		var source = fixture.CreateFile("first/facade.rs", "pub(crate) use crate::secret::Hidden;\n");
+		var secondRoot = fixture.CreateFile("second/main.rs", "mod secret;\n");
+		var hidden = fixture.CreateFile("second/secret.rs", "pub struct Hidden;\n");
 		using var engine = CreateEngine();
 
 		var index = await engine.IndexAsync(
 			fixture.Path,
-			[manifest, source, first, second],
+			[manifest, firstRoot, source, secondRoot, hidden],
 			cancellationToken: TestContext.Current.CancellationToken);
 
 		var edge = Assert.Single(index.Edges, static edge =>
-			edge.Source == "crates/core/flags/mod.rs" && edge.Reference == "flags::doc::help::generate");
-		Assert.Equal(ResolutionStatus.Ambiguous, edge.Status);
+			edge.Source == "first/facade.rs" && edge.Reference == "secret::Hidden");
+		Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
 		Assert.Null(edge.Target);
-		Assert.Equal(2, edge.Candidates.Count);
+		Assert.Empty(edge.Candidates);
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -1006,6 +1006,9 @@ public sealed class DependencyFactsEngineIntegrationTests
 			    void call(Service Helper) {
 			        Helper.run();
 			    }
+			    void qualified(Service sample) {
+			        sample.Helper.run();
+			    }
 			}
 			""");
 		using var engine = CreateEngine();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -469,6 +469,39 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task KotlinGenericReferencesPreserveDeclaredArityWithoutResolvingTypeParameters()
+	{
+		using var fixture = new TemporaryDirectory();
+		var namedT = fixture.CreateFile("src/sample/T.kt", "package sample\nclass T\n");
+		var options = fixture.CreateFile("src/sample/TypedOptions.kt", "package sample\nclass TypedOptions<T>\n");
+		var source = fixture.CreateFile("src/sample/Consumer.kt", """
+			package sample
+			class Consumer {
+			  fun <T : Any> select(options: TypedOptions<T>): T? = null
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[namedT, options, source],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var typedOptions = Assert.Single(index.Edges, static edge => edge.Source == "src/sample/Consumer.kt" &&
+			edge.Reference == "TypedOptions");
+		Assert.Equal(ResolutionStatus.Resolved, typedOptions.Status);
+		Assert.Equal("src/sample/TypedOptions.kt", typedOptions.Target);
+		Assert.All(index.Edges.Where(static edge => edge.Source == "src/sample/Consumer.kt" && edge.Reference == "T"),
+			static edge =>
+			{
+				Assert.Equal(ResolutionStatus.Unresolved, edge.Status);
+				Assert.Contains("type parameter shadows declarations", edge.Reasons);
+			});
+		Assert.DoesNotContain(index.Edges, static edge => edge.Source == "src/sample/Consumer.kt" &&
+			edge.Target == "src/sample/T.kt");
+	}
+
+	[Fact]
 	public async Task KotlinNavigationDistinguishesOwnersAndRepeatedMembers()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -582,6 +582,40 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task KotlinObjectReceiversResolveWithoutTreatingValuesAsTypes()
+	{
+		using var fixture = new TemporaryDirectory();
+		var pool = fixture.CreateFile("src/commonMain/kotlin/okio/SegmentPool.kt", """
+			package okio
+			object SegmentPool {
+			  fun take() = Unit
+			  fun recycle(value: Any) = Unit
+			}
+			""");
+		var consumer = fixture.CreateFile("src/commonMain/kotlin/okio/Segment.kt", """
+			package okio
+			fun use(value: Any) {
+			  SegmentPool.take()
+			  SegmentPool.recycle(value)
+			}
+			fun shadow(Local: Any) {
+			  val SegmentPool = Local
+			  SegmentPool.take()
+			}
+			""");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[pool, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+		var edge = Assert.Single(index.Edges, static edge => edge.Source.EndsWith("Segment.kt", StringComparison.Ordinal) &&
+			edge.Reference == "SegmentPool" && edge.Status == ResolutionStatus.Resolved);
+		Assert.Equal("src/commonMain/kotlin/okio/SegmentPool.kt", edge.Target);
+		Assert.Equal(2, edge.Evidence.Count);
+	}
+
+	[Fact]
 	public async Task RustFactsResolveModulesUsesAndTypesFromTheManifest()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -238,6 +238,40 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task RubyGemspecReceiversExposeDeclaredRepositoryDependencies()
+	{
+		using var fixture = new TemporaryDirectory();
+		var rootGemspec = fixture.CreateFile("sinatra.gemspec", "Gem::Specification.new 'sinatra', '1.0' do |s|\nend\n");
+		var indifferentHash = fixture.CreateFile("lib/sinatra/indifferent_hash.rb", "module Sinatra\n  class IndifferentHash\n  end\nend\n");
+		var contribGemspec = fixture.CreateFile("sinatra-contrib/sinatra-contrib.gemspec", """
+			Gem::Specification.new do |s|
+			  metadata.name = 'not-the-package'
+			  s.name = 'sinatra-contrib'
+			  s.add_dependency 'sinatra'
+			end
+			""");
+		var consumer = fixture.CreateFile("sinatra-contrib/lib/sinatra/config_file.rb", """
+			module Sinatra
+			  module ConfigFile
+			    VALUE = IndifferentHash.new
+			  end
+			end
+			""");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[rootGemspec, indifferentHash, contribGemspec, consumer],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(index.Edges, static edge =>
+			edge.Source == "sinatra-contrib/lib/sinatra/config_file.rb" &&
+			edge.Target == "lib/sinatra/indifferent_hash.rb" &&
+			edge.Status == ResolutionStatus.Resolved &&
+			edge.CrossScope);
+	}
+
+	[Fact]
 	public async Task RubySyntaxErrorsFailClosedWithoutPublishingRecoveredFacts()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -661,11 +661,20 @@ public sealed class DependencyFactsEngineIntegrationTests
 			  fun recycle(value: Any) = Unit
 			}
 			""");
+		var classPool = fixture.CreateFile("src/commonMain/kotlin/okio/ClassPool.kt", """
+			package okio
+			class ClassPool {
+			  companion object {
+			    fun take() = Unit
+			  }
+			}
+			""");
 		var consumer = fixture.CreateFile("src/commonMain/kotlin/okio/Segment.kt", """
 			package okio
 			fun use(value: Any) {
 			  SegmentPool.take()
 			  SegmentPool.recycle(value)
+			  ClassPool.take()
 			}
 			fun shadow(Local: Any) {
 			  val SegmentPool = Local
@@ -676,12 +685,15 @@ public sealed class DependencyFactsEngineIntegrationTests
 
 		var index = await engine.IndexAsync(
 			fixture.Path,
-			[pool, consumer],
+			[pool, classPool, consumer],
 			cancellationToken: TestContext.Current.CancellationToken);
 		var edge = Assert.Single(index.Edges, static edge => edge.Source.EndsWith("Segment.kt", StringComparison.Ordinal) &&
 			edge.Reference == "SegmentPool" && edge.Status == ResolutionStatus.Resolved);
 		Assert.Equal("src/commonMain/kotlin/okio/SegmentPool.kt", edge.Target);
 		Assert.Equal(2, edge.Evidence.Count);
+		Assert.DoesNotContain(index.Edges, static candidate =>
+			candidate.Source.EndsWith("Segment.kt", StringComparison.Ordinal) &&
+			candidate.Target == "src/commonMain/kotlin/okio/ClassPool.kt");
 	}
 
 	[Fact]

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -141,6 +141,26 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task RubyRackEntryFilesUseRubyFacts()
+	{
+		using var fixture = new TemporaryDirectory();
+		var framework = fixture.CreateFile("lib/sinatra/base.rb", "module Sinatra\n  class Base\n  end\nend\n");
+		var entry = fixture.CreateFile("examples/stream.ru", "require 'sinatra/base'\nclass Stream < Sinatra::Base\nend\nrun Stream\n");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[framework, entry],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var facts = index.Files.Single(static file => file.Path == "examples/stream.ru");
+		Assert.Equal(DependencyFileStatus.Supported, facts.Status);
+		Assert.Contains(facts.Declarations, static declaration => declaration.Identity.QualifiedName == "Stream");
+		Assert.Contains(index.Edges, static edge => edge.Source == "examples/stream.ru" &&
+			edge.Target == "lib/sinatra/base.rb" && edge.Status == ResolutionStatus.Resolved);
+	}
+
+	[Fact]
 	public async Task RubyReopenedContainersDoNotCreateEdgesToEveryDeclarationFile()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
+++ b/Tests/DevProjex.Tests.Integration/DependencyFactsEngineIntegrationTests.cs
@@ -771,6 +771,69 @@ public sealed class DependencyFactsEngineIntegrationTests
 	}
 
 	[Fact]
+	public async Task RustRestrictedReexportsResolveFromANonstandardCrateRoot()
+	{
+		using var fixture = new TemporaryDirectory();
+		var manifest = fixture.CreateFile("Cargo.toml", """
+			[package]
+			name = "command"
+			version = "1.0.0"
+
+			[[bin]]
+			name = "command"
+			path = "crates/core/main.rs"
+			""");
+		var root = fixture.CreateFile("crates/core/main.rs", "mod flags;\n");
+		var facade = fixture.CreateFile("crates/core/flags/mod.rs", """
+			pub(crate) use crate::flags::{
+			    complete::bash::generate as generate_complete_bash,
+			    doc::help::generate as generate_help,
+			};
+			mod complete;
+			mod doc;
+			""");
+		var complete = fixture.CreateFile("crates/core/flags/complete/mod.rs", "pub mod bash;\n");
+		var bash = fixture.CreateFile("crates/core/flags/complete/bash.rs", "pub fn generate() {}\n");
+		var doc = fixture.CreateFile("crates/core/flags/doc/mod.rs", "pub mod help;\n");
+		var help = fixture.CreateFile("crates/core/flags/doc/help.rs", "pub fn generate() {}\n");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[manifest, root, facade, complete, bash, doc, help],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		Assert.Contains(index.Edges, static edge => edge.Source == "crates/core/flags/mod.rs" &&
+			edge.Target == "crates/core/flags/complete/bash.rs" && edge.Reference == "flags::complete::bash::generate" &&
+			edge.Status == ResolutionStatus.Resolved);
+		Assert.Contains(index.Edges, static edge => edge.Source == "crates/core/flags/mod.rs" &&
+			edge.Target == "crates/core/flags/doc/help.rs" && edge.Reference == "flags::doc::help::generate" &&
+			edge.Status == ResolutionStatus.Resolved);
+	}
+
+	[Fact]
+	public async Task RustCrateQualifiedSuffixesRemainUnresolvedWhenTargetsAreNotUnique()
+	{
+		using var fixture = new TemporaryDirectory();
+		var manifest = fixture.CreateFile("Cargo.toml", "[package]\nname = \"command\"\nversion = \"1.0.0\"\n");
+		var source = fixture.CreateFile("crates/core/flags/mod.rs", "pub(crate) use crate::flags::doc::help::generate;\n");
+		var first = fixture.CreateFile("crates/core/flags/doc/help.rs", "pub fn generate() {}\n");
+		var second = fixture.CreateFile("alternate/flags/doc/help.rs", "pub fn generate() {}\n");
+		using var engine = CreateEngine();
+
+		var index = await engine.IndexAsync(
+			fixture.Path,
+			[manifest, source, first, second],
+			cancellationToken: TestContext.Current.CancellationToken);
+
+		var edge = Assert.Single(index.Edges, static edge =>
+			edge.Source == "crates/core/flags/mod.rs" && edge.Reference == "flags::doc::help::generate");
+		Assert.Equal(ResolutionStatus.Ambiguous, edge.Status);
+		Assert.Null(edge.Target);
+		Assert.Equal(2, edge.Candidates.Count);
+	}
+
+	[Fact]
 	public async Task RustModuleDeclarationsFollowTheOwningModuleDirectory()
 	{
 		using var fixture = new TemporaryDirectory();

--- a/Tests/DevProjex.Tests.Unit/NativeDependencyLanguageBoundaryTests.cs
+++ b/Tests/DevProjex.Tests.Unit/NativeDependencyLanguageBoundaryTests.cs
@@ -1,0 +1,18 @@
+namespace DevProjex.Tests.Unit;
+
+public sealed class NativeDependencyLanguageBoundaryTests
+{
+	[Theory]
+	[InlineData("c", "UNITTEST void parse(void);")]
+	[InlineData("cpp", "FMT_BEGIN_EXPORT class parsed_type {};")]
+	public void PrefixDeclarationMacrosProduceGrammarDefects(string languageId, string source)
+	{
+		using var harness = CodeCompressionTestHarness.For(languageId);
+		using var tree = harness.Parser.Parse(source)!;
+
+		Assert.True(tree.RootNode.HasError);
+		Assert.Contains(
+			tree.RootNode.Children,
+			static node => node.HasError || node.IsError || node.IsMissing);
+	}
+}


### PR DESCRIPTION
## Summary
- document the native macro parsing boundary with minimal regression coverage
- improve supported-language facts against pinned repositories
- validate every added relationship on real source trees

## Validation
- targeted dependency and navigation tests only
- pinned repository checks are recorded per commit