### PR TITLE
Validate task-specific oracle paths

### DIFF
--- a/tools/McpUsageRecorder/README.md
+++ b/tools/McpUsageRecorder/README.md
@@ -53,10 +53,18 @@ parallel tool calls by the model response identifier.
 
 ## Saved-answer evaluation
 
-`oracles/tasks.json` records task-specific required files and factual claims. The deterministic
-oracle classifies each saved answer as complete, incomplete, incorrect, or empty and reports every
-missing, unexpected, or contradicted criterion. Tasks marked `partial` retain an explicit list of
-criteria that still require qualitative assessment.
+`oracles/tasks.json` records task-specific required files, factual claims, and `pathExtensions`.
+Every declared required, optional, or forbidden path must use an extension listed by its task, so a
+new language is enabled in registry data rather than in extractor code. Registry loading fails when
+these declarations disagree.
+
+A file is named only when the answer contains a complete, standalone path declared by that task;
+either slash style and an optional `:line` or `:start-end` suffix are accepted. An undeclared bare
+filename such as `package.json`, or an undeclared path shown in prose or sample code, is ignored.
+Code formatting does not exempt a declared path: an exact declared token still counts. The
+deterministic oracle classifies each saved answer as complete, incomplete, incorrect, or empty and
+reports every missing, unexpected, or contradicted criterion. Tasks marked `partial` retain an
+explicit list of criteria that still require qualitative assessment.
 
 Qualitative comparisons keep correctness and preference as separate dimensions. Each pair is
 assessed in both candidate orders. A verdict exists only when both orders map to the same candidate;

--- a/tools/McpUsageRecorder/README.md
+++ b/tools/McpUsageRecorder/README.md
@@ -58,10 +58,12 @@ Every declared required, optional, or forbidden path must use an extension liste
 new language is enabled in registry data rather than in extractor code. Registry loading fails when
 these declarations disagree.
 
-A file is named only when the answer contains a complete, standalone path declared by that task;
-either slash style and an optional `:line` or `:start-end` suffix are accepted. An undeclared bare
-filename such as `package.json`, or an undeclared path shown in prose or sample code, is ignored.
-Code formatting does not exempt a declared path: an exact declared token still counts. The
+A file is named only when the answer contains a complete, standalone path declared by that task.
+The path ends at its exact declared spelling; an adjacent `:line`, `:start-end`, `::test_name`,
+`:SymbolName`, `#L42`, or `#anchor` is its selector, while any other adjacent character rejects
+the match. Either slash style is accepted. An undeclared bare filename such as `package.json`, or
+an undeclared path shown in prose or sample code, is ignored. Code formatting does not exempt a
+declared path: an exact declared token still counts. The
 deterministic oracle classifies each saved answer as complete, incomplete, incorrect, or empty and
 reports every missing, unexpected, or contradicted criterion. Tasks marked `partial` retain an
 explicit list of criteria that still require qualitative assessment.

--- a/tools/McpUsageRecorder/lib/task-oracle.mjs
+++ b/tools/McpUsageRecorder/lib/task-oracle.mjs
@@ -1,11 +1,9 @@
 import { readFileSync } from 'node:fs';
 
-const pathPattern = /(?:^|[\s`"'(\[])(((?:[A-Za-z0-9_.@+\-]+\/)*[A-Za-z0-9_.@+\-]+\.(?:cs|csproj|py|ts|md|json))(?::\d+(?:-\d+)?)?)/gim;
-
 export function loadTaskOracleRegistry(path) {
   const source = JSON.parse(readFileSync(path, 'utf8'));
-  if (source.schemaVersion !== 1 || !Array.isArray(source.tasks))
-    throw new Error('Task oracle registry must use schema version 1 and contain a tasks array.');
+  if (source.schemaVersion !== 2 || !Array.isArray(source.tasks))
+    throw new Error('Task oracle registry must use schema version 2 and contain a tasks array.');
   return new Map(source.tasks.map(task => [task.id, validateTask(task)]));
 }
 
@@ -18,12 +16,7 @@ export function evaluateTaskAnswer(task, answer) {
   }
 
   const required = new Set(task.requiredPaths.map(normalizePath));
-  const recognizedRootPaths = new Set([
-    ...task.requiredPaths,
-    ...(task.optionalPaths ?? []),
-    ...(task.forbiddenPaths ?? []),
-  ].map(normalizePath));
-  const namedPaths = extractNamedPaths(text).filter(path => path.includes('/') || recognizedRootPaths.has(path));
+  const namedPaths = extractDeclaredPaths(text, task);
   const missingPaths = [...required].filter(path => !namedPaths.includes(path));
   const forbiddenPaths = new Set((task.forbiddenPaths ?? []).map(normalizePath));
   const unexpectedPaths = namedPaths.filter(path => forbiddenPaths.has(path));
@@ -88,7 +81,27 @@ export function splitComparedAnswers(text) {
   };
 }
 
-export function extractNamedPaths(text) {
+export function extractNamedPaths(text, task) {
+  validateTask(task);
+  return extractDeclaredPaths(text, task);
+}
+
+function extractDeclaredPaths(text, task) {
+  const declaredPaths = [...new Set([
+    ...task.requiredPaths,
+    ...(task.optionalPaths ?? []),
+    ...(task.forbiddenPaths ?? []),
+  ].map(normalizePath))];
+  if (declaredPaths.length === 0)
+    return [];
+
+  const alternatives = declaredPaths
+    .sort((left, right) => right.length - left.length || left.localeCompare(right, 'en'))
+    .map(pathPatternFor)
+    .join('|');
+  const pathPattern = new RegExp(
+    `(?:^|[\\s\x60"'(\\[])(${alternatives})(?::\\d+(?:-\\d+)?)?(?=$|[\\s\x60"',.;!?)}\\]])`,
+    'gm');
   const paths = new Set();
   for (const match of text.matchAll(pathPattern))
     paths.add(normalizePath(match[1]));
@@ -100,6 +113,23 @@ function validateTask(task) {
     throw new Error('Every task oracle requires an id.');
   if (!Array.isArray(task.requiredPaths) || !Array.isArray(task.requiredClaims))
     throw new Error(`Task oracle '${task.id}' requires path and claim arrays.`);
+  if (!Array.isArray(task.pathExtensions) || task.pathExtensions.length === 0 ||
+      task.pathExtensions.some(extension => typeof extension !== 'string' ||
+        !/^[A-Za-z0-9][A-Za-z0-9+_-]*$/.test(extension)))
+    throw new Error(`Task oracle '${task.id}' requires valid pathExtensions without leading dots.`);
+  const pathExtensions = new Set(task.pathExtensions.map(extension => extension.toLocaleLowerCase('en-US')));
+  if (pathExtensions.size !== task.pathExtensions.length)
+    throw new Error(`Task oracle '${task.id}' has duplicate pathExtensions.`);
+  const pathGroups = [task.requiredPaths, task.optionalPaths ?? [], task.forbiddenPaths ?? []];
+  if (pathGroups.some(paths => !Array.isArray(paths) ||
+      paths.some(path => typeof path !== 'string' || path.length === 0)))
+    throw new Error(`Task oracle '${task.id}' has an invalid path array.`);
+  for (const path of pathGroups.flat()) {
+    const normalized = normalizePath(path).toLocaleLowerCase('en-US');
+    if (![...pathExtensions].some(extension => normalized.endsWith(`.${extension}`)))
+      throw new Error(
+        `Task oracle '${task.id}' path '${path}' uses an extension not listed in pathExtensions.`);
+  }
   if (task.requiredSymbols !== undefined && !Array.isArray(task.requiredSymbols))
     throw new Error(`Task oracle '${task.id}' has an invalid symbol array.`);
   for (const claim of [...task.requiredClaims, ...(task.forbiddenClaims ?? [])]) {
@@ -134,6 +164,13 @@ function result(task, classification, namedPaths, missingPaths, missingClaims, m
 
 function normalizePath(path) {
   return path.replaceAll('\\', '/').replace(/:\d+(?:-\d+)?$/, '');
+}
+
+function pathPatternFor(path) {
+  return path
+    .split('/')
+    .map(component => component.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('[\\\\/]');
 }
 
 function includesText(text, term) {

--- a/tools/McpUsageRecorder/lib/task-oracle.mjs
+++ b/tools/McpUsageRecorder/lib/task-oracle.mjs
@@ -99,8 +99,9 @@ function extractDeclaredPaths(text, task) {
     .sort((left, right) => right.length - left.length || left.localeCompare(right, 'en'))
     .map(pathPatternFor)
     .join('|');
+  const selector = '(?:(?::\\d+(?:-\\d+)?)|(?:::[A-Za-z_][A-Za-z0-9_.+\\-]*(?:::[A-Za-z_][A-Za-z0-9_.+\\-]*)*)|(?::[A-Za-z_][A-Za-z0-9_.+\\-]*)|(?:#[A-Za-z0-9_][A-Za-z0-9_.:+\\-]*))?';
   const pathPattern = new RegExp(
-    `(?:^|[\\s\x60"'(\\[])(${alternatives})(?::\\d+(?:-\\d+)?)?(?=$|[\\s\x60"',.;!?)}\\]])`,
+    `(?:^|[\\s\x60"'(\\[])(${alternatives})${selector}(?=$|[\\s\x60"',.;!?)}\\]])`,
     'gm');
   const paths = new Set();
   for (const match of text.matchAll(pathPattern))

--- a/tools/McpUsageRecorder/oracles/tasks.json
+++ b/tools/McpUsageRecorder/oracles/tasks.json
@@ -1,9 +1,10 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "tasks": [
     {
       "id": "T1",
       "oracleCoverage": "partial",
+      "pathExtensions": ["py"],
       "requiredPaths": ["httpx/_client.py", "tests/client/test_redirects.py"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "redirect-headers", "terms": ["_redirect_headers"] }],
@@ -18,6 +19,7 @@
     {
       "id": "T2",
       "oracleCoverage": "complete",
+      "pathExtensions": ["py", "md"],
       "requiredPaths": ["httpx/_transports/default.py", "httpx/_client.py", "httpx/_transports/base.py", "docs/advanced/transports.md", "docs/advanced/proxies.md", "tests/client/test_proxies.py"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "transport-types", "terms": ["HTTPTransport", "AsyncHTTPTransport"] }],
@@ -30,6 +32,7 @@
     {
       "id": "T3",
       "oracleCoverage": "partial",
+      "pathExtensions": ["py", "md"],
       "requiredPaths": ["httpx/_client.py", "httpx/_models.py", "docs/advanced/extensions.md", "httpx/_types.py", "tests/client/test_client.py"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "build-request", "terms": ["build_request"] }],
@@ -43,6 +46,7 @@
     {
       "id": "T4",
       "oracleCoverage": "partial",
+      "pathExtensions": ["ts"],
       "requiredPaths": ["src/request.ts", "src/utils/url.ts", "src/hono-base.ts", "src/request.test.ts", "src/utils/url.test.ts"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "decode-functions", "terms": ["tryDecodeURIComponent", "getPath"] }],
@@ -56,6 +60,7 @@
     {
       "id": "T5",
       "oracleCoverage": "complete",
+      "pathExtensions": ["ts"],
       "requiredPaths": ["src/context.ts", "src/types.ts", "src/client/types.ts", "src/middleware/bearer-auth/index.ts", "src/middleware/cors/index.ts", "src/context.test.ts"],
       "optionalPaths": ["src/middleware/bearer-auth/index.test.ts", "src/middleware/cors/index.test.ts"],
       "requiredSymbols": [{ "id": "json-method", "terms": ["json"] }],
@@ -68,6 +73,7 @@
     {
       "id": "T6",
       "oracleCoverage": "partial",
+      "pathExtensions": ["json", "ts"],
       "strictPaths": false,
       "requiredPaths": ["package.json", "jsr.json"],
       "optionalPaths": ["src/middleware/method-not-allowed/index.ts", "src/middleware/body-limit/index.ts", "src/middleware/powered-by/index.ts", "src/middleware/method-not-allowed/index.test.ts", "src/middleware/body-limit/index.test.ts", "src/middleware/powered-by/index.test.ts"],
@@ -82,6 +88,7 @@
     {
       "id": "T7",
       "oracleCoverage": "partial",
+      "pathExtensions": ["cs"],
       "requiredPaths": ["src/Serilog/Core/LevelOverrideMap.cs", "src/Serilog/Core/Logger.cs", "src/Serilog/LoggerConfiguration.cs", "src/Serilog/Configuration/LoggerMinimumLevelConfiguration.cs", "test/Serilog.Tests/Core/LevelOverrideMapTests.cs", "test/Serilog.Tests/Core/ChildLoggerTests.cs"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "effective-level", "terms": ["GetEffectiveLevel"] }],
@@ -96,6 +103,7 @@
     {
       "id": "T8",
       "oracleCoverage": "complete",
+      "pathExtensions": ["cs"],
       "requiredPaths": ["src/Serilog/Core/ILogEventEnricher.cs", "src/Serilog/Core/Logger.cs", "src/Serilog/Core/Enrichers/PropertyEnricher.cs", "src/Serilog/Core/Enrichers/FixedPropertyEnricher.cs", "src/Serilog/Core/Enrichers/ConditionalEnricher.cs", "src/Serilog/Core/Enrichers/SafeAggregateEnricher.cs", "src/Serilog/Core/Enrichers/EmptyEnricher.cs", "src/Serilog/Context/LogContextEnricher.cs", "src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs", "test/Serilog.Tests/Core/LoggerTests.cs", "test/Serilog.Tests/Context/LogContextTests.cs"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "enrich-method", "terms": ["Enrich"] }],
@@ -109,6 +117,7 @@
     {
       "id": "N1",
       "oracleCoverage": "partial",
+      "pathExtensions": ["cs", "csproj"],
       "requiredPaths": ["src/Serilog/Core/IScalarConversionPolicy.cs", "src/Serilog/Capturing/PropertyValueConverter.cs", "src/Serilog/Policies/PrimitiveScalarConversionPolicy.cs", "src/Serilog/Policies/SimpleScalarConversionPolicy.cs", "src/Serilog/Policies/EnumScalarConversionPolicy.cs", "src/Serilog/Policies/ByteArrayScalarConversionPolicy.cs", "src/Serilog/Policies/ByteMemoryScalarConversionPolicy.cs"],
       "optionalPaths": ["src/Serilog/Serilog.csproj"],
       "requiredSymbols": [{ "id": "conversion-interface", "terms": ["IScalarConversionPolicy"] }],
@@ -123,6 +132,7 @@
     {
       "id": "N2",
       "oracleCoverage": "complete",
+      "pathExtensions": ["py"],
       "requiredPaths": ["httpx/_urlparse.py", "httpx/_urls.py", "httpx/_exceptions.py", "tests/models/test_url.py"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "url-exception", "terms": ["InvalidURL"] }],
@@ -137,6 +147,7 @@
     {
       "id": "N3",
       "oracleCoverage": "partial",
+      "pathExtensions": ["ts"],
       "strictPaths": false,
       "requiredPaths": ["src/hono-base.ts", "src/context.ts", "src/request.ts", "src/compose.ts", "src/request/constants.ts"],
       "optionalPaths": ["src/helper/route/index.ts", "src/router.ts", "src/types.ts"],
@@ -152,6 +163,7 @@
     {
       "id": "N4",
       "oracleCoverage": "partial",
+      "pathExtensions": ["cs"],
       "requiredPaths": ["src/Serilog/Configuration/BatchingOptions.cs", "src/Serilog/Core/Sinks/Batching/BatchingSink.cs", "src/Serilog/Configuration/LoggerSinkConfiguration.cs", "src/Serilog/Core/LoggingFailureKind.cs", "src/Serilog/Core/ILoggingFailureListener.cs", "src/Serilog/Debugging/SelfLog.cs"],
       "optionalPaths": [],
       "requiredSymbols": [{ "id": "failure-listener", "terms": ["ILoggingFailureListener"] }],

--- a/tools/McpUsageRecorder/tests/recorder.test.mjs
+++ b/tools/McpUsageRecorder/tests/recorder.test.mjs
@@ -1,9 +1,17 @@
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 import { recordEvents } from '../lib/recorder.mjs';
 import { validateSeriesConfiguration } from '../lib/series-preflight.mjs';
 import { recordStreamJson } from '../lib/stream-json.mjs';
-import { compareTaskAnswers, evaluateTaskAnswer } from '../lib/task-oracle.mjs';
+import {
+  compareTaskAnswers,
+  evaluateTaskAnswer,
+  extractNamedPaths,
+  loadTaskOracleRegistry,
+} from '../lib/task-oracle.mjs';
 import { reconcileOrderedAssessments, summarizeOrderedAssessments } from '../lib/order-consistency.mjs';
 
 test('parallel tool calls share one model turn and one usage snapshot', () => {
@@ -203,6 +211,7 @@ function validConfiguration() {
 const oracleFixture = {
   id: 'sample',
   oracleCoverage: 'complete',
+  pathExtensions: ['cs', 'md'],
   requiredPaths: ['src/core.cs', 'tests/core.test.cs'],
   optionalPaths: ['docs/guide.md'],
   forbiddenPaths: ['src/unrelated.cs'],
@@ -270,6 +279,82 @@ test('task oracle comparison favors the answer covering more required criteria',
     basis: 'equal-criteria',
   });
 });
+
+for (const extension of ['go', 'js', 'jsx', 'tsx', 'rs', 'java', 'kt', 'rb', 'php', 'c', 'h', 'cpp', 'hpp']) {
+  test(`task oracle evaluates declared ${extension} paths`, () => {
+    const task = pathOracleFixture(extension);
+    const complete = evaluateTaskAnswer(task,
+      `The implementation is in \`src/main.${extension}\` and satisfies the expected behavior.`);
+    const incorrect = evaluateTaskAnswer(task,
+      `Use src/main.${extension}; src/forbidden.${extension} also satisfies the expected behavior.`);
+    const incomplete = evaluateTaskAnswer(task, 'The expected behavior is implemented.');
+
+    assert.equal(complete.classification, 'complete');
+    assert.deepEqual(complete.namedPaths, [`src/main.${extension}`]);
+    assert.equal(incorrect.classification, 'incorrect');
+    assert.deepEqual(incorrect.unexpectedPaths, [`src/forbidden.${extension}`]);
+    assert.equal(incomplete.classification, 'incomplete');
+    assert.deepEqual(incomplete.missingPaths, [`src/main.${extension}`]);
+  });
+}
+
+test('task oracle registry rejects a path whose extension is not declared', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'mcp-oracle-'));
+  const registryPath = join(directory, 'tasks.json');
+  try {
+    writeFileSync(registryPath, JSON.stringify({
+      schemaVersion: 2,
+      tasks: [{ ...pathOracleFixture('go'), requiredPaths: ['src/main.zig'] }],
+    }));
+
+    assert.throws(
+      () => loadTaskOracleRegistry(registryPath),
+      /path 'src\/main\.zig' uses an extension not listed in pathExtensions/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('task oracle ignores undeclared filenames and sample paths', () => {
+  const task = pathOracleFixture('go');
+  const answer = [
+    'The prose mentions package.json and main.go without declaring either path.',
+    'Sample code: `load("examples/demo.go")`.',
+    'The expected behavior is implemented.',
+  ].join('\n');
+
+  const result = evaluateTaskAnswer(task, answer);
+
+  assert.equal(result.classification, 'incomplete');
+  assert.deepEqual(result.namedPaths, []);
+  assert.deepEqual(extractNamedPaths(answer, task), []);
+});
+
+test('task oracle accepts a declared filename at the repository root', () => {
+  const task = {
+    ...pathOracleFixture('json'),
+    requiredPaths: ['package.json'],
+    forbiddenPaths: [],
+  };
+
+  const result = evaluateTaskAnswer(task, 'The expected behavior is configured in package.json.');
+
+  assert.equal(result.classification, 'complete');
+  assert.deepEqual(result.namedPaths, ['package.json']);
+});
+
+function pathOracleFixture(extension) {
+  return {
+    id: `path-${extension}`,
+    oracleCoverage: 'complete',
+    pathExtensions: [extension],
+    requiredPaths: [`src/main.${extension}`],
+    optionalPaths: [],
+    forbiddenPaths: [`src/forbidden.${extension}`],
+    requiredClaims: [{ id: 'behavior', terms: [['expected behavior']] }],
+    requiredSymbols: [],
+  };
+}
 
 test('order-dependent assessment is reported as disagreement instead of a verdict', () => {
   const result = reconcileOrderedAssessments(

--- a/tools/McpUsageRecorder/tests/recorder.test.mjs
+++ b/tools/McpUsageRecorder/tests/recorder.test.mjs
@@ -362,6 +362,56 @@ test('task oracle requires standalone declared paths and normalizes line-qualifi
   assert.deepEqual(result.namedPaths, ['src/main.go']);
 });
 
+for (const [name, reference] of [
+  ['line number', 'src/main.go:42'],
+  ['line range', 'src/main.go:42-99'],
+  ['pytest node id', 'src/main.go::test_name'],
+  ['named symbol', 'src/main.go:SymbolName'],
+  ['line anchor', 'src/main.go#L42'],
+  ['named anchor', 'src/main.go#anchor'],
+]) {
+  test(`task oracle accepts a declared path with a ${name} selector`, () => {
+    const result = evaluateTaskAnswer(
+      pathOracleFixture('go'),
+      `The expected behavior is implemented in ${reference}.`);
+
+    assert.equal(result.classification, 'complete');
+    assert.deepEqual(result.namedPaths, ['src/main.go']);
+  });
+}
+
+test('task oracle rejects a declared path followed directly by a letter', () => {
+  const result = evaluateTaskAnswer(
+    pathOracleFixture('go'),
+    'The expected behavior is implemented in src/main.goSuffix.');
+
+  assert.equal(result.classification, 'incomplete');
+  assert.deepEqual(result.namedPaths, []);
+});
+
+test('task oracle rejects a declared path inside a longer path', () => {
+  const result = evaluateTaskAnswer(
+    pathOracleFixture('go'),
+    'The expected behavior is implemented in generated/src/main.go.');
+
+  assert.equal(result.classification, 'incomplete');
+  assert.deepEqual(result.namedPaths, []);
+});
+
+test('task oracle recognizes a test selector appended to a declared Python path', () => {
+  const task = {
+    ...pathOracleFixture('py'),
+    requiredPaths: ['tests/client/test_redirects.py'],
+    forbiddenPaths: [],
+  };
+
+  const result = evaluateTaskAnswer(task,
+    'The expected behavior is covered by tests/client/test_redirects.py:test_cross_domain_redirect_with_auth_header.');
+
+  assert.equal(result.classification, 'complete');
+  assert.deepEqual(result.namedPaths, ['tests/client/test_redirects.py']);
+});
+
 function pathOracleFixture(extension) {
   return {
     id: `path-${extension}`,

--- a/tools/McpUsageRecorder/tests/recorder.test.mjs
+++ b/tools/McpUsageRecorder/tests/recorder.test.mjs
@@ -298,18 +298,24 @@ for (const extension of ['go', 'js', 'jsx', 'tsx', 'rs', 'java', 'kt', 'rb', 'ph
   });
 }
 
-test('task oracle registry rejects a path whose extension is not declared', () => {
+test('task oracle registry rejects any declared path whose extension is not listed', () => {
   const directory = mkdtempSync(join(tmpdir(), 'mcp-oracle-'));
   const registryPath = join(directory, 'tasks.json');
   try {
-    writeFileSync(registryPath, JSON.stringify({
-      schemaVersion: 2,
-      tasks: [{ ...pathOracleFixture('go'), requiredPaths: ['src/main.zig'] }],
-    }));
+    for (const paths of [
+      { requiredPaths: ['src/main.zig'] },
+      { optionalPaths: ['src/optional.zig'] },
+      { forbiddenPaths: ['src/forbidden.zig'] },
+    ]) {
+      writeFileSync(registryPath, JSON.stringify({
+        schemaVersion: 2,
+        tasks: [{ ...pathOracleFixture('go'), ...paths }],
+      }));
 
-    assert.throws(
-      () => loadTaskOracleRegistry(registryPath),
-      /path 'src\/main\.zig' uses an extension not listed in pathExtensions/);
+      assert.throws(
+        () => loadTaskOracleRegistry(registryPath),
+        /uses an extension not listed in pathExtensions/);
+    }
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -341,6 +347,19 @@ test('task oracle accepts a declared filename at the repository root', () => {
 
   assert.equal(result.classification, 'complete');
   assert.deepEqual(result.namedPaths, ['package.json']);
+});
+
+test('task oracle requires standalone declared paths and normalizes line-qualified separators', () => {
+  const task = pathOracleFixture('go');
+  const answer = [
+    'Ignore prefix/src/main.go and src/main.go.example.',
+    'Use `src\\main.go:12-18` for the expected behavior.',
+  ].join('\n');
+
+  const result = evaluateTaskAnswer(task, answer);
+
+  assert.equal(result.classification, 'complete');
+  assert.deepEqual(result.namedPaths, ['src/main.go']);
 });
 
 function pathOracleFixture(extension) {


### PR DESCRIPTION
## Изменения
- извлечение учитывает только точные пути, объявленные задачей
- расширения задаются в реестре и проверяются при загрузке
- поддержаны селекторы строк, диапазонов, тестов, символов и якорей после объявленного пути
- добавлено покрытие go, js, jsx, tsx, rs, java, kt, rb, php, c, h, cpp и hpp
- посторонние имена файлов и пути из примеров не влияют на результат

## Проверка
- node --test tools/McpUsageRecorder/tests/recorder.test.mjs — 42/42
- сохранённый ответ с tests/client/test_redirects.py:test_cross_domain_redirect_with_auth_header классифицируется как полный
- базовая классификация сохранённых ответов не изменилась
- обязательные пути: p6 28/36, p7 27/36
- расхождение по порядку для 18 пар: корректность 11,1%, предпочтение 22,2%, любое 33,3%
- сравнение p6/p7: корректность 33,3%, предпочтение 50%, любое 50%